### PR TITLE
Release locks that haven't expired regardless of the exact expiration timestamp

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2653,8 +2653,9 @@ class Lock(object):
         if self.acquired_until is None:
             raise ValueError("Cannot release an unlocked lock")
         existing = float(self.redis.get(self.name) or 1)
+        unixtime = mod_time.time()
         # if the lock time is in the future, delete the lock
-        delete_lock = existing >= self.acquired_until
+        delete_lock = existing >= unixtime
         self.acquired_until = None
         if delete_lock:
             self.redis.delete(self.name)


### PR DESCRIPTION
When deciding wether to delete the lock or not on `release()`, we should compare it to the current time, not the stored expiration time, which could be different (a bit ahead, or a bit behind) in Redis.
