### PR TITLE
Enable testing on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.4"
   - "3.3"
   - "3.2"
   - "2.7"
@@ -18,5 +19,5 @@ matrix:
   include:
     - python: "2.7"
       env: TEST_PEP8=1
-    - python: "3.3"
+    - python: "3.4"
       env: TEST_PEP8=1

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ To install redis-py, simply:
 
     $ sudo pip install redis
 
-or alternatively (you really should be using pip though):
+or alternatively (you *really* should be using pip though):
 
 .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ]
 )


### PR DESCRIPTION
As per [this Travis CI blog post](http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/), testing on Python 3.4 is now supported.
