### PR TITLE
[bugfix] Fix srandmember(key, 0) returns 1 element bug

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1644,7 +1644,7 @@ class StrictRedis(object):
         memebers of set ``name``. Note this is only available when running
         Redis 2.6+.
         """
-        args = number and [number] or []
+        args = (number is not None) and [number] or []
         return self.execute_command('SRANDMEMBER', name, *args)
 
     def srem(self, name, *values):


### PR DESCRIPTION
#881