### PR TITLE
Fix tests on latest python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,6 @@ try:
     from setuptools.command.test import test as TestCommand
 
     class PyTest(TestCommand):
-        def finalize_options(self):
-            TestCommand.finalize_options(self)
-            self.test_args = []
-            self.test_suite = True
-
         def run_tests(self):
             # import here, because outside the eggs aren't loaded
             import pytest


### PR DESCRIPTION
Tests fail with

``` python
/usr/bin/python3.4 setup.py test --verbose
running test
Traceback (most recent call last):
  File "setup.py", line 61, in <module>
    'Programming Language :: Python :: 3.4',
  File "/usr/lib64/python3.4/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib64/python3.4/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python3.4/distutils/dist.py", line 973, in run_command
    cmd_obj.ensure_finalized()
  File "/usr/lib64/python3.4/distutils/cmd.py", line 107, in ensure_finalized
    self.finalize_options()
  File "setup.py", line 14, in finalize_options
    self.test_args = []
AttributeError: can't set attribute
```

Signed-off-by: Justin Lecher jlec@gentoo.org
