### PR TITLE
Handle percent-encoded URLs in parsing code

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -3,6 +3,7 @@ import sys
 
 
 if sys.version_info[0] < 3:
+    from urllib import unquote
     from urlparse import parse_qs, urlparse
     from itertools import imap, izip
     from string import letters as ascii_letters
@@ -38,7 +39,7 @@ if sys.version_info[0] < 3:
     bytes = str
     long = long
 else:
-    from urllib.parse import parse_qs, urlparse
+    from urllib.parse import parse_qs, unquote, urlparse
     from io import BytesIO
     from string import ascii_letters
     from queue import Queue

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -163,6 +163,17 @@ class TestConnectionPoolURLParsing(object):
             'password': None,
         }
 
+    def test_quoted_hostname(self):
+        pool = redis.ConnectionPool.from_url('redis://my %2F host %2B%3D+',
+                                             decode_components=True)
+        assert pool.connection_class == redis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'my / host +=+',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+        }
+
     def test_port(self):
         pool = redis.ConnectionPool.from_url('redis://localhost:6380')
         assert pool.connection_class == redis.Connection
@@ -181,6 +192,18 @@ class TestConnectionPoolURLParsing(object):
             'port': 6379,
             'db': 0,
             'password': 'mypassword',
+        }
+
+    def test_quoted_password(self):
+        pool = redis.ConnectionPool.from_url(
+            'redis://:%2Fmypass%2F%2B word%3D%24+@localhost',
+            decode_components=True)
+        assert pool.connection_class == redis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': '/mypass/+ word=$+',
         }
 
     def test_db_as_argument(self):
@@ -256,6 +279,28 @@ class TestConnectionPoolUnixSocketURLParsing(object):
         assert pool.connection_class == redis.UnixDomainSocketConnection
         assert pool.connection_kwargs == {
             'path': '/socket',
+            'db': 0,
+            'password': 'mypassword',
+        }
+
+    def test_quoted_password(self):
+        pool = redis.ConnectionPool.from_url(
+            'unix://:%2Fmypass%2F%2B word%3D%24+@/socket',
+            decode_components=True)
+        assert pool.connection_class == redis.UnixDomainSocketConnection
+        assert pool.connection_kwargs == {
+            'path': '/socket',
+            'db': 0,
+            'password': '/mypass/+ word=$+',
+        }
+
+    def test_quoted_path(self):
+        pool = redis.ConnectionPool.from_url(
+            'unix://:mypassword@/my%2Fpath%2Fto%2F..%2F+_%2B%3D%24ocket',
+            decode_components=True)
+        assert pool.connection_class == redis.UnixDomainSocketConnection
+        assert pool.connection_kwargs == {
+            'path': '/my/path/to/../+_+=$ocket',
             'db': 0,
             'password': 'mypassword',
         }


### PR DESCRIPTION
Hi,

Clients of redis-py that attempt to instantiate a `ConnectionPool` object by using the `from_url` class method can run into problems if components of the passed-in URL contain illegal characters (e.g. `rediss://:my/password@localhost:6379`). Understandably the forward slash in this example URL causes it to be parsed incorrectly, but even if a client attempts to percent-encode their URL (e.g. `rediss://:my%2Fpassword@localhost:6379`) this will not fix the problem since `from_url` will not know to decode the password after the URL is parsed.

This commit attempts to fix the problem by introducing a new argument, `decode_components`, to `from_url` that allows URL components to be decoded after the URL has been parsed. I used a flag here because existing clients might be relying on the current behavior.

I added some unit tests and verified that they pass with python2 and python3.

This fixes issue #579 

Thanks,
Paul