### PR TITLE
Pipelines now have a __len__() method.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1624,6 +1624,9 @@ class BasePipeline(object):
         except:
             pass
 
+    def __len__(self):
+        return len(self.command_stack)
+
     def reset(self):
         self.command_stack = []
         self.scripts = set()

--- a/tests/pipeline.py
+++ b/tests/pipeline.py
@@ -28,6 +28,22 @@ class PipelineTestCase(unittest.TestCase):
                 ]
             )
 
+    def test_pipeline_length(self):
+        with self.client.pipeline() as pipe:
+            # Initially empty.
+            self.assertEquals(len(pipe), 0)
+            self.assertFalse(pipe)
+
+            # Fill 'er up!
+            pipe.set('a', 'a1').set('b', 'b1').set('c', 'c1')
+            self.assertEquals(len(pipe), 3)
+            self.assertTrue(pipe)
+
+            # Execute calls reset(), so empty once again.
+            pipe.execute()
+            self.assertEquals(len(pipe), 0)
+            self.assertFalse(pipe)
+
     def test_pipeline_no_transaction(self):
         with self.client.pipeline(transaction=False) as pipe:
             pipe.set('a', 'a1').set('b', 'b1').set('c', 'c1')


### PR DESCRIPTION
The length of a pipeline is defined as the length of its command
stack.  This makes it easy to inspect the number of batched commands
and to write conditional logic for empty pipelines.
