### PR TITLE
Sync tox.ini configuration with supported Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27,py32,py33,py34,py35,py36}-{plain,hiredis}, pycodestyle
+envlist = {py26,py27,py33,py34,py35,py36}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =


### PR DESCRIPTION
Per Travis CI configuration and trove classifiers, Python 3.2 is not supported. Remove it from tox.ini.