### PR TITLE
add url support for sentinel

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -170,9 +170,9 @@ class Sentinel(object):
     def from_url(cls, url, **kwargs):
         """
         return a sentinel object from url
-        :param url: sentinels://<host1>:<port1>,<host2>:<port2>/<db>?<querystring>
-        :param kwargs: parameters for constructing Sentinel object
-        :return: tuple of sentinel object, db from url, service_name parsed from url
+        ``url`` sentinels://<host1>:<port1>,<host2>:<port2>/<db>?<querystring>
+        ``param`` kwargs: parameters for constructing Sentinel object
+        ``return`` tuple of sentinel object, db from url, service_name in url
 
         url example::
             sentinels://10.1.2.122:17700

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -1,12 +1,11 @@
 import os
 import random
 import weakref
-from urlparse import urlparse, parse_qs
 
 from redis.client import StrictRedis
 from redis.connection import ConnectionPool, Connection
 from redis.exceptions import ConnectionError, ResponseError, ReadOnlyError
-from redis._compat import iteritems, nativestr, xrange
+from redis._compat import iteritems, nativestr, xrange, urlparse, parse_qs
 
 
 class MasterNotFoundError(ConnectionError):

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -17,16 +17,25 @@ def from_url(url, db=None, master_for_args={}, **kwargs):
     none is provided.
 
     When url is starting with sentinels://, a sentinel object will be returned
-    if no query parameter service_name in url, otherwise the master redis client
-    will be returned. master_for_args will be applied to  Sentinel.master_for.
+    if no query parameter service_name in url, otherwise the master redis
+    client will be returned. master_for_args will be applied to
+    Sentinel.master_for.
     >>> import redis
     >>> redis.from_url('sentinels://node1:17700,node2:17700')
     Sentinel<sentinels=[node1:17700,node2:17700]>
-    >>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster', db=1)
+
+    >>> redis.from_url(
+        'sentinels://node1:17700,node2:17700?service_name=mymaster', db=1)
     StrictRedis<SentinelConnectionPool<service=mymaster(master)>
-    >>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster&db=3', db=1)
+
+    >>> redis.from_url(
+       'sentinels://node1:17700,node2:17700?service_name=mymaster&db=3', db=1)
     StrictRedis<SentinelConnectionPool<service=mymaster(master)>
-    >>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster', db=1, master_for_args={'redis_class':redis.Redis})
+
+    >>> redis.from_url(
+        'sentinels://node1:17700,node2:17700?service_name=mymaster',
+        db=1,
+        master_for_args={'redis_class':redis.Redis})
     Redis<SentinelConnectionPool<service=mymaster(master)>
     """
     parse_result = urlparse(url)

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from urlparse import urlparse
 
 
 try:
@@ -8,13 +9,37 @@ except ImportError:
     HIREDIS_AVAILABLE = False
 
 
-def from_url(url, db=None, **kwargs):
+def from_url(url, db=None, master_for_args={}, **kwargs):
     """
     Returns an active Redis client generated from the given database URL.
 
     Will attempt to extract the database id from the path url fragment, if
     none is provided.
+
+    When url is starting with sentinels://, a sentinel object will be returned
+    if no query parameter service_name in url, otherwise the master redis client
+    will be returned. master_for_args will be applied to  Sentinel.master_for.
+    >>> import redis
+    >>> redis.from_url('sentinels://node1:17700,node2:17700')
+    Sentinel<sentinels=[node1:17700,node2:17700]>
+    >>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster', db=1)
+    StrictRedis<SentinelConnectionPool<service=mymaster(master)>
+    >>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster&db=3', db=1)
+    StrictRedis<SentinelConnectionPool<service=mymaster(master)>
+    >>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster', db=1, master_for_args={'redis_class':redis.Redis})
+    Redis<SentinelConnectionPool<service=mymaster(master)>
     """
+    parse_result = urlparse(url)
+    if parse_result.scheme == 'sentinels':
+        from sentinel import Sentinel
+        sentinel, db_from_url, service_name = Sentinel.from_url(url, **kwargs)
+
+        if not service_name:
+            return sentinel
+        else:
+            return sentinel.master_for(service_name,
+                                       db=(db_from_url or db or 0),
+                                       **master_for_args)
     from redis.client import Redis
     return Redis.from_url(url, db, **kwargs)
 

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from urlparse import urlparse
+from redis._compat import urlparse
 
 
 try:


### PR DESCRIPTION
Enhanced `from_url` function in utils.py. Support fetch a sentinel object or  master redis node.

With the ability to get master redis node from url, other libraries based on redis-py are able to benefit from redis sentinel feature, including django-redis-cache and redis backend in celery etc.

Return sentinel object if not service_name provided in url

``` python
>>> redis.from_url('sentinels://10.1.2.122:17700')
Sentinel<sentinels=[10.1.2.122:17700]>
>>> redis.from_url('sentinels://node1:17700,node2:17700')
Sentinel<sentinels=[node1:17700,node2:17700]>
```

Return master node if service_name provided in url

``` python
>>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster', db=1)
StrictRedis<SentinelConnectionPool<service=mymaster(master)>
```

you can pass same parameters used in `Sentinel.master_for` by parameter `master_for_args` in new `from_url`, of course, we can consider not to put `master_for_args` parameter in function declaration explicitly.

``` python
>>> redis.from_url('sentinels://node1:17700,node2:17700?service_name=mymaster', db=1, master_for_args={'redis_class':redis.Redis})
Redis<SentinelConnectionPool<service=mymaster(master)>
```
