### PR TITLE
Connection management improvements.

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -547,6 +547,9 @@ class Connection(object):
             return
         try:
             self._sock.shutdown(socket.SHUT_RDWR)
+        except (OSError, socket.error):
+            pass
+        try:
             self._sock.close()
         except socket.error:
             pass

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -17,6 +17,9 @@ class DummyConnection(object):
         self.kwargs = kwargs
         self.pid = os.getpid()
 
+    def validate(self):
+        return True
+
 
 class TestConnectionPool(object):
     def get_pool(self, connection_kwargs=None, max_connections=None,


### PR DESCRIPTION
This PR addresses #306 and #824. We ran into these issues (many connections in CLOSE_WAIT state, and too many open connections following a load spike).

Specifically, I modified `ConnectionPool.get_connection()` so that it retrieves the connection at the head of the list of available connections. `release()` still appends to the tail, so all connections will be utilized in round-robin fashion. This change was made to support the other change to `get_connection()` which verifies a connection's "liveness". If a connection is not live, it is disconnected, and the next available is similarly tested. If no connections are usable, then a new one is created.

I also modified the `Connection.disconnect()` method so that if `shutdown()` errors (due to CLOSE_WAIT or other socket state) `close()` will still be called. I am not sure this is necessary, but I figured it was safer to ensure close is always called before the reference to the socket is deleted by setting `self._sock = None`.