### PR TITLE
Add an option to avoid releasing PubSub connection

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -515,16 +515,6 @@ class StrictRedis(object):
             time = int(time.total_seconds())
         return self.execute_command('EXPIRE', name, time)
 
-    def pexpire(self, name, time):
-        """
-        Set an expire flag on key ``name`` for ``time`` milliseconds. 
-        ``time`` can be represented by an integer or a Python timedelta 
-        object.
-        """
-        if isinstance(time, datetime.timedelta):
-            time = int(time.total_seconds()) * 1000
-        return self.execute_command('PEXPIRE', name, time)
-
     def expireat(self, name, when):
         """
         Set an expire flag on key ``name``. ``when`` can be represented
@@ -672,10 +662,6 @@ class StrictRedis(object):
     def ttl(self, name):
         "Returns the number of seconds until the key ``name`` will expire"
         return self.execute_command('TTL', name)
-
-    def pttl(self, name):
-        "Returns the number of milliseconds until the key ``name`` will expire"
-        return self.execute_command('PTTL', name)
 
     def type(self, name):
         "Returns the type of key ``name``"

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -168,21 +168,6 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assertEquals(self.client.persist('a'), True)
         self.assertEquals(self.client.ttl('a'), None)
 
-    def test_pexpire(self):
-        version = self.client.info()['redis_version']
-        if StrictVersion(version) < StrictVersion('2.6.0'):
-            try:
-                raise unittest.SkipTest()
-            except AttributeError:
-                return
-
-        self.assertEquals(self.client.pexpire('a', 10000), False)
-        self.client['a'] = 'foo'
-        self.assertEquals(self.client.expire('a', 10000), True)
-        self.assertEquals(self.client.pttl('a'), 10000)
-        self.assertEquals(self.client.persist('a'), True)
-        self.assertEquals(self.client.pttl('a'), None)
-
     def test_expireat(self):
         expire_at = datetime.datetime.now() + datetime.timedelta(minutes=1)
         self.assertEquals(self.client.expireat('a', expire_at), False)


### PR DESCRIPTION
I ran into a problem trying to reuse a single PubSub object for many channels:

``` python
client = Redis()
pubsub = client.pubsub()
pubsub.subscribe('foo')
# [...]
pubsub.unsubscribe('foo')
pubsub.subscribe('bar')
for message in pubsub.listen():
    pass
```

The last listen() fails, because the PubSub connection is None at this time:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent/greenlet.py", line 328, in run
    result = self._run(*self.args, **self.kwargs)
# [...]
  File "/home/flupke/src/ext/redis-py/redis/client.py", line 1496, in listen
    r = self.parse_response()
  File "/home/flupke/src/ext/redis-py/redis/client.py", line 1440, in parse_response
    response = self.connection.read_response()
AttributeError: 'NoneType' object has no attribute 'read_response'
```

This is because I wasn't parsing responses, and PubSub recycles the connection when it catches a response indicating there are no more channels subscriptions. The fix is to parse responses after each pub/sub call:

``` python
client = Redis()
pubsub = client.pubsub()
pubsub.subscribe('foo')
pubsub.parse_response()
# [...]
pubsub.unsubscribe('foo')
pubsub.parse_response()
pubsub.subscribe('bar')
pubsub.parse_response()
for message in pubsub.listen():
    pass
```

This is a bit cumbersome, but the real problem is that an unnecessary Redis disconnect/connect cycle is made. The patch adds a release_connection option to StrictRedis.pubsub() and PubSub's constructor to avoid this behavior.
