### PR TITLE
Bug: Terminating CRLF split across buffers

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -339,7 +339,7 @@ class HiredisParser(BaseParser):
                     # an empty string indicates the server shutdown the socket
                     if not isinstance(buffer, bytes) or len(buffer) == 0:
                         raise socket.error(SERVER_CLOSED_CONNECTION_ERROR)
-                    tail = tail[-2:] + bytes(buffer[-2:])
+                    tail = tail[-2:] + buffer[-2:]
             except socket.timeout:
                 raise TimeoutError("Timeout reading from socket")
             except socket.error:


### PR DESCRIPTION
The expected terminating sequence is not guaranteed to reside in the same socket read.  When the CR and LF are split across buffer reads, the loop will either timeout (if timeouts are set) or never terminate.  Further, if using HIREDIS_USE_BYTE_BUFFER and the last bufflen is exactly 2 bytes, the terminating condition will not be checked ( bufflen > 2 ). 

I've introduced a tail buffer to track and verify terminating conditions across the last two buffers.
The tail can be thought of as a 4-byte buffer.  It does not attempt to be contiguous, instead it is comprised of the last two bytes of the previous and current buffers. Once all data has been spooled from the socket, the last 2 bytes will be the last two bytes sent from redis, regardless of byte packing.

You'll see sizing as follows
 * len 2 - first socket read
 * len 3 - last socket read is split (CR LF were split across reads, but preserved in tail)
 * len 4 - secondary socket reads (CR LF are packed together)

