### PR TITLE
Add a new "close_on_error" boolean kwarg to pubsub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -510,8 +510,9 @@ PubSub objects remember what channels and patterns they are subscribed to. In
 the event of a disconnection such as a network error or timeout, the
 PubSub object will re-subscribe to all prior channels and patterns when
 reconnecting. Messages that were published while the client was disconnected
-cannot be delivered. When you're finished with a PubSub object, call its
-`.close()` method to shutdown the connection.
+cannot be delivered. Automated reconnection can be disabled by passing
+`close_on_error=True` to `r.pubsub()`. When you're finished with a PubSub object,
+call its `.close()` method to shutdown the connection.
 
 .. code-block:: pycon
 


### PR DESCRIPTION
I have a use-case where I need to handle disconnects explicitly (since they mean data was dropped, I want them to show up in my logs and metrics), and the auto-reconnect feature gets in the way.

This small PR adds a "close_on_error" boolean flag to pubsub, which lets pubsub callers get an exception instead.
