### PR TITLE
fixed can't raise invalid expire time when set ex param is 0

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1150,7 +1150,7 @@ class StrictRedis(object):
             already exists.
         """
         pieces = [name, value]
-        if ex:
+        if ex is not None:
             pieces.append('EX')
             if isinstance(ex, datetime.timedelta):
                 ex = ex.seconds + ex.days * 24 * 3600

--- a/redis/client.py
+++ b/redis/client.py
@@ -1155,7 +1155,7 @@ class StrictRedis(object):
             if isinstance(ex, datetime.timedelta):
                 ex = ex.seconds + ex.days * 24 * 3600
             pieces.append(ex)
-        if px:
+        if px is not None:
             pieces.append('PX')
             if isinstance(px, datetime.timedelta):
                 ms = int(px.microseconds / 1000)


### PR DESCRIPTION
redis-cli
`set  py python ex 0` will raise invalid expire time in set 
but
redis-py call set function
`set('py', "python",  ex=0)` can't raise invalid expire time in set,  lead to persist the key 

I think this redis-py bug. 