### PR TITLE
Connection pool leak with pipelining

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1381,6 +1381,8 @@ class Pipeline(Redis):
             # predicated on any state
             return execute(conn, stack)
         finally:
+            if conn and not self.connection:
+                self.connection_pool.release(conn)
             self.reset()
 
     def watch(self, *names):


### PR DESCRIPTION
In `Pipeline`, `execute()` does not return connections to the pool unless they had been put in `self.connection` by `immediate_execute_command()`. This can leak connections very quickly; it's been killing my server periodically for the past week, which was kind of a pain to track down :-). The fix is a couple of lines of code. All tests pass, of course.
