### PR TITLE
[sentinel] update master address if it changes.

### DIFF
--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -104,6 +104,7 @@ class SentinelConnectionPool(ConnectionPool):
                 self.master_address = master_address
             elif master_address != self.master_address:
                 # Master address changed, disconnect all clients in this pool
+                self.master_address = master_address
                 self.disconnect()
         return master_address
 


### PR DESCRIPTION
Otherwise we'll end up spamming the connection pool because each time the master is discovered, it'll trigger the disconnect of the pool - as `self.master_address` never gets updated.