### PR TITLE
Reapplied dcolish's Python3 patch to the current code base

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2,7 +2,16 @@ from __future__ import with_statement
 import datetime
 import time
 import warnings
-from itertools import imap, izip, starmap
+from itertools import starmap
+from redis.compat import (
+    basestring,
+    bytes,
+    imap,
+    izip,
+    long,
+    MAJOR_VERSION,
+    unicode,
+    )
 from redis.connection import ConnectionPool, UnixDomainSocketConnection
 from redis.exceptions import (
     ConnectionError,
@@ -84,7 +93,7 @@ def zset_score_pairs(response, **options):
         return response
     score_cast_func = options.get('score_cast_func', float)
     it = iter(response)
-    return zip(it, imap(score_cast_func, it))
+    return list(zip(it, imap(score_cast_func, it)))
 
 def int_or_none(response):
     if response is None:
@@ -425,7 +434,7 @@ class StrictRedis(object):
     def mset(self, mapping):
         "Sets each key in the ``mapping`` dict to its corresponding value"
         items = []
-        for pair in mapping.iteritems():
+        for pair in mapping.items():
             items.extend(pair)
         return self.execute_command('MSET', *items)
 
@@ -435,7 +444,7 @@ class StrictRedis(object):
         none of the keys are already set
         """
         items = []
-        for pair in mapping.iteritems():
+        for pair in mapping.items():
             items.extend(pair)
         return self.execute_command('MSETNX', *items)
 
@@ -819,7 +828,7 @@ class StrictRedis(object):
                 raise RedisError("ZADD requires an equal number of "
                                  "values and scores")
             pieces.extend(args)
-        for pair in kwargs.iteritems():
+        for pair in kwargs.items():
             pieces.append(pair[1])
             pieces.append(pair[0])
         return self.execute_command('ZADD', name, *pieces)
@@ -1047,7 +1056,7 @@ class StrictRedis(object):
         if not mapping:
             raise DataError("'hmset' with 'mapping' of length 0")
         items = []
-        for pair in mapping.iteritems():
+        for pair in mapping.items():
             items.extend(pair)
         return self.execute_command('HMSET', name, *items)
 
@@ -1133,7 +1142,7 @@ class Redis(StrictRedis):
                 raise RedisError("ZADD requires an equal number of "
                                  "values and scores")
             pieces.extend(reversed(args))
-        for pair in kwargs.iteritems():
+        for pair in kwargs.items():
             pieces.append(pair[1])
             pieces.append(pair[0])
         return self.execute_command('ZADD', name, *pieces)

--- a/redis/compat.py
+++ b/redis/compat.py
@@ -1,0 +1,27 @@
+import sys
+
+__all__ = ['basestring', 'bytes', 'imap', 'izip', 'long', 'unicode', 'unichr', 'xrange']
+
+MAJOR_VERSION = sys.version_info.major
+
+if MAJOR_VERSION >= 3:
+    basestring = str
+    bytes = bytes
+    imap = map
+    izip = zip
+    long = int
+    unichr = chr
+    unicode = str
+    xrange = range
+else:
+    from itertools import imap, izip
+
+    basestring = basestring
+    try:
+        bytes = bytes
+    except NameError:
+        bytes = str
+    long = long
+    unichr = unichr
+    unicode = unicode
+    xrange = xrange

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,6 +1,15 @@
 import errno
 import socket
-from itertools import chain, imap
+import sys
+from itertools import chain
+from redis.compat import (
+    bytes,
+    imap,
+    long,
+    unicode,
+    xrange,
+    MAJOR_VERSION
+    )
 from redis.exceptions import ConnectionError, ResponseError, InvalidResponse
 
 class PythonParser(object):
@@ -9,7 +18,11 @@ class PythonParser(object):
 
     def on_connect(self, connection):
         "Called when the socket connects"
-        self._fp = connection._sock.makefile('r')
+        if MAJOR_VERSION >= 3:
+            fmode = 'rb'
+        else:
+            fmode = 'r'
+        self._fp = connection._sock.makefile(fmode)
 
     def on_disconnect(self):
         "Called when the socket disconnects"
@@ -24,9 +37,14 @@ class PythonParser(object):
         """
         try:
             if length is not None:
-                return self._fp.read(length+2)[:-2]
-            return self._fp.readline()[:-2]
-        except (socket.error, socket.timeout), e:
+                result = self._fp.read(length+2)[:-2]
+            else:
+                result = self._fp.readline()[:-2]
+            if MAJOR_VERSION >= 3:
+                result = result.decode()
+            return result
+        except (socket.error, socket.timeout):
+            e = sys.exc_info()[1]
             raise ConnectionError("Error while reading from socket: %s" % \
                 (e.args,))
 
@@ -83,7 +101,8 @@ class HiredisParser(object):
         while response is False:
             try:
                 buffer = self._sock.recv(4096)
-            except (socket.error, socket.timeout), e:
+            except (socket.error, socket.timeout):
+                e = sys.exc_info()[1]
                 raise ConnectionError("Error while reading from socket: %s" % \
                     (e.args,))
             if not buffer:
@@ -123,7 +142,8 @@ class Connection(object):
             return
         try:
             sock = self._connect()
-        except socket.error, e:
+        except socket.error:
+            e = sys.exc_info()[1]
             raise ConnectionError(self._error_message(e))
 
         self._sock = sock
@@ -179,8 +199,11 @@ class Connection(object):
         if not self._sock:
             self.connect()
         try:
+            if MAJOR_VERSION >= 3:
+                command = command.encode()
             self._sock.sendall(command)
-        except socket.error, e:
+        except socket.error:
+            e = sys.exc_info()[1]
             self.disconnect()
             if len(e.args) == 1:
                 _errno, errmsg = 'UNKNOWN', e.args[0]
@@ -215,9 +238,23 @@ class Connection(object):
 
     def pack_command(self, *args):
         "Pack a series of arguments into a value Redis command"
-        command = ['$%s\r\n%s\r\n' % (len(enc_value), enc_value)
-                   for enc_value in imap(self.encode, args)]
-        return '*%s\r\n%s' % (len(command), ''.join(command))
+
+        cmds = []
+        if MAJOR_VERSION >= 3:
+            for enc_value in imap(self.encode, args):
+                if isinstance(enc_value, bytes):
+                    cmds += ['$%s\r\n%s\r\n' % (len(enc_value),
+                                                enc_value.decode())]
+                else:
+                    cmds += ['$%s\r\n%s\r\n' % (len(enc_value),
+                                                 enc_value)]
+        else:
+            for enc_value in imap(self.encode, args):
+                cmds += ['$%s\r\n%s\r\n' % (len(enc_value),
+                                             enc_value)]
+
+        return '*%s\r\n%s' % (len(cmds), ''.join(cmds))
+
 
 class UnixDomainSocketConnection(Connection):
     def __init__(self, path='', db=0, password=None,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,9 @@
 import unittest
-from server_commands import ServerCommandsTestCase
-from connection_pool import ConnectionPoolTestCase
-from pipeline import PipelineTestCase
-from lock import LockTestCase
-from pubsub import PubSubTestCase
+from tests.server_commands import ServerCommandsTestCase
+from tests.connection_pool import ConnectionPoolTestCase
+from tests.pipeline import PipelineTestCase
+from tests.lock import LockTestCase
+from tests.pubsub import PubSubTestCase
 
 use_hiredis = False
 try:

--- a/tests/pubsub.py
+++ b/tests/pubsub.py
@@ -17,7 +17,7 @@ class PubSubTestCase(unittest.TestCase):
             )
         self.assertEquals(self.client.publish('foo', 'hello foo'), 1)
         self.assertEquals(
-            self.pubsub.listen().next(),
+            next(self.pubsub.listen()),
             {
                 'type': 'message',
                 'pattern': None,
@@ -37,7 +37,7 @@ class PubSubTestCase(unittest.TestCase):
             )
         self.assertEquals(self.client.publish('foo', 'hello foo'), 1)
         self.assertEquals(
-            self.pubsub.listen().next(),
+            next(self.pubsub.listen()),
             {
                 'type': 'pmessage',
                 'pattern': 'fo*',

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -4,6 +4,11 @@ import datetime
 import time
 from distutils.version import StrictVersion
 from redis.client import parse_info
+from redis.compat import (
+    unichr,
+    unicode,
+    MAJOR_VERSION
+    )
 
 class ServerCommandsTestCase(unittest.TestCase):
 
@@ -40,15 +45,19 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assertEquals(self.client.get('a'), None)
         byte_string = 'value'
         integer = 5
-        unicode_string = unichr(3456) + u'abcd' + unichr(3421)
+        unicode_string = unichr(3456) + unicode('abcd') + unichr(3421)
         self.assert_(self.client.set('byte_string', byte_string))
         self.assert_(self.client.set('integer', 5))
         self.assert_(self.client.set('unicode_string', unicode_string))
         self.assertEquals(self.client.get('byte_string'), byte_string)
         self.assertEquals(self.client.get('integer'), str(integer))
-        self.assertEquals(
-                self.client.get('unicode_string').decode('utf-8'),
-                unicode_string)
+        if MAJOR_VERSION >= 3:
+                self.assertEquals(self.client.get("unicode_string"),
+                        unicode_string)
+        else:
+                self.assertEquals(
+                        self.client.get('unicode_string').decode('utf-8'),
+                        unicode_string)
 
     def test_getitem_and_setitem(self):
         self.client['a'] = 'bar'
@@ -104,7 +113,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         # real logic
         self.assertEquals(self.client.append('a', 'a1'), 2)
         self.assertEquals(self.client['a'], 'a1')
-        self.assert_(self.client.append('a', 'a2'), 4)
+        self.assertEqual(self.client.append('a', 'a2'), 4)
         self.assertEquals(self.client['a'], 'a1a2')
 
     def test_decr(self):
@@ -184,7 +193,7 @@ class ServerCommandsTestCase(unittest.TestCase):
     def test_mset(self):
         d = {'a': '1', 'b': '2', 'c': '3'}
         self.assert_(self.client.mset(d))
-        for k,v in d.iteritems():
+        for k,v in d.items():
             self.assertEquals(self.client[k], v)
 
     def test_msetnx(self):
@@ -192,7 +201,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assert_(self.client.msetnx(d))
         d2 = {'a': 'x', 'd': '4'}
         self.assert_(not self.client.msetnx(d2))
-        for k,v in d.iteritems():
+        for k,v in d.items():
             self.assertEquals(self.client[k], v)
         self.assertEquals(self.client.get('d'), None)
 
@@ -940,7 +949,7 @@ class ServerCommandsTestCase(unittest.TestCase):
 
     # HASHES
     def make_hash(self, key, d):
-        for k,v in d.iteritems():
+        for k,v in d.items():
             self.client.hset(key, k, v)
 
     def test_hget_and_hset(self):
@@ -1063,7 +1072,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         h = {'a1': '1', 'a2': '2', 'a3': '3'}
         self.make_hash('a', h)
         keys = h.keys()
-        keys.sort()
+        keys = sorted(keys)
         remote_keys = self.client.hkeys('a')
         remote_keys.sort()
         self.assertEquals(keys, remote_keys)
@@ -1092,7 +1101,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         h = {'a1': '1', 'a2': '2', 'a3': '3'}
         self.make_hash('a', h)
         vals = h.values()
-        vals.sort()
+        vals = sorted(vals)
         remote_vals = self.client.hvals('a')
         remote_vals.sort()
         self.assertEquals(vals, remote_vals)
@@ -1218,7 +1227,7 @@ class ServerCommandsTestCase(unittest.TestCase):
                    'foo\tbar\x07': '789',
                    }
         # fill in lists
-        for key, value in mapping.iteritems():
+        for key, value in mapping.items():
             for c in value:
                 self.assertTrue(self.client.rpush(key, c))
 


### PR DESCRIPTION
Hi,

I was looking for a Python3 version of redis-py and found https://github.com/andymccurdy/redis-py/pull/122 by dcolish. Since it wasn't merged to the current code base, I manually merged it myself. For me, it runs all test cases both on Python and Python3 (except one about ZADD, but that fails on master too).
I hope this can be helpful.

Greetings,
Julian
