### PR TITLE
Add utility for pipelining within 'with' statement.

### DIFF
--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,3 +1,6 @@
+from contextlib import contextmanager
+
+
 try:
     import hiredis
     HIREDIS_AVAILABLE = True
@@ -16,7 +19,6 @@ def from_url(url, db=None, **kwargs):
     return Redis.from_url(url, db, **kwargs)
 
 
-from contextlib import contextmanager
 @contextmanager
 def pipeline(redis_obj):
     p = redis_obj.pipeline()


### PR DESCRIPTION
Just a small utility to use a pipeline in a controlled _with_ block, like

``` python
import redis
from utils import pipeline

r = redis.StrictRedis(host='localhost', port=6379, db=0)

with pipeline(r) as p:
      p.set("foo", "bar")
      p.set("answer", 42)
```

Around the block, it's going to instantiate the pipeline and then execute it.
