### PR TITLE
raise exception when lock can't be acquired

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -81,7 +81,8 @@ class Lock(object):
     def __enter__(self):
         # force blocking, as otherwise the user would have to check whether
         # the lock was actually acquired or not.
-        self.acquire(blocking=True)
+        if not self.acquire(blocking=True):
+            raise LockError("unable to acquire lock")
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -59,6 +59,16 @@ class TestLock(object):
             assert sr.get('foo') == lock.local.token
         assert sr.get('foo') is None
 
+    def test_context_manager_failed_acquire(self, sr):
+        # Ensure context manager block isn't run when lock can't be acquired.
+        run = False
+        sr.setnx("foo", "bar")
+        with pytest.raises(LockError) as excinfo:
+            with self.get_lock(sr, 'foo', blocking_timeout=0.2) as lock:
+                run = True
+        assert str(excinfo.value) == "unable to acquire lock"
+        assert run is False
+
     def test_high_sleep_raises_error(self, sr):
         "If sleep is higher than timeout, it should raise an error"
         with pytest.raises(LockError):


### PR DESCRIPTION
This prevents the context manager block from executing if a lock can't be acquired within 'blocking_timeout' seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andymccurdy/redis-py/661)
<!-- Reviewable:end -->
