### PR TITLE
Fixes andymccurdy/redis-py#467

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -324,8 +324,8 @@ class StrictRedis(object):
         string_keys_to_dict('ZRANK ZREVRANK', int_or_none),
         {
             'BGREWRITEAOF': (
-                lambda r: nativestr(r) == ('Background rewriting of AOF '
-                                           'file started')
+                lambda r: nativestr(r) == ('Background append only file '
+                                           'rewriting started')
             ),
             'BGSAVE': lambda r: nativestr(r) == 'Background saving started',
             'CLIENT': parse_client,


### PR DESCRIPTION
BGREWRITEAOF returns "Background append only file rewriting started" in Redis 2.6+
