### PR TITLE
Docstring for ZCOUNT

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1155,6 +1155,10 @@ class StrictRedis(object):
         return self.execute_command('ZCARD', name)
 
     def zcount(self, name, min, max):
+        """
+        Returns the number of elements in the sorted set at key ``name`` with
+        a score between ``min`` and ``max``.
+        """
         return self.execute_command('ZCOUNT', name, min, max)
 
     def zincrby(self, name, value, amount=1):


### PR DESCRIPTION
Added missing documentation for `zcount` as requested by issue #339.
