### PR TITLE
add support for spop count argument in redis 3.2

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1627,9 +1627,9 @@ class StrictRedis(object):
         "Move ``value`` from set ``src`` to set ``dst`` atomically"
         return self.execute_command('SMOVE', src, dst, value)
 
-    def spop(self, name):
-        "Remove and return a random member of set ``name``"
-        return self.execute_command('SPOP', name)
+    def spop(self, name,count=1):
+        "Remove and return one or more random member of set ``name``"
+        return self.execute_command('SPOP', name, count)
 
     def srandmember(self, name, number=None):
         """


### PR DESCRIPTION
note:
SPOP key [count]
Removes and returns one or more random elements from the set value store
at key.
This operation is similar to SRANDMEMBER, that returns one or more random
elements from a set but does not remove it.
The count argument is available since version 3.2.