### PR TITLE
Specify mock requirement for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ minversion = 1.8
 envlist = {py26,py27,py32,py33,py34,py35}-{plain,hiredis}, pep8
 
 [testenv]
-deps = pytest >= 2.5.0
+deps =
+    pytest==2.9.2
+    mock==2.0.0
     hiredis: hiredis >= 0.1.3
 commands = py.test {posargs}
 


### PR DESCRIPTION
Adds `mock` requirement to `tox.ini`

Without this `git clone ... ` followed by `tox` fails with `ImportError: No module named 'mock'` in all environments. 