### PR TITLE
Support for Redis Modules

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2208,12 +2208,24 @@ class StrictRedis(object):
 
     # MODULE COMMANDS
     def module_load(self, path):
+        """
+        Loads the module from ``path``.
+        Raises ``ModuleError`` if a module is not found at ``path``.
+        """
         return self.execute_command('MODULE LOAD', path)
 
     def module_unload(self, module_name):
+        """
+        Unloads the module ``module_name``.
+        Raises ``ModuleError`` if ``module_name`` is not in loaded modules.
+        """
         return self.execute_command('MODULE UNLOAD', module_name)
 
     def module_list(self):
+        """
+        Returns a list of dictionaries containing the name and version of
+        all loaded modules.
+        """
         return self.execute_command('MODULE LIST')
 
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -2214,12 +2214,12 @@ class StrictRedis(object):
         """
         return self.execute_command('MODULE LOAD', path)
 
-    def module_unload(self, module_name):
+    def module_unload(self, name):
         """
-        Unloads the module ``module_name``.
-        Raises ``ModuleError`` if ``module_name`` is not in loaded modules.
+        Unloads the module ``name``.
+        Raises ``ModuleError`` if ``name`` is not in loaded modules.
         """
-        return self.execute_command('MODULE UNLOAD', module_name)
+        return self.execute_command('MODULE UNLOAD', name)
 
     def module_list(self):
         """

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -58,7 +58,15 @@ SYM_CRLF = b('\r\n')
 SYM_EMPTY = b('')
 
 SERVER_CLOSED_CONNECTION_ERROR = "Connection closed by server."
-
+MAX_CLIENTS_REACHED_ERROR = 'max number of clients reached'
+MODULE_LOAD_ERROR = 'Error loading the extension. ' \
+                    'Please check the server logs.'
+NO_SUCH_MODULE_ERROR = 'Error unloading module: no such module with that name'
+MODULE_UNLOAD_NOT_POSSIBLE_ERROR = 'Error unloading module: operation not ' \
+                                   'possible.'
+MODULE_EXPORTS_DATA_TYPES_ERROR = "Error unloading module: the module " \
+                                  "exports one or more module-side data " \
+                                  "types, can't unload"
 
 class Token(object):
     """
@@ -96,20 +104,13 @@ class Token(object):
 
 
 class BaseParser(object):
-    module_load_err = 'Error loading the extension. ' \
-                      'Please check the server logs.'
-    no_such_module_err = 'Error unloading module: ' \
-                         'no such module with that name'
-    cant_unload_module_err = "Error unloading module: the module exports one" \
-                             " or more module-side data types, can't unload"
-
     EXCEPTION_CLASSES = {
         'ERR': {
-            'max number of clients reached': ConnectionError,
-            module_load_err: ModuleError,
-            no_such_module_err: ModuleError,
-            cant_unload_module_err: ModuleError,
-            'Error unloading module: operation not possible.': ModuleError
+            MAX_CLIENTS_REACHED_ERROR: ConnectionError,
+            MODULE_LOAD_ERROR: ModuleError,
+            MODULE_EXPORTS_DATA_TYPES_ERROR: ModuleError,
+            NO_SUCH_MODULE_ERROR: ModuleError,
+            MODULE_UNLOAD_NOT_POSSIBLE_ERROR: ModuleError
         },
         'EXECABORT': ExecAbortError,
         'LOADING': BusyLoadingError,

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -27,7 +27,8 @@ from redis.exceptions import (
     AuthenticationError,
     NoScriptError,
     ExecAbortError,
-    ReadOnlyError
+    ReadOnlyError,
+    ModuleError
 )
 from redis.utils import HIREDIS_AVAILABLE
 if HIREDIS_AVAILABLE:
@@ -95,9 +96,20 @@ class Token(object):
 
 
 class BaseParser(object):
+    module_load_err = 'Error loading the extension. ' \
+                      'Please check the server logs.'
+    no_such_module_err = 'Error unloading module: ' \
+                         'no such module with that name'
+    cant_unload_module_err = "Error unloading module: the module exports one" \
+                             " or more module-side data types, can't unload"
+
     EXCEPTION_CLASSES = {
         'ERR': {
-            'max number of clients reached': ConnectionError
+            'max number of clients reached': ConnectionError,
+            module_load_err: ModuleError,
+            no_such_module_err: ModuleError,
+            cant_unload_module_err: ModuleError,
+            'Error unloading module: operation not possible.': ModuleError
         },
         'EXECABORT': ExecAbortError,
         'LOADING': BusyLoadingError,

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -64,6 +64,10 @@ class ReadOnlyError(ResponseError):
     pass
 
 
+class ModuleError(RedisError):
+    pass
+
+
 class LockError(RedisError, ValueError):
     "Errors acquiring or releasing a lock"
     # NOTE: For backwards compatability, this class derives from ValueError.


### PR DESCRIPTION
I know this is early since modules are not in a stable release yet, but I felt this might be a good time to get some feedback. 

**Changes:**
* Support for `MODULE LOAD`, `MODULE UNLOAD` and `MODULE LIST` commands through `redis.StrictRedis.module_load`, `redis.StrictRedis.module_unload` and `redis.StrictRedis.module_list` methods respectively.
* Throws `ModuleError` exception on errors while loading or unloading modules.

Tested on antirez/redis 4.0 branch

    import redis
    r = redis.StrictRedis()

    r.module_load('../password/password.so')
    r.module_load('../topk/src/topk.so')

    l = r.module_list()
    print(l)  # => [{b'name': b'TOPK', b'ver': 1}, {b'name': b'password', b'ver': 1}]

    r.module_unload('topk')

    l = r.module_list()
    print(l)  # => [{b'name': b'password', b'ver': 1}]
    

To execute module commands, `execute_command` can be used. It returns the parsed response or throws `redis.exceptions.ResponseError` on error.

    print(r.execute_command('PASSWORD.SET', 'key', 'value'))  # => b'OK'
    print(r.execute_command('PASSWORD.CHECK', 'key', 'value'))  # => 1
    print(r.execute_command('PASSWORD.CHECK', 'key', 'walue'))  # => 0
    print(r.execute_command('PASSWORD.CHECK', 'key'))  # => redis.exceptions.ResponseError: wrong number of arguments for 'PASSWORD.CHECK' command
    # Error prefix: ERR

Also, how should I write test cases for this? I've tested manually using [topk](http://redismodules.com/modules/topk/) and [password](http://redismodules.com/modules/password/) modules built from their Github master branch.