### PR TITLE
Add WAIT command for Redis synchronous replication

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -767,6 +767,15 @@ class StrictRedis(object):
         """
         return self.execute_command('TIME')
 
+    def wait(self, num_replicas, timeout):
+        """
+        Redis synchronous replication
+        That returns the number of replicas that processed the query when
+        we finally have at least ``num_replicas``, or when the ``timeout`` was
+        reached.
+        """
+        return self.execute_command('WAIT', num_replicas, timeout)
+
     # BASIC KEY COMMANDS
     def append(self, key, value):
         """


### PR DESCRIPTION
ref1: https://github.com/antirez/redis/blob/unstable/src/replication.c#L1783, at SYNCHRONOUS REPLICATION
ref2: http://antirez.com/news/66
This command for Redis-3.0.0 and above now.