### PR TITLE
added support for GETRANGE

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -393,6 +393,13 @@ class StrictRedis(object):
         """
         return self.execute_command('APPEND', key, value)
 
+    def getrange(self, key, start, end):
+        """
+        Returns the substring of the string value stored at ``key``,
+        determined by the offsets ``start`` and ``end`` (both are inclusive)
+        """
+        return self.execute_command('GETRANGE', key, start, end)
+
     def decr(self, name, amount=1):
         """
         Decrements the value of ``key`` by ``amount``.  If no key exists,

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -125,6 +125,12 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assert_(self.client.append('a', 'a2'), 4)
         self.assertEquals(self.client['a'], 'a1a2')
 
+    def test_getrange(self):
+        self.client['a'] = 'foo'
+        self.assertEquals(self.client.getrange('a', 0, 0), 'f')
+        self.assertEquals(self.client.getrange('a', 0, 2), 'foo')
+        self.assertEquals(self.client.getrange('a', 3, 4), '')
+
     def test_decr(self):
         self.assertEquals(self.client.decr('a'), -1)
         self.assertEquals(self.client['a'], '-1')


### PR DESCRIPTION
I needed a python client to work with GETRANGE on redis 2.4. This command is kind of a mirror of APPEND.
see http://redis.io/commands/getrange

-- jpcaruana
