### PR TITLE
fix<lock>: fix "expire may failed in some extreme situations and then lock failed"

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -118,12 +118,15 @@ class Lock(object):
             mod_time.sleep(sleep)
 
     def do_acquire(self, token):
-        if self.redis.setnx(self.name, token):
-            if self.timeout:
-                # convert to milliseconds
-                timeout = int(self.timeout * 1000)
-                self.redis.pexpire(self.name, timeout)
-            return True
+        if self.timeout:
+            # convert to milliseconds
+            timeout = int(self.timeout * 1000)
+            if self.redis.set(self.name, token, px=timeout, nx=True):
+                return True
+        else:
+            if self.redis.setnx(self.name, token):
+                return True
+
         return False
 
     def release(self):


### PR DESCRIPTION
- In function "do_acquirea"(in lock.py), if a client crash before
      "self.redis.pexpire" and after "self.redis.setnx", the key
"self.name" will store in redis with unexpired, another client couldn't
acquire this lock any more. That is unexpected.

Change-Id: I5aebf76ada669fa9267f562254c4123b3f256ab9