### PR TITLE
New classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python']
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        ]
 )


### PR DESCRIPTION
Added classifiers to indicate which Python versions are supported. This will also cause redis to appear on the Python 3 packages list on PyPI.
