### PR TITLE
Allow pubsub listener to be shut down while in a callback.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2306,10 +2306,10 @@ class PubSub(object):
             def stop(self):
                 self._running = False
                 try:
-                  self.join()
+                    self.join()
                 except RuntimeError:
-                  # safe to ignore this, called stop from WorkerThread
-                  pass
+                    # safe to ignore this, called stop from WorkerThread
+                    pass
 
         thread = WorkerThread()
         thread.start()

--- a/redis/client.py
+++ b/redis/client.py
@@ -2305,7 +2305,11 @@ class PubSub(object):
 
             def stop(self):
                 self._running = False
-                self.join()
+                try:
+                  self.join()
+                except RuntimeError:
+                  # safe to ignore this, called stop from WorkerThread
+                  pass
 
         thread = WorkerThread()
         thread.start()


### PR DESCRIPTION
Allow pubsub listener thread shutdown from within a callback by trapping the RuntimeError on join not being able to join itself.