### PR TITLE
A base class for server-side exceptions to be grouped by

### DIFF
--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -6,13 +6,16 @@ class RedisError(Exception):
 class AuthenticationError(RedisError):
     pass
 
-class ConnectionError(RedisError):
+class ServerError(RedisError):
+    pass
+
+class ConnectionError(ServerError):
+    pass
+
+class InvalidResponse(ServerError):
     pass
 
 class ResponseError(RedisError):
-    pass
-
-class InvalidResponse(RedisError):
     pass
 
 class DataError(RedisError):


### PR DESCRIPTION
This is important if you want to detect if there was an issue that resulted from the server being broken specifically, as opposed to the client issuing a bad command.

See: https://github.com/disqus/nydus/pull/31

Also, let me know if there are other exceptions that could extend the base `ServerError`. These are just the two that stood out.
