### PR TITLE
Make iterators more useful

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1478,8 +1478,20 @@ class StrictRedis(object):
         ``deduplicate`` remembers seen keys and avoids them being returned in
         duplicate
         """
-        return self._scan_iter(self.hscan, name=name, match=match, count=count,
-                               deduplicate=deduplicate)
+        if deduplicate:
+            seen = set()
+        cursor = '0'
+        while cursor != 0:
+            cursor, data = scan_func(cursor=cursor, **kwargs)
+            if deduplicate:
+                for key, value in data.items():
+                    if key not in seen:
+                        yield key, value
+                        seen.add(key)
+            else:
+                for key, value in data.items():
+                    yield key, value
+
 
     def hscan_iteritems(self, name, match=None, count=None,
                         deduplicate=False):


### PR DESCRIPTION
- Refactor `*scan_iter` methods
- Add iteritems variants for `scan_iter` and `hscan_iter`
- Provide option to deduplicate keys during iteration
- Provide sorted iteration in `zrange_iter` (with different guarantees to `ZSCAN`)

This further extends user convenience when iterating, but distances the implementation from the redis API calls. Is it a welcome contribution?

TODO:
- [ ] tests
- [ ] extend README documentation
