### PR TITLE
redis.client.Lock: use float timestamp

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2101,7 +2101,7 @@ class Lock(object):
         sleep = self.sleep
         timeout = self.timeout
         while 1:
-            unixtime = int(mod_time.time())
+            unixtime = mod_time.time()
             if timeout:
                 timeout_at = unixtime + timeout
             else:


### PR DESCRIPTION
See: https://github.com/andymccurdy/redis-py/issues/370
