### PR TITLE
Check if Script.sha is None. 

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2642,7 +2642,7 @@ class Script(object):
     def __init__(self, registered_client, script):
         self.registered_client = registered_client
         self.script = script
-        self.sha = ''
+        self.sha = None
 
     def __call__(self, keys=[], args=[], client=None):
         "Execute the script, passing any required ``args``"
@@ -2653,10 +2653,13 @@ class Script(object):
         if isinstance(client, BasePipeline):
             # make sure this script is good to go on pipeline
             client.script_load_for_pipeline(self)
+
+        if self.sha is None:
+            self.sha = client.script_load(self.script)
+
         try:
             return client.evalsha(self.sha, len(keys), *args)
         except NoScriptError:
             # Maybe the client is pointed to a differnet server than the client
             # that created this instance?
-            self.sha = client.script_load(self.script)
             return client.evalsha(self.sha, len(keys), *args)


### PR DESCRIPTION
It's nonsensical to make a network call that's guaranteed to fail.

When a script object is instantiated, unless the dev manually sets the script_instance.sha attribute, it will always call evalsha the first time with an empty string. This will always fail, fall through to the except, and set the sha.

Especially in a large scale applications, there is a high probability the redis server already has the script.

p.s. I talked through this change with my colleagues and I initially wanted to just set the sha attribute up front in the init function. My colleagues suggested that the current implementation is probably to provide additional laziness for the dev that instantiates all their scripts up front. This commit therefore attempts to maintain the same level of laziness as before, only calculating the sha once we know we're actually going to use the script.
