### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
   - "3.3"
   - "2.7"
-  - "2.6"
 services:
   - redis-server
 env:

--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -162,27 +162,5 @@ else:
 
 try:  # Python 3
     from queue import LifoQueue, Empty, Full
-except ImportError:
-    from Queue import Empty, Full
-    try:  # Python 2.6 - 2.7
-        from Queue import LifoQueue
-    except ImportError:  # Python 2.5
-        from Queue import Queue
-        # From the Python 2.7 lib. Python 2.5 already extracted the core
-        # methods to aid implementating different queue organisations.
-
-        class LifoQueue(Queue):
-            "Override queue methods to implement a last-in first-out queue."
-
-            def _init(self, maxsize):
-                self.maxsize = maxsize
-                self.queue = []
-
-            def _qsize(self, len=len):
-                return len(self.queue)
-
-            def _put(self, item):
-                self.queue.append(item)
-
-            def _get(self):
-                return self.queue.pop()
+except ImportError:  # Python 2
+    from Queue import LifoQueue, Empty, Full

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -45,10 +45,8 @@ if HIREDIS_AVAILABLE:
         warnings.warn(msg)
 
     HIREDIS_USE_BYTE_BUFFER = True
-    # only use byte buffer if hiredis supports it and the Python version
-    # is >= 2.7
-    if not HIREDIS_SUPPORTS_BYTE_BUFFER or (
-            sys.version_info[0] == 2 and sys.version_info[1] < 7):
+    # only use byte buffer if hiredis supports it
+    if not HIREDIS_SUPPORTS_BYTE_BUFFER:
         HIREDIS_USE_BYTE_BUFFER = False
 
 SYM_STAR = b('*')
