### PR TITLE
Let callers set a client name at the pool level

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -494,7 +494,7 @@ class StrictRedis(object):
                  decode_responses=False, retry_on_timeout=False,
                  ssl=False, ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs=None, ssl_ca_certs=None,
-                 max_connections=None):
+                 max_connections=None, client_name=None):
         if not connection_pool:
             if charset is not None:
                 warnings.warn(DeprecationWarning(
@@ -513,7 +513,8 @@ class StrictRedis(object):
                 'encoding_errors': encoding_errors,
                 'decode_responses': decode_responses,
                 'retry_on_timeout': retry_on_timeout,
-                'max_connections': max_connections
+                'max_connections': max_connections,
+                'client_name': client_name,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -409,7 +409,8 @@ class Connection(object):
                  socket_keepalive=False, socket_keepalive_options=None,
                  retry_on_timeout=False, encoding='utf-8',
                  encoding_errors='strict', decode_responses=False,
-                 parser_class=DefaultParser, socket_read_size=65536):
+                 parser_class=DefaultParser, socket_read_size=65536,
+                 client_name=None):
         self.pid = os.getpid()
         self.host = host
         self.port = int(port)
@@ -423,6 +424,7 @@ class Connection(object):
         self.encoding = encoding
         self.encoding_errors = encoding_errors
         self.decode_responses = decode_responses
+        self.client_name = client_name
         self._sock = None
         self._parser = parser_class(socket_read_size=socket_read_size)
         self._description_args = {
@@ -537,6 +539,12 @@ class Connection(object):
             self.send_command('SELECT', self.db)
             if nativestr(self.read_response()) != 'OK':
                 raise ConnectionError('Invalid Database')
+
+        # if a client name is specified, set it
+        if self.client_name:
+            self.send_command('CLIENT SETNAME', self.client_name)
+            # raises redis.exceptions.ResponseError for invalid client names
+            self.read_response()
 
     def disconnect(self):
         "Disconnects from the Redis server"

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -490,3 +490,12 @@ class TestConnection(object):
             'UnixDomainSocketConnection',
             'path=/path/to/socket,db=0',
         )
+
+    def test_on_reconnect_set_client_name(self):
+        name = 'my-client-name'
+        connection = redis.Redis(client_name=name)
+        assert connection.client_getname() == name
+        connection.client_kill([client['addr']
+                               for client in connection.client_list()
+                               if client['name'] == name][0])
+        assert connection.client_getname() == name


### PR DESCRIPTION
Setting a client name helps debugging, but names set via client_setname don't survive reconnects, for example, making it harder to track failing clients.

This PR adds yet another kwarg, similar to password or db. This lets users specify a name in such a way that we can remember it and set it on every connection for a given pool (including when reconnecting).

Disclaimer: I think this is useful, so I'm offering it for review... but I'll admit, I haven't thought about this a great deal (just went for a simple/trivial change).
