### PR TITLE
Better message on Protocol error

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -110,7 +110,8 @@ class PythonParser(object):
         byte, response = byte_to_chr(response[0]), response[1:]
 
         if byte not in ('-', '+', ':', '$', '*'):
-            raise InvalidResponse("Protocol Error: %s, %s" % (str(byte), str(response)))
+            message = "Protocol Error: %s, %s" % (str(byte), str(response))
+            raise InvalidResponse("%s" % message)
 
         # server returned an error
         if byte == '-':


### PR DESCRIPTION
In my setup, recently I got lot of 'Protocol error' (and pipeline.execute - with lot of rpush failed).
However, it wasn't apparent what it meant, until I printed the response along with 'Protocol error' in connection.py.
Found it was giving 'Out of memory' error and then checked that redis configuration had pretty low maxmemory while my system was using lot more and hence lots of protocol error (OOM).

IMO, printing the response, byte along with Protocol error would be much more informative and helpful and it should be included.

As a side note, I just increased maxmemory by 4 times and things are cool.
