### PR TITLE
Added the option to call run_in_thread as daemon

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2295,7 +2295,7 @@ class PubSub(object):
 
         return message
 
-    def run_in_thread(self, sleep_time=0):
+    def run_in_thread(self, sleep_time=0, daemon=False):
         for channel, handler in iteritems(self.channels):
             if handler is None:
                 raise PubSubError("Channel: '%s' has no handler registered")
@@ -2303,16 +2303,17 @@ class PubSub(object):
             if handler is None:
                 raise PubSubError("Pattern: '%s' has no handler registered")
 
-        thread = PubSubWorkerThread(self, sleep_time)
+        thread = PubSubWorkerThread(self, sleep_time, daemon)
         thread.start()
         return thread
 
 
 class PubSubWorkerThread(threading.Thread):
-    def __init__(self, pubsub, sleep_time):
+    def __init__(self, pubsub, sleep_time, daemon):
         super(PubSubWorkerThread, self).__init__()
         self.pubsub = pubsub
         self.sleep_time = sleep_time
+        self.daemon = daemon
         self._running = False
 
     def run(self):


### PR DESCRIPTION
Since PubSub.run_in_thread() starts the thread before returning it, it
is impossible for the caller to mark it as a daemon, which can be
desirable for many reasons.

This change adds an additional optional parameter which will cause the
thread to be run as a daemon. It is a keyword argument and defaults to
false so the current behavior will not change and it will not break any
current consumers on upgrade.
