### PR TITLE
Added number of members to be popped from set, by spop command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1642,9 +1642,10 @@ class StrictRedis(object):
         "Move ``value`` from set ``src`` to set ``dst`` atomically"
         return self.execute_command('SMOVE', src, dst, value)
 
-    def spop(self, name):
+    def spop(self, name, count=None):
         "Remove and return a random member of set ``name``"
-        return self.execute_command('SPOP', name)
+        args = (count is not None) and [count] or []
+        return self.execute_command('SPOP', name, *args)
 
     def srandmember(self, name, number=None):
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -866,6 +866,17 @@ class TestRedisCommands(object):
         assert value in s
         assert r.smembers('a') == set(s) - set([value])
 
+    def test_spop_multi_value(self, r):
+        s = [b('1'), b('2'), b('3')]
+        r.sadd('a', *s)
+        values = r.spop('a', 2)
+        assert len(values) == 2
+
+        for value in values:
+            assert value in s
+
+        assert r.spop('a', 1) == list(set(s) - set(values))
+
     def test_srandmember(self, r):
         s = [b('1'), b('2'), b('3')]
         r.sadd('a', *s)


### PR DESCRIPTION
Redis spop commands supportes a number of items to be popped parameter which was missing from the redis.py's spop command.