### PR TITLE
When line is not splittable, add to a __raw__ key

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -105,8 +105,12 @@ def parse_info(response):
 
     for line in response.splitlines():
         if line and not line.startswith('#'):
-            key, value = line.split(':', 1)
-            info[key] = get_value(value)
+            if line.find(':') != -1:
+                key, value = line.split(':', 1)
+                info[key] = get_value(value)
+            else:
+                info.setdefault('__raw__', []).append(line)
+
     return info
 
 


### PR DESCRIPTION
Some redis compatible databases such as "ardb" will output non splittable lines on INFO, handle them gracefully:

In [3]: r.info()
Out[3]: 
{'**raw**': ['                               Compactions',
  'Level  Files Size(MB) Time(sec) Read(MB) Write(MB)',
  '--------------------------------------------------',
  '  0        0        0        72        0      4573',
  '  1        4        7        56     4680      2111',
  '  2       80       99        71     3349      3040',
  '  3      531      998       219    10078      9997',
  '  4      265      501         9      361       353'],
 'ardb_home': '/map_int/home/larroy/devel',
 'ardb_version': '0.6.0',
 'connected_clients': 4,
 'connected_slaves': 0,
 'data_dir': '/map_int/home/larroy/devel/data',
 'db_used_space': 2042920872,
 'engine': 'LevelDB',
 'gcc_version': '4.6.4',
 'master_repl_offset': 8541185804,
 'period_commands_processed(1min)': 345102,
 'repl_backlog_first_byte_offset': 8436328205,
 'repl_backlog_histlen': 104857600,
 'repl_backlog_size': 104857600,
 'repl_dir': ' /map_int/home/larroy/devel/repl',
 'role': ' master',
 'server_key': '10f5be480f2c0783ecd9678876f9cd756ed8395d',
 'tcp_port': 6200,
 'total_commands_processed': 44296977,
 'total_connections_received': 355}
