### PR TITLE
Escape 2 asterisks in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ to the official command syntax. There are a few exceptions:
   `this comment on issue #151
   <https://github.com/andymccurdy/redis-py/issues/151#issuecomment-1545015>`_
   for details).
-* **SCAN/SSCAN/HSCAN/ZSCAN**: The *SCAN commands are implemented as they
+* **SCAN/SSCAN/HSCAN/ZSCAN**: The \*SCAN commands are implemented as they
   exist in the Redis documentation. In addition, each command has an equivilant
   iterator method. These are purely for convenience so the user doesn't have
   to keep track of the cursor while iterating. Use the
@@ -643,7 +643,7 @@ See `Guidelines for Redis clients with support for Redis Sentinel
 Scan Iterators
 ^^^^^^^^^^^^^^
 
-The *SCAN commands introduced in Redis 2.8 can be cumbersome to use. While
+The \*SCAN commands introduced in Redis 2.8 can be cumbersome to use. While
 these commands are fully supported, redis-py also exposes the following methods
 that return Python iterators for convenience: `scan_iter`, `hscan_iter`,
 `sscan_iter` and `zscan_iter`.


### PR DESCRIPTION
Eliminates 2 warnings when running `rst2html`:

    $ rst2html.py README.rst
    README.rst:71: (WARNING/2) Inline emphasis start-string without end-string.
    README.rst:646: (WARNING/2) Inline emphasis start-string without end-string.