### PR TITLE
Reset Sentinel connection pool after failover.

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -104,6 +104,7 @@ class SentinelConnectionPool(ConnectionPool):
             elif master_address != self.master_address:
                 # Master address changed, disconnect all clients in this pool
                 self.disconnect()
+                self.reset()
         return master_address
 
     def rotate_slaves(self):


### PR DESCRIPTION
In current implementation SentinelConnectionPool.master_address isn't changed when sentinel_manager.discover_master returns different value.
