### PR TITLE
Improved `from_url()` support.

### DIFF
--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,31 +1,9 @@
-from urlparse import urlparse
-
 from .client import Redis
 
-DEFAULT_DATABASE_ID = 0
-
-def from_url(url, db=None):
+def from_url(url, db=None, **kwargs):
     """Returns an active Redis client generated from the given database URL.
 
     Will attempt to extract the database id from the path url fragment, if
     none is provided.
     """
-
-    url = urlparse(url)
-
-    # Make sure it's a redis database.
-    if url.scheme:
-        assert url.scheme == 'redis'
-
-    # Attempt to resolve database id.
-    if db is None:
-        try:
-            db = int(url.path.replace('/', ''))
-        except (AttributeError, ValueError):
-            db = DEFAULT_DATABASE_ID
-
-    return Redis(
-        host=url.hostname,
-        port=url.port,
-        db=db,
-        password=url.password)
+    return Redis.from_url(url, db, **kwargs)


### PR DESCRIPTION
`from_url()` is now implemented as a classmethod.  The previous
implementation always returned instances of the `Redis` class.  This
new approach lets us construct StrictRedis instances (or any other
class derived from StrictRedis, including Redis).

`utils.from_url()` has been preserved for backwards compatibility.

Also, both versions of `from_url()` now pass along any additional
keyword arguments to the class's initializer.
