### PR TITLE
Improve if statement throwing KeyError

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -207,7 +207,7 @@ def zset_score_pairs(response, **options):
     If ``withscores`` is specified in the options, return the response as
     a list of (value, score) pairs
     """
-    if not response or not options['withscores']:
+    if not response or 'withscores' not in options.keys() or options['withscores'] is None:
         return response
     score_cast_func = options.get('score_cast_func', float)
     it = iter(response)

--- a/redis/client.py
+++ b/redis/client.py
@@ -207,7 +207,7 @@ def zset_score_pairs(response, **options):
     If ``withscores`` is specified in the options, return the response as
     a list of (value, score) pairs
     """
-    if not response or 'withscores' not in options.keys() or options['withscores'] is None:
+    if not response or not options.get('withscores'):
         return response
     score_cast_func = options.get('score_cast_func', float)
     it = iter(response)


### PR DESCRIPTION
At line 210, if WITHSCORES is not specified within `execute_command()`, this line used to throw a `KeyError` because the relative key in `options` is not present. Solution: this PR add a check on the key 'withscores' before the key is accessed.