### PR TITLE
hold connection for duration of WATCH

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1354,7 +1354,7 @@ class Pipeline(Redis):
             # if we were watching a variable, the watch is no longer valid since
             # this connection has died.
             if self.watching:
-                raise
+                raise WatchError("Watched variable changed.")
             return execute(conn, stack)
         finally:
             self.reset()


### PR DESCRIPTION
The first commit causes watch() to make the connection become 'sticky' until pipeline() or unwatch() is executed. It preserves existing calls, only adding an optional keyword argument for constructing the PubSub and Pipeline classes. It is still safe to share the Redis client for normal operation, but using watch() will mean taking care to not share blindly. After looking at the code for a long time I think I'm happiest with this compromise.

Second commit modifies the test slightly to make sure that starting a pipeline() after watch() frees the Redis object for immediate re-use.
