### PR TITLE
Do not discard pipeline unless in multi.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1741,7 +1741,8 @@ class BasePipeline(object):
         try:
             response = self.parse_response(connection, '_')
         except ExecAbortError:
-            self.immediate_execute_command('DISCARD')
+            if self.explicit_transaction:
+                self.immediate_execute_command('DISCARD')
             if errors:
                 raise errors[0][1]
             raise sys.exc_info()[1]


### PR DESCRIPTION
Fixes an error that occurred if you exec'd a pipeline on which you
hadn't called `multi()`. When an error happened, the code was
automatically calling discard. This causes an a 'DISCARD without MULTI'
error from redis which obscures the actual cause of the error.
