### PR TITLE
fix zincrby params

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1589,7 +1589,7 @@ class StrictRedis(object):
         """
         return self.execute_command('ZCOUNT', name, min, max)
 
-    def zincrby(self, name, value, amount=1):
+    def zincrby(self, name, amount=1, value=None):
         "Increment the score of ``value`` in sorted set ``name`` by ``amount``"
         return self.execute_command('ZINCRBY', name, amount, value)
 


### PR DESCRIPTION
Fix zincrby params order ->

```
"ZINCRBY" "test" "one" "5"
```

to

```
"ZINCRBY" "test" "5" "one"
```
