### PR TITLE
Link to redis:// & rediss:// scheme IANA registrations in docs

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -367,7 +367,10 @@ class StrictRedis(object):
     @classmethod
     def from_url(cls, url, db=None, **kwargs):
         """
-        Return a Redis client object configured from the given URL.
+        Return a Redis client object configured from the given URL, which must
+        use either `the ``redis://`` scheme
+        <http://www.iana.org/assignments/uri-schemes/prov/redis>`_ for RESP
+        connections or the ``unix://`` scheme for Unix domain sockets.
 
         For example::
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -742,9 +742,14 @@ class ConnectionPool(object):
             unix://[:password]@/path/to/socket.sock?db=0
 
         Three URL schemes are supported:
-            redis:// creates a normal TCP socket connection
-            rediss:// creates a SSL wrapped TCP socket connection
-            unix:// creates a Unix Domain Socket connection
+
+        - ```redis://``
+          <http://www.iana.org/assignments/uri-schemes/prov/redis>`_ creates a
+          normal TCP socket connection
+        - ```rediss://``
+          <http://www.iana.org/assignments/uri-schemes/prov/rediss>`_ creates a
+          SSL wrapped TCP socket connection
+        - ``unix://`` creates a Unix Domain Socket connection
 
         There are several ways to specify a database number. The parse function
         will return the first specified option:


### PR DESCRIPTION
The registrations were written with redis-py in mind, so it already complies with the de facto specs.