### PR TITLE
Fix zadd: 'tuple' object has no attribute 'reverse' (and args is a tuple)

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1111,9 +1111,7 @@ class Redis(StrictRedis):
             if len(args) % 2 != 0:
                 raise RedisError("ZADD requires an equal number of "
                                  "values and scores")
-            temp_args = args
-            temp_args.reverse()
-            pieces.extend(temp_args)
+            pieces.extend(reversed(args))
         for pair in kwargs.iteritems():
             pieces.append(pair[1])
             pieces.append(pair[0])


### PR DESCRIPTION
Very small fix to revert correctly the tuple in zadd
