### PR TITLE
add support for command `ROLE`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 redis.egg-info
 build/
 dist/
+.idea/
 dump.rdb
 /.tox
 _build

--- a/redis/client.py
+++ b/redis/client.py
@@ -885,10 +885,11 @@ class StrictRedis(object):
 
     def role(self):
         """
-        Provide information on the role of a Redis instance in the context of replication,
-        by returning if the instance is currently a master, slave, or sentinel.
-        The command also returns additional information about the state of the replication
-        (if the role is master or slave)
+        Provide information on the role of a Redis instance in the
+        context of replication, by returning if the instance is
+        currently a master, slave, or sentinel.
+        The command also returns additional information about
+        the state of the replication(if the role is master or slave)
         or the list of monitored master names (if the role is sentinel).
         :return:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,3 +111,9 @@ def mock_cluster_resp_slaves(request, **kwargs):
                 "slave 19efe5a631f3296fdf21a5441680f893e8cc96ec 0 "
                 "1447836789290 3 connected']")
     return _gen_cluster_mock_resp(r, response)
+
+@pytest.fixture()
+def mock_resp_role(**kwargs):
+    r = _get_client(redis.Redis, **kwargs)
+    response = [b'master', 169, [[b'172.17.0.2', b'7004', b'169']]]
+    return _gen_cluster_mock_resp(r, response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from mock import Mock
 
 from distutils.version import StrictVersion
 
-
 _REDIS_VERSIONS = {}
 
 
@@ -28,6 +27,7 @@ def _get_client(cls, request=None, **kwargs):
         def teardown():
             client.flushdb()
             client.connection_pool.disconnect()
+
         request.addfinalizer(teardown)
     return client
 
@@ -111,6 +111,7 @@ def mock_cluster_resp_slaves(request, **kwargs):
                 "slave 19efe5a631f3296fdf21a5441680f893e8cc96ec 0 "
                 "1447836789290 3 connected']")
     return _gen_cluster_mock_resp(r, response)
+
 
 @pytest.fixture()
 def mock_resp_role(**kwargs):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -118,6 +118,14 @@ class TestRedisCommands(object):
     def test_ping(self, r):
         assert r.ping()
 
+    @skip_if_server_version_lt('2.8.12')
+    def test_role_master(self, mock_resp_role):
+        role = mock_resp_role.role()
+        assert isinstance(role, dict)
+        assert role['role'] == 'master'
+        slave_offset = role['slaves'][0]['offset']
+        assert slave_offset == role['offset']
+
     def test_slowlog_get(self, r, slowlog):
         assert r.slowlog_reset()
         unicode_string = unichr(3456) + u('abcd') + unichr(3421)


### PR DESCRIPTION
I add support for command [role](https://redis.io/commands/role) in my async redis client(most code of which is from redis-py) and notice that the command is not supported yet in redis-py, so i make this pr to help.

Do you think it is necessary to catch KeyError caused by unknown role type?

Hope that be helpful~