### PR TITLE
Fix problem with hiredis on disconnect()

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -79,6 +79,8 @@ class HiredisParser(object):
         self._reader = None
 
     def read_response(self):
+        if not self._reader:
+            raise ConnectionError("Socket closed on remote end")
         response = self._reader.gets()
         while response is False:
             try:


### PR DESCRIPTION
Raise ConnectionError if the reader has been closed under us. This
happens if someone calls the disconnect method. This matches the same
behavior as in PythonParser.
