### PR TITLE
Adjust to changed TTL, PTTL semantics

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1670,8 +1670,8 @@ class Redis(StrictRedis):
     RESPONSE_CALLBACKS = dict_merge(
         StrictRedis.RESPONSE_CALLBACKS,
         {
-            'TTL': lambda r: r != -1 and r or None,
-            'PTTL': lambda r: r != -1 and r or None,
+            'TTL': lambda r: r >= 0 and r or None,
+            'PTTL': lambda r: r >= 0 and r or None,
         }
     )
 


### PR DESCRIPTION
Redis >= 2.8 might return -2 in TTL or PTTL commands:
http://redis.io/commands/ttl
http://redis.io/commands/pttl

This patch ensures that redis-py just returns None in that case, as before with -1 return values.
