### PR TITLE
Fix tests under Redis 3.x; we can be of an "embedded string" format now.

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -112,7 +112,7 @@ class TestRedisCommands(object):
         r['a'] = 'foo'
         assert isinstance(r.object('refcount', 'a'), int)
         assert isinstance(r.object('idletime', 'a'), int)
-        assert r.object('encoding', 'a') == b('raw')
+        assert r.object('encoding', 'a') in (b('raw'), b('embstr'))
         assert r.object('idletime', 'invalid-key') is None
 
     def test_ping(self, r):


### PR DESCRIPTION
Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>