### PR TITLE
After shutdown don't try to reconnect (fixes #595).

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -733,8 +733,9 @@ class StrictRedis(object):
                 connection.send_command(command_name)
             except (ConnectionError, TimeoutError) as e:
                 connection.disconnect()
-                if not connection.retry_on_timeout and isinstance(e, TimeoutError):
-                    raise
+                if not connection.retry_on_timeout:
+                    if isinstance(e, TimeoutError):
+                        raise
                 connection.send_command(command_name)
             try:
                 self.parse_response(connection, command_name)


### PR DESCRIPTION
This expects the ConnectionError at a more precise place (namely the
parse_response call) instead of covering the full command dialog.
And it will not restart the whole execute_command body after the
(expected) failure.

On the down side some code is duplicated from execute_command.
