### PR TITLE
Add support for Python collections backed by Redis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,30 @@ or from source:
 Getting Started
 ---------------
 
+For using Redis backed by collections
 .. code-block:: pycon
 
+    >>> from redis.collections import ObjectRedis
+    >>> r = ObjectRedis()
+    >>> r['myset']=('oats','peas','beans')
+    >>> len(r['myset'])
+    3
+    >>> r['mylist']=['bread','milk','butter']
+    >>> str(r['mylist'])
+    "['bread', 'milk', 'butter']"
+    >>> r['mykey']='myvalue'
+    >>> r['ltue']=42
+    >>> r['ltue']
+    42
+    >>> r['truth']=True
+    >>> r['truth']
+    True
+
+You can also instantiate a RedisList, RedisDict, RedisSet, or RedisSortedSet directly.  All take a name parameter
+and offer redis parameter for passing in the StrictRedis instance to use.
+
+For executing Redis commands explicitly
+.. code-block:: pycon
     >>> import redis
     >>> r = redis.StrictRedis(host='localhost', port=6379, db=0)
     >>> r.set('foo', 'bar')

--- a/redis/collections.py
+++ b/redis/collections.py
@@ -1,0 +1,463 @@
+# -*- coding: utf-8 -*-
+from redis import StrictRedis
+import pickle
+import collections
+from collections import OrderedDict
+from future.utils import listitems
+
+__author__ = 'jscarbor'
+
+
+class ObjectRedis(collections.MutableMapping):
+    """
+    View on a Redis database, supporting object keys and arbitrary object values.  This implementation
+    uses the Redis key namespace as the namespace for its keys.
+
+    If collections are stored in Redis with the supported collection types, the basic
+    python-wrapped collections will be returned, using the same serlalizers provided (default is pickle).
+    """
+
+    def __init__(self, redis=StrictRedis(), namespace=None, serializer=pickle, key_serializer=pickle):
+        """
+        :param redis: The StrictRedis connection to use
+        :param namespace: Prepended to keys, None to prepend nothing.  If namespace is none, then all contents of the
+              database are considered members of the collection and processed through the serializers.  The namespace
+              will be encoded as bytes (str(ns).encode('utf-8')) if it's not already a byte array
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        :param key_serializer: Like serializer, but applied to keys
+        """
+        self.redis = redis
+        self.namespace = None
+        if namespace is not None:
+            self.namespace = ((type(namespace) is bytes and namespace) or str(namespace).encode('utf-8')) + b":::"
+        self.serializer = serializer
+        self.key_serializer = key_serializer
+
+    def __getitem__(self, key):
+        rkey = self._ns(key)
+        rtype = self.redis.type(rkey)
+        if rtype == b'none':
+            raise KeyError(str(key))
+        elif rtype == b'string':
+            bval = self.redis.get(rkey)
+            if bval is not None:
+                return self.serializer.loads(bval)
+            raise KeyError(str(key))  # It went away between typing and getting
+        elif rtype == b'list':
+            return RedisList(rkey, self.redis, self.serializer)
+        elif rtype == b'set':
+            return RedisSet(rkey, self.redis, self.serializer)
+        elif rtype == b'hash':
+            return RedisDict(rkey, self.redis, self.serializer, self.key_serializer)
+        elif rtype == b'zset':
+            return RedisSortedSet(rkey, self.redis, self.serializer)
+        else:
+            raise NotImplementedError(str(rtype))
+
+    def get(self, key, default=None):
+        try:
+            self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def __setitem__(self, key, value):
+        key.__hash__()
+        bkey = self._ns(key)
+        d = dir(value)
+        if "__imul__" in d and "__iter__" in d:  # list
+            def new_list(pipe):
+                rl = RedisList(bkey, pipe, self.serializer)
+                rl.clear()
+                rl.extend(value)
+
+            self.redis.transaction(new_list, key)
+        elif "__xor__" in d and "__iter__" in d:  # set
+            def new_set(pipe):
+                rs = RedisSet(bkey, pipe, self.serializer)
+                rs.clear()
+                rs.update(value)
+
+            self.redis.transaction(new_set, key)
+        elif "__getitem__" in d and 'index' not in d:  # hash
+            def new_hash(pipe):
+                rd = RedisDict(bkey, pipe, self.serializer, self.serializer)
+                rd.clear()
+                rd.update(value)
+
+            self.redis.transaction(new_hash, key)
+        elif "__getitem__" in d and 'values' in d:  # zset
+            def new_zset(pipe):
+                rz = RedisSortedSet(bkey, pipe, self.serializer)
+                rz.clear()
+                rz.update(value)
+
+            self.redis.transaction(new_zset, key)
+        else:  # string (other)
+            self.redis.set(name=bkey, value=self.serializer.dumps(value))
+
+    def __contains__(self, key):
+        return self.redis.exists(self._ns(key))
+
+    def __delitem__(self, key):
+        if self.redis.delete(self._ns(key)) == 0:
+            raise KeyError(str(key))
+
+    def __iter__(self):
+        for k in self.redis.scan_iter(match=(self.namespace is not None and self.namespace + b'*') or None):
+            try:
+                # __dns can't be done in a list comprehension because the exceptions need to be handled in
+                # the case of a null namespace and traversing other items, or in case of different
+                # pickling schemes, different namespace termination levels ("foo:" and "foo:bar:", etc.).
+                yield self._dns(k)
+            except ValueError:  # Other namespaces won't match
+                pass
+            except pickle.UnpicklingError:  # Other namespaces and schemes won't work
+                pass
+
+    def __len__(self):
+        return sum(1 for _ in self.__iter__())
+
+    def _dns(self, key):
+        """
+        decode a stored key by removing the namespace and deserializing it
+        :param key: the key as stored in redis with the namespace
+        :return: the object key,
+        :raises ValueError if the namespace doesn't match
+        """
+        if self.namespace is not None:
+            if key.startswith(self.namespace):
+                bkey = key[len(self.namespace):]
+            else:
+                raise ValueError("mismatched namespace: " + str(key))
+        else:
+            bkey = key
+        return self.key_serializer.loads(bkey)
+
+    def _ns(self, key):
+        """
+        Convert an object key into one with the redis namespace and a serialized version of the suffix
+        :param key: any object
+        :return: a redis key beginning with the namepsace for this object, followed by the serialized object
+        """
+        if self.namespace is not None:
+            return self.namespace + self.key_serializer.dumps(key)
+        else:
+            return self.key_serializer.dumps(key)
+
+    def copy(self):
+        d = {}
+        for k in self.keys():
+            d[k] = self[k]
+        return d
+
+
+class RedisList(collections.MutableSequence):
+    """A list backed by Redis, using the Redis linked list construct, and stored a single Redis value.
+    Operations on the ends of the list, and len() are O(1).
+    Operations on elements by index are O(N)."""
+
+    def __init__(self, name, redis=StrictRedis(), serializer=pickle):
+        """
+
+        :param name: The key for this entry in Redis
+        :param redis: The StrictRedis connection to use
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        """
+        self.name = name
+        self.redis = redis
+        self.serializer = serializer
+
+    def __getitem__(self, index):
+        rval = self.redis.lindex(self.name, index)
+        if rval is None:
+            raise IndexError("empty list")
+        return self.serializer.loads(rval)
+
+    def __setitem__(self, index, value):
+        self.redis.lset(self.name, index, self.serializer.dumps(value))
+
+    def __delitem__(self, index):
+        self.redis.pipeline().lset(self.name, index, '-=-DELETING-=-').lrem(self.name, 1, '-=-DELETING-=-').execute()
+
+    def __len__(self):
+        return self.redis.llen(self.name)
+
+    def __insert(self, pipe, index, value):
+        value = self.serializer.dumps(value)
+        if index >= pipe.llen(self.name):
+            pipe.rpush(self.name, value)
+        else:
+            current = pipe.lindex(self.name, index)
+            pipe.lset(self.name, index, '-=-INSERTING-=-')
+            pipe.linsert(self.name, 'BEFORE', '-=-INSERTING-=-', value)
+            pipe.linsert(self.name, 'AFTER', '-=-INSERTING-=-', current)
+            pipe.lrem(self.name, 1, '-=-INSERTING-=-')
+
+    def insert(self, index, value):
+        self.redis.transaction(lambda pipe: self.__insert(pipe, index, value), self.name)
+
+    def append(self, value):
+        self.redis.rpush(self.name, self.serializer.dumps(value))
+
+    def extend(self, values):
+        self.redis.rpush(self.name, *[self.serializer.dumps(v) for v in values])
+
+    def clear(self):
+        self.redis.delete(self.name)
+
+    def remove(self, value):
+        if not self.redis.lrem(self.name, 1, self.serializer.dumps(value)):
+            raise ValueError()
+
+    def __pop(self, pipe, index, rbox):
+        bval = pipe.lindex(self.name, index)
+        if bval is None:
+            raise IndexError()
+
+        rbox.append(bval)
+        pipe.lset(self.name, index, '-=-DELETING-=-')
+        pipe.lrem(self.name, 1, '-=-DELETING-=-')
+
+    def pop(self, index=-1):
+        if index == -1:
+            rval = self.redis.rpop(self.name)
+        elif index == 0:
+            rval = self.redis.lpop(self.name)
+        else:
+            rbox = []
+            self.redis.transaction(lambda pipe: self.__pop(pipe, index, rbox), self.name)
+            if len(rbox):
+                rval = rbox[-1]
+            else:
+                raise IndexError()
+        if rval is None:
+            raise IndexError()
+        return self.serializer.loads(rval)
+
+    def __iter__(self):
+        return [self.serializer.loads(x) for x in self.redis.lrange(self.name, 0, self.__len__())].__iter__()
+
+    def __contains__(self, item):
+        try:
+            return self.index(item) is not None and True
+        except ValueError:
+            return False
+
+    def __reversed__(self):
+        return list(self).__reversed__()
+
+    def __index(self, pipe, value, start, stop, rbox):
+        if stop is None:
+            stop = pipe.llen(self.name)
+        bi = self.serializer.dumps(value)
+        ix = 0
+        for x in pipe.lrange(self.name, start, stop):
+            if x == bi:
+                rbox.append(ix)
+                return
+            ix += 1
+
+    def index(self, value, start=0, stop=None):
+        rbox = []
+        self.redis.transaction(lambda pipe: self.__index(pipe, value, start, stop, rbox), self.name)
+        if len(rbox):
+            return rbox[-1]
+        else:
+            raise ValueError()
+
+    def copy(self):
+        return list(self)
+
+    def __str__(self):
+        return '[%s]' % ', '.join(map(repr, self))
+
+
+class RedisSet(collections.MutableSet):
+    """
+    A set, backed by the Redis set construct.
+    """
+
+    def __init__(self, name, redis=StrictRedis(), serializer=pickle):
+        """
+
+        :param name: The key for this entry in Redis
+        :param redis: The StrictRedis connection to use
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        """
+        self.name = name
+        self.redis = redis
+        self.serializer = serializer
+
+    def __iter__(self):
+        for item in self.redis.sscan_iter(self.name):
+            yield self.serializer.loads(item)
+
+    def __len__(self):
+        return self.redis.scard(self.name)
+
+    def __contains__(self, item):
+        return self.redis.sismember(self.name, self.serializer.dumps(item))
+
+    def update(self, *others):
+        return self.add(*[item for sublist in others for item in sublist])
+
+    def add(self, *item):
+        """
+        :param item: One or more items to be added
+        :return: the number of things added
+        """
+        if len(item):
+            # The call to __hash__ for each item insures it's hashable (i.e. unmodifiable), and thus suitable for a set.
+            # These sets are persisted and unmodifiable once they're saved, but I haven't thought of a good reason
+            # to change the basic contract for set - because this set will also be transformed into an in-memory set
+            # in some cases.
+            return self.redis.sadd(self.name,
+                                   *[(item.__hash__() or True) and self.serializer.dumps(item) for item in item])
+        else:
+            return 0
+
+    def discard(self, item):
+        return self.redis.srem(self.name, self.serializer.dumps(item))
+
+    def copy(self):
+        return set(self.__iter__())
+
+    def clear(self):
+        self.redis.delete(self.name)
+
+    def __str__(self):
+        return '{%s}' % ', '.join(map(repr, self))
+
+
+class RedisDict(collections.MutableMapping):
+    """
+    A dictionary, backed by Redis
+    """
+
+    def __init__(self, name, redis=StrictRedis(), serializer=pickle, key_serializer=pickle):
+        """
+
+        :param name: The key for this entry in Redis
+        :param redis: The StrictRedis connection to use
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        :param key_serializer: Like serializer, but applied to keys
+        """
+        self.name = name
+        self.redis = redis
+        self.serializer = serializer
+        self.key_serializer = key_serializer
+
+    def __getitem__(self, item):
+        val = self.redis.hget(self.name, self.key_serializer.dumps(item))
+        if val is None:
+            raise KeyError()
+        return self.serializer.loads(val)
+
+    def __setitem__(self, item, value):
+        item.__hash__()  # raise a TypeError if it isn't immutable
+        self.redis.hset(self.name, self.key_serializer.dumps(item), self.serializer.dumps(value))
+
+    def __delitem__(self, item):
+        if not self.redis.hdel(self.name, self.key_serializer.dumps(item)):
+            raise KeyError()
+
+    def __iter__(self):
+        for k, v in self.redis.hscan_iter(self.name):
+            yield self.key_serializer.loads(k)
+
+    def __len__(self):
+        return self.redis.hlen(self.name)
+
+    def clear(self):
+        self.redis.delete(self.name)
+
+    def copy(self):
+        d = {}
+        d.update(self)
+        return d
+
+    def __str__(self):
+        return '{%s}' % ', '.join(([": ".join(map(repr, (k, v))) for k, v in listitems(self)]))
+
+
+class RedisSortedSet(collections.MutableMapping):
+    """
+    A Redis sorted set wrapped as a dict.  Entries are stored in the dictionary keys, scores are their values.
+    Items are sorted in order by their values.  Values must be floating point numbers.
+    """
+
+    #     This class provides concrete generic implementations of all
+    # methods except for __getitem__, __setitem__, __delitem__,
+    #     __iter__, and __len__.
+
+    def __init__(self, name, redis=StrictRedis(), serializer=pickle):
+        """
+
+        :param name: The name of this set in Redis
+        :param redis: The StrictRedis you want to use
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        """
+        self.name = name
+        self.redis = redis
+        self.serializer = serializer
+
+    def __contains__(self, item):
+        """Test to see if a key is in the set. O(1)"""
+        return self.redis.zscore(self.name, self.serializer.dumps(item)) is not None
+
+    def copy(self):
+        """Create a Python OrderedDict of the contents of this set"""
+        return OrderedDict([(self.serializer.loads(k), v) for k, v in self.redis.zscan_iter(self.name)])
+
+    def __iter__(self):
+        """Iterate over the whole set. O(N)"""
+        return [self.serializer.loads(k) for k, v in self.redis.zscan_iter(self.name)].__iter__()
+
+    def __len__(self):
+        """Get the size of the set. O(1)"""
+        return self.redis.zcard(self.name)
+
+    def __getitem__(self, key):
+        """Get the score of an item in the set. O(log N)"""
+        rval = self.redis.zscore(self.name, self.serializer.dumps(key))
+        if rval is None:
+            raise KeyError(str(key))
+        return rval
+
+    def __setitem__(self, key, value):
+        """Put an item in the set. O(log N)"""
+        key.__hash__()  # See that it's hashable, otherwise it's not suitable for a key
+        self.redis.zadd(self.name, value + 0.0, self.serializer.dumps(key))
+
+    def index(self, value):
+        """Return the rank of the value (its ordinal position in the set).  O(log N)"""
+        # This signature doesn't match the one from collections.Sequence because specifying range is nonsense
+        rval = self.redis.zrank(self.name, self.serializer.dumps(value))
+        if rval is not None:
+            return rval
+        else:
+            raise ValueError()
+
+    def __delitem__(self, value):
+        if self.redis.zrem(self.name, self.serializer.dumps(value)) == 0:
+            raise KeyError()
+
+    def update(*args, **kwds):
+        newstuff = {}
+        self = args[0]
+        args = args[1:]
+        newstuff.update(*args, **kwds)
+        self.redis.zadd(self.name,
+                        *[i for sub in [(v + 0, self.serializer.dumps(k)) for k, v in listitems(newstuff)] for i in
+                          sub])
+
+    def clear(self):
+        self.redis.delete(self.name)
+
+    def __str__(self):
+        return 'RedisSortedSet({%s})' % ', '.join(([": ".join(map(repr, (k, v))) for k, v in listitems(self)]))

