### PR TITLE
Make redis.lrange('foo') return the entire list

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -618,7 +618,7 @@ class StrictRedis(object):
         "Push ``value`` onto the head of the list ``name`` if ``name`` exists"
         return self.execute_command('LPUSHX', name, value)
 
-    def lrange(self, name, start, end):
+    def lrange(self, name, start=0, end=-1):
         """
         Return a slice of the list ``name`` between
         position ``start`` and ``end``

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -397,6 +397,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.make_list('a', 'abcde')
         self.assertEquals(self.client.lrange('a', 0, 2), ['a', 'b', 'c'])
         self.assertEquals(self.client.lrange('a', 2, 10), ['c', 'd', 'e'])
+        self.assertEquals(self.client.lrange('a'), ['a', 'b', 'c', 'd', 'e'])
 
     def test_lrem(self):
         # no key


### PR DESCRIPTION
Redis does not have a no argument command to retrieve the entire list.
Instead of remembering to run:

  r.lrange('foo', 0, -1)

default start to 0 and end to -1 making it possible to just run:

  r.lrange('foo')

If only start is specified, behavior remains sensible (all list elements
from that index onward are returned).
