### PR TITLE
Feature/Bitopt and Bitcount

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -413,6 +413,9 @@ class StrictRedis(object):
           raise RedisError("Both start and end must be specified")
         return self.execute_command('BITCOUNT', *params)
 
+    def bitop(self, op, dest, *keys):
+        return self.execute_command('BITOP', op, dest, *keys)
+
 
     def decr(self, name, amount=1):
         """


### PR DESCRIPTION
Added client support for the 2.6 bitopt and bitcount commands.  Includes tests.  In general, the tests didn't seem to skip based on redis version, so I didn't add that in for the new ones I wrote.  If that's desirable, I can add that.
