### PR TITLE
Changed the way commands are packed to increase performance

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -26,6 +26,7 @@ SYM_STAR = b('*')
 SYM_DOLLAR = b('$')
 SYM_CRLF = b('\r\n')
 SYM_LF = b('\n')
+SYM_EMPTY = b('')
 
 
 class PythonParser(object):
@@ -329,10 +330,11 @@ class Connection(object):
 
     def pack_command(self, *args):
         "Pack a series of arguments into a value Redis command"
-        args_output = "".join(
-            ["%s%s%s%s%s" % (SYM_DOLLAR, len(k), SYM_CRLF, k, SYM_CRLF) for k in imap(self.encode, args)]
-        )
-        output = "%s%s%s%s" % (SYM_STAR, len(args), SYM_CRLF, args_output)
+        args_output = SYM_EMPTY.join([
+            SYM_EMPTY.join((SYM_DOLLAR, b(str(len(k))), SYM_CRLF, k, SYM_CRLF))
+            for k in imap(self.encode, args)])
+        output = SYM_EMPTY.join(
+            (SYM_STAR, b(str(len(args))), SYM_CRLF, args_output))
         return output
 
 


### PR DESCRIPTION
I have initially made this change on an older version, when BytesIO was not used yet. The performance improvement was really significant.
Compared to BytesIO, the join still gives a nice performance improvement in the few tests I did.

Side note: Removing unicode support and using imap(str, args) also gives a nice improvement. It might be worth adding the option to disable unicode support in some way for people who need maximum performance and don't use unicode strings on redis.
