### PR TITLE
Use hiredis for protocol parsing when available

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -123,7 +123,7 @@ class Redis(threading.local):
         string_keys_to_dict(
             # these return OK, or int if redis-server is >=1.3.4
             'LPUSH RPUSH',
-            lambda r: isinstance(r, int) and r or r == 'OK'
+            lambda r: isinstance(r, long) and r or r == 'OK'
             ),
         string_keys_to_dict('ZSCORE ZINCRBY', float_or_none),
         string_keys_to_dict(

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -124,7 +124,7 @@ class PythonConnection(BaseConnection):
             return response
         # int value
         elif byte == ':':
-            return int(response)
+            return long(response)
         # bulk response
         elif byte == '$':
             length = int(response)


### PR DESCRIPTION
Hi Andy,

This changeset uses hiredis for protocol parsing when it can be imported. Otherwise, it falls back to the original way to parse replies. I've extract the ConnectionPool and Connection classes to a separate file in the process. Clearly, installing hiredis should be optional because it's a C-ext. However, when users have a proper build env, it would be cool if they can benefit from faster reply parsing. I've done some minor benchmarks, that show huge improvement for large multi bulks (see: http://github.com/pietern/hiredis-py). This patchset is only a suggestion (I created it to properly benchmark the impact of using hiredis), and we could discuss for a bit if this is the right approach.

Thanks!
Pieter
