### PR TITLE
HMGET variant returning a dict.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1954,6 +1954,11 @@ class StrictRedis(object):
         args = list_or_args(keys, args)
         return self.execute_command('HMGET', name, *args)
 
+    def hmget_dict(self, name, keys, *args):
+        "Return a dict with keys equal to ``keys`` from within hash ``name``"
+        args = list_or_args(keys, args)
+        return dict(izip(args, self.execute_command('HMGET', name, *args)))
+
     def hvals(self, name):
         "Return the list of values within hash ``name``"
         return self.execute_command('HVALS', name)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1200,6 +1200,13 @@ class TestRedisCommands(object):
         assert r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         assert r.hmget('a', 'a', 'b', 'c') == [b('1'), b('2'), b('3')]
 
+    def test_hmget_dict(self, r):
+        assert r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
+        assert r.hmget_dict('a', 'a', 'b', 'c') == \
+            {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        assert r.hmget_dict('a', ['a', 'b', 'c']) == \
+            {'a': b('1'), 'b': b('2'), 'c': b('3')}
+
     def test_hmset(self, r):
         h = {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
         assert r.hmset('a', h)


### PR DESCRIPTION
When calling HMGET, I almost always need the results wrapped up with the keys in a dict. This would simply allow the caller to designate their desired return type.

Test included.