### PR TITLE
Add differentiation for lock not owned errors

### DIFF
--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -69,3 +69,7 @@ class LockError(RedisError, ValueError):
     # NOTE: For backwards compatability, this class derives from ValueError.
     # This was originally chosen to behave like threading.Lock.
     pass
+
+
+class LockNotOwnedError(LockError):
+    """Lock errors related to lose of prior ownership."""


### PR DESCRIPTION
It is quite useful to be able to distinguish between
between general lock errors and lock errors that are releated
to ownership lose (and handle the cases differently).

To be able to do this add a new lock error subclass and
use it in the locations where lock error was raised previously
when ownership lose was detected.
