### PR TITLE
Allow pubsub WorkerThread to be shut down while in a callback 

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2310,7 +2310,11 @@ class PubSub(object):
 
             def stop(self):
                 self._running = False
-                self.join()
+                try:
+                    self.join()
+                except RuntimeError:
+                    # safe to ignore this, called stop from WorkerThread
+                    pass
 
         thread = WorkerThread()
         thread.start()


### PR DESCRIPTION
Allow pubsub WorkerThread to be shut down while in a callback by ignoring the RuntimeError thrown when join is called on the running thread.