### PR TITLE
here's the reorder of the zadd parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ API Reference
   Unsubscribe from _channels_. If empty, unsubscribe
   from all channels
 
-### zadd(self, name, value, score)
+### zadd(self, name, score, value)
   Add member _value_ with score _score_ to sorted set _name_
 
 ### zcard(self, name)

--- a/redis/client.py
+++ b/redis/client.py
@@ -777,10 +777,6 @@ class Redis(threading.local):
     def lpush(self, name, value):
         "Push ``value`` onto the head of the list ``name``"
         return self.execute_command('LPUSH', name, value)
-    
-    def lpushx(self, name, value):
-        "Push ``value`` onto the head of the list ``name`` if ``name`` exists"
-        return self.execute_command('LPUSHX', name, value)
 
     def lrange(self, name, start, end):
         """
@@ -856,10 +852,6 @@ class Redis(threading.local):
     def rpush(self, name, value):
         "Push ``value`` onto the tail of the list ``name``"
         return self.execute_command('RPUSH', name, value)
-
-    def rpushx(self, name, value):
-        "Push ``value`` onto the tail of the list ``name`` if ``name`` exists"
-        return self.execute_command('RPUSHX', name, value)
 
     def sort(self, name, start=None, num=None, by=None, get=None,
              desc=False, alpha=False, store=None):
@@ -990,7 +982,7 @@ class Redis(threading.local):
 
 
     #### SORTED SET COMMANDS ####
-    def zadd(self, name, value, score):
+    def zadd(self, name, score, value):
         "Add member ``value`` with score ``score`` to sorted set ``name``"
         return self.execute_command('ZADD', name, score, value)
 

--- a/tests/pipeline.py
+++ b/tests/pipeline.py
@@ -11,7 +11,7 @@ class PipelineTestCase(unittest.TestCase):
 
     def test_pipeline(self):
         pipe = self.client.pipeline()
-        pipe.set('a', 'a1').get('a').zadd('z', 'z1', 1).zadd('z', 'z2', 4)
+        pipe.set('a', 'a1').get('a').zadd('z', 1, 'z1').zadd('z', 4, 'z2')
         pipe.zincrby('z', 'z1').zrange('z', 0, 5, withscores=True)
         self.assertEquals(pipe.execute(),
             [


### PR DESCRIPTION
This is my fix for  andymccurdy/redis-py#72
