### PR TITLE
Allow empty watches in Redis.transaction()

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -240,7 +240,8 @@ class StrictRedis(object):
         with self.pipeline(True, shard_hint) as pipe:
             while 1:
                 try:
-                    pipe.watch(*watches)
+                    if watches:
+                        pipe.watch(*watches)
                     func(pipe)
                     return pipe.execute()
                 except WatchError:


### PR DESCRIPTION
Useful when watches list is empty or can change upon transaction failure.

Notably In this example code https://github.com/andymccurdy/redis-py/issues/197/#issuecomment-2350913
