### PR TITLE
Round-robin sentinel nodes balancer

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -175,7 +175,9 @@ class Sentinel(object):
                                     if k.startswith('socket_')
                                     ])
         self.sentinel_kwargs = sentinel_kwargs
-
+        
+        # Round-robin sentinel nodes balancer
+        random.shuffle(sentinels)
         self.sentinels = [StrictRedis(hostname, port, **self.sentinel_kwargs)
                           for hostname, port in sentinels]
         self.min_other_sentinels = min_other_sentinels


### PR DESCRIPTION
when sentinel init with arg sentinels,the function `discover_master` always make the first node as used, so connections of the  first node is more many than others, so shuffle the nodes of sentinels, can balance the connections. 

In each processing, the sentinels node list is different.

Maybe 20000+ connections is hard to rearch, but in our project and users, it's not hard~     

Thank you~
