### PR TITLE
Make docstring for hmset less ambiguous

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1484,8 +1484,8 @@ class StrictRedis(object):
 
     def hmset(self, name, mapping):
         """
-        Sets each key in the ``mapping`` dict to its corresponding value
-        in the hash ``name``
+        Set key to value within hash ``name`` for each corresponding
+        key and value from the ``mapping`` dict.
         """
         if not mapping:
             raise DataError("'hmset' with 'mapping' of length 0")


### PR DESCRIPTION
Original docstring:
Sets each key in the `mapping` dict to its corresponding value in the hash `name`

..this sounds like it updates the `mapping` dict from the values in the hash `name`.

Altered docstring:
Set key to value within hash `name` for each corresponding key and value from the `mapping` dict.

..this sounds like it updates the hash `name` from the `mapping` dict.
