### PR TITLE
pubsub: improve error reporting if caller forgets to subscribe (issue #716)

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2226,6 +2226,10 @@ class PubSub(object):
     def parse_response(self, block=True, timeout=0):
         "Parse the response from a publish/subscribe command"
         connection = self.connection
+        if connection is None:
+            raise RuntimeError(
+                'pubsub connection not set: '
+                'did you forget to call subscribe() or psubscribe()?')
         if not block and not connection.can_read(timeout=timeout):
             return None
         return self._execute(connection, connection.read_response)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -283,6 +283,14 @@ class TestPubSubMessages(object):
         assert self.message == make_message('pmessage', channel,
                                             'test message', pattern=pattern)
 
+    def test_get_message_without_subscribe(self, r):
+        p = r.pubsub()
+        with pytest.raises(RuntimeError) as info:
+            p.get_message()
+        expect = ('connection not set: '
+                  'did you forget to call subscribe() or psubscribe()?')
+        assert expect in info.exconly()
+
 
 class TestPubSubAutoDecoding(object):
     "These tests only validate that we get unicode values back"


### PR DESCRIPTION
This is an easy mistake to make -- at least, I keep making it. It
formerly resulted in a confusing crash, "AttributeError: 'NoneType'
object has no attribute 'can_read'", from parse_response(). I have had
to dig into the redis-py source code more than once to figure out what
went wrong.

With this patch, it still crashes, but with a clearer error that
clarifies what the calling code forgot to do.

Fixes issue #716.