### PR TITLE
Redis map

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -179,7 +179,7 @@ def zset_score_pairs(response, **options):
     """
     if not response or not options['withscores']:
         return response
-    # We should return the izip iterator relly.
+    # We should return the izip iterator really.
     # But tests fail (which can be fixed) and, more importantly,
     # it may cause problems to existing implementations. So lets stick with zip.
     return zip(response[::2], map(float, response[1::2]))


### PR DESCRIPTION
Hi Andy,
Just a small modification.
I replaced the zip iterator with izip in the pairs_to_dict function in client.py.
izip takes 60% of the zip time, quite big saving on large responses.
Check  https://gist.github.com/676153 a benchmark

Luca
