### PR TITLE
BlockingConnectionPool generation

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,5 @@
 from __future__ import with_statement
+from copy import copy
 from distutils.version import StrictVersion
 from itertools import chain
 from select import select
@@ -393,7 +394,8 @@ class Connection(object):
                  socket_keepalive=False, socket_keepalive_options=None,
                  retry_on_timeout=False, encoding='utf-8',
                  encoding_errors='strict', decode_responses=False,
-                 parser_class=DefaultParser, socket_read_size=65536):
+                 parser_class=DefaultParser, socket_read_size=65536,
+                 **kwargs):
         self.pid = os.getpid()
         self.host = host
         self.port = int(port)
@@ -415,6 +417,14 @@ class Connection(object):
             'db': self.db,
         }
         self._connect_callbacks = []
+
+        # If the connection isn't used in a process that forks, there are
+        # certain optimizations we can make. Default assumes that we have to
+        # be safe for process forks.
+        self.fork_safe = kwargs.get('fork_safe', True)
+
+        # Connection pool generation id
+        self.pool_generation = 0
 
     def __repr__(self):
         return self.description_format % self._description_args
@@ -526,7 +536,14 @@ class Connection(object):
         if self._sock is None:
             return
         try:
-            self._sock.shutdown(socket.SHUT_RDWR)
+            # socket.shutdown() kills the underlying TCP connection
+            # immediately. Good when you can do it, but it ignores
+            # the ref count on the descriptor. If the process forked
+            # and the child inherited the socket, it's not safe to
+            # call .shutdown(). Just close() the socket and let the OS
+            # close the connection when appropriate.
+            if not self.fork_safe:
+                self._sock.shutdown(socket.SHUT_RDWR)
             self._sock.close()
         except socket.error:
             pass
@@ -697,7 +714,8 @@ class UnixDomainSocketConnection(Connection):
                  socket_timeout=None, encoding='utf-8',
                  encoding_errors='strict', decode_responses=False,
                  retry_on_timeout=False,
-                 parser_class=DefaultParser, socket_read_size=65536):
+                 parser_class=DefaultParser, socket_read_size=65536,
+                 **kwargs):
         self.pid = os.getpid()
         self.path = path
         self.db = db
@@ -714,6 +732,14 @@ class UnixDomainSocketConnection(Connection):
             'db': self.db,
         }
         self._connect_callbacks = []
+
+        # If the connection isn't used in a process that forks, there are
+        # certain optimizations we can make. Default assumes that we have to
+        # be safe for process forks.
+        self.fork_safe = kwargs.get('fork_safe', True)
+
+        # Connection pool generation id
+        self.pool_generation = 0
 
     def _connect(self):
         "Create a Unix domain socket connection"
@@ -862,6 +888,9 @@ class ConnectionPool(object):
         self.connection_class = connection_class
         self.connection_kwargs = connection_kwargs
         self.max_connections = max_connections
+        self.fork_safe = connection_kwargs.get('fork_safe', True)
+
+        self.generation = 0
 
         self.reset()
 
@@ -879,20 +908,28 @@ class ConnectionPool(object):
         self._check_lock = threading.Lock()
 
     def _checkpid(self):
-        if self.pid != os.getpid():
-            with self._check_lock:
-                if self.pid == os.getpid():
-                    # another thread already did the work while we waited
-                    # on the lock.
-                    return
-                self.disconnect()
-                self.reset()
+        # No need to check PID if process isn't supposed to fork
+        if self.fork_safe:
+            if self.pid != os.getpid():
+                with self._check_lock:
+                    if self.pid == os.getpid():
+                        # another thread already did the work while we waited
+                        # on the lock.
+                        return
+                    self.disconnect()
+                    self.reset()
 
     def get_connection(self, command_name, *keys, **options):
         "Get a connection from the pool"
         self._checkpid()
         try:
             connection = self._available_connections.pop()
+            if connection.pool_generation != self.generation:
+                # generation counter mismatch: let this connection go and
+                # create a new one
+                connection.disconnect()
+                self._created_connections -= 1
+                connection = self.make_connection()
         except IndexError:
             connection = self.make_connection()
         self._in_use_connections.add(connection)
@@ -902,8 +939,11 @@ class ConnectionPool(object):
         "Create a new connection"
         if self._created_connections >= self.max_connections:
             raise ConnectionError("Too many connections")
+
+        new_connection = self.connection_class(**self.connection_kwargs)
+        new_connection.pool_generation = self.generation
         self._created_connections += 1
-        return self.connection_class(**self.connection_kwargs)
+        return new_connection
 
     def release(self, connection):
         "Releases the connection back to the pool"
@@ -911,14 +951,33 @@ class ConnectionPool(object):
         if connection.pid != self.pid:
             return
         self._in_use_connections.remove(connection)
-        self._available_connections.append(connection)
 
-    def disconnect(self):
-        "Disconnects all connections in the pool"
-        all_conns = chain(self._available_connections,
-                          self._in_use_connections)
-        for connection in all_conns:
+        # Verify generation id before putting connection back in the free list
+        if connection.pool_generation == self.generation:
+            self._available_connections.append(connection)
+        else:
+            # generation id mismatch, kill the connection
             connection.disconnect()
+            self._created_connections -= 1
+
+    def disconnect(self, immediate=False):
+        """
+        Disconnects all connections in the pool
+
+        By default, the disconnect happens over time as connections
+        cycle into and out of the pool. This avoids the problem of ripping
+        connections out from under threads that are using them.
+
+        If `immediate` is True, then we forcibly disconnect all connections
+        and leave it to the owner of the connection to deal with the various
+        errors that can occur. This option is not recommended.
+        """
+        self.generation += 1
+        if immediate:
+            all_conns = chain(copy(self._available_connections),
+                              copy(self._in_use_connections))
+            for connection in all_conns:
+                connection.disconnect()
 
 
 class BlockingConnectionPool(ConnectionPool):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def _get_client(cls, request=None, **kwargs):
     if request:
         def teardown():
             client.flushdb()
-            client.connection_pool.disconnect()
+            client.connection_pool.disconnect(immediate=True)
         request.addfinalizer(teardown)
     return client
 


### PR DESCRIPTION
This PR adds generational support for the `BlockingConnectionPool`, continuing the work in: 

https://github.com/andymccurdy/redis-py/issues/732 