### PR TITLE
Fix for socket "hang" when remote server disconnects

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -83,6 +83,8 @@ class SocketBuffer(object):
         try:
             while length > marker:
                 data = self._sock.recv(socket_read_size)
+                if isinstance(data, str) and len(data) == 0:
+                    raise socket.error("Connection closed by remote server.")
                 buf.write(data)
                 self.bytes_written += len(data)
                 marker += socket_read_size


### PR DESCRIPTION
Fixes https://github.com/andymccurdy/redis-py/issues/386

"hang" in quotes because it's actually stuck in a tight loop that just looks like a hang from the outside.

According to this post, https://groups.google.com/d/msg/gevent/b8PrC-y9J6Y/lhKgKzuPl_cJ, on google groups, when socket.recv() returns an empty string it means the remote server has disconnected. The added lines simply check for this being the case and raise a socket.error if the empty string is returned. Raising the error appears to be the cleanest way to handle this as the existing code in place will then attempt to reconnect and bubble up a ConnectionError if the reconnect fails.
