### PR TITLE
fix sentinel.discover_slaves, raise SlaveNotFound error when no slaves found, instead of empty list

### DIFF
--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -121,7 +121,8 @@ def test_master_sdown(cluster, sentinel):
 
 
 def test_discover_slaves(cluster, sentinel):
-    assert sentinel.discover_slaves('mymaster') == []
+    with pytest.raises(SlaveNotFoundError):
+        sentinel.discover_slaves('mymaster')
 
     cluster.slaves = [
         {'ip': 'slave0', 'port': 1234, 'is_odown': False, 'is_sdown': False},
@@ -137,7 +138,8 @@ def test_discover_slaves(cluster, sentinel):
 
     # slave1 -> SDOWN
     cluster.slaves[1]['is_sdown'] = True
-    assert sentinel.discover_slaves('mymaster') == []
+    with pytest.raises(SlaveNotFoundError):
+        sentinel.discover_slaves('mymaster')
 
     cluster.slaves[0]['is_odown'] = False
     cluster.slaves[1]['is_sdown'] = False


### PR DESCRIPTION
Hi, I've been using this library for quite some time now and thank you all for your hardwork :+1: 
Like **discover_master(service_name)**, I believe that a _SlaveNotFound_ error should raised when **discover_slaves(service_name)** returns no slaves at all. And I also tried to fix the sentinel test case for this commit :)