### PR TITLE
Add support for showing db connection info via repr

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -369,10 +369,7 @@ class StrictRedis(object):
         self.response_callbacks = self.__class__.RESPONSE_CALLBACKS.copy()
 
     def __repr__(self):
-        return "{class_name}<host={host},port={port},db={db}>".format(
-            class_name=type(self).__name__,
-            **self.connection_pool.connection_kwargs
-        )
+        return "%s<%s>" % (type(self).__name__, repr(self.connection_pool))
 
     def set_response_callback(self, command, callback):
         "Set a custom Response Callback"

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -203,6 +203,8 @@ else:
 
 class Connection(object):
     "Manages TCP communication to and from a Redis server"
+    description_format = "Connection<host=%(host)s,port=%(port)s,db=%(db)s>"
+
     def __init__(self, host='localhost', port=6379, db=0, password=None,
                  socket_timeout=None, encoding='utf-8',
                  encoding_errors='strict', decode_responses=False,
@@ -218,6 +220,14 @@ class Connection(object):
         self.decode_responses = decode_responses
         self._sock = None
         self._parser = parser_class()
+        self._description_args = {
+            'host': self.host,
+            'port': self.port,
+            'db': self.db,
+        }
+
+    def __repr__(self):
+        return self.description_format % self._description_args
 
     def __del__(self):
         try:
@@ -345,6 +355,8 @@ class Connection(object):
 
 
 class UnixDomainSocketConnection(Connection):
+    description_format = "UnixDomainSocketConnection<path=%(path)s,db=%(db)s>"
+
     def __init__(self, path='', db=0, password=None,
                  socket_timeout=None, encoding='utf-8',
                  encoding_errors='strict', decode_responses=False,
@@ -359,6 +371,10 @@ class UnixDomainSocketConnection(Connection):
         self.decode_responses = decode_responses
         self._sock = None
         self._parser = parser_class()
+        self._description_args = {
+            'path': self.path,
+            'db': self.db,
+        }
 
     def _connect(self):
         "Create a Unix domain socket connection"
@@ -390,6 +406,12 @@ class ConnectionPool(object):
         self._created_connections = 0
         self._available_connections = []
         self._in_use_connections = set()
+
+    def __repr__(self):
+        return "%s<%s>" % (
+            type(self).__name__,
+            self.connection_class.description_format % self.connection_kwargs,
+        )
 
     def _checkpid(self):
         if self.pid != os.getpid():
@@ -499,6 +521,12 @@ class BlockingConnectionPool(object):
         # Keep a list of actual connection instances so that we can
         # disconnect them later.
         self._connections = []
+
+    def __repr__(self):
+        return "%s<%s>" % (
+            type(self).__name__,
+            self.connection_class.description_format % self.connection_kwargs,
+        )
 
     def _checkpid(self):
         """

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -3,12 +3,15 @@ import os
 import pytest
 import redis
 import time
+import re
 
 from threading import Thread
 from redis._compat import Queue
 
 
 class DummyConnection(object):
+    description_format = "DummyConnection<>"
+
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.pid = os.getpid()
@@ -47,6 +50,28 @@ class TestConnectionPoolCase(object):
         pool.release(c1)
         c2 = pool.get_connection('_')
         assert c1 == c2
+
+    def test_repr_contains_db_info_tcp(self):
+        pool = redis.ConnectionPool(host='localhost', port=6379, db=0)
+
+        assert re.match('(.*)<(.*)<(.*)>>', repr(pool)).groups() == (
+            'ConnectionPool',
+            'Connection',
+            'host=localhost,port=6379,db=0',
+        )
+
+    def test_repr_contains_db_info_unix(self):
+        pool = redis.ConnectionPool(
+            connection_class=redis.UnixDomainSocketConnection,
+            path='abc',
+            db=0,
+        )
+
+        assert re.match('(.*)<(.*)<(.*)>>', repr(pool)).groups() == (
+            'ConnectionPool',
+            'UnixDomainSocketConnection',
+            'path=abc,db=0',
+        )
 
 
 class TestBlockingConnectionPool(object):
@@ -107,9 +132,35 @@ class TestBlockingConnectionPool(object):
         c2 = pool.get_connection('_')
         assert c1 == c2
 
+    def test_repr_contains_db_info_tcp(self):
+        pool = redis.BlockingConnectionPool(
+            host='localhost',
+            port=6379,
+            db=0,
+        )
+
+        assert re.match('(.*)<(.*)<(.*)>>', repr(pool)).groups() == (
+            'BlockingConnectionPool',
+            'Connection',
+            'host=localhost,port=6379,db=0',
+        )
+
+    def test_repr_contains_db_info_unix(self):
+        pool = redis.BlockingConnectionPool(
+            connection_class=redis.UnixDomainSocketConnection,
+            path='abc',
+            db=0
+        )
+
+        assert re.match('(.*)<(.*)<(.*)>>', repr(pool)).groups() == (
+            'BlockingConnectionPool',
+            'UnixDomainSocketConnection',
+            'path=abc,db=0',
+        )
+
 
 class TestConnection(object):
-    def test_on_connect_error(self, r):
+    def test_on_connect_error(self):
         """
         An error in Connection.on_connect should disconnect from the server
         see for details: https://github.com/andymccurdy/redis-py/issues/368
@@ -123,9 +174,3 @@ class TestConnection(object):
         pool = bad_connection.connection_pool
         assert len(pool._available_connections) == 1
         assert not pool._available_connections[0]._sock
-
-    def test_repr_contains_db_info(self, r):
-        """
-        Repr should contain database connection info
-        """
-        assert repr(redis.Redis()) == 'Redis<host=localhost,port=6379,db=0>'


### PR DESCRIPTION
Hi, it would sometimes be convenient if the database connection information was available directly from the connection object.  I added support for repr() displaying the connection info instead of just the memory address.
