### PR TITLE
socket_timeout that works when new connection times out

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -49,6 +49,7 @@ class Connection(object):
             return
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(self.socket_timeout)
             sock.connect((self.host, self.port))
         except socket.error, e:
             # args for socket.error can either be (errno, "message")
@@ -61,7 +62,6 @@ class Connection(object):
                     (e.args[0], self.host, self.port, e.args[1])
             raise ConnectionError(error_message)
         sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
-        sock.settimeout(self.socket_timeout)
         self._sock = sock
         self._fp = sock.makefile('r')
         redis_instance._setup_connection()


### PR DESCRIPTION
Hello Andy!
In our environment when some boxes went out of memory, new connections were timing out. However I was wondering why socket_timeout didn't work.

In http://docs.python.org/library/socket.html there is a convenience function called 'create_connection' that accepts timeout as argument, and it is said that it applies timeout before (!) connecting. So I made the according change in redis-py source code and now timeout works as expected ;)
