### PR TITLE
Fix transposition of GEORADIUS arguments

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2106,7 +2106,7 @@ class StrictRedis(object):
         """
         return self.execute_command('GEOPOS', name, *values)
 
-    def georadius(self, name, latitude, longitude, radius, unit=None,
+    def georadius(self, name, longitude, latitude, radius, unit=None,
                   withdist=False, withcoord=False, withhash=False, count=None,
                   sort=None, store=None, store_dist=None):
         """
@@ -2138,7 +2138,7 @@ class StrictRedis(object):
         destination score is set with the distance.
         """
         return self._georadiusgeneric('GEORADIUS',
-                                      name, latitude, longitude, radius,
+                                      name, longitude, latitude, radius,
                                       unit=unit, withdist=withdist,
                                       withcoord=withcoord, withhash=withhash,
                                       count=count, sort=sort, store=store,


### PR DESCRIPTION
Latitude and longitude are transposed in the `georadius` [method signature](https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L2109) (compare to [official Redis docs](http://redis.io/commands/georadius)). No effect on functionality, assuming users were using the order specified by the official docs, but it makes the [redis-py docs](http://redis-py-doc.readthedocs.io/en/master/#redis.StrictRedis.georadius) more clear.