### PR TITLE
Lock.acquire() to respect blocking_timeout argument

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -105,8 +105,8 @@ class Lock(object):
         if blocking_timeout is None:
             blocking_timeout = self.blocking_timeout
         stop_trying_at = None
-        if self.blocking_timeout is not None:
-            stop_trying_at = mod_time.time() + self.blocking_timeout
+        if blocking_timeout is not None:
+            stop_trying_at = mod_time.time() + blocking_timeout
         while 1:
             if self.do_acquire(token):
                 self.local.token = token


### PR DESCRIPTION
This pull request fixes issue https://github.com/andymccurdy/redis-py/issues/498 .  The `blocking_timeout` argument to `Lock.acquire()` had no effect, as only `self.blocking_timeout` was used when setting the `stop_trying_at` timeout value.
