### PR TITLE
Revert python2.4 incompatible change

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -64,7 +64,10 @@ def parse_info(response):
     for line in response.splitlines():
         key, value = line.split(':')
         try:
-            info[key] = float(value) if '.' in value else int(value)
+            if '.' in value:
+                info[key] = float(value)
+            else:
+                info[key] = int(value)
         except ValueError:
             info[key] = get_value(value)
     return info


### PR DESCRIPTION
- SHA: 32a7469ef67a358d4e07c4f543a31d4587303c88
  This one introduced a python2.4 incomptible change. Would be nice if redis-py stays 2.4-compatible.
