### PR TITLE
Implement PUBSUB * commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -519,6 +519,22 @@ cannot be delivered. When you're finished with a PubSub object, call its
     >>> ...
     >>> p.close()
 
+
+The PUBSUB set of subcommands CHANNELS, NUMSUB and NUMPAT are also
+supported:
+
+.. code-block:: pycon
+
+    >>> r.pubsub_channels()
+    ['foo', 'bar']
+    >>> r.pubsub_numsub('foo', 'bar')
+    [('foo', 9001), ('bar', 42)]
+    >>> r.pubsub_numsub('baz')
+    [('baz', 0)]
+    >>> r.pubsub_numpat()
+    1204
+
+
 LUA Scripting
 ^^^^^^^^^^^^^
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -2019,7 +2019,7 @@ class StrictRedis(object):
 
     def pubsub_channels(self):
         """
-        Return a list of channels
+        Return a list of channels that have at least one subscriber
         """
         return self.execute_command('PUBSUB CHANNELS')
 
@@ -2031,7 +2031,7 @@ class StrictRedis(object):
 
     def pubsub_numsub(self, *args):
         """
-        Return a list of the number of subscribers for each channel given in ``*args``
+        Return a list of (channel, number of subscribers) tuples for each channel given in ``*args``
         """
         return self.execute_command('PUBSUB NUMSUB', *args)
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -2031,7 +2031,8 @@ class StrictRedis(object):
 
     def pubsub_numsub(self, *args):
         """
-        Return a list of (channel, number of subscribers) tuples for each channel given in ``*args``
+        Return a list of (channel, number of subscribers) tuples
+        for each channel given in ``*args``
         """
         return self.execute_command('PUBSUB NUMSUB', *args)
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -339,6 +339,10 @@ def parse_georadius_generic(response, **options):
     ]
 
 
+def parse_pubsub_numsub(response, **options):
+    return list(zip(response[0::2], response[1::2]))
+
+
 class StrictRedis(object):
     """
     Implementation of the Redis protocol.
@@ -447,6 +451,7 @@ class StrictRedis(object):
             'GEOHASH': lambda r: list(map(nativestr, r)),
             'GEORADIUS': parse_georadius_generic,
             'GEORADIUSBYMEMBER': parse_georadius_generic,
+            'PUBSUB NUMSUB': parse_pubsub_numsub,
         }
     )
 
@@ -2011,6 +2016,24 @@ class StrictRedis(object):
         Returns the number of subscribers the message was delivered to.
         """
         return self.execute_command('PUBLISH', channel, message)
+
+    def pubsub_channels(self):
+        """
+        Return a list of channels
+        """
+        return self.execute_command('PUBSUB CHANNELS')
+
+    def pubsub_numpat(self):
+        """
+        Returns the number of subscriptions to patterns
+        """
+        return self.execute_command('PUBSUB NUMPAT')
+
+    def pubsub_numsub(self, *args):
+        """
+        Return a list of the number of subscribers for each channel given in ``*args``
+        """
+        return self.execute_command('PUBSUB NUMSUB', *args)
 
     def cluster(self, cluster_arg, *args):
         return self.execute_command('CLUSTER %s' % cluster_arg.upper(), *args)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -423,4 +423,3 @@ class TestPubSubPubSubSubcommands(object):
         p = r.pubsub(ignore_subscribe_messages=True)
         p.psubscribe('*oo', '*ar', 'b*z')
         assert r.pubsub_numpat() == 3
-

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -4,7 +4,7 @@ import time
 
 import redis
 from redis.exceptions import ConnectionError
-from redis._compat import basestring, u, unichr
+from redis._compat import basestring, u, unichr, b
 
 from .conftest import r as _redis_client
 
@@ -398,3 +398,29 @@ class TestPubSubRedisDown(object):
         p = r.pubsub()
         with pytest.raises(ConnectionError):
             p.subscribe('foo')
+
+
+class TestPubSubPubSubSubcommands(object):
+
+    def test_pubsub_channels(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        p.subscribe('foo', 'bar', 'baz', 'quux')
+        channels = sorted(r.pubsub_channels())
+        assert channels == [b('bar'), b('baz'), b('foo'), b('quux')]
+
+    def test_pubsub_numsub(self, r):
+        p1 = r.pubsub(ignore_subscribe_messages=True)
+        p1.subscribe('foo', 'bar', 'baz')
+        p2 = r.pubsub(ignore_subscribe_messages=True)
+        p2.subscribe('bar', 'baz')
+        p3 = r.pubsub(ignore_subscribe_messages=True)
+        p3.subscribe('baz')
+
+        channels = [(b('foo'), 1), (b('bar'), 2), (b('baz'), 3)]
+        assert channels == r.pubsub_numsub('foo', 'bar', 'baz')
+
+    def test_pubsub_numpat(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        p.psubscribe('*oo', '*ar', 'b*z')
+        assert r.pubsub_numpat() == 3
+

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -7,6 +7,7 @@ from redis.exceptions import ConnectionError
 from redis._compat import basestring, u, unichr, b
 
 from .conftest import r as _redis_client
+from .conftest import skip_if_server_version_lt
 
 
 def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
@@ -402,12 +403,14 @@ class TestPubSubRedisDown(object):
 
 class TestPubSubPubSubSubcommands(object):
 
+    @skip_if_server_version_lt('2.8.0')
     def test_pubsub_channels(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         p.subscribe('foo', 'bar', 'baz', 'quux')
         channels = sorted(r.pubsub_channels())
         assert channels == [b('bar'), b('baz'), b('foo'), b('quux')]
 
+    @skip_if_server_version_lt('2.8.0')
     def test_pubsub_numsub(self, r):
         p1 = r.pubsub(ignore_subscribe_messages=True)
         p1.subscribe('foo', 'bar', 'baz')
@@ -419,6 +422,7 @@ class TestPubSubPubSubSubcommands(object):
         channels = [(b('foo'), 1), (b('bar'), 2), (b('baz'), 3)]
         assert channels == r.pubsub_numsub('foo', 'bar', 'baz')
 
+    @skip_if_server_version_lt('2.8.0')
     def test_pubsub_numpat(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         p.psubscribe('*oo', '*ar', 'b*z')


### PR DESCRIPTION
PUBSUB CHANNELS, PUBSUB NUMSUB and PUBSUB NUMPAT are implemented as per https://redis.io/commands/pubsub and suggested in Issue #526.