### PR TITLE
added zrevrangebylex

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1660,6 +1660,22 @@ class StrictRedis(object):
             pieces.extend([Token('LIMIT'), start, num])
         return self.execute_command(*pieces)
 
+    def zrevrangebylex(self, name, min, max, start=None, num=None):
+        """
+        Return the reversed lexicographical range of values from sorted set
+        ``name`` between ``min`` and ``max``.
+
+        If ``start`` and ``num`` are specified, then return a slice of the
+        range.
+        """
+        if (start is not None and num is None) or \
+                (num is not None and start is None):
+            raise RedisError("``start`` and ``num`` must both be specified")
+        pieces = ['ZREVRANGEBYLEX', name, min, max]
+        if start is not None and num is not None:
+            pieces.extend([Token('LIMIT'), start, num])
+        return self.execute_command(*pieces)
+
     def zrangebyscore(self, name, min, max, start=None, num=None,
                       withscores=False, score_cast_func=float):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -1660,10 +1660,10 @@ class StrictRedis(object):
             pieces.extend([Token('LIMIT'), start, num])
         return self.execute_command(*pieces)
 
-    def zrevrangebylex(self, name, min, max, start=None, num=None):
+    def zrevrangebylex(self, name, upper, lower, start=None, num=None):
         """
         Return the reversed lexicographical range of values from sorted set
-        ``name`` between ``min`` and ``max``.
+        ``name`` between ``upper`` and ``lower``.
 
         If ``start`` and ``num`` are specified, then return a slice of the
         range.
@@ -1671,7 +1671,7 @@ class StrictRedis(object):
         if (start is not None and num is None) or \
                 (num is not None and start is None):
             raise RedisError("``start`` and ``num`` must both be specified")
-        pieces = ['ZREVRANGEBYLEX', name, min, max]
+        pieces = ['ZREVRANGEBYLEX', name, upper, lower]
         if start is not None and num is not None:
             pieces.extend([Token('LIMIT'), start, num])
         return self.execute_command(*pieces)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -959,6 +959,16 @@ class TestRedisCommands(object):
         assert r.zrangebylex('a', '[f', '+') == [b('f'), b('g')]
         assert r.zrangebylex('a', '-', '+', start=3, num=2) == [b('d'), b('e')]
 
+    @skip_if_server_version_lt('2.9.9')
+    def test_zrevrangebylex(self, r):
+        r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
+        assert r.zrevrangebylex('a', '[c', '-') == [b('c'), b('b'), b('a')]
+        assert r.zrevrangebylex('a', '(c', '-') == [b('b'), b('a')]
+        assert r.zrevrangebylex('a', '(g', '[aaa') == \
+            [b('f'), b('e'), b('d'), b('c'), b('b')]
+        assert r.zrevrangebylex('a', '+', '[f') == [b('g'), b('f')]
+        assert r.zrevrangebylex('a', '+', '-', start=3, num=2) == [b('d'), b('c')]
+
     def test_zrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
         assert r.zrangebyscore('a', 2, 4) == [b('a2'), b('a3'), b('a4')]


### PR DESCRIPTION
Hi Andy & redis-py developers,
I was in need of "zrevrangebylex" which was not available in "redis 2.10.3", so I have added it for myself. Redis supports this since 2.9.9. Maybe you have use for it.
Cheers
Christian
