### PR TITLE
Open socket connection with mode='rb' instead of 'r' to support IronPython

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -35,7 +35,7 @@ class PythonParser(object):
 
     def on_connect(self, connection):
         "Called when the socket connects"
-        self._fp = connection._sock.makefile('r')
+        self._fp = connection._sock.makefile('rb')
 
     def on_disconnect(self):
         "Called when the socket disconnects"


### PR DESCRIPTION
Open socket connection with mode='rb' instead of 'r'.
    From Python documentation: ...when opening a binary file, you should append 'b' to the mode value to open the file in binary mode, which will improve portability. (Appending 'b' is useful even on systems that don’t treat binary and text files differently, where it serves as documentation.)

Without this, ironpython kills the last byte of each line of the response, because it assumes a \r\n at the end of the line, but gets only \n, because IronPython newline-normalizes the string.

I tested this change with IronPython, Python on Windows, and Python on Linux. All tests pass.
