### PR TITLE
fix getitem syntax for redis get when value is the empty string

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -885,7 +885,7 @@ class StrictRedis(object):
         doesn't exist.
         """
         value = self.get(name)
-        if value:
+        if value is not None:
             return value
         raise KeyError(name)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -341,6 +341,10 @@ class TestRedisCommands(object):
         with pytest.raises(KeyError):
             r['a']
 
+    def test_getitem_does_not_raise_keyerror_for_empty_string(self, r):
+        r['a'] = b("")
+        assert r['a'] == b("")
+
     def test_get_set_bit(self, r):
         # no value
         assert not r.getbit('a', 5)


### PR DESCRIPTION
When using `__getitem__` syntax to retrieve an empty string, an exception is produced, just as if the key were unset:

```
>>> r = Redis(**connection_data)
>>> print(r.get('bah'))
None
>>>r['bah']
KeyError: 'bah'
>>> r['bah'] = ""
>>> r.get('bah')
b''
>>> r['bah']
KeyError: 'bah'
```

The behaviour should be the same as for any other set value, and the exception only produced for unset keys:

```
>>> r['bah'] = ""
>>> r.get('bah')
b''
>>> r['bah']
b''
```

This patch provides a test and a fix.