### PR TITLE
Precalculate sha1 on Script initialization

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2927,7 +2927,10 @@ class Script(object):
     def __init__(self, registered_client, script):
         self.registered_client = registered_client
         self.script = script
-        self.sha = hashlib.sha1(script.encode('utf-8')).hexdigest()
+        # Precalculate and store the SHA1 hex digest of the script.
+        # Encode the digest because it should match the return type of script_load, which
+        # in Python 3 is bytes.
+        self.sha = hashlib.sha1(script.encode('utf-8')).hexdigest().encode('utf-8')
 
     def __call__(self, keys=[], args=[], client=None):
         "Execute the script, passing any required ``args``"

--- a/redis/client.py
+++ b/redis/client.py
@@ -2849,12 +2849,11 @@ class BasePipeline(object):
         shas = [s.sha for s in scripts]
         # we can't use the normal script_* methods because they would just
         # get buffered in the pipeline.
-        exists = immediate('SCRIPT', 'EXISTS', *shas, **{'parse': 'EXISTS'})
+        exists = immediate('SCRIPT EXISTS', *shas)
         if not all(exists):
             for s, exist in izip(scripts, exists):
                 if not exist:
-                    s.sha = immediate('SCRIPT', 'LOAD', s.script,
-                                      **{'parse': 'LOAD'})
+                    s.sha = immediate('SCRIPT LOAD', s.script)
 
     def execute(self, raise_on_error=True):
         "Execute all the commands in the current pipeline"
@@ -2924,9 +2923,7 @@ class Script(object):
         self.registered_client = registered_client
         self.script = script
         # Precalculate and store the SHA1 hex digest of the script.
-        # Encode the digest because it should match the return type of script_load, which
-        # in Python 3 is bytes.
-        self.sha = hashlib.sha1(script.encode('utf-8')).hexdigest().encode('utf-8')
+        self.sha = hashlib.sha1(b(script)).hexdigest()
 
     def __call__(self, keys=[], args=[], client=None):
         "Execute the script, passing any required ``args``"

--- a/redis/client.py
+++ b/redis/client.py
@@ -6,6 +6,7 @@ import warnings
 import time
 import threading
 import time as mod_time
+import hashlib
 from redis._compat import (b, basestring, bytes, imap, iteritems, iterkeys,
                            itervalues, izip, long, nativestr, unicode,
                            safe_unicode)
@@ -2932,7 +2933,7 @@ class Script(object):
     def __init__(self, registered_client, script):
         self.registered_client = registered_client
         self.script = script
-        self.sha = ''
+        self.sha = hashlib.sha1(script).hexdigest()
 
     def __call__(self, keys=[], args=[], client=None):
         "Execute the script, passing any required ``args``"

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -57,44 +57,49 @@ class TestScripting(object):
     def test_script_object(self, r):
         r.set('a', 2)
         multiply = r.register_script(multiply_script)
-        assert not multiply.sha
-        # test evalsha fail -> script load + retry
+        precalculated_sha = multiply.sha
+        assert precalculated_sha
+        assert r.script_exists(multiply.sha) == [False]
+        # Test second evalsha block (after NoScriptError)
         assert multiply(keys=['a'], args=[3]) == 6
-        assert multiply.sha
+        # At this point, the script should be loaded
         assert r.script_exists(multiply.sha) == [True]
-        # test first evalsha
+        # Test that the precalculated sha matches the one from redis
+        assert multiply.sha == precalculated_sha
+        # Test first evalsha block
         assert multiply(keys=['a'], args=[3]) == 6
 
     def test_script_object_in_pipeline(self, r):
         multiply = r.register_script(multiply_script)
-        assert not multiply.sha
+        precalculated_sha = multiply.sha
+        assert precalculated_sha
         pipe = r.pipeline()
         pipe.set('a', 2)
         pipe.get('a')
-        multiply(keys=['a'], args=[3], client=pipe)
-        # even though the pipeline wasn't executed yet, we made sure the
-        # script was loaded and got a valid sha
-        assert multiply.sha
-        assert r.script_exists(multiply.sha) == [True]
-        # [SET worked, GET 'a', result of multiple script]
-        assert pipe.execute() == [True, b('2'), 6]
-
-        # purge the script from redis's cache and re-run the pipeline
-        # the multiply script object knows it's sha, so it shouldn't get
-        # reloaded until pipe.execute()
-        r.script_flush()
-        pipe = r.pipeline()
-        pipe.set('a', 2)
-        pipe.get('a')
-        assert multiply.sha
         multiply(keys=['a'], args=[3], client=pipe)
         assert r.script_exists(multiply.sha) == [False]
         # [SET worked, GET 'a', result of multiple script]
         assert pipe.execute() == [True, b('2'), 6]
+        # The script should have been loaded by pipe.execute()
+        assert r.script_exists(multiply.sha) == [True]
+        # The precalculated sha should have been the correct one
+        assert multiply.sha == precalculated_sha
+
+        # purge the script from redis's cache and re-run the pipeline
+        # the multiply script should be reloaded by pipe.execute()
+        r.script_flush()
+        pipe = r.pipeline()
+        pipe.set('a', 2)
+        pipe.get('a')
+        multiply(keys=['a'], args=[3], client=pipe)
+        assert r.script_exists(multiply.sha) == [False]
+        # [SET worked, GET 'a', result of multiple script]
+        assert pipe.execute() == [True, b('2'), 6]
+        assert r.script_exists(multiply.sha) == [True]
 
     def test_eval_msgpack_pipeline_error_in_lua(self, r):
         msgpack_hello = r.register_script(msgpack_hello_script)
-        assert not msgpack_hello.sha
+        assert msgpack_hello.sha
 
         pipe = r.pipeline()
 

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -109,8 +109,9 @@ class TestScripting(object):
 
         msgpack_hello(args=[msgpack_message_1], client=pipe)
 
-        assert r.script_exists(msgpack_hello.sha) == [True]
+        assert r.script_exists(msgpack_hello.sha) == [False]
         assert pipe.execute()[0] == b'hello Joe'
+        assert r.script_exists(msgpack_hello.sha) == [True]
 
         msgpack_hello_broken = r.register_script(msgpack_hello_script_broken)
 


### PR DESCRIPTION
Currently, `Script` instances initializes their `sha` attribute to the empty string, which means that the first time a `Script` is called, it will attempt to `EVALSHA` the empty string. This is guaranteed to fail, and results in unnecessary round-trips to the server. We were seeing a lot of useless network traffic in our deployment because of this. The workaround is to manually set the `sha` attribute after initializing each `Script`, but this is not a very clean solution.

This change makes `Script` precalculate the SHA1 of of the script string, so that in the case where it is called on a connection to a server where the script is already registered, it saves itself an `EVALSHA` call and a `SCRIPT LOAD` call.

It also modifies the way `Script` interacts with `BasePipeline`. Previously, the `Script` would call `script_load_for_pipeline` prior to executing, which would call `SCRIPT LOAD` if the `Script.sha` was empty. That condition will never be `True` anymore, plus it is unnecessary because the pipeline calls `load_scripts` during `execute`. I removed that method and made `Script` directly add itself to the pipeline's `scripts` set so that the pipeline will register it during `load_scripts`.

I know there is already a PR for this same issue, but its approach is not quite right in my opinion, and it has been inactive since 2015.