### PR TITLE
Disconnect clients from pool safely

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -973,7 +973,7 @@ class ConnectionPool(object):
     def disconnect(self):
         "Disconnects all connections in the pool"
         all_conns = chain(copy(self._available_connections),
-                          copy(self._in_use_connections.copy()))
+                          copy(self._in_use_connections))
         for connection in all_conns:
             connection.shutdown_socket()
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2,6 +2,8 @@ from __future__ import with_statement
 from distutils.version import StrictVersion
 from itertools import chain
 from select import select
+from copy import copy
+
 import os
 import socket
 import sys
@@ -547,6 +549,12 @@ class Connection(object):
             # either _sock attribute does not exist or
             # connection thread removed it.
             pass
+        except OSError as e:
+            if e.errno == 107:
+                # Transport endpoint is not connected
+                pass
+            else:
+                raise
 
     def send_packed_command(self, command):
         "Send an already packed command to the Redis server"
@@ -964,8 +972,8 @@ class ConnectionPool(object):
 
     def disconnect(self):
         "Disconnects all connections in the pool"
-        all_conns = chain(self._available_connections,
-                          self._in_use_connections)
+        all_conns = chain(copy(self._available_connections),
+                          copy(self._in_use_connections.copy()))
         for connection in all_conns:
             connection.shutdown_socket()
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,5 +1,4 @@
 from __future__ import with_statement
-from mock import Mock
 
 import os
 import pytest


### PR DESCRIPTION
This PR tries to solve the issues raised by #732 regarding
the danger of disconnect clients from the `ConnectionPool.disconnect`
method executed by a Thread different that those ones that are in charge
of the connections.

Instead of call the `Connection.disconnect` method it uses the syscall
`shutdown` to leave the socket unusable. Once the connection tries to use
the socket, even when it is already blocked such us the `PubSub` pattern, it
gets a `socket.error` exception that will be cactched by the
`Connection` class to then raise an `ConnectionError` and disconnect the
socket in a clean and safe way.

The `Client.execute_command` function catches the `ConnectionError` exception
and tries to connect again and run the command that raised the error.

Worth mentioning that in the case of the `Sentinel` environment, if the disconnect was because of a 
change of the Redis pool servers - perhaps the master went
down and a slave was promoted, the next command will be executed using a new connection that will take into account these changes.