### PR TITLE
Fix getset docstring

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -766,8 +766,8 @@ class StrictRedis(object):
 
     def getset(self, name, value):
         """
-        Set the value at key ``name`` to ``value`` if key doesn't exist
-        Return the value at key ``name`` atomically
+        Sets the value at key ``name`` to ``value``
+        and returns the old value at key ``name`` atomically.
         """
         return self.execute_command('GETSET', name, value)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -334,6 +334,11 @@ class TestRedisCommands(object):
         assert r.getset('a', 'foo') is None
         assert r.getset('a', 'bar') == b('foo')
 
+    def test_getset_exists(self, r):
+        r.set('a', 'foo')
+        assert r.getset('a', 'bar') == b('foo')
+        assert r.get('a') == b('bar')
+
     def test_incr(self, r):
         assert r.incr('a') == 1
         assert r['a'] == b('1')


### PR DESCRIPTION
The old docstring was incorrect. See http://redis.io/commands/GETSET for
more information.
