### PR TITLE
Add TCP_NODELAY to TCP sockets.

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -399,6 +399,7 @@ class Connection(object):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(self.socket_timeout)
             sock.connect((self.host, self.port))
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         return sock
 
     def _error_message(self, exception):


### PR DESCRIPTION
Just like hiredis client:
https://github.com/redis/hiredis/blob/8332a88393cc79b6f7d431859e5bbf157d8c1ea3/net.c#L323
And the redis server itself:
https://github.com/antirez/redis/blob/0bcc7cb4bfe733e7ea12599a926e52aece3bfa50/src/networking.c#L73

I also it gives (in some minor tests I did) a minor performance benefit in some cases. I am no Unix domain socket to know if it's applicable there?
