### PR TITLE
Daemonize PubSubWorkerThread

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2305,6 +2305,7 @@ class PubSubWorkerThread(threading.Thread):
         self.pubsub = pubsub
         self.sleep_time = sleep_time
         self._running = False
+        self.daemon = True
 
     def run(self):
         if self._running:


### PR DESCRIPTION
Prevents Python process from hanging when using run_in_thread without
explicitly stopping.