### PR TITLE
Added new utils function to merge dictionaries deeply, BaseParser.parse_error was improved to handle more type of exceptions.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -64,6 +64,49 @@ def dict_merge(*dicts):
     return merged
 
 
+def dict_deep_merge(*dicts):
+    """
+    class BaseParser(object):
+        EXCEPTION_CLASSES = {
+            'ERR': {
+                'max number of clients reached': ConnectionError
+            }
+        }
+
+    class HedeParser(BaseParser):
+        EXCEPTION_CLASSES = dict_deep_merge(
+            DefaultParser.EXCEPTION_CLASSES, {
+                'ERR': {
+                    'Unknown node': UnknownNodeError
+                },
+            })
+
+    Result:
+
+    EXCEPTION_CLASSES = {
+            'ERR': {
+                'max number of clients reached': ConnectionError
+                'Unknown node': UnknownNodeError
+            }
+        }
+
+    """
+    def merge(source, destination):
+        for key, value in source.items():
+            if isinstance(value, dict):
+                node = destination.setdefault(key, {})
+                merge(value, node)
+            else:
+                destination[key] = value
+
+        return destination
+
+    merged = {}
+    for d in dicts:
+        merged = merge(d, merged)
+    return merged
+
+
 def parse_debug_object(response):
     "Parse the results of Redis's DEBUG OBJECT command into a Python dict"
     # The 'type' of the object is the first item in the response, but isn't

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -97,7 +97,7 @@ class BaseParser(object):
             exception_class = self.EXCEPTION_CLASSES[error_code]
             if isinstance(exception_class, dict):
                 found = False
-                for reason, inner_exception_class in exception_class.iteritems():
+                for reason, inner_exception_class in exception_class.items():
                     new_response = response.replace(reason, '').strip()
                     if new_response != response:
                         exception_class = inner_exception_class

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -96,7 +96,16 @@ class BaseParser(object):
             response = response[len(error_code) + 1:]
             exception_class = self.EXCEPTION_CLASSES[error_code]
             if isinstance(exception_class, dict):
-                exception_class = exception_class.get(response, ResponseError)
+                found = False
+                for reason, inner_exception_class in exception_class.iteritems():
+                    new_response = response.replace(reason, '').strip()
+                    if new_response != response:
+                        exception_class = inner_exception_class
+                        response = new_response
+                        found = True
+                        break
+                if not found:
+                    exception_class = ResponseError
             return exception_class(response)
         return ResponseError(response)
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -96,16 +96,10 @@ class BaseParser(object):
             response = response[len(error_code) + 1:]
             exception_class = self.EXCEPTION_CLASSES[error_code]
             if isinstance(exception_class, dict):
-                found = False
                 for reason, inner_exception_class in exception_class.items():
-                    new_response = response.replace(reason, '').strip()
-                    if new_response != response:
-                        exception_class = inner_exception_class
-                        response = new_response
-                        found = True
-                        break
-                if not found:
-                    exception_class = ResponseError
+                    if reason in response:
+                        return inner_exception_class(response)
+                return ResponseError(response)
             return exception_class(response)
         return ResponseError(response)
 


### PR DESCRIPTION
With this PR, we will be able to merge dictionaries deeply using "dict_deep_merge" function. Also i ve changed the parse_error logic to handle more types of exceptions like below.

'ERR': {
            'max number of clients reached': ConnectionError
            'Unknown node': UnknownNodeError
        }

Currently, i am developing something to manage redis cluster and i need to write my own parser which is ClusterParser. I need to extend EXCEPTION_CLASSES on BaseParser with mine, cause i should parse ResponseError('ERR Unknown node 012e6851abadb8c1c948c0f1cbbe7f68deb8bd24') into UnknownNodeError <node_id>. So with this implementation, everyone can write their own parsers easily.
