### PR TITLE
set weight of sentinel nodes balancer, avoid the first sentinel node too busy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -830,12 +830,12 @@ to discover Redis nodes. You need to have at least one Sentinel daemon running
 in order to use redis-py's Sentinel support.
 
 Connecting redis-py to the Sentinel instance(s) is easy. You can use a
-Sentinel connection to discover the master and slaves network addresses:
+Sentinel connection to discover the master and slaves network addresses.Also you can set weight of each instance optionally:
 
 .. code-block:: pycon
 
     >>> from redis.sentinel import Sentinel
-    >>> sentinel = Sentinel([('localhost', 26379)], socket_timeout=0.1)
+    >>> sentinel = Sentinel([('localhost', 26379, 1), ('localhost', 26380, 2)], socket_timeout=0.1)
     >>> sentinel.discover_master('mymaster')
     ('127.0.0.1', 6379)
     >>> sentinel.discover_slaves('mymaster')

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import contextmanager
 
 
@@ -31,3 +32,14 @@ class dummy(object):
     Instances of this class can be used as an attribute container.
     """
     pass
+
+
+def random_choices(population, weights):
+    """
+    randomly by weight
+    """
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
+        from random import choices
+        return choices(population, weights, k=len(population))
+    else:
+        return population

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -76,6 +76,11 @@ def sentinel(request, cluster):
     return Sentinel([('foo', 26379), ('bar', 26379)])
 
 
+@pytest.fixture()
+def sentinel_with_weight(request, cluster):
+    return Sentinel([('foo', 26379, 1), ('bar', 26379, 2)])
+
+
 def test_discover_master(sentinel, master_ip):
     address = sentinel.discover_master('mymaster')
     assert address == (master_ip, 6379)


### PR DESCRIPTION
As the order of sentinel in queue,the first sentinel node always received more connections,so shuffle the sentinel to make balance as same as possible.
