### PR TITLE
PubSub publish fix

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1075,7 +1075,8 @@ class PubSub(object):
     def parse_response(self):
         "Parse the response from a publish/subscribe command"
         response = self.connection.read_response()
-        if response[0] in self.subscribe_commands:
+        if not isinstance(response, long) and \
+                response[0] in self.subscribe_commands:
             self.subscription_count = response[2]
             # if we've just unsubscribed from the remaining channels,
             # release the connection back to the pool


### PR DESCRIPTION
PUBLISH returns an int indicating the number of subscribed clients who received the message. Simply modified PubSub.parse_response to handle the single value, type long response.
