### PR TITLE
Add CLIENT GETNAME/SETNAME support

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -148,6 +148,10 @@ def parse_client(response, **options):
         return clients
     elif parse == 'KILL':
         return bool(response)
+    elif parse == 'GETNAME':
+        return response and nativestr(response)
+    elif parse == 'SETNAME':
+        return nativestr(response) == 'OK'
 
 
 def parse_config(response, **options):
@@ -389,6 +393,14 @@ class StrictRedis(object):
     def client_list(self):
         "Returns a list of currently connected clients"
         return self.execute_command('CLIENT', 'LIST', parse='LIST')
+
+    def client_getname(self):
+        "Returns the current connection name"
+        return self.execute_command('CLIENT', 'GETNAME', parse='GETNAME')
+
+    def client_setname(self, name):
+        "Sets the current connection name"
+        return self.execute_command('CLIENT', 'SETNAME', name, parse='SETNAME')
 
     def config_get(self, pattern="*"):
         "Return a dictionary of configuration based on the ``pattern``"

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -74,6 +74,31 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assert_(isinstance(clients[0], dict))
         self.assert_('addr' in clients[0])
 
+    def test_client_getname(self):
+        version = self.client.info()['redis_version']
+        if StrictVersion(version) < StrictVersion('2.6.9'):
+            try:
+                raise unittest.SkipTest()
+            except AttributeError:
+                return
+
+        name = self.client.client_getname()
+        self.assertEquals(name, None)
+
+    def test_client_setname(self):
+        version = self.client.info()['redis_version']
+        if StrictVersion(version) < StrictVersion('2.6.9'):
+            try:
+                raise unittest.SkipTest()
+            except AttributeError:
+                return
+
+        self.assert_(self.client.client_setname('redis_py_test'))
+        self.assertEquals(
+            self.client.client_getname(),
+            'redis_py_test'
+        )
+
     def test_config_get(self):
         data = self.client.config_get()
         self.assert_('maxmemory' in data)


### PR DESCRIPTION
This pull request adds two commands CLIENT GETNAME (http://redis.io/commands/client-getname) and CLIENT SETNAME (http://redis.io/commands/client-setname), which are available from Redis 2.6.9.
