### PR TITLE
Bitcount start end params raised Exception when equal to 0

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -500,10 +500,11 @@ class StrictRedis(object):
         ``start`` and ``end`` paramaters indicate which bytes to consider
         """
         params = [key]
-        if start and end:
+        if start is not None and end is not None:
             params.append(start)
             params.append(end)
-        elif (start and not end) or (end and not start):
+        elif (start is not None and end is None) or \
+                (end is not None and start is None):
             raise RedisError("Both start and end must be specified")
         return self.execute_command('BITCOUNT', *params)
 

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -251,6 +251,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.client.setbit('a', 25, True)
         self.client.setbit('a', 33, True)
         self.assertEquals(self.client.bitcount('a'), 5)
+        self.assertEquals(self.client.bitcount('a', 0, -1), 5)
         self.assertEquals(self.client.bitcount('a', 2, 3), 2)
         self.assertEquals(self.client.bitcount('a', 2, -1), 3)
         self.assertEquals(self.client.bitcount('a', -2, -1), 2)


### PR DESCRIPTION
`bitcount mykey 0 -1`

was triggering `raise RedisError("Both start and end must be specified")` because `if` and `not` evaluated `0` to `False` but we want to check whether both are not None when at least one is specified.
