### PR TITLE
Implement support for passing an arg to INFO command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -87,27 +87,24 @@ def parse_info(response):
 
     def get_value(value):
         if ',' not in value or '=' not in value:
-            return value
-
-        sub_dict = {}
-        for item in value.split(','):
-            k, v = item.rsplit('=', 1)
             try:
-                sub_dict[k] = int(v)
+                if '.' in value:
+                    return float(value)
+                else:
+                    return int(value)
             except ValueError:
-                sub_dict[k] = v
-        return sub_dict
+                return value
+        else:
+            sub_dict = {}
+            for item in value.split(','):
+                k, v = item.rsplit('=', 1)
+                sub_dict[k] = get_value(v)  
+            return sub_dict
 
     for line in response.splitlines():
         if line and not line.startswith('#'):
             key, value = line.split(':')
-            try:
-                if '.' in value:
-                    info[key] = float(value)
-                else:
-                    info[key] = int(value)
-            except ValueError:
-                info[key] = get_value(value)
+            info[key] = get_value(value)
     return info
 
 


### PR DESCRIPTION
The INFO command in Redis Server has an optional parameter used to select a specific section. The implementation of the info command in redis-py does not implement the optional parameter. Without this parameter it is not possible to retrieve command counters and stats.

I've forked redis-py to implement support for passing a parameter to the INFO command. In older versions of Redis Server that do not support this optional parameter, the command would return an empty dictionary.

Hope you would find this patch worthy of adding to redis-py,
Thanks in advance.
