### PR TITLE
socket gets corrupted if errors in pipeline happen

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1787,8 +1787,8 @@ class BasePipeline(object):
             try:
                 response.append(
                     self.parse_response(connection, args[0], **options))
-            except ResponseError as error:
-                response.append(error)
+            except ResponseError:
+                response.append(sys.exc_info()[1])
 
         if raise_on_error:
             self.raise_first_error(response)

--- a/tests/pipeline.py
+++ b/tests/pipeline.py
@@ -198,4 +198,4 @@ class PipelineTestCase(unittest.TestCase):
                 raise
 
         ret = self.client.hgetall('x')
-        self.assertEquals(ret, {'a': 'b'})
+        self.assertEqual(ret, {b('a'): b('b')})


### PR DESCRIPTION
Hey the following code triggers this exception 

```
TypeError: 'long' object is not iterable
```

``` python
import redis
x = redis.Redis()
x.flushall()
x.config_set("maxmemory", 10*1024*1024)
try:
    with x.pipeline(transaction=False) as pipe:
        pipe.hmset('x', {'d1': 'v'})
        pipe.hmset('x', {'d1': 'v' * 5*1024*1024})
        pipe.expire('x', 100)
        print pipe.execute()
except Exception as error:
    pass

x.hgetall('x')
```

The problem is, that is soon as the second hmset fails with "OOM command not allowed when used memory > 'maxmemory'" the results for the 'expire' is _not_ read.
It is stucked into the socket until another command is executed. In this case the hgetall gets the response of the expire command.

I changed '_execute_pipeline' to catch the 'ResponseError' so the client proceeds in reading data from the socket
