### PR TITLE
in _compat for py3k only encode if param is not bytes type in b()

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -38,7 +38,7 @@ else:
     nativestr = lambda x: \
         x if isinstance(x, str) else x.decode('utf-8', 'replace')
     u = lambda x: x
-    b = lambda x: x.encode('iso-8859-1')
+    b = lambda x: x.encode('iso-8859-1') if not isinstance(x, bytes) else x
     next = next
     unichr = chr
     imap = map


### PR DESCRIPTION
in _compat for py3k only encode if param is not bytes type in b()
Thanks
