### PR TITLE
Command Reference Docs Moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage
     'bar'
 
 For a complete list of commands, check out the list of Redis commands here:
-http://code.google.com/p/redis/wiki/CommandReference
+http://redis.io/commands
 
 Installation
 ------------


### PR DESCRIPTION
Docs have moved from their google code page onto their own site. Updated command refs to link to http://redis.io/commands
