### PR TITLE
Added socket disconnection if commands are rejected due to AOF/RDB load.

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -97,6 +97,11 @@ class PythonConnection(BaseConnection):
         if byte == '-':
             if response.startswith('ERR '):
                 response = response[4:]
+            if response.startswith('LOADING '):
+                # If we're loading the dataset into memory, kill the socket
+                # so we re-initialize (and re-SELECT) next time.
+                self.disconnect()
+                response = response[8:]
             raise ResponseError(response)
         # single value
         elif byte == '+':


### PR DESCRIPTION
SELECT commands are issued only on initial socket connection. If a user issues a command during an AOF/RDB load, the socket connection will be successfully opened, but the SELECT command will be lost. If subsequent commands are sent after the AOF/RDB load is completed, the SELECT command will not be retried (due to the open socket), and those commands will go to the wrong DB. This behavior appears to be present in hiredis as well as redis-py. Fixing it here by special casing the AOF/RDB load message and closing the socket connection before raising ResponseError.
