### PR TITLE
raising KeyErrors from __getitem__

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -443,10 +443,20 @@ class Redis(threading.local):
 
     def get(self, name):
         """
-        Return the value at key ``name``, or None of the key doesn't exist
+        Return the value at key ``name``, or None if the key doesn't exist
         """
         return self.execute_command('GET', name)
-    __getitem__ = get
+
+    def __getitem__(self, name):
+        """
+        Return the value at key ``name``, raises a KeyError if the key
+        doesn't exist.
+        """
+        _name = self.get(name)
+        if _name:
+            return _name
+        else:
+            raise KeyError(name)
 
     def getbit(self, name, offset):
         "Returns a boolean indicating the value of ``offset`` in ``name``"


### PR DESCRIPTION
Hi,

Since r['foo'] works, the first usecase I stumbled upon was this:

try:
  rabbits = r['foo']
except KeyError:
  print "I don't know who foo is"

This patch raises the KeyError.

Thanks! 
-Ionuț
