### PR TITLE
delete method should take multiple keys

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -415,9 +415,11 @@ class StrictRedis(object):
         "Returns version specific metainformation about a give key"
         return self.execute_command('DEBUG', 'OBJECT', key)
 
-    def delete(self, *names):
-        "Delete one or more keys specified by ``names``"
-        return self.execute_command('DEL', *names)
+    def delete(self, keys, *args):
+        "Delete one or more keys specified by ``keys``"
+        args = list_or_args(keys, args)
+        return self.execute_command('DEL', *args)
+
     __delitem__ = delete
 
     def echo(self, value):

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -63,6 +63,10 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assertEquals(self.client.delete('a'), False)
         self.client['a'] = 'foo'
         self.assertEquals(self.client.delete('a'), True)
+        self.assertEquals(self.client.mget(['a', 'b']), [None, None])
+        self.client['a'] = 'foo'
+        self.client['b'] = 'bar'
+        self.assertEquals(self.client.delete(['a', 'b']), True)
 
     def test_delitem(self):
         self.client['a'] = 'foo'


### PR DESCRIPTION
From http://redis.io/commands/del, delete command should be able to take multiple keys
