### PR TITLE
Extend ConnectionPool.to_url to parse querystring arguments to correct type.

### DIFF
--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -239,7 +239,9 @@ class TestConnectionPoolURLParsing(object):
 
     def test_extra_typed_querystring_options(self):
         pool = redis.ConnectionPool.from_url(
-            'redis://localhost/2?socket_timeout=20&socket_connect_timeout=10&socket_keepalive=&retry_on_timeout=Yes')
+            'redis://localhost/2?socket_timeout=20&socket_connect_timeout=10'
+            '&socket_keepalive=&retry_on_timeout=Yes'
+        )
 
         assert pool.connection_class == redis.Connection
         assert pool.connection_kwargs == {
@@ -267,9 +269,15 @@ class TestConnectionPoolURLParsing(object):
     def test_invalid_extra_typed_querystring_options(self):
         import warnings
         with warnings.catch_warnings(record=True) as warning_log:
-            redis.ConnectionPool.from_url('redis://localhost/2?socket_timeout=_&socket_connect_timeout=abc')
+            redis.ConnectionPool.from_url(
+                'redis://localhost/2?socket_timeout=_&'
+                'socket_connect_timeout=abc'
+            )
         # Compare the message values
-        assert [str(m.message) for m in sorted(warning_log, key=lambda l: str(l.message))] == [
+        assert [
+            str(m.message) for m in
+            sorted(warning_log, key=lambda l: str(l.message))
+        ] == [
             'Invalid value for `socket_connect_timeout` in connection URL.',
             'Invalid value for `socket_timeout` in connection URL.',
         ]

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -6,7 +6,7 @@ import time
 import re
 
 from threading import Thread
-from redis.connection import ssl_available
+from redis.connection import ssl_available, to_bool
 from .conftest import skip_if_server_version_lt
 
 
@@ -236,6 +236,43 @@ class TestConnectionPoolURLParsing(object):
             'db': 3,
             'password': None,
         }
+
+    def test_extra_typed_querystring_options(self):
+        pool = redis.ConnectionPool.from_url(
+            'redis://localhost/2?socket_timeout=20&socket_connect_timeout=10&socket_keepalive=&retry_on_timeout=Yes')
+
+        assert pool.connection_class == redis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 2,
+            'socket_timeout': 20.0,
+            'socket_connect_timeout': 10.0,
+            'retry_on_timeout': True,
+            'password': None,
+        }
+
+    def test_boolean_parsing(self):
+        for expected, value in (
+                (None, None),
+                (None, ''),
+                (False, 0), (False, '0'),
+                (False, 'f'), (False, 'F'), (False, 'False'),
+                (False, 'n'), (False, 'N'), (False, 'No'),
+                (True, 1), (True, '1'),
+                (True, 'y'), (True, 'Y'), (True, 'Yes'),
+        ):
+            assert expected is to_bool(value)
+
+    def test_invalid_extra_typed_querystring_options(self):
+        import warnings
+        with warnings.catch_warnings(record=True) as warning_log:
+            redis.ConnectionPool.from_url('redis://localhost/2?socket_timeout=_&socket_connect_timeout=abc')
+        # Compare the message values
+        assert [str(m.message) for m in sorted(warning_log, key=lambda l: str(l.message))] == [
+            'Invalid value for `socket_connect_timeout` in connection URL.',
+            'Invalid value for `socket_timeout` in connection URL.',
+        ]
 
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url('redis://localhost?a=1&b=2')


### PR DESCRIPTION
Previously if a value for socket_timeout was supplied as part fo the URL an error would be raised when a socket was created with an invalid type, this change fixes that by parsing `socket_timeout`, `socket_connect_timeout` to float values.
In addition the boolean values `socket_keepalive` and `retry_on_timeout` are parsed to bool types taking into account the usage of True/False, Yes/No strings.