### PR TITLE
simplified testing configuration and added Python 3.5 to the matrix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
+[pep8]
+show-source = 1
+exclude = .venv,.tox,dist,docs,build,*.egg
+
 [bdist_wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,15 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, hi26, hi27, hi32, hi33, hi34, pep8
+minversion = 1.8
+envlist = {py26,py27,py32,py33,py34,py35}-{plain,hiredis}, pep8
 
 [testenv]
-deps=pytest>=2.5.0
-commands = py.test []
-
-[testenv:hi26]
-basepython = python2.6
-deps =
-    hiredis>=0.1.3
-    pytest>=2.5.0
-commands = py.test []
-
-[testenv:hi27]
-basepython = python2.7
-deps =
-    hiredis>=0.1.3
-    pytest>=2.5.0
-commands = py.test []
-
-[testenv:hi32]
-basepython = python3.2
-deps =
-    hiredis>=0.1.3
-    pytest>=2.5.0
-commands = py.test []
-
-[testenv:hi33]
-basepython = python3.3
-deps =
-    hiredis>=0.1.3
-    pytest>=2.5.0
-commands = py.test []
-
-[testenv:hi34]
-basepython = python3.4
-deps =
-    hiredis>=0.1.3
-    pytest>=2.5.0
-commands = py.test []
+deps = pytest >= 2.5.0
+    hiredis: hiredis >= 0.1.3
+commands = py.test {posargs}
 
 [testenv:pep8]
+basepython = python2.6
 deps = pep8
-commands = pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,*.egg .
+commands = pep8
+skipsdist = true
+skip_install = true


### PR DESCRIPTION
Turns out flake8 complained a bit too much about the code so I left pep8 in the configuration.