### PR TITLE
WIP: add Lock.locked property

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -134,6 +134,10 @@ class Lock(object):
         self.local.token = None
         self.do_release(expected_token)
 
+    @property
+    def locked(self):
+        return bool(self.local.token)
+
     def do_release(self, expected_token):
         name = self.name
 


### PR DESCRIPTION
Note that `Lock` lack a common method (or property) `lock.locked`, and I think it seems pretty obvious that `Lock.local.token` can be used to implement the `locked` method, but I haven't been reading the code very carefully.

I'll add docs later if this implementation is approved.