### PR TITLE
Added note that redis-py requires a running Redis server (Issue #329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The Python interface to the Redis key-value store.
 
 ## Installation
 
+*NOTE:* redis-py requires a running Redis server.
+See [Redis's quickstart](http://redis.io/topics/quickstart) for installation instructions.
+
     $ sudo pip install redis
 
 or alternatively (you really should be using pip though):


### PR DESCRIPTION
Added note that redis-py requires a running Redis server along with a link to Redis's own installation instructions. (andymccurdy/redis-py#329)
