### PR TITLE
Catch ReponseError in discover_masters

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -211,7 +211,7 @@ class Sentinel(object):
         for sentinel_no, sentinel in enumerate(self.sentinels):
             try:
                 masters = sentinel.sentinel_masters()
-            except ConnectionError:
+            except (ConnectionError, ResponseError):
                 continue
             state = masters.get(service_name)
             if state and self.check_master_state(state, service_name):


### PR DESCRIPTION
`discover_slaves` catches both ConnectionError and ResponseError.
`discover_masters` only caught ConnectionError prior to this change.

This helps by catching a ResponseError that was previously uncaught when
the targetted sentinel had its max number of clients exceeded.