### PR TITLE
Support getting multiple external keys from sort

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -891,8 +891,17 @@ class Redis(threading.local):
             pieces.append(start)
             pieces.append(num)
         if get is not None:
-            pieces.append('GET')
-            pieces.append(get)
+            # If get is a string assume we want to get a single value.
+            # Otherwise assume it's an interable and we want to get multiple
+            # values. We can't just iterate blindly because strings are
+            # iterable.
+            if isinstance(get, basestring):
+                pieces.append('GET')
+                pieces.append(get)
+            else:
+                for g in get:
+                    pieces.append('GET')
+                    pieces.append(g)
         if desc:
             pieces.append('DESC')
         if alpha:

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -1071,6 +1071,14 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assertEquals(self.client.sort('a', get='user:*'),
             ['u1', 'u2', 'u3'])
 
+    def test_sort_get_multi(self):
+        self.client['user:1'] = 'u1'
+        self.client['user:2'] = 'u2'
+        self.client['user:3'] = 'u3'
+        self.make_list('a', '231')
+        self.assertEquals(self.client.sort('a', get=('user:*', '#')),
+            ['u1', '1', 'u2', '2', 'u3', '3'])
+
     def test_sort_desc(self):
         self.make_list('a', '231')
         self.assertEquals(self.client.sort('a', desc=True), ['3', '2', '1'])


### PR DESCRIPTION
Sort supports getting multiple external keys (since Redis 1.1); this adds that support to redis-py.

Syntax looks like: `client.sort('key', get=('key2:*', 'key3:*'))`
