### PR TITLE
Sentinel connection pool discarding is_master flag on reset

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -129,6 +129,7 @@ class SentinelConnectionPool(ConnectionPool):
             self.disconnect()
             self.reset()
             self.__init__(self.service_name, self.sentinel_manager,
+                          is_master=self.is_master,
                           connection_class=self.connection_class,
                           max_connections=self.max_connections,
                           **self.connection_kwargs)


### PR DESCRIPTION
Problem:
When resetting a sentinel connection pool which is set to point at the slaves, it resets to point at the master every time as the is_master flag is not passed into the constructor on reset.

Solution:
Pass the is_master flag through on reset, which will attempt to reconnect to the master or slave depending on what the programmer originally asked for. 

Risk:
No real risk here as the client will connect to the master if no slaves are available. The desired behaviour is that the connection pool retains the knowledge that it should be connected to a master or a slave. We have been using this change in production for 2 weeks with no problems.