@@ -820,17 +818,7 @@ class ConnectionPool(object):
         """
         url_string = url
         url = urlparse(url)
-        qs = ''
-
-        # in python2.6, custom URL schemes don't recognize querystring values
-        # they're left as part of the url.path.
-        if '?' in url.path and not url.query:
-            # chop the querystring including the ? off the end of the url
-            # and reparse it.
-            qs = url.path.split('?', 1)[1]
-            url = urlparse(url_string[:-(len(qs) + 1)])
-        else:
-            qs = url.query
+        qs = url.query
 
         url_options = {}
 

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -171,10 +171,10 @@ class Sentinel(object):
         # if sentinel_kwargs isn't defined, use the socket_* options from
         # connection_kwargs
         if sentinel_kwargs is None:
-            sentinel_kwargs = dict([(k, v)
-                                    for k, v in iteritems(connection_kwargs)
-                                    if k.startswith('socket_')
-                                    ])
+            sentinel_kwargs = {k: v
+                               for k, v in iteritems(connection_kwargs)
+                               if k.startswith('socket_')
+                               }
         self.sentinel_kwargs = sentinel_kwargs
 
         self.sentinels = [StrictRedis(hostname, port, **self.sentinel_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -404,8 +404,8 @@ class TestRedisCommands(object):
 
     def test_keys(self, r):
         assert r.keys() == []
-        keys_with_underscores = set([b('test_a'), b('test_b')])
-        keys = keys_with_underscores.union(set([b('testc')]))
+        keys_with_underscores = {b('test_a'), b('test_b')}
+        keys = keys_with_underscores.union({b('testc')})
         for key in keys:
             r[key] = 1
         assert set(r.keys(pattern='test_*')) == keys_with_underscores
@@ -730,9 +730,9 @@ class TestRedisCommands(object):
         r.set('c', 3)
         cursor, keys = r.scan()
         assert cursor == 0
-        assert set(keys) == set([b('a'), b('b'), b('c')])
+        assert set(keys) == {b('a'), b('b'), b('c')}
         _, keys = r.scan(match='a')
-        assert set(keys) == set([b('a')])
+        assert set(keys) == {b('a')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_scan_iter(self, r):
@@ -740,26 +740,26 @@ class TestRedisCommands(object):
         r.set('b', 2)
         r.set('c', 3)
         keys = list(r.scan_iter())
-        assert set(keys) == set([b('a'), b('b'), b('c')])
+        assert set(keys) == {b('a'), b('b'), b('c')}
         keys = list(r.scan_iter(match='a'))
-        assert set(keys) == set([b('a')])
+        assert set(keys) == {b('a')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_sscan(self, r):
         r.sadd('a', 1, 2, 3)
         cursor, members = r.sscan('a')
         assert cursor == 0
-        assert set(members) == set([b('1'), b('2'), b('3')])
+        assert set(members) == {b('1'), b('2'), b('3')}
         _, members = r.sscan('a', match=b('1'))
-        assert set(members) == set([b('1')])
+        assert set(members) == {b('1')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_sscan_iter(self, r):
         r.sadd('a', 1, 2, 3)
         members = list(r.sscan_iter('a'))
-        assert set(members) == set([b('1'), b('2'), b('3')])
+        assert set(members) == {b('1'), b('2'), b('3')}
         members = list(r.sscan_iter('a', match=b('1')))
-        assert set(members) == set([b('1')])
+        assert set(members) == {b('1')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_hscan(self, r):
@@ -783,21 +783,21 @@ class TestRedisCommands(object):
         r.zadd('a', 'a', 1, 'b', 2, 'c', 3)
         cursor, pairs = r.zscan('a')
         assert cursor == 0
-        assert set(pairs) == set([(b('a'), 1), (b('b'), 2), (b('c'), 3)])
+        assert set(pairs) == {(b('a'), 1), (b('b'), 2), (b('c'), 3)}
         _, pairs = r.zscan('a', match='a')
-        assert set(pairs) == set([(b('a'), 1)])
+        assert set(pairs) == {(b('a'), 1)}
 
     @skip_if_server_version_lt('2.8.0')
     def test_zscan_iter(self, r):
         r.zadd('a', 'a', 1, 'b', 2, 'c', 3)
         pairs = list(r.zscan_iter('a'))
-        assert set(pairs) == set([(b('a'), 1), (b('b'), 2), (b('c'), 3)])
+        assert set(pairs) == {(b('a'), 1), (b('b'), 2), (b('c'), 3)}
         pairs = list(r.zscan_iter('a', match='a'))
-        assert set(pairs) == set([(b('a'), 1)])
+        assert set(pairs) == {(b('a'), 1)}
 
     # SET COMMANDS
     def test_sadd(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = {b('1'), b('2'), b('3')}
         r.sadd('a', *members)
         assert r.smembers('a') == members
 
@@ -807,23 +807,23 @@ class TestRedisCommands(object):
 
     def test_sdiff(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.sdiff('a', 'b') == set([b('1'), b('2'), b('3')])
+        assert r.sdiff('a', 'b') == {b('1'), b('2'), b('3')}
         r.sadd('b', '2', '3')
-        assert r.sdiff('a', 'b') == set([b('1')])
+        assert r.sdiff('a', 'b') == {b('1')}
 
     def test_sdiffstore(self, r):
         r.sadd('a', '1', '2', '3')
         assert r.sdiffstore('c', 'a', 'b') == 3
-        assert r.smembers('c') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('c') == {b('1'), b('2'), b('3')}
         r.sadd('b', '2', '3')
         assert r.sdiffstore('c', 'a', 'b') == 1
-        assert r.smembers('c') == set([b('1')])
+        assert r.smembers('c') == {b('1')}
 
     def test_sinter(self, r):
         r.sadd('a', '1', '2', '3')
         assert r.sinter('a', 'b') == set()
         r.sadd('b', '2', '3')
-        assert r.sinter('a', 'b') == set([b('2'), b('3')])
+        assert r.sinter('a', 'b') == {b('2'), b('3')}
 
     def test_sinterstore(self, r):
         r.sadd('a', '1', '2', '3')
@@ -831,7 +831,7 @@ class TestRedisCommands(object):
         assert r.smembers('c') == set()
         r.sadd('b', '2', '3')
         assert r.sinterstore('c', 'a', 'b') == 2
-        assert r.smembers('c') == set([b('2'), b('3')])
+        assert r.smembers('c') == {b('2'), b('3')}
 
     def test_sismember(self, r):
         r.sadd('a', '1', '2', '3')
@@ -842,21 +842,21 @@ class TestRedisCommands(object):
 
     def test_smembers(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.smembers('a') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('a') == {b('1'), b('2'), b('3')}
 
     def test_smove(self, r):
         r.sadd('a', 'a1', 'a2')
         r.sadd('b', 'b1', 'b2')
         assert r.smove('a', 'b', 'a1')
-        assert r.smembers('a') == set([b('a2')])
-        assert r.smembers('b') == set([b('b1'), b('b2'), b('a1')])
+        assert r.smembers('a') == {b('a2')}
+        assert r.smembers('b') == {b('b1'), b('b2'), b('a1')}
 
     def test_spop(self, r):
         s = [b('1'), b('2'), b('3')]
         r.sadd('a', *s)
         value = r.spop('a')
         assert value in s
-        assert r.smembers('a') == set(s) - set([value])
+        assert r.smembers('a') == set(s) - {value}
 
     def test_srandmember(self, r):
         s = [b('1'), b('2'), b('3')]
@@ -875,18 +875,18 @@ class TestRedisCommands(object):
         r.sadd('a', '1', '2', '3', '4')
         assert r.srem('a', '5') == 0
         assert r.srem('a', '2', '4') == 2
-        assert r.smembers('a') == set([b('1'), b('3')])
+        assert r.smembers('a') == {b('1'), b('3')}
 
     def test_sunion(self, r):
         r.sadd('a', '1', '2')
         r.sadd('b', '2', '3')
-        assert r.sunion('a', 'b') == set([b('1'), b('2'), b('3')])
+        assert r.sunion('a', 'b') == {b('1'), b('2'), b('3')}
 
     def test_sunionstore(self, r):
         r.sadd('a', '1', '2')
         r.sadd('b', '2', '3')
         assert r.sunionstore('c', 'a', 'b') == 3
-        assert r.smembers('c') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('c') == {b('1'), b('2'), b('3')}
 
     # SORTED SET COMMANDS
     def test_zadd(self, r):
@@ -1121,26 +1121,26 @@ class TestRedisCommands(object):
     # HYPERLOGLOG TESTS
     @skip_if_server_version_lt('2.8.9')
     def test_pfadd(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = {b('1'), b('2'), b('3')}
         assert r.pfadd('a', *members) == 1
         assert r.pfadd('a', *members) == 0
         assert r.pfcount('a') == len(members)
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfcount(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = {b('1'), b('2'), b('3')}
         r.pfadd('a', *members)
         assert r.pfcount('a') == len(members)
-        members_b = set([b('2'), b('3'), b('4')])
+        members_b = {b('2'), b('3'), b('4')}
         r.pfadd('b', *members_b)
         assert r.pfcount('b') == len(members_b)
         assert r.pfcount('a', 'b') == len(members_b.union(members))
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfmerge(self, r):
-        mema = set([b('1'), b('2'), b('3')])
-        memb = set([b('2'), b('3'), b('4')])
-        memc = set([b('5'), b('6'), b('7')])
+        mema = {b('1'), b('2'), b('3')}
+        memb = {b('2'), b('3'), b('4')}
+        memc = {b('5'), b('6'), b('7')}
         r.pfadd('a', *mema)
         r.pfadd('b', *memb)
         r.pfadd('c', *memc)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27,py32,py33,py34,py35}-{plain,hiredis}, pep8
+envlist = {py27,py32,py33,py34,py35}-{plain,hiredis}, pep8
 
 [testenv]
 deps =
@@ -10,7 +10,7 @@ deps =
 commands = py.test {posargs}
 
 [testenv:pep8]
-basepython = python2.6
+basepython = python2.7
 deps = pep8
 commands = pep8
 skipsdist = true


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
