### PR TITLE
Fixing INCRBY inconsistent naming

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -614,6 +614,16 @@ class StrictRedis(object):
         """
         return self.execute_command('INCRBY', name, amount)
 
+    def incrby(self, name, amount=1):
+        """
+        Increments the value of ``key`` by ``amount``.  If no key exists,
+        the value will be initialized as ``amount``
+        """
+
+        # An alias for ``incr()``, because it is already implemented
+        # as INCRBY redis command.
+        return self.incr(name, amount)
+
     def incrbyfloat(self, name, amount=1.0):
         """
         Increments the value at key ``name`` by floating ``amount``.


### PR DESCRIPTION
According to redis documentation there are two commands:
INCR - (incrementing by 1)
INCRBY - (incrementing by N)

Redis-py client implements it in the least obvious way: there is `incr()` that requests INCRBY redis command, and there is no `incrby()` method.

This is very confusing, as Redis-py README asks for referencing original Redis commands documentation for actions names.

This convention is also not consistent in the client itself. For example HINCRBY is called `hincrby()` method, rather than `hincr()` (as could be suspected?)

This fix just adds `incrby()` method that is an aliast for `incr()` method (as both already are using INCRBY) to maintain maximum backward compatibility but also be less confusing for developers referencing original redis command documentation.