--- a/redis/collections.py
+++ b/redis/collections.py
@@ -3,7 +3,7 @@ from redis import StrictRedis
 import pickle
 import collections
 from collections import OrderedDict
-from future.utils import listitems
+from ._compat import iteritems
 
 __author__ = 'jscarbor'
 
@@ -381,7 +381,7 @@ class RedisDict(collections.MutableMapping):
         return d
 
     def __str__(self):
-        return '{%s}' % ', '.join(([": ".join(map(repr, (k, v))) for k, v in listitems(self)]))
+        return '{%s}' % ', '.join(([": ".join(map(repr, (k, v))) for k, v in iteritems(self)]))
 
 
 class RedisSortedSet(collections.MutableMapping):
@@ -453,11 +453,11 @@ class RedisSortedSet(collections.MutableMapping):
         args = args[1:]
         newstuff.update(*args, **kwds)
         self.redis.zadd(self.name,
-                        *[i for sub in [(v + 0, self.serializer.dumps(k)) for k, v in listitems(newstuff)] for i in
+                        *[i for sub in [(v + 0, self.serializer.dumps(k)) for k, v in iteritems(newstuff)] for i in
                           sub])
 
     def clear(self):
         self.redis.delete(self.name)
 
     def __str__(self):
-        return 'RedisSortedSet({%s})' % ', '.join(([": ".join(map(repr, (k, v))) for k, v in listitems(self)]))
+        return 'RedisSortedSet({%s})' % ', '.join(([": ".join(map(repr, (k, v))) for k, v in iteritems(self)]))

--- a/redis/ttl.py
+++ b/redis/ttl.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+__author__ = 'jscarbor'
+import collections
+import redis
+import pickle
+import time
+from .collections import ObjectRedis, RedisSortedSet
+
+
+def _missing(x):
+    raise KeyError(str(x))
+
+
+class ObjectRedisTTL(ObjectRedis):
+    """
+    A TTL cache backed by a Redis database, supporting object keys and arbitrary object values.  This implementation
+    uses the Redis key namespace as the namespace for its keys, and uses Redis to manage the TTL aspect.
+    """
+
+    def __init__(self, ttl, missing=_missing, redis=redis.StrictRedis(), namespace=None, serializer=pickle,
+                 key_serializer=pickle):
+        """
+
+        :param ttl: the time-to-live in seconds
+        :param missing: A function for cache miss, otherwise KeyError
+        :param redis: The StrictRedis connection to use
+        :param namespace: Prepended to keys, None to prepend nothing.  If namespace is none, then all contents of the
+              database are considered members of the collection and processed through the serializers.  The namespace
+              will be encoded as bytes (str(ns).encode('utf-8')) if it's not already a byte array
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        :param key_serializer: Like serializer, but applied to keys
+        """
+        super(ObjectRedisTTL, self).__init__(redis=redis, namespace=namespace, serializer=serializer,
+                                             key_serializer=key_serializer)
+        self.ttl = ttl
+        self.missing = missing
+
+    def __getitem__(self, key):
+        try:
+            super(ObjectRedisTTL, self).__getitem__(key)
+        except KeyError:
+            return self.__missing(key)
+
+    def __setitem__(self, key, value):
+        self.redis.setex(name=self._ns(key), time=self.ttl, value=self.serializer.dumps(value))
+
+    def __missing(self, key):
+        val = self.missing(key)
+        self.__setitem__(key, val)
+        return val
+
+
+class RedisTime(object):
+    """
+    A clock backed by Redis, used to save on round-trip calls to check database time for TTL sets.  This is
+    particularly useful during iterating over an entire collection - the clock need not be fetched for each
+    item.
+    """
+
+    def __init__(self, redis=None, refresh_interval=5):
+        """
+
+        :param redis: The redis connection to use
+        :param refresh_interval: The time (in seconds) to allow between checks of the redis clock
+        """
+        self.refresh_interval = refresh_interval
+        self.redis = redis
+        self.delta = 0
+        self.next_check = 0
+
+    def time(self):
+        if self.next_check < time.time():
+            sec, micros = self.redis.time()
+            rclock = sec + micros * 1e-6
+            now = time.time()
+            self.delta = rclock - now
+            self.next_check = now + self.refresh_interval
+            return rclock
+        else:
+            return self.delta + time.time()
+
+
+class RedisTTLSet(collections.MutableSet):
+    """
+    A set, whose items expire after a specified time.
+    """
+
+    def __init__(self, name, ttl, redis=redis.StrictRedis(), serializer=pickle, time=None):
+        """
+
+        :param name: The name of this collection - its key in Redis
+        :param ttl: How long items stay in the set
+        :param redis: The StrictRedis connection to use
+        :param serializer: An object containing functions "dumps" to turn an object (to store) into a byte array, and
+             "loads" to turn a byte array into an object.  Default = pickle
+        :param time: a function to return the current time, default = use RedisTime.time to periodically
+        check Redis for the official time and use the local clock to measure during intervals in-between those checks,
+        thus saving some round-trip delays to consult the Redis clock, especially with fast iterations over the set
+        (which have already discarded the expired members a priori) and the slow iterations which might need to discard
+        other elements as they expire and before yielding them.
+        """
+        self.redis = redis
+        self.name = name
+        self.serializer = serializer
+        self.ttl = ttl
+        self.time = time or RedisTime(redis=redis).time
+        self.dict = RedisSortedSet(name, redis=redis, serializer=serializer)
+
+    def __iter__(self):
+        """
+        :return: An iterator over all the items.  Only items that were available at the initial
+          call time will be returned.  Only non-expired items will be returned.
+        """
+        self.__cleanup()
+        for k, v in self.dict.items():
+            if v < self.time():
+                # If the expiry time has passed, check to see if it might have been refreshed
+                if self.__contains__(k):
+                    yield k
+            else:
+                yield k
+
+    def __contains__(self, item):
+        """
+        :param item:
+        :return: True if the item is in the set and not expired, false otherwise
+        """
+        expiry = self.dict.get(item, None)
+        if expiry is None:
+            return False
+        if expiry < self.time():
+            self.discard(item)
+            return False
+        return True
+
+    def __len__(self):
+        """
+        :return: The number of non-expired elements.  This will clear out any expired elements.  Time is O(log(N)+M),
+        where M is the number of expired elements.
+        """
+        self.__cleanup()
+        return len(self.dict)
+
+    def __cleanup(self):
+        """Remove expired elements. O(log(N) + M)"""
+        self.redis.zremrangebyscore(self.name, float("-inf"), self.time())
+
+    def copy(self):
+        """
+        :return: A copy of this set
+        """
+        return set(self.__iter__())
+
+    def update(self, *other):
+        t = self.time() + self.ttl
+        self.dict.update({k: t for k in [item for sublist in other for item in sublist]})
+
+    def add(self, item):
+        self.dict[item] = self.time() + self.ttl
+
+    def discard(self, item):
+        try:
+            self.dict.__delitem__(item)
+        except KeyError:
+            pass
+
+    def clear(self):
+        self.dict.clear()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+import pytest
+import redis.collections as p
+import collections
+
+
+class TestRedisList(object):
+    def test_list(self, sr):
+        l = p.RedisList('foo', redis=sr)
+        assert 0 == len(l)
+        with pytest.raises(StopIteration):
+            l.__iter__().__next__()
+        l.append(1)
+        assert 1 == len(l)
+        assert 1 == l[0]
+        l.append(3)
+        assert 3 == l[1]
+        assert 2 == len(l)
+        assert 1 == l[0]
+        l[1] = 2
+        assert 2 == l[1]
+        assert 2 == l[-1]
+        assert 1 == l[-2]
+        assert [1, 2] == list(l)
+        assert 2 == len(l)
+        with pytest.raises(IndexError):
+            l[2]
+        assert 3 == sum(l)
+
+        l.insert(1, 'x')
+        assert 'x', l[1] == str(list(l))
+        assert [1, 'x', 2] == list(l)
+
+        l.insert(3, 'z')
+        assert l[3] == 'z'
+
+        assert ['z', 2, 'x', 1] == list(l.__reversed__())
+
+        assert 4 == len(l)
+        assert 3 == l.index('z')
+        with pytest.raises(ValueError):
+            l.remove('t')
+        assert 4 == len(l)
+        assert 'z' in l
+        l.remove('z')
+        assert 3 == len(l)
+        assert not ('z' in l)
+
+        l.extend([7, 8, 9])
+        assert [1, 'x', 2, 7, 8, 9] == list(l)
+        assert (1 in l)
+
+        del l[3]
+        assert [1, 'x', 2, 8, 9] == list(l)
+
+        assert 1 == l.index('x')
+        with pytest.raises(ValueError):
+            l.index('t')
+
+        assert 9 == l.pop()
+        assert [1, 'x', 2, 8] == list(l)
+
+        assert 'x' == l.pop(1)
+        assert [1, 2, 8] == list(l)
+        with pytest.raises(IndexError):
+            l.pop(3)
+
+        l.clear()
+        with pytest.raises(IndexError):
+            l.pop(0)
+        with pytest.raises(IndexError):
+            l.pop(-1)
+
+        assert 0 == len(l)
+        l.append(1)
+        with pytest.raises(IndexError):
+            l.pop(1)
+
+    def test_copy(self, sr):
+        l = p.RedisList('l', sr)
+        l.extend([1, 2, 3, 4])
+        assert [1, 2, 3, 4] == l.copy()
+
+    def test_str(self, sr):
+        l = p.RedisList('l', sr)
+        l.extend([1, 2, 3, 4])
+        assert str([1, 2, 3, 4]) == str(l)
+        l.append('x')
+        assert str([1, 2, 3, 4, 'x']) == str(l)
+
+
+class TestObjectRedis(object):
+    def test_basic_dict(self, sr):
+        d = p.ObjectRedis(sr)
+        assert len(d) == 0
+        with pytest.raises(KeyError):
+            d[True]
+        d[True] = 42.1
+        assert len(d) == 1
+        assert d[True] == 42.1
+        d[3] = 'three'  # turns out d[1] and d[True] are equivalent in the standard implementations
+        assert d[3] == 'three'
+        assert len(d) == 2
+
+        assert {True, 3} == set(d.keys())
+        assert {True: 42.1, 3: 'three'} == d.copy()
+
+    def test_namespace(self, sr):
+        d = p.ObjectRedis(sr, namespace="foo")
+        assert len(d) == 0
+        with pytest.raises(KeyError):
+            d[True]
+        d[True] = 42.1
+        assert len(d) == 1
+        assert d[True] == 42.1
+        d[1] = 'one'
+        assert d[1] == 'one'
+        assert len(d) == 2
+
+        d2 = p.ObjectRedis(sr)
+        assert len(d2) == 0  # This instance won't unpickle keys from the other instance, so can't see them
+        d2[True] = 38
+        assert len(d) == 2
+        assert len(d2) == 1
+        assert d2[True] == 38
+        assert d[True] == 42.1
+
+    def test_storing_collections(self, sr):
+        d = p.ObjectRedis(sr)
+        d['list'] = [1, 2, 3, 4, 5]
+        assert [1, 2, 3, 4, 5] == d['list'].copy()
+        d['map'] = {'a': 'red', 'b': 'blue'}
+        assert {'a': 'red', 'b': 'blue'} == d['map'].copy()
+        od = collections.OrderedDict()
+        od[89.7] = 'WCPE'
+        od[91.5] = 'WUNC'
+        d['od'] = od
+        assert od == d['od'].copy()
+        s = {'oats', 'peas', 'beans'}
+        d['set'] = s
+        assert s == d['set'].copy()
+
+
+class TestRedisDict(object):
+    def test_values(self, sr):
+        d = p.RedisDict('foo', redis=sr)
+        d['a'] = 'b'
+        assert 'b' == d['a']
+        assert list({'a': 'b'}.__iter__()) == list(d.__iter__())
+        assert ['b'] == list(d.values())
+        with pytest.raises(TypeError):
+            d[['a']] = 'b'
+
+    def test_keys(self, sr):
+        d = p.RedisDict('foo', redis=sr)
+        d['a'] = 'A'
+        d['c'] = 'C'
+        assert {'a', 'c'} == set(d.keys())
+
+    def test_copy(self, sr):
+        d = p.RedisDict('foo', redis=sr)
+        d['a'] = 'A'
+        d['c'] = 'C'
+        assert {'a': 'A', 'c': 'C'} == d.copy()
+
+    def test_str(self, sr):
+        d = p.RedisDict('foo', redis=sr)
+        refd = {'sunshine': 'rainbows', 'moon': 'eclipse'}
+        d.update(refd)
+        assert "{'moon': 'eclipse', 'sunshine': 'rainbows'}" == str(d) or \
+               "{'sunshine': 'rainbows', 'moon': 'eclipse'}" == str(d)
+
+
+class TestRedisSortedSet(object):
+    def test_sorted(self, sr):
+        s = p.RedisSortedSet('foo', redis=sr)
+        assert 0 == len(s)
+        assert not ('bar' in s)
+        s['bar'] = 5
+        assert ('bar' in s)
+        assert 5.0 == s['bar']
+        with pytest.raises(TypeError):
+            s['bar'] = 'baz'
+        od = collections.OrderedDict()
+        od['bar'] = 5.0
+        assert od == s.copy()
+        assert 1 == len(s)
+
+        assert not ('bat' in s)
+        s['bat'] = 1
+        assert ('bat' in s)
+        assert 1.0 == s['bat']
+        od['bat'] = 1.0
+        od.move_to_end('bar')
+        assert od == s.copy()
+
+    def test_iter(self, sr):
+        s = p.RedisSortedSet('foo', redis=sr)
+        s['tigers'] = 2
+        s['lions'] = 1
+        s['bears'] = 3
+        i = s.__iter__()
+        assert 'lions' == next(i)
+        assert 'tigers' == next(i)
+        assert 'bears' == next(i)
+
+    def test_update(self, sr):
+        s = p.RedisSortedSet('foo', redis=sr)
+        s.update({'red': 650, 'green': 510, 'blue': 475})
+        od = collections.OrderedDict()
+        od['blue'] = 475
+        od['green'] = 510
+        od['red'] = 650
+        assert od == s.copy()
+
+    def test_hashable_key(self, sr):
+        s = p.RedisSortedSet('foo', redis=sr)
+        with pytest.raises(TypeError):
+            s[['nohash']] = 1
+
+    def test_str(self, sr):
+        s = p.RedisSortedSet('foo', redis=sr)
+        s.update({'H': 1, 'He': 2, 'Li': 3})
+        assert "RedisSortedSet({'H': 1.0, 'He': 2.0, 'Li': 3.0})" == str(s)
+
+
+class TestRedisSet(object):
+    def test_set(self, sr):
+        s = p.RedisSet('foo', redis=sr)
+        s.add('grunge')
+        assert ('grunge' in s)
+        s.add(True)
+        s.add(('graph'))
+        assert {'grunge', True, ('graph')} == set(s)
+        assert 3 == len(s)
+        assert 3 == sum(1 for _ in s)
+
+        with pytest.raises(TypeError):
+            s.add(['nohash'])
+
+        s.clear()
+        assert 0 == len(s)
+
+    def test_zero_element(self, sr):
+        s = p.RedisSet('foo', redis=sr)
+        s.add(0)
+        assert 1 == len(s)
+        assert {0} == s.copy()
+        assert {0} == set(s)
+
+        s.add(None)
+        assert 2 == len(s)
+        assert {0, None} == s.copy()
+        assert {0, None} == set(s)
+
+    def test_update(self, sr):
+        s = p.RedisSet('bar', redis=sr)
+        ref = {'oats', 'peas', 'beans'}
+        s.update(tuple(ref))
+        assert ref == set(s)
+        assert ref == s.copy()
+
+    def test_update_with_nothing(self, sr):
+        s = p.RedisSet('bar', sr)
+        s.update([])  # should have no effect
+        assert set() == set(s)
+        assert set() == s.copy()
+        assert 0 == len(s)
+
+        s.update()
+        assert 0 == len(s)
+
+        with pytest.raises(TypeError):
+            s.update(None)
+
+        with pytest.raises(TypeError):
+            s.update(0)
+
+    def test_bigger_set(self, sr):
+        s = p.RedisSet('bar', sr)
+
+        ref = set(range(0, 10000))
+        s.update(ref)
+        assert len(ref) == len(s)
+        assert ref == s.copy()
+        assert ref == set(s.__iter__())
+        s.clear()
+        assert 0 == len(s)
+
+    def test_str(self, sr):
+        s = p.RedisSet('bar', sr)
+        s.update(['foo', 'bar'])
+        assert "{'foo', 'bar'}" == str(s) or "{'bar', 'foo'}" == str(s)

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+import pytest
+from redis.ttl import RedisTTLSet, ObjectRedisTTL
+import pickle
+
+__author__ = 'jscarbor'
+
+
+class TestRedisTTLSet(object):
+    def test_set(self, sr):
+        t = 1
+        s = RedisTTLSet('foo', 5, redis=sr, time=lambda: t)
+        s.add('grunge')
+        assert ('grunge' in s)
+        t = 2
+        s.add(True)
+        t = 3
+        s.add(('graph'))
+        assert {'grunge', True, ('graph')} == set(s)
+        assert 3 == len(s)
+        t = 6
+        assert 2 == sum(1 for _ in s)
+        assert {True, ('graph')} == set(s)
+
+        with pytest.raises(TypeError):
+            s.add(['nohash'])
+
+        s.clear()
+        assert 0 == len(s)
+
+    def test_len_cleanup(self, sr):
+        t = 1
+        s = RedisTTLSet('foo', 5, redis=sr, time=lambda: t)
+        s.add('grunge')
+        t = 2
+        s.add('oscar')
+        t = 3
+        s.add('abby')
+        assert 3 == len(s)
+
+        # Watch actual size in storage decrease as an element is removed for expiration
+        assert 3 == sr.zcard('foo')
+        t = 6.1
+        assert 3 == sr.zcard('foo')
+        assert 2 == len(s)
+        assert 2 == sr.zcard('foo')
+        t = 10
+        assert 0 == len(s)
+        assert 0 == sr.zcard('foo')
+
+    def test_copy_cleanup(self, sr):
+        t = 1
+        s = RedisTTLSet('foo', 5, redis=sr, time=lambda: t)
+        s.add('grunge')
+        t = 2
+        s.add('oscar')
+        t = 3
+        s.add('abby')
+        assert {'grunge', 'oscar', 'abby'} == s.copy()
+        assert 3 == len(s)
+
+        # Watch actual size in storage decrease as an element is removed for expiration
+        assert 3 == sr.zcard('foo')
+        t = 6.1
+        assert 3 == sr.zcard('foo')
+        assert {'oscar', 'abby'} == s.copy()
+        assert 2 == sr.zcard('foo')
+        t = 10
+        assert set() == s.copy()
+        assert 0 == sr.zcard('foo')
+
+        s.update(list(range(0, 50)))
+        assert 50 == len(s)
+        t = 16
+        assert 0 == len(s)
+
+
+class TestObjectRedisTTL(object):
+    def test_ort(self, sr):
+        ort = ObjectRedisTTL(5, redis=sr)
+        ort['foo'] = 'bar'
+        assert 0 < sr.ttl(pickle.dumps('foo')) <= 5
+
+    def test_missing(self, sr):
+        def m(k):
+            return '1-800-THE-LOST x' + str(k)
+
+        ort = ObjectRedisTTL(5, redis=sr, missing=m)
+        assert '1-800-THE-LOST x' + str('foo') == ort['foo']
+        assert 0 < sr.ttl(pickle.dumps('foo')) <= 5
+        assert 'log' not in ort


### PR DESCRIPTION
I needed to bring in Redis after I'd already written code to work with Python collections, so this adapter code was born, offering the ability to store arbitrary objects and dress up structures in Redis to support the standard operations of lists, sets, and dicts.  The library is designed to use the most efficient routines to perform each operation.  

Further, there is justification to offer similar drop-in replacements for the queue module, but I thought the basic collections and the TTL collections would be a good start.  