### PR TITLE
add optional "timeout" parameter to pubsub.can_read

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2142,10 +2142,10 @@ class PubSub(object):
             # previously listening to
             return command(*args)
 
-    def parse_response(self, block=True):
+    def parse_response(self, block=True, timeout=0):
         "Parse the response from a publish/subscribe command"
         connection = self.connection
-        if not block and not connection.can_read():
+        if not block and not connection.can_read(timeout=timeout):
             return None
         return self._execute(connection, connection.read_response)
 
@@ -2216,9 +2216,9 @@ class PubSub(object):
             if response is not None:
                 yield response
 
-    def get_message(self, ignore_subscribe_messages=False):
+    def get_message(self, ignore_subscribe_messages=False, timeout=0):
         "Get the next message if one is available, otherwise None"
-        response = self.parse_response(block=False)
+        response = self.parse_response(block=False, timeout=timeout)
         if response:
             return self.handle_message(response, ignore_subscribe_messages)
         return None

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -555,13 +555,13 @@ class Connection(object):
         "Pack and send a command to the Redis server"
         self.send_packed_command(self.pack_command(*args))
 
-    def can_read(self):
+    def can_read(self, timeout=0):
         "Poll the socket to see if there's data that can be read."
         sock = self._sock
         if not sock:
             self.connect()
             sock = self._sock
-        return bool(select([sock], [], [], 0)[0]) or self._parser.can_read()
+        return self._parser.can_read() or bool(select([sock], [], [], timeout)[0])
 
     def read_response(self):
         "Read the response from a previously sent command"


### PR DESCRIPTION
The UNIX anti-pattern of

```
     ret = select([fd], [], [], 0)
     if not ret: sleep(timeout)
```

should instead pass the timeout to select, for one fewer syscall.

I'm unclear if the ordering in connection.can_read() is correct -- it seems to me the short-circuit-or should check the parser before doing the select(). But I don't know how to trigger the appropriate condition to test the logic, so I'm leaving it alone for now.
