### PR TITLE
from_url supports URI without a port number, defaults to 6379

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -275,7 +275,7 @@ class StrictRedis(object):
             except (AttributeError, ValueError):
                 db = 0
 
-        return cls(host=url.hostname, port=url.port, db=db,
+        return cls(host=url.hostname, port=int(url.port or 6379), db=db,
                    password=url.password, **kwargs)
 
     def __init__(self, host='localhost', port=6379,


### PR DESCRIPTION
Supports URIs that do not include a port number, defaulting to the standard port 6379.
