### PR TITLE
error in the __call__ method of class Script

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1969,7 +1969,7 @@ class Script(object):
 
     def __call__(self, keys=[], args=[], client=None):
         "Execute the script, passing any required ``args``"
-        if client == None:
+        if client is None:
             client = self.registered_client
         args = tuple(keys) + tuple(args)
         # make sure the Redis server knows about the script


### PR DESCRIPTION
If `client` is a pipeline, and this pipeline is empty, python converts `client` to `False` when casting in bool because Class `BasePipeline` has a method `__len__`. 
`client` is reset to `self.registered_client`, and the script is not executed in the pipeline as it should.
The correct test is to check if `client` equals `None`.

see http://stackoverflow.com/questions/100732/why-is-if-not-someobj-better-than-if-someobj-none-in-python for bool conversion (first answer).
