### PR TITLE
Add block_timeout to StrictRedis.lock

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -428,7 +428,7 @@ class StrictRedis(object):
                 except WatchError:
                     continue
 
-    def lock(self, name, timeout=None, sleep=0.1):
+    def lock(self, name, timeout=None, sleep=0.1, blocking_timeout=None):
         """
         Return a new Lock object using key ``name`` that mimics
         the behavior of threading.Lock.
@@ -440,7 +440,7 @@ class StrictRedis(object):
         when the lock is in blocking mode and another client is currently
         holding the lock.
         """
-        return Lock(self, name, timeout=timeout, sleep=sleep)
+        return Lock(self, name, timeout=timeout, sleep=sleep, blocking_timeout=blocking_timeout)
 
     def pubsub(self, shard_hint=None):
         """
@@ -2236,13 +2236,18 @@ class Lock(object):
 
     LOCK_FOREVER = float(2 ** 31 + 1)  # 1 past max unix time
 
-    def __init__(self, redis, name, timeout=None, sleep=0.1):
+    def __init__(self, redis, name, timeout=None, sleep=0.1, blocking_timeout=None):
         """
         Create a new Lock instnace named ``name`` using the Redis client
         supplied by ``redis``.
 
         ``timeout`` indicates a maximum life for the lock.
         By default, it will remain locked until release() is called.
+
+
+        ``blocking_timeout`` indicates block wait threshold.
+        So the code won't wait a lock longer than this threshold when current lock
+        holder need hold this lock to finish a time consuming task.
 
         ``sleep`` indicates the amount of time to sleep per loop iteration
         when the lock is in blocking mode and another client is currently
@@ -2256,6 +2261,7 @@ class Lock(object):
         self.name = name
         self.acquired_until = None
         self.timeout = timeout
+        self.blocking_timeout = blocking_timeout
         self.sleep = sleep
         if self.timeout and self.sleep > self.timeout:
             raise LockError("'sleep' must be less than 'timeout'")
@@ -2276,6 +2282,11 @@ class Lock(object):
         """
         sleep = self.sleep
         timeout = self.timeout
+        if self.blocking_timeout:
+            block_until = mod_time.time() + self.blocking_timeout
+        else:
+            block_until = Lock.LOCK_FOREVER
+
         while 1:
             unixtime = mod_time.time()
             if timeout:
@@ -2296,8 +2307,9 @@ class Lock(object):
                     # we successfully acquired the lock
                     self.acquired_until = timeout_at
                     return True
-            if not blocking:
+            if (not blocking) or (unixtime > block_until):
                 return False
+
             mod_time.sleep(sleep)
 
     def release(self):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -36,6 +36,16 @@ class TestLock(object):
         assert lock2.acquire(blocking=False)
         lock2.release()
 
+    def test_blocking_timeouts(self, r):
+        lock1 = r.lock('foo', timeout=2, blocking_timeout=1)
+        lock2 = r.lock('foo', timeout=2, blocking_timeout=1)
+        assert lock1.acquire()
+        before = time.time()
+        assert not lock2.acquire()
+        after = time.time()
+        assert (after - before) > 1
+        assert (after - before) < 2
+
     def test_non_blocking(self, r):
         lock1 = r.lock('foo')
         assert lock1.acquire(blocking=False)


### PR DESCRIPTION
Add block_timeout to StrictRedis.lock. So when we lock a resource exlusively (timeout is long, or forever), we won't let others wait forever (stop blocking on a threshold).

Scenarios:
1. timeout=None, blocking_timeout=1: We want to lock a resource exclusively. So the lock won't expire. But we need a timeout threshold for other waiters. So those waiters may try their luck if the winner fail fast, but stop waiting for too long.
2. We need to make sure some critical resource only serve at interval of X. So we can set X as the lock's timeout. This will smooth the traffic by limit acquire interval, in that case if there are too much waiters, we will some of them timeout.
