### PR TITLE
Compatibility For Python3

### DIFF
--- a/redis/compat.py
+++ b/redis/compat.py
@@ -1,0 +1,26 @@
+import sys
+
+__all__ = ['basestring', 'bytes', 'imap', 'izip', 'long', 'unicode', 'unichr']
+
+MAJOR_VERSION = sys.version_info.major
+
+if MAJOR_VERSION >= 3:
+    basestring = str
+    bytes = bytes
+    imap = map
+    izip = zip
+    long = int
+    unichr = chr
+    unicode = str
+else:
+    from itertools import imap, izip
+
+    basestring = basestring
+    try:
+        bytes = bytes
+    except NameError:
+        bytes = str
+    long = long
+    unichr = unichr
+    unicode = unicode
+    unicode = unicode

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,7 +1,10 @@
 import errno
 import socket
+import sys
 import threading
+from redis.compat import long, MAJOR_VERSION
 from redis.exceptions import ConnectionError, ResponseError, InvalidResponse
+
 
 class BaseConnection(object):
     "Manages TCP communication to and from a Redis server"
@@ -23,7 +26,8 @@ class BaseConnection(object):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(self.socket_timeout)
             sock.connect((self.host, self.port))
-        except socket.error, e:
+        except socket.error:
+            e = sys.exc_info()[1]
             # args for socket.error can either be (errno, "message")
             # or just "message"
             if len(e.args) == 1:
@@ -35,7 +39,11 @@ class BaseConnection(object):
             raise ConnectionError(error_message)
         sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
         self._sock = sock
-        self._fp = sock.makefile('r')
+        if MAJOR_VERSION >= 3:
+            fmode = 'rb'
+        else:
+            fmode = 'r'
+        self._fp = sock.makefile(fmode)
         redis_instance._setup_connection()
 
     def disconnect(self):
@@ -53,8 +61,11 @@ class BaseConnection(object):
         "Send ``command`` to the Redis server. Return the result."
         self.connect(redis_instance)
         try:
+            if MAJOR_VERSION >= 3:
+                command = command.encode()
             self._sock.sendall(command)
-        except socket.error, e:
+        except socket.error:
+            e = sys.exc_info()[1]
             if e.args[0] == errno.EPIPE:
                 self.disconnect()
             if len(e.args) == 1:
@@ -71,9 +82,14 @@ class BaseConnection(object):
         """
         try:
             if length is not None:
-                return self._fp.read(length)
-            return self._fp.readline()
-        except socket.error, e:
+                result = self._fp.read(length)
+            else:
+                result = self._fp.readline()
+            if sys.version_info.major >= 3:
+                result = result.decode()
+            return result
+        except socket.error:
+            e = sys.exc_info()[1]
             self.disconnect()
             if e.args and e.args[0] == errno.EAGAIN:
                 raise ConnectionError("Error while reading from socket: %s" % \
@@ -82,7 +98,7 @@ class BaseConnection(object):
 
 class PythonConnection(BaseConnection):
     def read_response(self, command_name, catch_errors):
-        response = self.read()[:-2] # strip last two characters (\r\n)
+        response = self.read().strip()  # strip last two characters (\r\n)
         if not response:
             self.disconnect()
             raise ConnectionError("Socket closed on remote end")
@@ -129,7 +145,8 @@ class PythonConnection(BaseConnection):
                         data.append(
                             self.read_response(command_name, catch_errors)
                             )
-                    except Exception, e:
+                    except Exception:
+                        e = sys.exc_info()[1]
                         data.append(e)
                 return data
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,9 @@
 import unittest
-from server_commands import ServerCommandsTestCase
-from connection_pool import ConnectionPoolTestCase
-from pipeline import PipelineTestCase
-from lock import LockTestCase
+
+from tests.server_commands import ServerCommandsTestCase
+from tests.connection_pool import ConnectionPoolTestCase
+from tests.pipeline import PipelineTestCase
+from tests.lock import LockTestCase
 
 use_hiredis = False
 try:

--- a/tests/connection_pool.py
+++ b/tests/connection_pool.py
@@ -14,18 +14,17 @@ class ConnectionPoolTestCase(unittest.TestCase):
         # if one of them switches, they should have
         # separate conncetion objects
         r2.select(db=10, host='localhost', port=6379)
-        self.assertNotEqual(r1.connection, r2.connection)
+        self.assertNotEqual(id(r1.connection), id(r2.connection))
 
         conns = [r1.connection, r2.connection]
-        conns.sort()
+        conns.sort(key=lambda x: id(x))
 
         # but returning to the original state shares the object again
         r2.select(db=9, host='localhost', port=6379)
         self.assertEquals(r1.connection, r2.connection)
 
         # the connection manager should still have just 2 connections
-        mgr_conns = pool.get_all_connections()
-        mgr_conns.sort()
+        mgr_conns = sorted(pool.get_all_connections(), key=lambda x: id(x))
         self.assertEquals(conns, mgr_conns)
 
     def test_threaded_workers(self):
@@ -40,7 +39,7 @@ class ConnectionPoolTestCase(unittest.TestCase):
 
         def _keys_worker():
             for i in range(50):
-                _ = r.keys()
+                _ = list(r.keys())
                 time.sleep(0.01)
 
         t1 = threading.Thread(target=_info_worker)
@@ -50,4 +49,3 @@ class ConnectionPoolTestCase(unittest.TestCase):
 
         for i in [t1, t2]:
             i.join()
-


### PR DESCRIPTION
I've completed the changes required to have redis-py work with python 2 and python 3. The only issue outstanding is that hiredis-py will not work with python 3. I have begun that port and made some good progress, but there are still a few unfinished items. I'm not sure its a blocker for us.
