### PR TITLE
Wrap `select` to retry on `InterruptedError`

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -9,6 +9,15 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
     import time
     import errno
 
+    from select import select as _select
+
+    def select(rlist, wlist, xlist, timeout):
+        while True:
+            try:
+                return _select(rlist, wlist, xlist, timeout)
+            except InterruptedError:
+                continue
+
     # Wrapper for handling interruptable system calls.
     def _retryable_call(s, func, *args, **kwargs):
         # Some modules (SSL) use the _fileobject wrapper directly and
@@ -54,6 +63,8 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
         return _retryable_call(sock, sock.recv_into, *args, **kwargs)
 
 else:  # Python 3.5 and above automatically retry EINTR
+    from select import select
+
     def recv(sock, *args, **kwargs):
         return sock.recv(*args, **kwargs)
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,7 +1,6 @@
 from __future__ import with_statement
 from distutils.version import StrictVersion
 from itertools import chain
-from select import select
 import os
 import socket
 import sys
@@ -17,7 +16,7 @@ except ImportError:
 from redis._compat import (b, xrange, imap, byte_to_chr, unicode, bytes, long,
                            BytesIO, nativestr, basestring, iteritems,
                            LifoQueue, Empty, Full, urlparse, parse_qs,
-                           recv, recv_into, unquote)
+                           recv, recv_into, select, unquote)
 from redis.exceptions import (
     RedisError,
     ConnectionError,

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ minversion = 1.8
 envlist = {py26,py27,py32,py33,py34,py35}-{plain,hiredis}, pep8
 
 [testenv]
-deps = pytest >= 2.5.0
+deps =
+    pytest==2.9.2
+    mock==2.0.0
     hiredis: hiredis >= 0.1.3
 commands = py.test {posargs}
 


### PR DESCRIPTION
Replaces #738

Attempt at a minimal wrapper around `select` to handle `InterruptedError`.

* I'm not sure it's explicitly covered by the test suite. 
* It makes no attempt to handle any math around `timeout`. 
    * `select` itself will return when `timeout` expires
    * But the call with be retried with the full timeout if the `InterruptedError` is triggered. 

Happy to take feedback

(Note: includes https://github.com/andymccurdy/redis-py/commit/67f9adca849ff104ede2a1e79591fcfeac960262 from #749 because I needed it to run the test suite.)