### PR TITLE
less specific check for closed socket

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -314,7 +314,7 @@ class HiredisParser(BaseParser):
             try:
                 buffer = self._sock.recv(socket_read_size)
                 # an empty string indicates the server shutdown the socket
-                if not data:
+                if not buffer:
                     raise socket.error("Connection closed by remote server.")
             except socket.timeout:
                 raise TimeoutError("Timeout reading from socket")


### PR DESCRIPTION
This fixes issue #508 for me, but maybe there is a good reason this check is so overly specific about the return value being a string?
