### PR TITLE
@transactional decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,6 +324,25 @@ which is much easier to read:
     >>> r.transaction(client_side_incr, 'OUR-SEQUENCE-KEY')
     [True]
 
+There is also a similar convenience decorator named "transactional" for
+decorating functions to be executed in a transaction. The decorated callable
+can take any number of positional and keyword parameters with the first one
+being a pipeline object. The client-side INCR command above can be also
+written like this:
+
+.. code-block:: pycon
+
+    >>> @redis.transactional('OUR-SEQUENCE-KEY'):
+    ... def client_side_incr(pipe):
+    ...     current_value = pipe.get('OUR-SEQUENCE-KEY')
+    ...     next_value = int(current_value) + 1
+    ...     pipe.multi()
+    ...     pipe.set('OUR-SEQUENCE-KEY', next_value)
+    >>>
+    >>> client_side_incr(r)
+    [True]
+
+
 Publish / Subscribe
 ^^^^^^^^^^^^^^^^^^^
 

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -6,7 +6,7 @@ from redis.connection import (
     SSLConnection,
     UnixDomainSocketConnection
 )
-from redis.utils import from_url
+from redis.utils import from_url, transactional
 from redis.exceptions import (
     AuthenticationError,
     BusyLoadingError,

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -40,7 +40,10 @@ def transactional(*watches, **trans_kwargs):
                             pipe.watch(*watches)
                         func_value = func(pipe, *args, **kwargs)
                         exec_value = pipe.execute()
-                        return func_value if value_from_callable else exec_value
+                        if value_from_callable:
+                            return func_value
+                        else:
+                            return exec_value
                     except WatchError:
                         continue
         return wrapper


### PR DESCRIPTION
Added an alternative to the StrictRedis.transaction() method for decorating callables to be run in a transaction. Makes it a little easier to pass additional arguments to the callable, plus it moves the watches and the transaction parameters from the caller to the function definition.
