### PR TITLE
Only load lua script if it's not already loaded

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2422,9 +2422,12 @@ class Script(object):
     "An executable Lua script object returned by ``register_script``"
 
     def __init__(self, registered_client, script):
+        import hashlib
         self.registered_client = registered_client
         self.script = script
-        self.sha = registered_client.script_load(script)
+        self.sha = hashlib.sha1(script).hexdigest()
+        if not registered_client.script_exists(self.sha)[0]:
+            self.sha = registered_client.script_load(script)
 
     def __call__(self, keys=[], args=[], client=None):
         "Execute the script, passing any required ``args``"


### PR DESCRIPTION
In register_script, check if the script already exist with the SHA1 digest first. If it doesn't, then load it.

Another option would be to not load it all in `Script.__init__` and let Script.call load it when it doesn't find it.
