### PR TITLE
Minor - fix exception message formatting

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2187,10 +2187,10 @@ class PubSub(object):
     def run_in_thread(self, sleep_time=0):
         for channel, handler in iteritems(self.channels):
             if handler is None:
-                raise PubSubError("Channel: '%s' has no handler registered")
+                raise PubSubError("Channel: '%s' has no handler registered" % channel)
         for pattern, handler in iteritems(self.patterns):
             if handler is None:
-                raise PubSubError("Pattern: '%s' has no handler registered")
+                raise PubSubError("Pattern: '%s' has no handler registered" % pattern)
         pubsub = self
 
         class WorkerThread(threading.Thread):


### PR DESCRIPTION
There's a '%s' formatting string which wasn't matched. I'm pretty sure this is what was intended
