### PR TITLE
clientlist response, client_name value might contain the '=' character, in that case response parser will fail

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -245,7 +245,8 @@ def bool_ok(response):
 def parse_client_list(response, **options):
     clients = []
     for c in nativestr(response).splitlines():
-        clients.append(dict([pair.split('=') for pair in c.split(' ')]))
+        # Values might contain '='
+        clients.append(dict([pair.split('=', 1) for pair in c.split(' ')]))
     return clients
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,6 +68,14 @@ class TestRedisCommands(object):
         assert r.client_setname('redis_py_test')
         assert r.client_getname() == 'redis_py_test'
 
+    @skip_if_server_version_lt('2.6.9')
+    def test_client_list_after_client_setname(self, r):
+        r.client_setname('cl=i=ent')
+        clients = r.client_list()
+        assert isinstance(clients[0], dict)
+        assert 'name' in clients[0]
+        assert clients[0]['name'] == 'cl=i=ent'
+
     def test_config_get(self, r):
         data = r.config_get()
         assert 'maxmemory' in data


### PR DESCRIPTION
Recreate
127.0.0.1:6379> CLIENT SETNAME roi=lipman
OK
127.0.0.1:6379> CLIENT LIST
id=2 addr=127.0.0.1:49481 fd=8 name=roi=lipman age=27 ...

redis-py

File "/opt/redislabs/lib/cnm/python/redis/client.py", line 609, in client_list
  File "/opt/redislabs/lib/cnm/python/redis/client.py", line 574, in execute_command
  File "/opt/redislabs/lib/cnm/python/redis/client.py", line 588, in parse_response
  File "/opt/redislabs/lib/cnm/python/redis/client.py", line 248, in parse_client_list
ValueError: dictionary update sequence element #3 has length 3; 2 is required

This PR splits on '=' only once,
such that client_name key will be "name" and the value would be "roi=lipman".