### PR TITLE
Ignore "Interrupted system call" errors in PubSubWorkerThread

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2390,8 +2390,11 @@ class PubSubWorkerThread(threading.Thread):
         pubsub = self.pubsub
         sleep_time = self.sleep_time
         while pubsub.subscribed:
-            pubsub.get_message(ignore_subscribe_messages=True,
-                               timeout=sleep_time)
+            try:
+                pubsub.get_message(ignore_subscribe_messages=True,
+                                   timeout=sleep_time)
+            except InterruptedError:
+                pass  # Ignore "Interrupted system call" errors.
         pubsub.close()
         self._running = False
 


### PR DESCRIPTION
The pubsub worker thread was sometimes dying on me silently because my process was interrupted by a signal while `pubsub.get_message -> pubsub.parse_response -> connection.can_read -> select.select` was blocking.

This fix simply ignores `InterruptedError`s raised during the `select` poll and retries. I have been testing this in production for about half a year now.

Note that this is only needed for Python < 3.5. In 3.5 `select` ignores interruptions and retries automatically (https://docs.python.org/3/library/select.html#select.select).