### PR TITLE
Check also `int` not only `long` for PyPy.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -335,7 +335,7 @@ class StrictRedis(object):
         string_keys_to_dict(
             # these return OK, or int if redis-server is >=1.3.4
             'LPUSH RPUSH',
-            lambda r: isinstance(r, long) and r or nativestr(r) == 'OK'
+            lambda r: isinstance(r, (long, int)) and r or nativestr(r) == 'OK'
         ),
         string_keys_to_dict('SORT', sort_return_tuples),
         string_keys_to_dict('ZSCORE ZINCRBY', float_or_none),


### PR DESCRIPTION
This is a patch to enhance PyPy compatibility.
I don't know well about the code - but it seems it is related to binary unpacking.
In some case of that, PyPy can generate `int` instead of `long`.