### PR TITLE
Several improvements to PubSub.parse_response() method.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2177,6 +2177,9 @@ class PubSub(object):
 
     def parse_response(self, block=True, timeout=0):
         "Parse the response from a publish/subscribe command"
+        # block=True: block forever, ignoring timeout
+        # block=False, timeout > 0: block for up to timeout sec
+        # block=False, timeout=0: non-blocking, return immediately
         connection = self.connection
         if connection is None:
             raise RuntimeError(

--- a/redis/client.py
+++ b/redis/client.py
@@ -2178,6 +2178,10 @@ class PubSub(object):
     def parse_response(self, block=True, timeout=0):
         "Parse the response from a publish/subscribe command"
         connection = self.connection
+        if connection is None:
+            raise RuntimeError(
+                'pubsub connection not set: '
+                'did you forget to call subscribe() or psubscribe()?')
         if not block and not connection.can_read(timeout=timeout):
             return None
         return self._execute(connection, connection.read_response)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -303,7 +303,7 @@ class TestPubSubMessages(object):
     def test_parse_response(self, r):
         p = r.pubsub()
         p.subscribe('foobar')
-        response = p.parse_response(block=True)
+        response = p.parse_response(timeout=None)
         assert isinstance(response, list)
         assert response[0:2] == ['subscribe', 'foobar']
 
@@ -328,28 +328,22 @@ class TestPubSubMessages(object):
             return (response, elapsed)
 
         # hard_timeout beats the timeout passed to parse_response()
-        (response, elapsed) = parse_response_sigalrm(block=False, timeout=1.5)
+        (response, elapsed) = parse_response_sigalrm(timeout=1.5)
         assert response is None
         assert hard_timeout <= elapsed <= hard_timeout + fuzz
 
         # timeout passed to parse_response() wins because it's shorter
-        (response, elapsed) = parse_response_sigalrm(block=False, timeout=0.5)
+        (response, elapsed) = parse_response_sigalrm(timeout=0.5)
         assert response is None
         assert 0.5 <= elapsed <= 0.5 + fuzz
 
         # same thing -- this is really non-blocking
-        (response, elapsed) = parse_response_sigalrm(block=False, timeout=0)
+        (response, elapsed) = parse_response_sigalrm(timeout=0)
         assert response is None
         assert 0 <= elapsed <= 0 + fuzz
 
-        # and this blocks forever, so hard_timeout is essential here!
-        (response, elapsed) = parse_response_sigalrm(block=True)
-        assert hard_timeout <= elapsed <= hard_timeout + fuzz
-        # this test fails! response == ['subscribe', 'foobar', 1L]
-        # assert response is None
-
         # this blocks forever too, but does not have that bug
-        (response, elapsed) = parse_response_sigalrm(block=False, timeout=None)
+        (response, elapsed) = parse_response_sigalrm(timeout=None)
         assert hard_timeout <= elapsed <= hard_timeout + fuzz
         assert response is None
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -283,6 +283,14 @@ class TestPubSubMessages(object):
         assert self.message == make_message('pmessage', channel,
                                             'test message', pattern=pattern)
 
+    def test_get_message_without_subscribe(self, r):
+        p = r.pubsub()
+        with pytest.raises(RuntimeError) as info:
+            p.get_message()
+        expect = ('connection not set: '
+                  'did you forget to call subscribe() or psubscribe()?')
+        assert expect in info.exconly()
+
 
 class TestPubSubAutoDecoding(object):
     "These tests only validate that we get unicode values back"


### PR DESCRIPTION
In trying to understand blocking/timeout semantics, I think I found an easier way to do things, and I found a bug.