### PR TITLE
Implement extended set options added in Redis 2.6.12.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -213,7 +213,6 @@ class StrictRedis(object):
         string_keys_to_dict('ZSCORE ZINCRBY', float_or_none),
         string_keys_to_dict(
             'FLUSHALL FLUSHDB LSET LTRIM MSET RENAME '
-#            'SAVE SELECT SET SHUTDOWN SLAVEOF WATCH UNWATCH',
             'SAVE SELECT SHUTDOWN SLAVEOF WATCH UNWATCH',
             lambda r: nativestr(r) == 'OK'
         ),

--- a/tests/server_commands.py
+++ b/tests/server_commands.py
@@ -473,7 +473,7 @@ class ServerCommandsTestCase(unittest.TestCase):
         self.assertEquals(self.client['foo'], b('1'))
         self.assert_(self.client.pttl('foo'), 10000)
         self.assert_(self.client.ttl('foo'), 10)
-        # expire given a timeelta
+        # expire given a timedelta
         expire_at = datetime.timedelta(milliseconds=1000)
         self.assertEquals(self.client.set('foo', '1', px=expire_at), True)
         self.assert_(self.client.pttl('foo'), 1000)
@@ -482,7 +482,7 @@ class ServerCommandsTestCase(unittest.TestCase):
     def test_set_ex(self):
         self.assertEquals(self.client.set('foo', '1', ex=10), True)
         self.assertEquals(self.client.ttl('foo'), 10)
-        # expire given a timeelta
+        # expire given a timedelta
         expire_at = datetime.timedelta(seconds=60)
         self.assertEquals(self.client.set('foo', '1', ex=expire_at), True)
         self.assertEquals(self.client.ttl('foo'), 60)


### PR DESCRIPTION
SPECS :
- http://redis.io/commands/set
- https://github.com/antirez/redis/issues/931

Some Notes
- When combined with nx/xx options, `set` command can return nil.
- test cases are ported from Redis' .

Feedbacks welcomed.
