### PR TITLE
SLOWLOG GET Complexity Analysis

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -279,11 +279,12 @@ def parse_slowlog_get(response, **options):
         }
         if len(item) == 5:
             # Garantia Data custom Redis result, with complexity analysis
+            command_idx = 4
             result['complexity'] = item[3]
-            result['command'] = b(' ').join(item[4])
         else:
             # Vanilla Redis result
-            result['command'] = b(' ').join(item[3])
+            command_idx = 3
+        result['command'] = b(' ').join(item[command_idx])
         return result
     return [parse_item(item) for item in response]
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -271,12 +271,21 @@ def parse_zscan(response, **options):
 
 
 def parse_slowlog_get(response, **options):
-    return [{
-        'id': item[0],
-        'start_time': int(item[1]),
-        'duration': int(item[2]),
-        'command': b(' ').join(item[3])
-    } for item in response]
+    def parse_item(item):
+        result = {
+            'id': item[0],
+            'start_time': int(item[1]),
+            'duration': int(item[2]),
+        }
+        if len(item) == 5:
+            # Garantia Data custom Redis result, with complexity analysis
+            result['complexity'] = item[3]
+            result['command'] = b(' ').join(item[4])
+        else:
+            # Vanilla Redis result
+            result['command'] = b(' ').join(item[3])
+        return result
+    return [parse_item(item) for item in response]
 
 
 def parse_cluster_info(response, **options):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -145,6 +145,7 @@ class TestRedisCommands(object):
             # monkey patch parse_response()
             COMPLEXITY_STATEMENT = "Complexity info: N:4712,M:3788"
             old_parse_response = r.parse_response
+
             def parse_response(connection, command_name, **options):
                 if command_name != 'SLOWLOG GET':
                     return old_parse_response(connection,


### PR DESCRIPTION
The [Garantia Data custom Redis version (Redis Labs' flavor)](https://github.com/RedisLabs/redis) returns `Complexity info` as part of the `SLOWLOG GET` result (see [here](https://github.com/RedisLabs/redis/blob/a5727898831552dd231a05aa20f9f97ccdac8395/src/slowlog.c#L167)).

This pull request parses that data out and handles those responses properly.

Test included.
