### PR TITLE
Support multiple keys for pfcount call

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1813,12 +1813,12 @@ class StrictRedis(object):
         "Adds the specified elements to the specified HyperLogLog."
         return self.execute_command('PFADD', name, *values)
 
-    def pfcount(self, name):
+    def pfcount(self, *sources):
         """
         Return the approximated cardinality of
-        the set observed by the HyperLogLog at key.
+        the set observed by the HyperLogLog at key(s).
         """
-        return self.execute_command('PFCOUNT', name)
+        return self.execute_command('PFCOUNT', *sources)
 
     def pfmerge(self, dest, *sources):
         "Merge N different HyperLogLogs into a single one."

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1106,6 +1106,10 @@ class TestRedisCommands(object):
         members = set([b('1'), b('2'), b('3')])
         r.pfadd('a', *members)
         assert r.pfcount('a') == len(members)
+        members_b = set([b('2'), b('3'), b('4')])
+        r.pfadd('b', *members_b)
+        assert r.pfcount('b') == len(members_b)
+        assert r.pfcount('a', 'b') == len(members_b.union(members))
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfmerge(self, r):


### PR DESCRIPTION
http://redis.io/commands/pfcount supports multiple keys in the request, it internally merges them together in a temporary key, returns the result, and deletes the temp key.

I find it handy when wanting to sum up a lot of keys and don't care to keep the pfmerge around.