### PR TITLE
Python 3 support in Connection.send_packed_command

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -542,11 +542,11 @@ class Connection(object):
                 if python_version == 2:
                     command = [command]
                 elif python_version == 3:
-                    raise TypeError("Expected <class 'bytes'> argument,"
-                                    + " got string instead."
-                                    + " Use string.encode(encoding) method"
-                                    + " to convert the"
-                                    + " argument before passing.")
+                    raise TypeError("Expected <class 'bytes'> argument," +
+                                    " got string instead." +
+                                    " Use string.encode(encoding) method" +
+                                    " to convert the" +
+                                    " argument before passing.")
             elif isinstance(command, bytes):  # Works both in Python 2 and 3
                     command = [command]
             for item in command:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -532,15 +532,19 @@ class Connection(object):
         "Send an already packed command to the Redis server"
         if not self._sock:
             self.connect()
-        python_version = sys.version_info.major
         try:
-            if isinstance(command, str): #Works in Python 2 only, must be <class 'bytes'> in 3
-                if python_version == 2: 
+            python_version = sys.version_info.major  #Python 2.7 and above
+        except AttributeError:  #Below 2.7
+            python_version = sys.version_info[0]
+        try:
+            if isinstance(command, str):  #Works in Python 2 only, must be <class 'bytes'> in 3
+                if python_version == 2:
                     command = [command]
                 elif python_version == 3:
                     raise TypeError("Expected <class 'bytes'> argument, got string instead."\
-                                    + " Use string.encode(encoding) method to convert the argument before passing.")
-            elif isinstance(command, bytes): #Works both in Python 2 and 3
+                                    + " Use string.encode(encoding) method to convert the"\
+                                    + " argument before passing.")
+            elif isinstance(command, bytes):  #Works both in Python 2 and 3
                     command = [command]
             for item in command:
                 self._sock.sendall(item)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -538,14 +538,14 @@ class Connection(object):
             python_version = sys.version_info[0]
         try:
             if isinstance(command, str):
-            # Works in Python 2 only, must be <class 'bytes'> in 3
+                # Works in Python 2 only, must be <class 'bytes'> in 3
                 if python_version == 2:
                     command = [command]
                 elif python_version == 3:
-                    raise TypeError("Expected <class 'bytes'> argument,"\
-                                    + " got string instead."\
-                                    + " Use string.encode(encoding) method"\
-                                    + " to convert the"\
+                    raise TypeError("Expected <class 'bytes'> argument,"
+                                    + " got string instead."
+                                    + " Use string.encode(encoding) method"
+                                    + " to convert the"
                                     + " argument before passing.")
             elif isinstance(command, bytes):  # Works both in Python 2 and 3
                     command = [command]

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -532,9 +532,16 @@ class Connection(object):
         "Send an already packed command to the Redis server"
         if not self._sock:
             self.connect()
+        python_version = sys.version_info.major
         try:
-            if isinstance(command, str):
-                command = [command]
+            if isinstance(command, str): #Works in Python 2 only, must be <class 'bytes'> in 3
+                if python_version == 2: 
+                    command = [command]
+                elif python_version == 3:
+                    raise TypeError("Expected <class 'bytes'> argument, got string instead."\
+                                    + " Use string.encode(encoding) method to convert the argument before passing.")
+            elif isinstance(command, bytes): #Works both in Python 2 and 3
+                    command = [command]
             for item in command:
                 self._sock.sendall(item)
         except socket.timeout:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -533,18 +533,21 @@ class Connection(object):
         if not self._sock:
             self.connect()
         try:
-            python_version = sys.version_info.major  #Python 2.7 and above
-        except AttributeError:  #Below 2.7
+            python_version = sys.version_info.major  # Python 2.7 and above
+        except AttributeError:  # Below 2.7
             python_version = sys.version_info[0]
         try:
-            if isinstance(command, str):  #Works in Python 2 only, must be <class 'bytes'> in 3
+            if isinstance(command, str):
+            # Works in Python 2 only, must be <class 'bytes'> in 3
                 if python_version == 2:
                     command = [command]
                 elif python_version == 3:
-                    raise TypeError("Expected <class 'bytes'> argument, got string instead."\
-                                    + " Use string.encode(encoding) method to convert the"\
+                    raise TypeError("Expected <class 'bytes'> argument,"\
+                                    + " got string instead."\
+                                    + " Use string.encode(encoding) method"\
+                                    + " to convert the"\
                                     + " argument before passing.")
-            elif isinstance(command, bytes):  #Works both in Python 2 and 3
+            elif isinstance(command, bytes):  # Works both in Python 2 and 3
                     command = [command]
             for item in command:
                 self._sock.sendall(item)


### PR DESCRIPTION
In Python 3 the argument of a socket.sendall must be a list of byte sequences, not strings. I changed the type check in send_packed_command as to preserve the old behavior in Python 2, expect a <class 'bytes'> or a list of those as an argument, and raise TypeError if a string is passed instead.

(Maxim Kovalev, Zugata)
