### PR TITLE
ZADD options (Redis 3.0.2 or greater)

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1626,6 +1626,14 @@ class StrictRedis(object):
         """
         pieces = []
         if args:
+          
+            args = list(args)
+            for each in args:
+                if 'INCR' in str(each).upper():
+                    pieces.append('INCR')
+                    args.remove(each)
+            args = tuple(args)
+          
             if len(args) % 2 != 0:
                 raise RedisError("ZADD requires an equal number of "
                                  "values and scores")

--- a/redis/client.py
+++ b/redis/client.py
@@ -1626,14 +1626,14 @@ class StrictRedis(object):
         """
         pieces = []
         if args:
-          
+
             args = list(args)
             for each in args:
                 if 'INCR' in str(each).upper():
                     pieces.append('INCR')
                     args.remove(each)
             args = tuple(args)
-          
+
             if len(args) % 2 != 0:
                 raise RedisError("ZADD requires an equal number of "
                                  "values and scores")


### PR DESCRIPTION
Hello,

First of all, this PR is not a complete patch for zadd options.

AND, Yes, i know this -> #638  ,really excellent.

but, it's look like not good for
1.old code because of this change
2.Strict Redis
3.Easy to use

My purpose is like this (and my temporary code already use this change):
`redis.zadd('incr', 1.1, 'key')`

SO, i just give a idea( if accepted, i could code more), forgive me.
