### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.4"
   - "3.3"
   - "2.7"
-  - "2.6"
 before_install:
   - wget http://download.redis.io/releases/redis-5.0.0.tar.gz && mkdir redis_install && tar -xvzf redis-5.0.0.tar.gz -C redis_install && cd redis_install/redis-5.0.0 && make && src/redis-server --daemonize yes && cd ../..
   - redis-cli info

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 before_install:
   - wget http://download.redis.io/releases/redis-5.0.0.tar.gz && mkdir redis_install && tar -xvzf redis-5.0.0.tar.gz -C redis_install && cd redis_install/redis-5.0.0 && make && src/redis-server --daemonize yes && cd ../..

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 * UNRELEASED
-    * Removed support for EOL Python 2.6.
+    * Removed support for EOL Python 2.6 and 3.3.
 * 2.10.6
     * Various performance improvements. Thanks cjsimpson
     * Fixed a bug with SRANDMEMBER where the behavior for `number=0` did

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* UNRELEASED
+    * Removed support for EOL Python 2.6.
 * 2.10.6
     * Various performance improvements. Thanks cjsimpson
     * Fixed a bug with SRANDMEMBER where the behavior for `number=0` did

--- a/benchmarks/basic_operations.py
+++ b/benchmarks/basic_operations.py
@@ -54,7 +54,7 @@ def timer(func):
             count = kwargs['num']
         else:
             count = args[1]
-        print('{0} - {1} Requests'.format(func.__name__, count))
+        print('{} - {} Requests'.format(func.__name__, count))
         print('Duration  = {}'.format(duration))
         print('Rate = {}'.format(count/duration))
         print('')

--- a/benchmarks/command_packer_benchmark.py
+++ b/benchmarks/command_packer_benchmark.py
@@ -29,10 +29,11 @@ class StringJoiningConnection(Connection):
     def pack_command(self, *args):
         "Pack a series of arguments into a value Redis command"
         args_output = SYM_EMPTY.join([
-            SYM_EMPTY.join((SYM_DOLLAR, b(str(len(k))), SYM_CRLF, k, SYM_CRLF))
+            SYM_EMPTY.join(
+                (SYM_DOLLAR, str(len(k)).encode(), SYM_CRLF, k, SYM_CRLF))
             for k in imap(self.encoder.encode, args)])
         output = SYM_EMPTY.join(
-            (SYM_STAR, b(str(len(args))), SYM_CRLF, args_output))
+            (SYM_STAR, str(len(args)).encode(), SYM_CRLF, args_output))
         return output
 
 
@@ -61,17 +62,17 @@ class ListJoiningConnection(Connection):
     def pack_command(self, *args):
         output = []
         buff = SYM_EMPTY.join(
-            (SYM_STAR, b(str(len(args))), SYM_CRLF))
+            (SYM_STAR, str(len(args)).encode(), SYM_CRLF))
 
         for k in imap(self.encoder.encode, args):
             if len(buff) > 6000 or len(k) > 6000:
                 buff = SYM_EMPTY.join(
-                    (buff, SYM_DOLLAR, b(str(len(k))), SYM_CRLF))
+                    (buff, SYM_DOLLAR, str(len(k)).encode(), SYM_CRLF))
                 output.append(buff)
                 output.append(k)
                 buff = SYM_CRLF
             else:
-                buff = SYM_EMPTY.join((buff, SYM_DOLLAR, b(str(len(k))),
+                buff = SYM_EMPTY.join((buff, SYM_DOLLAR, str(len(k)).encode(),
                                        SYM_CRLF, k, SYM_CRLF))
         output.append(buff)
         return output

--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -86,10 +86,6 @@ if sys.version_info[0] < 3:
     from itertools import imap, izip
     from string import letters as ascii_letters
     from Queue import Queue
-    try:
-        from cStringIO import StringIO as BytesIO
-    except ImportError:
-        from StringIO import StringIO as BytesIO
 
     # special unicode handling for python2 to avoid UnicodeDecodeError
     def safe_unicode(obj, *args):
@@ -133,7 +129,6 @@ if sys.version_info[0] < 3:
     long = long
 else:
     from urllib.parse import parse_qs, unquote, urlparse
-    from io import BytesIO
     from string import ascii_letters
     from queue import Queue
 

--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -171,27 +171,5 @@ else:
 
 try:  # Python 3
     from queue import LifoQueue, Empty, Full
-except ImportError:
-    from Queue import Empty, Full
-    try:  # Python 2.6 - 2.7
-        from Queue import LifoQueue
-    except ImportError:  # Python 2.5
-        from Queue import Queue
-        # From the Python 2.7 lib. Python 2.5 already extracted the core
-        # methods to aid implementating different queue organisations.
-
-        class LifoQueue(Queue):
-            "Override queue methods to implement a last-in first-out queue."
-
-            def _init(self, maxsize):
-                self.maxsize = maxsize
-                self.queue = []
-
-            def _qsize(self, len=len):
-                return len(self.queue)
-
-            def _put(self, item):
-                self.queue.append(item)
-
-            def _get(self):
-                return self.queue.pop()
+except ImportError:  # Python 2
+    from Queue import LifoQueue, Empty, Full

--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -109,12 +109,6 @@ if sys.version_info[0] < 3:
     def nativestr(x):
         return x if isinstance(x, str) else x.encode('utf-8', 'replace')
 
-    def u(x):
-        return x.decode()
-
-    def b(x):
-        return x
-
     def next(x):
         return x.next()
 
@@ -146,12 +140,6 @@ else:
 
     def nativestr(x):
         return x if isinstance(x, str) else x.decode('utf-8', 'replace')
-
-    def u(x):
-        return x
-
-    def b(x):
-        return x.encode('latin-1') if not isinstance(x, bytes) else x
 
     next = next
     unichr = chr

--- a/redis/client.py
+++ b/redis/client.py
@@ -70,7 +70,7 @@ def parse_debug_object(response):
     # prefixed with a name
     response = nativestr(response)
     response = 'type:' + response
-    response = dict([kv.split(':') for kv in response.split()])
+    response = dict(kv.split(':') for kv in response.split())
 
     # parse some expected int values from the string response
     # note: this cmd isn't spec'd so these may not appear in all redis versions
@@ -303,7 +303,7 @@ def parse_client_list(response, **options):
     clients = []
     for c in nativestr(response).splitlines():
         # Values might contain '='
-        clients.append(dict([pair.split('=', 1) for pair in c.split(' ')]))
+        clients.append(dict(pair.split('=', 1) for pair in c.split(' ')))
     return clients
 
 
@@ -339,7 +339,7 @@ def parse_slowlog_get(response, **options):
 
 
 def parse_cluster_info(response, **options):
-    return dict([line.split(':') for line in response.splitlines() if line])
+    return dict(line.split(':') for line in response.splitlines() if line)
 
 
 def _parse_node_line(line):
@@ -364,7 +364,7 @@ def parse_cluster_nodes(response, **options):
     raw_lines = response
     if isinstance(response, basestring):
         raw_lines = response.splitlines()
-    return dict([_parse_node_line(line) for line in raw_lines])
+    return dict(_parse_node_line(line) for line in raw_lines)
 
 
 def parse_georadius_generic(response, **options):
@@ -2901,7 +2901,7 @@ class PubSub(object):
         """
         encode = self.encoder.encode
         decode = self.encoder.decode
-        return dict([(decode(encode(k)), v) for k, v in iteritems(data)])
+        return dict((decode(encode(k)), v) for k, v in iteritems(data))
 
     def psubscribe(self, *args, **kwargs):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -3091,7 +3091,7 @@ class BasePipeline(object):
     on a key of a different datatype.
     """
 
-    UNWATCH_COMMANDS = set(('DISCARD', 'EXEC', 'UNWATCH'))
+    UNWATCH_COMMANDS = {'DISCARD', 'EXEC', 'UNWATCH'}
 
     def __init__(self, connection_pool, response_callbacks, transaction,
                  shard_hint):

--- a/redis/client.py
+++ b/redis/client.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from itertools import chain
 import datetime
 import sys

--- a/redis/client.py
+++ b/redis/client.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from itertools import chain
 import datetime
 import sys
@@ -6,9 +7,8 @@ import time
 import threading
 import time as mod_time
 import hashlib
-from redis._compat import (b, basestring, bytes, imap, iteritems, iterkeys,
-                           itervalues, izip, long, nativestr, unicode,
-                           safe_unicode)
+from redis._compat import (basestring, bytes, imap, iteritems, iterkeys,
+                           itervalues, izip, long, nativestr, safe_unicode)
 from redis.connection import (ConnectionPool, UnixDomainSocketConnection,
                               SSLConnection, Token)
 from redis.lock import Lock, LuaLock
@@ -24,7 +24,7 @@ from redis.exceptions import (
     WatchError,
 )
 
-SYM_EMPTY = b('')
+SYM_EMPTY = b''
 
 
 def list_or_args(keys, args):
@@ -334,7 +334,7 @@ def parse_slowlog_get(response, **options):
         'id': item[0],
         'start_time': int(item[1]),
         'duration': int(item[2]),
-        'command': b(' ').join(item[3])
+        'command': b' '.join(item[3])
     } for item in response]
 
 
@@ -3292,8 +3292,8 @@ class BasePipeline(object):
                 raise r
 
     def annotate_exception(self, exception, number, command):
-        cmd = safe_unicode(' ').join(imap(safe_unicode, command))
-        msg = unicode('Command # %d (%s) of pipeline caused error: %s') % (
+        cmd = ' '.join(imap(safe_unicode, command))
+        msg = 'Command # %d (%s) of pipeline caused error: %s' % (
             number, cmd, safe_unicode(exception.args[0]))
         exception.args = (msg,) + exception.args[1:]
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1036,7 +1036,7 @@ class StrictRedis(object):
         can be represented by an integer or a Python timedelta object.
         """
         if isinstance(time, datetime.timedelta):
-            time = time.seconds + time.days * 24 * 3600
+            time = int(time.total_seconds())
         return self.execute_command('EXPIRE', name, time)
 
     def expireat(self, name, when):
@@ -1162,8 +1162,7 @@ class StrictRedis(object):
         object.
         """
         if isinstance(time, datetime.timedelta):
-            ms = int(time.microseconds / 1000)
-            time = (time.seconds + time.days * 24 * 3600) * 1000 + ms
+            time = int(time.total_seconds() * 1000)
         return self.execute_command('PEXPIRE', name, time)
 
     def pexpireat(self, name, when):
@@ -1184,8 +1183,7 @@ class StrictRedis(object):
         timedelta object
         """
         if isinstance(time_ms, datetime.timedelta):
-            ms = int(time_ms.microseconds / 1000)
-            time_ms = (time_ms.seconds + time_ms.days * 24 * 3600) * 1000 + ms
+            time_ms = int(time_ms.total_seconds() * 1000)
         return self.execute_command('PSETEX', name, time_ms, value)
 
     def pttl(self, name):
@@ -1234,13 +1232,12 @@ class StrictRedis(object):
         if ex is not None:
             pieces.append('EX')
             if isinstance(ex, datetime.timedelta):
-                ex = ex.seconds + ex.days * 24 * 3600
+                ex = int(ex.total_seconds())
             pieces.append(ex)
         if px is not None:
             pieces.append('PX')
             if isinstance(px, datetime.timedelta):
-                ms = int(px.microseconds / 1000)
-                px = (px.seconds + px.days * 24 * 3600) * 1000 + ms
+                px = int(px.total_seconds() * 1000)
             pieces.append(px)
 
         if nx:
@@ -1267,7 +1264,7 @@ class StrictRedis(object):
         timedelta object.
         """
         if isinstance(time, datetime.timedelta):
-            time = time.seconds + time.days * 24 * 3600
+            time = int(time.total_seconds())
         return self.execute_command('SETEX', name, time, value)
 
     def setnx(self, name, value):
@@ -2738,7 +2735,7 @@ class Redis(StrictRedis):
         timedelta object.
         """
         if isinstance(time, datetime.timedelta):
-            time = time.seconds + time.days * 24 * 3600
+            time = int(time.total_seconds())
         return self.execute_command('SETEX', name, time, value)
 
     def lrem(self, name, value, num=0):

--- a/redis/client.py
+++ b/redis/client.py
@@ -2901,7 +2901,7 @@ class PubSub(object):
         """
         encode = self.encoder.encode
         decode = self.encoder.decode
-        return dict((decode(encode(k)), v) for k, v in iteritems(data))
+        return {decode(encode(k)): v for k, v in iteritems(data)}
 
     def psubscribe(self, *args, **kwargs):
         """

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from distutils.version import StrictVersion
 from itertools import chain
 import os

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,5 +1,6 @@
 from distutils.version import StrictVersion
 from itertools import chain
+import io
 import os
 import socket
 import sys
@@ -13,7 +14,7 @@ except ImportError:
     ssl_available = False
 
 from redis._compat import (b, xrange, imap, byte_to_chr, unicode, bytes, long,
-                           BytesIO, nativestr, basestring, iteritems,
+                           nativestr, basestring, iteritems,
                            LifoQueue, Empty, Full, urlparse, parse_qs,
                            recv, recv_into, select, unquote)
 from redis.exceptions import (
@@ -152,7 +153,7 @@ class SocketBuffer(object):
     def __init__(self, socket, socket_read_size):
         self._sock = socket
         self.socket_read_size = socket_read_size
-        self._buffer = BytesIO()
+        self._buffer = io.BytesIO()
         # number of bytes written to the buffer from the socket
         self.bytes_written = 0
         # number of bytes read from the buffer

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -639,8 +639,8 @@ class Connection(object):
         # to prevent them from being encoded.
         command = args[0]
         if ' ' in command:
-            args = tuple([Token.get_token(s)
-                          for s in command.split()]) + args[1:]
+            args = tuple(Token.get_token(s)
+                         for s in command.split()) + args[1:]
         else:
             args = (Token.get_token(command),) + args[1:]
 

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -1,19 +1,8 @@
 "Core exceptions raised by the Redis client"
-from redis._compat import unicode
 
 
 class RedisError(Exception):
     pass
-
-
-# python 2.5 doesn't implement Exception.__unicode__. Add it here to all
-# our exception types
-if not hasattr(RedisError, '__unicode__'):
-    def __unicode__(self):
-        if isinstance(self.args[0], unicode):
-            return self.args[0]
-        return unicode(self.args[0])
-    RedisError.__unicode__ = __unicode__
 
 
 class AuthenticationError(RedisError):

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -3,7 +3,6 @@ import time as mod_time
 import uuid
 from redis.exceptions import LockError, WatchError
 from redis.utils import dummy
-from redis._compat import b
 
 
 class Lock(object):
@@ -99,7 +98,7 @@ class Lock(object):
         wait trying to acquire the lock.
         """
         sleep = self.sleep
-        token = b(uuid.uuid1().hex)
+        token = uuid.uuid1().hex.encode()
         if blocking is None:
             blocking = self.blocking
         if blocking_timeout is None:

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -171,10 +171,11 @@ class Sentinel(object):
         # if sentinel_kwargs isn't defined, use the socket_* options from
         # connection_kwargs
         if sentinel_kwargs is None:
-            sentinel_kwargs = dict((k, v)
-                                    for k, v in iteritems(connection_kwargs)
-                                    if k.startswith('socket_')
-                                    )
+            sentinel_kwargs = {
+                k: v
+                for k, v in iteritems(connection_kwargs)
+                if k.startswith('socket_')
+            }
         self.sentinel_kwargs = sentinel_kwargs
 
         self.sentinels = [StrictRedis(hostname, port, **self.sentinel_kwargs)

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -171,10 +171,10 @@ class Sentinel(object):
         # if sentinel_kwargs isn't defined, use the socket_* options from
         # connection_kwargs
         if sentinel_kwargs is None:
-            sentinel_kwargs = dict([(k, v)
+            sentinel_kwargs = dict((k, v)
                                     for k, v in iteritems(connection_kwargs)
                                     if k.startswith('socket_')
-                                    ])
+                                    )
         self.sentinel_kwargs = sentinel_kwargs
 
         self.sentinels = [StrictRedis(hostname, port, **self.sentinel_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     },
     tests_require=[
         'mock',
-        'pytest>=2.5.0',
+        'pytest>=2.7.0',
     ],
     cmdclass={'test': PyTest},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     keywords=['Redis', 'key-value store'],
     license='MIT',
     packages=['redis'],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     extras_require={
         'hiredis': [
             "hiredis>=0.1.3",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -418,8 +418,8 @@ class TestRedisCommands(object):
 
     def test_keys(self, r):
         assert r.keys() == []
-        keys_with_underscores = set([b('test_a'), b('test_b')])
-        keys = keys_with_underscores.union(set([b('testc')]))
+        keys_with_underscores = {b('test_a'), b('test_b')}
+        keys = keys_with_underscores.union({b('testc')})
         for key in keys:
             r[key] = 1
         assert set(r.keys(pattern='test_*')) == keys_with_underscores
@@ -744,9 +744,9 @@ class TestRedisCommands(object):
         r.set('c', 3)
         cursor, keys = r.scan()
         assert cursor == 0
-        assert set(keys) == set([b('a'), b('b'), b('c')])
+        assert set(keys) == {b('a'), b('b'), b('c')}
         _, keys = r.scan(match='a')
-        assert set(keys) == set([b('a')])
+        assert set(keys) == {b('a')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_scan_iter(self, r):
@@ -754,26 +754,26 @@ class TestRedisCommands(object):
         r.set('b', 2)
         r.set('c', 3)
         keys = list(r.scan_iter())
-        assert set(keys) == set([b('a'), b('b'), b('c')])
+        assert set(keys) == {b('a'), b('b'), b('c')}
         keys = list(r.scan_iter(match='a'))
-        assert set(keys) == set([b('a')])
+        assert set(keys) == {b('a')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_sscan(self, r):
         r.sadd('a', 1, 2, 3)
         cursor, members = r.sscan('a')
         assert cursor == 0
-        assert set(members) == set([b('1'), b('2'), b('3')])
+        assert set(members) == {b('1'), b('2'), b('3')}
         _, members = r.sscan('a', match=b('1'))
-        assert set(members) == set([b('1')])
+        assert set(members) == {b('1')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_sscan_iter(self, r):
         r.sadd('a', 1, 2, 3)
         members = list(r.sscan_iter('a'))
-        assert set(members) == set([b('1'), b('2'), b('3')])
+        assert set(members) == {b('1'), b('2'), b('3')}
         members = list(r.sscan_iter('a', match=b('1')))
-        assert set(members) == set([b('1')])
+        assert set(members) == {b('1')}
 
     @skip_if_server_version_lt('2.8.0')
     def test_hscan(self, r):
@@ -797,21 +797,21 @@ class TestRedisCommands(object):
         r.zadd('a', 'a', 1, 'b', 2, 'c', 3)
         cursor, pairs = r.zscan('a')
         assert cursor == 0
-        assert set(pairs) == set([(b('a'), 1), (b('b'), 2), (b('c'), 3)])
+        assert set(pairs) == {(b('a'), 1), (b('b'), 2), (b('c'), 3)}
         _, pairs = r.zscan('a', match='a')
-        assert set(pairs) == set([(b('a'), 1)])
+        assert set(pairs) == {(b('a'), 1)}
 
     @skip_if_server_version_lt('2.8.0')
     def test_zscan_iter(self, r):
         r.zadd('a', 'a', 1, 'b', 2, 'c', 3)
         pairs = list(r.zscan_iter('a'))
-        assert set(pairs) == set([(b('a'), 1), (b('b'), 2), (b('c'), 3)])
+        assert set(pairs) == {(b('a'), 1), (b('b'), 2), (b('c'), 3)}
         pairs = list(r.zscan_iter('a', match='a'))
-        assert set(pairs) == set([(b('a'), 1)])
+        assert set(pairs) == {(b('a'), 1)}
 
     # SET COMMANDS
     def test_sadd(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = {b('1'), b('2'), b('3')}
         r.sadd('a', *members)
         assert r.smembers('a') == members
 
@@ -821,23 +821,23 @@ class TestRedisCommands(object):
 
     def test_sdiff(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.sdiff('a', 'b') == set([b('1'), b('2'), b('3')])
+        assert r.sdiff('a', 'b') == {b('1'), b('2'), b('3')}
         r.sadd('b', '2', '3')
-        assert r.sdiff('a', 'b') == set([b('1')])
+        assert r.sdiff('a', 'b') == {b('1')}
 
     def test_sdiffstore(self, r):
         r.sadd('a', '1', '2', '3')
         assert r.sdiffstore('c', 'a', 'b') == 3
-        assert r.smembers('c') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('c') == {b('1'), b('2'), b('3')}
         r.sadd('b', '2', '3')
         assert r.sdiffstore('c', 'a', 'b') == 1
-        assert r.smembers('c') == set([b('1')])
+        assert r.smembers('c') == {b('1')}
 
     def test_sinter(self, r):
         r.sadd('a', '1', '2', '3')
         assert r.sinter('a', 'b') == set()
         r.sadd('b', '2', '3')
-        assert r.sinter('a', 'b') == set([b('2'), b('3')])
+        assert r.sinter('a', 'b') == {b('2'), b('3')}
 
     def test_sinterstore(self, r):
         r.sadd('a', '1', '2', '3')
@@ -845,7 +845,7 @@ class TestRedisCommands(object):
         assert r.smembers('c') == set()
         r.sadd('b', '2', '3')
         assert r.sinterstore('c', 'a', 'b') == 2
-        assert r.smembers('c') == set([b('2'), b('3')])
+        assert r.smembers('c') == {b('2'), b('3')}
 
     def test_sismember(self, r):
         r.sadd('a', '1', '2', '3')
@@ -856,21 +856,21 @@ class TestRedisCommands(object):
 
     def test_smembers(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.smembers('a') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('a') == {b('1'), b('2'), b('3')}
 
     def test_smove(self, r):
         r.sadd('a', 'a1', 'a2')
         r.sadd('b', 'b1', 'b2')
         assert r.smove('a', 'b', 'a1')
-        assert r.smembers('a') == set([b('a2')])
-        assert r.smembers('b') == set([b('b1'), b('b2'), b('a1')])
+        assert r.smembers('a') == {b('a2')}
+        assert r.smembers('b') == {b('b1'), b('b2'), b('a1')}
 
     def test_spop(self, r):
         s = [b('1'), b('2'), b('3')]
         r.sadd('a', *s)
         value = r.spop('a')
         assert value in s
-        assert r.smembers('a') == set(s) - set([value])
+        assert r.smembers('a') == set(s) - {value}
 
     def test_spop_multi_value(self, r):
         s = [b('1'), b('2'), b('3')]
@@ -900,18 +900,18 @@ class TestRedisCommands(object):
         r.sadd('a', '1', '2', '3', '4')
         assert r.srem('a', '5') == 0
         assert r.srem('a', '2', '4') == 2
-        assert r.smembers('a') == set([b('1'), b('3')])
+        assert r.smembers('a') == {b('1'), b('3')}
 
     def test_sunion(self, r):
         r.sadd('a', '1', '2')
         r.sadd('b', '2', '3')
-        assert r.sunion('a', 'b') == set([b('1'), b('2'), b('3')])
+        assert r.sunion('a', 'b') == {b('1'), b('2'), b('3')}
 
     def test_sunionstore(self, r):
         r.sadd('a', '1', '2')
         r.sadd('b', '2', '3')
         assert r.sunionstore('c', 'a', 'b') == 3
-        assert r.smembers('c') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('c') == {b('1'), b('2'), b('3')}
 
     # SORTED SET COMMANDS
     def test_zadd(self, r):
@@ -1190,26 +1190,26 @@ class TestRedisCommands(object):
     # HYPERLOGLOG TESTS
     @skip_if_server_version_lt('2.8.9')
     def test_pfadd(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = {b('1'), b('2'), b('3')}
         assert r.pfadd('a', *members) == 1
         assert r.pfadd('a', *members) == 0
         assert r.pfcount('a') == len(members)
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfcount(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = {b('1'), b('2'), b('3')}
         r.pfadd('a', *members)
         assert r.pfcount('a') == len(members)
-        members_b = set([b('2'), b('3'), b('4')])
+        members_b = {b('2'), b('3'), b('4')}
         r.pfadd('b', *members_b)
         assert r.pfcount('b') == len(members_b)
         assert r.pfcount('a', 'b') == len(members_b.union(members))
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfmerge(self, r):
-        mema = set([b('1'), b('2'), b('3')])
-        memb = set([b('2'), b('3'), b('4')])
-        memc = set([b('5'), b('6'), b('7')])
+        mema = {b('1'), b('2'), b('3')}
+        memb = {b('2'), b('3'), b('4')}
+        memc = {b('5'), b('6'), b('7')}
         r.pfadd('a', *mema)
         r.pfadd('b', *memb)
         r.pfadd('c', *memc)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import binascii
 import datetime
 import pytest

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import binascii
 import datetime
 import pytest
@@ -5,7 +6,7 @@ import re
 import redis
 import time
 
-from redis._compat import (unichr, u, b, ascii_letters, iteritems, iterkeys,
+from redis._compat import (unichr, ascii_letters, iteritems, iterkeys,
                            itervalues, long)
 from redis.client import parse_info
 from redis import exceptions
@@ -110,7 +111,7 @@ class TestRedisCommands(object):
         assert r.dbsize() == 2
 
     def test_echo(self, r):
-        assert r.echo('foo bar') == b('foo bar')
+        assert r.echo('foo bar') == b'foo bar'
 
     def test_info(self, r):
         r['a'] = 'foo'
@@ -126,7 +127,7 @@ class TestRedisCommands(object):
         r['a'] = 'foo'
         assert isinstance(r.object('refcount', 'a'), int)
         assert isinstance(r.object('idletime', 'a'), int)
-        assert r.object('encoding', 'a') in (b('raw'), b('embstr'))
+        assert r.object('encoding', 'a') in (b'raw', b'embstr')
         assert r.object('idletime', 'invalid-key') is None
 
     def test_ping(self, r):
@@ -134,20 +135,20 @@ class TestRedisCommands(object):
 
     def test_slowlog_get(self, r, slowlog):
         assert r.slowlog_reset()
-        unicode_string = unichr(3456) + u('abcd') + unichr(3421)
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         r.get(unicode_string)
         slowlog = r.slowlog_get()
         assert isinstance(slowlog, list)
         commands = [log['command'] for log in slowlog]
 
-        get_command = b(' ').join((b('GET'), unicode_string.encode('utf-8')))
+        get_command = b' '.join((b'GET', unicode_string.encode('utf-8')))
         assert get_command in commands
-        assert b('SLOWLOG RESET') in commands
+        assert b'SLOWLOG RESET' in commands
         # the order should be ['GET <uni string>', 'SLOWLOG RESET'],
         # but if other clients are executing commands at the same time, there
         # could be commands, before, between, or after, so just check that
         # the two we care about are in the appropriate order.
-        assert commands.index(get_command) < commands.index(b('SLOWLOG RESET'))
+        assert commands.index(get_command) < commands.index(b'SLOWLOG RESET')
 
         # make sure other attributes are typed correctly
         assert isinstance(slowlog[0]['start_time'], int)
@@ -160,8 +161,8 @@ class TestRedisCommands(object):
         slowlog = r.slowlog_get(1)
         assert isinstance(slowlog, list)
         commands = [log['command'] for log in slowlog]
-        assert b('GET foo') not in commands
-        assert b('GET bar') in commands
+        assert b'GET foo' not in commands
+        assert b'GET bar' in commands
 
     def test_slowlog_length(self, r, slowlog):
         r.get('foo')
@@ -177,9 +178,9 @@ class TestRedisCommands(object):
     # BASIC KEY COMMANDS
     def test_append(self, r):
         assert r.append('a', 'a1') == 2
-        assert r['a'] == b('a1')
+        assert r['a'] == b'a1'
         assert r.append('a', 'a2') == 4
-        assert r['a'] == b('a1a2')
+        assert r['a'] == b'a1a2'
 
     @skip_if_server_version_lt('2.6.0')
     def test_bitcount(self, r):
@@ -208,7 +209,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.6.0')
     def test_bitop_not(self, r):
-        test_str = b('\xAA\x00\xFF\x55')
+        test_str = b'\xAA\x00\xFF\x55'
         correct = ~0xAA00FF55 & 0xFFFFFFFF
         r['a'] = test_str
         r.bitop('not', 'r', 'a')
@@ -216,7 +217,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.6.0')
     def test_bitop_not_in_place(self, r):
-        test_str = b('\xAA\x00\xFF\x55')
+        test_str = b'\xAA\x00\xFF\x55'
         correct = ~0xAA00FF55 & 0xFFFFFFFF
         r['a'] = test_str
         r.bitop('not', 'a', 'a')
@@ -224,7 +225,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.6.0')
     def test_bitop_single_string(self, r):
-        test_str = b('\x01\x02\xFF')
+        test_str = b'\x01\x02\xFF'
         r['a'] = test_str
         r.bitop('and', 'res1', 'a')
         r.bitop('or', 'res2', 'a')
@@ -235,8 +236,8 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.6.0')
     def test_bitop_string_operands(self, r):
-        r['a'] = b('\x01\x02\xFF\xFF')
-        r['b'] = b('\x01\x02\xFF')
+        r['a'] = b'\x01\x02\xFF\xFF'
+        r['b'] = b'\x01\x02\xFF'
         r.bitop('and', 'res1', 'a', 'b')
         r.bitop('or', 'res2', 'a', 'b')
         r.bitop('xor', 'res3', 'a', 'b')
@@ -247,20 +248,20 @@ class TestRedisCommands(object):
     @skip_if_server_version_lt('2.8.7')
     def test_bitpos(self, r):
         key = 'key:bitpos'
-        r.set(key, b('\xff\xf0\x00'))
+        r.set(key, b'\xff\xf0\x00')
         assert r.bitpos(key, 0) == 12
         assert r.bitpos(key, 0, 2, -1) == 16
         assert r.bitpos(key, 0, -2, -1) == 12
-        r.set(key, b('\x00\xff\xf0'))
+        r.set(key, b'\x00\xff\xf0')
         assert r.bitpos(key, 1, 0) == 8
         assert r.bitpos(key, 1, 1) == 8
-        r.set(key, b('\x00\x00\x00'))
+        r.set(key, b'\x00\x00\x00')
         assert r.bitpos(key, 1) == -1
 
     @skip_if_server_version_lt('2.8.7')
     def test_bitpos_wrong_arguments(self, r):
         key = 'key:bitpos:wrong:args'
-        r.set(key, b('\xff\xf0\x00'))
+        r.set(key, b'\xff\xf0\x00')
         with pytest.raises(exceptions.RedisError):
             r.bitpos(key, 0, end=1) == 12
         with pytest.raises(exceptions.RedisError):
@@ -268,11 +269,11 @@ class TestRedisCommands(object):
 
     def test_decr(self, r):
         assert r.decr('a') == -1
-        assert r['a'] == b('-1')
+        assert r['a'] == b'-1'
         assert r.decr('a') == -2
-        assert r['a'] == b('-2')
+        assert r['a'] == b'-2'
         assert r.decr('a', amount=5) == -7
-        assert r['a'] == b('-7')
+        assert r['a'] == b'-7'
 
     def test_delete(self, r):
         assert r.delete('a') == 0
@@ -297,7 +298,7 @@ class TestRedisCommands(object):
         dumped = r.dump('a')
         del r['a']
         r.restore('a', 0, dumped)
-        assert r['a'] == b('foo')
+        assert r['a'] == b'foo'
 
     @skip_if_server_version_lt('3.0.0')
     def test_dump_and_restore_and_replace(self, r):
@@ -307,7 +308,7 @@ class TestRedisCommands(object):
             r.restore('a', 0, dumped)
 
         r.restore('a', 0, dumped, replace=True)
-        assert r['a'] == b('bar')
+        assert r['a'] == b'bar'
 
     def test_exists(self, r):
         assert not r.exists('a')
@@ -347,27 +348,27 @@ class TestRedisCommands(object):
     def test_get_and_set(self, r):
         # get and set can't be tested independently of each other
         assert r.get('a') is None
-        byte_string = b('value')
+        byte_string = b'value'
         integer = 5
-        unicode_string = unichr(3456) + u('abcd') + unichr(3421)
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         assert r.set('byte_string', byte_string)
         assert r.set('integer', 5)
         assert r.set('unicode_string', unicode_string)
         assert r.get('byte_string') == byte_string
-        assert r.get('integer') == b(str(integer))
+        assert r.get('integer') == str(integer).encode()
         assert r.get('unicode_string').decode('utf-8') == unicode_string
 
     def test_getitem_and_setitem(self, r):
         r['a'] = 'bar'
-        assert r['a'] == b('bar')
+        assert r['a'] == b'bar'
 
     def test_getitem_raises_keyerror_for_missing_key(self, r):
         with pytest.raises(KeyError):
             r['a']
 
     def test_getitem_does_not_raise_keyerror_for_empty_string(self, r):
-        r['a'] = b("")
-        assert r['a'] == b("")
+        r['a'] = b""
+        assert r['a'] == b""
 
     def test_get_set_bit(self, r):
         # no value
@@ -387,39 +388,39 @@ class TestRedisCommands(object):
 
     def test_getrange(self, r):
         r['a'] = 'foo'
-        assert r.getrange('a', 0, 0) == b('f')
-        assert r.getrange('a', 0, 2) == b('foo')
-        assert r.getrange('a', 3, 4) == b('')
+        assert r.getrange('a', 0, 0) == b'f'
+        assert r.getrange('a', 0, 2) == b'foo'
+        assert r.getrange('a', 3, 4) == b''
 
     def test_getset(self, r):
         assert r.getset('a', 'foo') is None
-        assert r.getset('a', 'bar') == b('foo')
-        assert r.get('a') == b('bar')
+        assert r.getset('a', 'bar') == b'foo'
+        assert r.get('a') == b'bar'
 
     def test_incr(self, r):
         assert r.incr('a') == 1
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert r.incr('a') == 2
-        assert r['a'] == b('2')
+        assert r['a'] == b'2'
         assert r.incr('a', amount=5) == 7
-        assert r['a'] == b('7')
+        assert r['a'] == b'7'
 
     def test_incrby(self, r):
         assert r.incrby('a') == 1
         assert r.incrby('a', 4) == 5
-        assert r['a'] == b('5')
+        assert r['a'] == b'5'
 
     @skip_if_server_version_lt('2.6.0')
     def test_incrbyfloat(self, r):
         assert r.incrbyfloat('a') == 1.0
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert r.incrbyfloat('a', 1.1) == 2.1
         assert float(r['a']) == float(2.1)
 
     def test_keys(self, r):
         assert r.keys() == []
-        keys_with_underscores = {b('test_a'), b('test_b')}
-        keys = keys_with_underscores.union({b('testc')})
+        keys_with_underscores = {b'test_a', b'test_b'}
+        keys = keys_with_underscores.union({b'testc'})
         for key in keys:
             r[key] = 1
         assert set(r.keys(pattern='test_*')) == keys_with_underscores
@@ -430,33 +431,33 @@ class TestRedisCommands(object):
         r['a'] = '1'
         r['b'] = '2'
         r['c'] = '3'
-        assert r.mget('a', 'other', 'b', 'c') == [b('1'), None, b('2'), b('3')]
+        assert r.mget('a', 'other', 'b', 'c') == [b'1', None, b'2', b'3']
 
     def test_mset(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.mset(d)
         for k, v in iteritems(d):
             assert r[k] == v
 
     def test_mset_kwargs(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.mset(**d)
         for k, v in iteritems(d):
             assert r[k] == v
 
     def test_msetnx(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.msetnx(d)
-        d2 = {'a': b('x'), 'd': b('4')}
+        d2 = {'a': b'x', 'd': b'4'}
         assert not r.msetnx(d2)
         for k, v in iteritems(d):
             assert r[k] == v
         assert r.get('d') is None
 
     def test_msetnx_kwargs(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.msetnx(**d)
-        d2 = {'a': b('x'), 'd': b('4')}
+        d2 = {'a': b'x', 'd': b'4'}
         assert not r.msetnx(**d2)
         for k, v in iteritems(d):
             assert r[k] == v
@@ -494,40 +495,40 @@ class TestRedisCommands(object):
     @skip_if_server_version_lt('2.6.0')
     def test_psetex(self, r):
         assert r.psetex('a', 1000, 'value')
-        assert r['a'] == b('value')
+        assert r['a'] == b'value'
         assert 0 < r.pttl('a') <= 1000
 
     @skip_if_server_version_lt('2.6.0')
     def test_psetex_timedelta(self, r):
         expire_at = datetime.timedelta(milliseconds=1000)
         assert r.psetex('a', expire_at, 'value')
-        assert r['a'] == b('value')
+        assert r['a'] == b'value'
         assert 0 < r.pttl('a') <= 1000
 
     def test_randomkey(self, r):
         assert r.randomkey() is None
         for key in ('a', 'b', 'c'):
             r[key] = 1
-        assert r.randomkey() in (b('a'), b('b'), b('c'))
+        assert r.randomkey() in (b'a', b'b', b'c')
 
     def test_rename(self, r):
         r['a'] = '1'
         assert r.rename('a', 'b')
         assert r.get('a') is None
-        assert r['b'] == b('1')
+        assert r['b'] == b'1'
 
     def test_renamenx(self, r):
         r['a'] = '1'
         r['b'] = '2'
         assert not r.renamenx('a', 'b')
-        assert r['a'] == b('1')
-        assert r['b'] == b('2')
+        assert r['a'] == b'1'
+        assert r['b'] == b'2'
 
     @skip_if_server_version_lt('2.6.0')
     def test_set_nx(self, r):
         assert r.set('a', '1', nx=True)
         assert not r.set('a', '2', nx=True)
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
 
     @skip_if_server_version_lt('2.6.0')
     def test_set_xx(self, r):
@@ -535,12 +536,12 @@ class TestRedisCommands(object):
         assert r.get('a') is None
         r['a'] = 'bar'
         assert r.set('a', '2', xx=True)
-        assert r.get('a') == b('2')
+        assert r.get('a') == b'2'
 
     @skip_if_server_version_lt('2.6.0')
     def test_set_px(self, r):
         assert r.set('a', '1', px=10000)
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert 0 < r.pttl('a') <= 10000
         assert 0 < r.ttl('a') <= 10
 
@@ -570,21 +571,21 @@ class TestRedisCommands(object):
 
     def test_setex(self, r):
         assert r.setex('a', '1', 60)
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert 0 < r.ttl('a') <= 60
 
     def test_setnx(self, r):
         assert r.setnx('a', '1')
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert not r.setnx('a', '2')
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
 
     def test_setrange(self, r):
         assert r.setrange('a', 5, 'foo') == 8
-        assert r['a'] == b('\0\0\0\0\0foo')
+        assert r['a'] == b'\0\0\0\0\0foo'
         r['a'] = 'abcdefghijh'
         assert r.setrange('a', 6, '12345') == 11
-        assert r['a'] == b('abcdef12345')
+        assert r['a'] == b'abcdef12345'
 
     def test_strlen(self, r):
         r['a'] = 'foo'
@@ -592,74 +593,74 @@ class TestRedisCommands(object):
 
     def test_substr(self, r):
         r['a'] = '0123456789'
-        assert r.substr('a', 0) == b('0123456789')
-        assert r.substr('a', 2) == b('23456789')
-        assert r.substr('a', 3, 5) == b('345')
-        assert r.substr('a', 3, -2) == b('345678')
+        assert r.substr('a', 0) == b'0123456789'
+        assert r.substr('a', 2) == b'23456789'
+        assert r.substr('a', 3, 5) == b'345'
+        assert r.substr('a', 3, -2) == b'345678'
 
     def test_type(self, r):
-        assert r.type('a') == b('none')
+        assert r.type('a') == b'none'
         r['a'] = '1'
-        assert r.type('a') == b('string')
+        assert r.type('a') == b'string'
         del r['a']
         r.lpush('a', '1')
-        assert r.type('a') == b('list')
+        assert r.type('a') == b'list'
         del r['a']
         r.sadd('a', '1')
-        assert r.type('a') == b('set')
+        assert r.type('a') == b'set'
         del r['a']
         r.zadd('a', **{'1': 1})
-        assert r.type('a') == b('zset')
+        assert r.type('a') == b'zset'
 
     # LIST COMMANDS
     def test_blpop(self, r):
         r.rpush('a', '1', '2')
         r.rpush('b', '3', '4')
-        assert r.blpop(['b', 'a'], timeout=1) == (b('b'), b('3'))
-        assert r.blpop(['b', 'a'], timeout=1) == (b('b'), b('4'))
-        assert r.blpop(['b', 'a'], timeout=1) == (b('a'), b('1'))
-        assert r.blpop(['b', 'a'], timeout=1) == (b('a'), b('2'))
+        assert r.blpop(['b', 'a'], timeout=1) == (b'b', b'3')
+        assert r.blpop(['b', 'a'], timeout=1) == (b'b', b'4')
+        assert r.blpop(['b', 'a'], timeout=1) == (b'a', b'1')
+        assert r.blpop(['b', 'a'], timeout=1) == (b'a', b'2')
         assert r.blpop(['b', 'a'], timeout=1) is None
         r.rpush('c', '1')
-        assert r.blpop('c', timeout=1) == (b('c'), b('1'))
+        assert r.blpop('c', timeout=1) == (b'c', b'1')
 
     def test_brpop(self, r):
         r.rpush('a', '1', '2')
         r.rpush('b', '3', '4')
-        assert r.brpop(['b', 'a'], timeout=1) == (b('b'), b('4'))
-        assert r.brpop(['b', 'a'], timeout=1) == (b('b'), b('3'))
-        assert r.brpop(['b', 'a'], timeout=1) == (b('a'), b('2'))
-        assert r.brpop(['b', 'a'], timeout=1) == (b('a'), b('1'))
+        assert r.brpop(['b', 'a'], timeout=1) == (b'b', b'4')
+        assert r.brpop(['b', 'a'], timeout=1) == (b'b', b'3')
+        assert r.brpop(['b', 'a'], timeout=1) == (b'a', b'2')
+        assert r.brpop(['b', 'a'], timeout=1) == (b'a', b'1')
         assert r.brpop(['b', 'a'], timeout=1) is None
         r.rpush('c', '1')
-        assert r.brpop('c', timeout=1) == (b('c'), b('1'))
+        assert r.brpop('c', timeout=1) == (b'c', b'1')
 
     def test_brpoplpush(self, r):
         r.rpush('a', '1', '2')
         r.rpush('b', '3', '4')
-        assert r.brpoplpush('a', 'b') == b('2')
-        assert r.brpoplpush('a', 'b') == b('1')
+        assert r.brpoplpush('a', 'b') == b'2'
+        assert r.brpoplpush('a', 'b') == b'1'
         assert r.brpoplpush('a', 'b', timeout=1) is None
         assert r.lrange('a', 0, -1) == []
-        assert r.lrange('b', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
+        assert r.lrange('b', 0, -1) == [b'1', b'2', b'3', b'4']
 
     def test_brpoplpush_empty_string(self, r):
         r.rpush('a', '')
-        assert r.brpoplpush('a', 'b') == b('')
+        assert r.brpoplpush('a', 'b') == b''
 
     def test_lindex(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.lindex('a', '0') == b('1')
-        assert r.lindex('a', '1') == b('2')
-        assert r.lindex('a', '2') == b('3')
+        assert r.lindex('a', '0') == b'1'
+        assert r.lindex('a', '1') == b'2'
+        assert r.lindex('a', '2') == b'3'
 
     def test_linsert(self, r):
         r.rpush('a', '1', '2', '3')
         assert r.linsert('a', 'after', '2', '2.5') == 4
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('2.5'), b('3')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'2.5', b'3']
         assert r.linsert('a', 'before', '2', '1.5') == 5
         assert r.lrange('a', 0, -1) == \
-            [b('1'), b('1.5'), b('2'), b('2.5'), b('3')]
+            [b'1', b'1.5', b'2', b'2.5', b'3']
 
     def test_llen(self, r):
         r.rpush('a', '1', '2', '3')
@@ -667,74 +668,74 @@ class TestRedisCommands(object):
 
     def test_lpop(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.lpop('a') == b('1')
-        assert r.lpop('a') == b('2')
-        assert r.lpop('a') == b('3')
+        assert r.lpop('a') == b'1'
+        assert r.lpop('a') == b'2'
+        assert r.lpop('a') == b'3'
         assert r.lpop('a') is None
 
     def test_lpush(self, r):
         assert r.lpush('a', '1') == 1
         assert r.lpush('a', '2') == 2
         assert r.lpush('a', '3', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('4'), b('3'), b('2'), b('1')]
+        assert r.lrange('a', 0, -1) == [b'4', b'3', b'2', b'1']
 
     def test_lpushx(self, r):
         assert r.lpushx('a', '1') == 0
         assert r.lrange('a', 0, -1) == []
         r.rpush('a', '1', '2', '3')
         assert r.lpushx('a', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('4'), b('1'), b('2'), b('3')]
+        assert r.lrange('a', 0, -1) == [b'4', b'1', b'2', b'3']
 
     def test_lrange(self, r):
         r.rpush('a', '1', '2', '3', '4', '5')
-        assert r.lrange('a', 0, 2) == [b('1'), b('2'), b('3')]
-        assert r.lrange('a', 2, 10) == [b('3'), b('4'), b('5')]
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4'), b('5')]
+        assert r.lrange('a', 0, 2) == [b'1', b'2', b'3']
+        assert r.lrange('a', 2, 10) == [b'3', b'4', b'5']
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4', b'5']
 
     def test_lrem(self, r):
         r.rpush('a', '1', '1', '1', '1')
         assert r.lrem('a', '1', 1) == 1
-        assert r.lrange('a', 0, -1) == [b('1'), b('1'), b('1')]
+        assert r.lrange('a', 0, -1) == [b'1', b'1', b'1']
         assert r.lrem('a', '1') == 3
         assert r.lrange('a', 0, -1) == []
 
     def test_lset(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3']
         assert r.lset('a', 1, '4')
-        assert r.lrange('a', 0, 2) == [b('1'), b('4'), b('3')]
+        assert r.lrange('a', 0, 2) == [b'1', b'4', b'3']
 
     def test_ltrim(self, r):
         r.rpush('a', '1', '2', '3')
         assert r.ltrim('a', 0, 1)
-        assert r.lrange('a', 0, -1) == [b('1'), b('2')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2']
 
     def test_rpop(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.rpop('a') == b('3')
-        assert r.rpop('a') == b('2')
-        assert r.rpop('a') == b('1')
+        assert r.rpop('a') == b'3'
+        assert r.rpop('a') == b'2'
+        assert r.rpop('a') == b'1'
         assert r.rpop('a') is None
 
     def test_rpoplpush(self, r):
         r.rpush('a', 'a1', 'a2', 'a3')
         r.rpush('b', 'b1', 'b2', 'b3')
-        assert r.rpoplpush('a', 'b') == b('a3')
-        assert r.lrange('a', 0, -1) == [b('a1'), b('a2')]
-        assert r.lrange('b', 0, -1) == [b('a3'), b('b1'), b('b2'), b('b3')]
+        assert r.rpoplpush('a', 'b') == b'a3'
+        assert r.lrange('a', 0, -1) == [b'a1', b'a2']
+        assert r.lrange('b', 0, -1) == [b'a3', b'b1', b'b2', b'b3']
 
     def test_rpush(self, r):
         assert r.rpush('a', '1') == 1
         assert r.rpush('a', '2') == 2
         assert r.rpush('a', '3', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4']
 
     def test_rpushx(self, r):
         assert r.rpushx('a', 'b') == 0
         assert r.lrange('a', 0, -1) == []
         r.rpush('a', '1', '2', '3')
         assert r.rpushx('a', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4']
 
     # SCAN COMMANDS
     @skip_if_server_version_lt('2.8.0')
@@ -744,9 +745,9 @@ class TestRedisCommands(object):
         r.set('c', 3)
         cursor, keys = r.scan()
         assert cursor == 0
-        assert set(keys) == {b('a'), b('b'), b('c')}
+        assert set(keys) == {b'a', b'b', b'c'}
         _, keys = r.scan(match='a')
-        assert set(keys) == {b('a')}
+        assert set(keys) == {b'a'}
 
     @skip_if_server_version_lt('2.8.0')
     def test_scan_iter(self, r):
@@ -754,64 +755,64 @@ class TestRedisCommands(object):
         r.set('b', 2)
         r.set('c', 3)
         keys = list(r.scan_iter())
-        assert set(keys) == {b('a'), b('b'), b('c')}
+        assert set(keys) == {b'a', b'b', b'c'}
         keys = list(r.scan_iter(match='a'))
-        assert set(keys) == {b('a')}
+        assert set(keys) == {b'a'}
 
     @skip_if_server_version_lt('2.8.0')
     def test_sscan(self, r):
         r.sadd('a', 1, 2, 3)
         cursor, members = r.sscan('a')
         assert cursor == 0
-        assert set(members) == {b('1'), b('2'), b('3')}
-        _, members = r.sscan('a', match=b('1'))
-        assert set(members) == {b('1')}
+        assert set(members) == {b'1', b'2', b'3'}
+        _, members = r.sscan('a', match=b'1')
+        assert set(members) == {b'1'}
 
     @skip_if_server_version_lt('2.8.0')
     def test_sscan_iter(self, r):
         r.sadd('a', 1, 2, 3)
         members = list(r.sscan_iter('a'))
-        assert set(members) == {b('1'), b('2'), b('3')}
-        members = list(r.sscan_iter('a', match=b('1')))
-        assert set(members) == {b('1')}
+        assert set(members) == {b'1', b'2', b'3'}
+        members = list(r.sscan_iter('a', match=b'1'))
+        assert set(members) == {b'1'}
 
     @skip_if_server_version_lt('2.8.0')
     def test_hscan(self, r):
         r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         cursor, dic = r.hscan('a')
         assert cursor == 0
-        assert dic == {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
+        assert dic == {b'a': b'1', b'b': b'2', b'c': b'3'}
         _, dic = r.hscan('a', match='a')
-        assert dic == {b('a'): b('1')}
+        assert dic == {b'a': b'1'}
 
     @skip_if_server_version_lt('2.8.0')
     def test_hscan_iter(self, r):
         r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         dic = dict(r.hscan_iter('a'))
-        assert dic == {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
+        assert dic == {b'a': b'1', b'b': b'2', b'c': b'3'}
         dic = dict(r.hscan_iter('a', match='a'))
-        assert dic == {b('a'): b('1')}
+        assert dic == {b'a': b'1'}
 
     @skip_if_server_version_lt('2.8.0')
     def test_zscan(self, r):
         r.zadd('a', 'a', 1, 'b', 2, 'c', 3)
         cursor, pairs = r.zscan('a')
         assert cursor == 0
-        assert set(pairs) == {(b('a'), 1), (b('b'), 2), (b('c'), 3)}
+        assert set(pairs) == {(b'a', 1), (b'b', 2), (b'c', 3)}
         _, pairs = r.zscan('a', match='a')
-        assert set(pairs) == {(b('a'), 1)}
+        assert set(pairs) == {(b'a', 1)}
 
     @skip_if_server_version_lt('2.8.0')
     def test_zscan_iter(self, r):
         r.zadd('a', 'a', 1, 'b', 2, 'c', 3)
         pairs = list(r.zscan_iter('a'))
-        assert set(pairs) == {(b('a'), 1), (b('b'), 2), (b('c'), 3)}
+        assert set(pairs) == {(b'a', 1), (b'b', 2), (b'c', 3)}
         pairs = list(r.zscan_iter('a', match='a'))
-        assert set(pairs) == {(b('a'), 1)}
+        assert set(pairs) == {(b'a', 1)}
 
     # SET COMMANDS
     def test_sadd(self, r):
-        members = {b('1'), b('2'), b('3')}
+        members = {b'1', b'2', b'3'}
         r.sadd('a', *members)
         assert r.smembers('a') == members
 
@@ -821,23 +822,23 @@ class TestRedisCommands(object):
 
     def test_sdiff(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.sdiff('a', 'b') == {b('1'), b('2'), b('3')}
+        assert r.sdiff('a', 'b') == {b'1', b'2', b'3'}
         r.sadd('b', '2', '3')
-        assert r.sdiff('a', 'b') == {b('1')}
+        assert r.sdiff('a', 'b') == {b'1'}
 
     def test_sdiffstore(self, r):
         r.sadd('a', '1', '2', '3')
         assert r.sdiffstore('c', 'a', 'b') == 3
-        assert r.smembers('c') == {b('1'), b('2'), b('3')}
+        assert r.smembers('c') == {b'1', b'2', b'3'}
         r.sadd('b', '2', '3')
         assert r.sdiffstore('c', 'a', 'b') == 1
-        assert r.smembers('c') == {b('1')}
+        assert r.smembers('c') == {b'1'}
 
     def test_sinter(self, r):
         r.sadd('a', '1', '2', '3')
         assert r.sinter('a', 'b') == set()
         r.sadd('b', '2', '3')
-        assert r.sinter('a', 'b') == {b('2'), b('3')}
+        assert r.sinter('a', 'b') == {b'2', b'3'}
 
     def test_sinterstore(self, r):
         r.sadd('a', '1', '2', '3')
@@ -845,7 +846,7 @@ class TestRedisCommands(object):
         assert r.smembers('c') == set()
         r.sadd('b', '2', '3')
         assert r.sinterstore('c', 'a', 'b') == 2
-        assert r.smembers('c') == {b('2'), b('3')}
+        assert r.smembers('c') == {b'2', b'3'}
 
     def test_sismember(self, r):
         r.sadd('a', '1', '2', '3')
@@ -856,24 +857,24 @@ class TestRedisCommands(object):
 
     def test_smembers(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.smembers('a') == {b('1'), b('2'), b('3')}
+        assert r.smembers('a') == {b'1', b'2', b'3'}
 
     def test_smove(self, r):
         r.sadd('a', 'a1', 'a2')
         r.sadd('b', 'b1', 'b2')
         assert r.smove('a', 'b', 'a1')
-        assert r.smembers('a') == {b('a2')}
-        assert r.smembers('b') == {b('b1'), b('b2'), b('a1')}
+        assert r.smembers('a') == {b'a2'}
+        assert r.smembers('b') == {b'b1', b'b2', b'a1'}
 
     def test_spop(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         value = r.spop('a')
         assert value in s
         assert r.smembers('a') == set(s) - {value}
 
     def test_spop_multi_value(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         values = r.spop('a', 2)
         assert len(values) == 2
@@ -884,13 +885,13 @@ class TestRedisCommands(object):
         assert r.spop('a', 1) == list(set(s) - set(values))
 
     def test_srandmember(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         assert r.srandmember('a') in s
 
     @skip_if_server_version_lt('2.6.0')
     def test_srandmember_multi_value(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         randoms = r.srandmember('a', number=2)
         assert len(randoms) == 2
@@ -900,23 +901,23 @@ class TestRedisCommands(object):
         r.sadd('a', '1', '2', '3', '4')
         assert r.srem('a', '5') == 0
         assert r.srem('a', '2', '4') == 2
-        assert r.smembers('a') == {b('1'), b('3')}
+        assert r.smembers('a') == {b'1', b'3'}
 
     def test_sunion(self, r):
         r.sadd('a', '1', '2')
         r.sadd('b', '2', '3')
-        assert r.sunion('a', 'b') == {b('1'), b('2'), b('3')}
+        assert r.sunion('a', 'b') == {b'1', b'2', b'3'}
 
     def test_sunionstore(self, r):
         r.sadd('a', '1', '2')
         r.sadd('b', '2', '3')
         assert r.sunionstore('c', 'a', 'b') == 3
-        assert r.smembers('c') == {b('1'), b('2'), b('3')}
+        assert r.smembers('c') == {b'1', b'2', b'3'}
 
     # SORTED SET COMMANDS
     def test_zadd(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a2'), b('a3')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a2', b'a3']
 
     def test_zcard(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
@@ -949,7 +950,7 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zinterstore('d', ['a', 'b', 'c']) == 2
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a3'), 8), (b('a1'), 9)]
+            [(b'a3', 8), (b'a1', 9)]
 
     def test_zinterstore_max(self, r):
         r.zadd('a', a1=1, a2=1, a3=1)
@@ -957,7 +958,7 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zinterstore('d', ['a', 'b', 'c'], aggregate='MAX') == 2
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a3'), 5), (b('a1'), 6)]
+            [(b'a3', 5), (b'a1', 6)]
 
     def test_zinterstore_min(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
@@ -965,7 +966,7 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zinterstore('d', ['a', 'b', 'c'], aggregate='MIN') == 2
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a1'), 1), (b('a3'), 3)]
+            [(b'a1', 1), (b'a3', 3)]
 
     def test_zinterstore_with_weight(self, r):
         r.zadd('a', a1=1, a2=1, a3=1)
@@ -973,102 +974,102 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zinterstore('d', {'a': 1, 'b': 2, 'c': 3}) == 2
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a3'), 20), (b('a1'), 23)]
+            [(b'a3', 20), (b'a1', 23)]
 
     @skip_if_server_version_lt('4.9.0')
     def test_zpopmax(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zpopmax('a') == [(b('a3'), 3)]
+        assert r.zpopmax('a') == [(b'a3', 3)]
 
         # with count
         assert r.zpopmax('a', count=2) == \
-            [(b('a2'), 2), (b('a1'), 1)]
+            [(b'a2', 2), (b'a1', 1)]
 
     @skip_if_server_version_lt('4.9.0')
     def test_zpopmin(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zpopmin('a') == [(b('a1'), 1)]
+        assert r.zpopmin('a') == [(b'a1', 1)]
 
         # with count
         assert r.zpopmin('a', count=2) == \
-            [(b('a2'), 2), (b('a3'), 3)]
+            [(b'a2', 2), (b'a3', 3)]
 
     @skip_if_server_version_lt('4.9.0')
     def test_bzpopmax(self, r):
         r.zadd('a', a1=1, a2=2)
         r.zadd('b', b1=10, b2=20)
-        assert r.bzpopmax(['b', 'a'], timeout=1) == (b('b'), b('b2'), 20)
-        assert r.bzpopmax(['b', 'a'], timeout=1) == (b('b'), b('b1'), 10)
-        assert r.bzpopmax(['b', 'a'], timeout=1) == (b('a'), b('a2'), 2)
-        assert r.bzpopmax(['b', 'a'], timeout=1) == (b('a'), b('a1'), 1)
+        assert r.bzpopmax(['b', 'a'], timeout=1) == (b'b', b'b2', 20)
+        assert r.bzpopmax(['b', 'a'], timeout=1) == (b'b', b'b1', 10)
+        assert r.bzpopmax(['b', 'a'], timeout=1) == (b'a', b'a2', 2)
+        assert r.bzpopmax(['b', 'a'], timeout=1) == (b'a', b'a1', 1)
         assert r.bzpopmax(['b', 'a'], timeout=1) is None
         r.zadd('c', c1=100)
-        assert r.bzpopmax('c', timeout=1) == (b('c'), b('c1'), 100)
+        assert r.bzpopmax('c', timeout=1) == (b'c', b'c1', 100)
 
     @skip_if_server_version_lt('4.9.0')
     def test_bzpopmin(self, r):
         r.zadd('a', a1=1, a2=2)
         r.zadd('b', b1=10, b2=20)
-        assert r.bzpopmin(['b', 'a'], timeout=1) == (b('b'), b('b1'), 10)
-        assert r.bzpopmin(['b', 'a'], timeout=1) == (b('b'), b('b2'), 20)
-        assert r.bzpopmin(['b', 'a'], timeout=1) == (b('a'), b('a1'), 1)
-        assert r.bzpopmin(['b', 'a'], timeout=1) == (b('a'), b('a2'), 2)
+        assert r.bzpopmin(['b', 'a'], timeout=1) == (b'b', b'b1', 10)
+        assert r.bzpopmin(['b', 'a'], timeout=1) == (b'b', b'b2', 20)
+        assert r.bzpopmin(['b', 'a'], timeout=1) == (b'a', b'a1', 1)
+        assert r.bzpopmin(['b', 'a'], timeout=1) == (b'a', b'a2', 2)
         assert r.bzpopmin(['b', 'a'], timeout=1) is None
         r.zadd('c', c1=100)
-        assert r.bzpopmin('c', timeout=1) == (b('c'), b('c1'), 100)
+        assert r.bzpopmin('c', timeout=1) == (b'c', b'c1', 100)
 
     def test_zrange(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zrange('a', 0, 1) == [b('a1'), b('a2')]
-        assert r.zrange('a', 1, 2) == [b('a2'), b('a3')]
+        assert r.zrange('a', 0, 1) == [b'a1', b'a2']
+        assert r.zrange('a', 1, 2) == [b'a2', b'a3']
 
         # withscores
         assert r.zrange('a', 0, 1, withscores=True) == \
-            [(b('a1'), 1.0), (b('a2'), 2.0)]
+            [(b'a1', 1.0), (b'a2', 2.0)]
         assert r.zrange('a', 1, 2, withscores=True) == \
-            [(b('a2'), 2.0), (b('a3'), 3.0)]
+            [(b'a2', 2.0), (b'a3', 3.0)]
 
         # custom score function
         assert r.zrange('a', 0, 1, withscores=True, score_cast_func=int) == \
-            [(b('a1'), 1), (b('a2'), 2)]
+            [(b'a1', 1), (b'a2', 2)]
 
     @skip_if_server_version_lt('2.8.9')
     def test_zrangebylex(self, r):
         r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
-        assert r.zrangebylex('a', '-', '[c') == [b('a'), b('b'), b('c')]
-        assert r.zrangebylex('a', '-', '(c') == [b('a'), b('b')]
+        assert r.zrangebylex('a', '-', '[c') == [b'a', b'b', b'c']
+        assert r.zrangebylex('a', '-', '(c') == [b'a', b'b']
         assert r.zrangebylex('a', '[aaa', '(g') == \
-            [b('b'), b('c'), b('d'), b('e'), b('f')]
-        assert r.zrangebylex('a', '[f', '+') == [b('f'), b('g')]
-        assert r.zrangebylex('a', '-', '+', start=3, num=2) == [b('d'), b('e')]
+            [b'b', b'c', b'd', b'e', b'f']
+        assert r.zrangebylex('a', '[f', '+') == [b'f', b'g']
+        assert r.zrangebylex('a', '-', '+', start=3, num=2) == [b'd', b'e']
 
     @skip_if_server_version_lt('2.9.9')
     def test_zrevrangebylex(self, r):
         r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
-        assert r.zrevrangebylex('a', '[c', '-') == [b('c'), b('b'), b('a')]
-        assert r.zrevrangebylex('a', '(c', '-') == [b('b'), b('a')]
+        assert r.zrevrangebylex('a', '[c', '-') == [b'c', b'b', b'a']
+        assert r.zrevrangebylex('a', '(c', '-') == [b'b', b'a']
         assert r.zrevrangebylex('a', '(g', '[aaa') == \
-            [b('f'), b('e'), b('d'), b('c'), b('b')]
-        assert r.zrevrangebylex('a', '+', '[f') == [b('g'), b('f')]
+            [b'f', b'e', b'd', b'c', b'b']
+        assert r.zrevrangebylex('a', '+', '[f') == [b'g', b'f']
         assert r.zrevrangebylex('a', '+', '-', start=3, num=2) == \
-            [b('d'), b('c')]
+            [b'd', b'c']
 
     def test_zrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
-        assert r.zrangebyscore('a', 2, 4) == [b('a2'), b('a3'), b('a4')]
+        assert r.zrangebyscore('a', 2, 4) == [b'a2', b'a3', b'a4']
 
         # slicing with start/num
         assert r.zrangebyscore('a', 2, 4, start=1, num=2) == \
-            [b('a3'), b('a4')]
+            [b'a3', b'a4']
 
         # withscores
         assert r.zrangebyscore('a', 2, 4, withscores=True) == \
-            [(b('a2'), 2.0), (b('a3'), 3.0), (b('a4'), 4.0)]
+            [(b'a2', 2.0), (b'a3', 3.0), (b'a4', 4.0)]
 
         # custom score function
         assert r.zrangebyscore('a', 2, 4, withscores=True,
                                score_cast_func=int) == \
-            [(b('a2'), 2), (b('a3'), 3), (b('a4'), 4)]
+            [(b'a2', 2), (b'a3', 3), (b'a4', 4)]
 
     def test_zrank(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1079,69 +1080,69 @@ class TestRedisCommands(object):
     def test_zrem(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
         assert r.zrem('a', 'a2') == 1
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a3')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a3']
         assert r.zrem('a', 'b') == 0
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a3')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a3']
 
     def test_zrem_multiple_keys(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
         assert r.zrem('a', 'a1', 'a2') == 2
-        assert r.zrange('a', 0, 5) == [b('a3')]
+        assert r.zrange('a', 0, 5) == [b'a3']
 
     @skip_if_server_version_lt('2.8.9')
     def test_zremrangebylex(self, r):
         r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
         assert r.zremrangebylex('a', '-', '[c') == 3
-        assert r.zrange('a', 0, -1) == [b('d'), b('e'), b('f'), b('g')]
+        assert r.zrange('a', 0, -1) == [b'd', b'e', b'f', b'g']
         assert r.zremrangebylex('a', '[f', '+') == 2
-        assert r.zrange('a', 0, -1) == [b('d'), b('e')]
+        assert r.zrange('a', 0, -1) == [b'd', b'e']
         assert r.zremrangebylex('a', '[h', '+') == 0
-        assert r.zrange('a', 0, -1) == [b('d'), b('e')]
+        assert r.zrange('a', 0, -1) == [b'd', b'e']
 
     def test_zremrangebyrank(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
         assert r.zremrangebyrank('a', 1, 3) == 3
-        assert r.zrange('a', 0, 5) == [b('a1'), b('a5')]
+        assert r.zrange('a', 0, 5) == [b'a1', b'a5']
 
     def test_zremrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
         assert r.zremrangebyscore('a', 2, 4) == 3
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a5')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a5']
         assert r.zremrangebyscore('a', 2, 4) == 0
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a5')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a5']
 
     def test_zrevrange(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zrevrange('a', 0, 1) == [b('a3'), b('a2')]
-        assert r.zrevrange('a', 1, 2) == [b('a2'), b('a1')]
+        assert r.zrevrange('a', 0, 1) == [b'a3', b'a2']
+        assert r.zrevrange('a', 1, 2) == [b'a2', b'a1']
 
         # withscores
         assert r.zrevrange('a', 0, 1, withscores=True) == \
-            [(b('a3'), 3.0), (b('a2'), 2.0)]
+            [(b'a3', 3.0), (b'a2', 2.0)]
         assert r.zrevrange('a', 1, 2, withscores=True) == \
-            [(b('a2'), 2.0), (b('a1'), 1.0)]
+            [(b'a2', 2.0), (b'a1', 1.0)]
 
         # custom score function
         assert r.zrevrange('a', 0, 1, withscores=True,
                            score_cast_func=int) == \
-            [(b('a3'), 3.0), (b('a2'), 2.0)]
+            [(b'a3', 3.0), (b'a2', 2.0)]
 
     def test_zrevrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
-        assert r.zrevrangebyscore('a', 4, 2) == [b('a4'), b('a3'), b('a2')]
+        assert r.zrevrangebyscore('a', 4, 2) == [b'a4', b'a3', b'a2']
 
         # slicing with start/num
         assert r.zrevrangebyscore('a', 4, 2, start=1, num=2) == \
-            [b('a3'), b('a2')]
+            [b'a3', b'a2']
 
         # withscores
         assert r.zrevrangebyscore('a', 4, 2, withscores=True) == \
-            [(b('a4'), 4.0), (b('a3'), 3.0), (b('a2'), 2.0)]
+            [(b'a4', 4.0), (b'a3', 3.0), (b'a2', 2.0)]
 
         # custom score function
         assert r.zrevrangebyscore('a', 4, 2, withscores=True,
                                   score_cast_func=int) == \
-            [(b('a4'), 4), (b('a3'), 3), (b('a2'), 2)]
+            [(b'a4', 4), (b'a3', 3), (b'a2', 2)]
 
     def test_zrevrank(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1161,7 +1162,7 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zunionstore('d', ['a', 'b', 'c']) == 4
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a2'), 3), (b('a4'), 4), (b('a3'), 8), (b('a1'), 9)]
+            [(b'a2', 3), (b'a4', 4), (b'a3', 8), (b'a1', 9)]
 
     def test_zunionstore_max(self, r):
         r.zadd('a', a1=1, a2=1, a3=1)
@@ -1169,7 +1170,7 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zunionstore('d', ['a', 'b', 'c'], aggregate='MAX') == 4
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a2'), 2), (b('a4'), 4), (b('a3'), 5), (b('a1'), 6)]
+            [(b'a2', 2), (b'a4', 4), (b'a3', 5), (b'a1', 6)]
 
     def test_zunionstore_min(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
@@ -1177,7 +1178,7 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zunionstore('d', ['a', 'b', 'c'], aggregate='MIN') == 4
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a1'), 1), (b('a2'), 2), (b('a3'), 3), (b('a4'), 4)]
+            [(b'a1', 1), (b'a2', 2), (b'a3', 3), (b'a4', 4)]
 
     def test_zunionstore_with_weight(self, r):
         r.zadd('a', a1=1, a2=1, a3=1)
@@ -1185,31 +1186,31 @@ class TestRedisCommands(object):
         r.zadd('c', a1=6, a3=5, a4=4)
         assert r.zunionstore('d', {'a': 1, 'b': 2, 'c': 3}) == 4
         assert r.zrange('d', 0, -1, withscores=True) == \
-            [(b('a2'), 5), (b('a4'), 12), (b('a3'), 20), (b('a1'), 23)]
+            [(b'a2', 5), (b'a4', 12), (b'a3', 20), (b'a1', 23)]
 
     # HYPERLOGLOG TESTS
     @skip_if_server_version_lt('2.8.9')
     def test_pfadd(self, r):
-        members = {b('1'), b('2'), b('3')}
+        members = {b'1', b'2', b'3'}
         assert r.pfadd('a', *members) == 1
         assert r.pfadd('a', *members) == 0
         assert r.pfcount('a') == len(members)
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfcount(self, r):
-        members = {b('1'), b('2'), b('3')}
+        members = {b'1', b'2', b'3'}
         r.pfadd('a', *members)
         assert r.pfcount('a') == len(members)
-        members_b = {b('2'), b('3'), b('4')}
+        members_b = {b'2', b'3', b'4'}
         r.pfadd('b', *members_b)
         assert r.pfcount('b') == len(members_b)
         assert r.pfcount('a', 'b') == len(members_b.union(members))
 
     @skip_if_server_version_lt('2.8.9')
     def test_pfmerge(self, r):
-        mema = {b('1'), b('2'), b('3')}
-        memb = {b('2'), b('3'), b('4')}
-        memc = {b('5'), b('6'), b('7')}
+        mema = {b'1', b'2', b'3'}
+        memb = {b'2', b'3', b'4'}
+        memc = {b'5', b'6', b'7'}
         r.pfadd('a', *mema)
         r.pfadd('b', *memb)
         r.pfadd('c', *memc)
@@ -1221,17 +1222,17 @@ class TestRedisCommands(object):
     # HASH COMMANDS
     def test_hget_and_hset(self, r):
         r.hmset('a', {'1': 1, '2': 2, '3': 3})
-        assert r.hget('a', '1') == b('1')
-        assert r.hget('a', '2') == b('2')
-        assert r.hget('a', '3') == b('3')
+        assert r.hget('a', '1') == b'1'
+        assert r.hget('a', '2') == b'2'
+        assert r.hget('a', '3') == b'3'
 
         # field was updated, redis returns 0
         assert r.hset('a', '2', 5) == 0
-        assert r.hget('a', '2') == b('5')
+        assert r.hget('a', '2') == b'5'
 
         # field is new, redis returns 1
         assert r.hset('a', '4', 4) == 1
-        assert r.hget('a', '4') == b('4')
+        assert r.hget('a', '4') == b'4'
 
         # key inside of hash that doesn't exist returns null value
         assert r.hget('a', 'b') is None
@@ -1249,7 +1250,7 @@ class TestRedisCommands(object):
         assert not r.hexists('a', '4')
 
     def test_hgetall(self, r):
-        h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
+        h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
         r.hmset('a', h)
         assert r.hgetall('a') == h
 
@@ -1265,7 +1266,7 @@ class TestRedisCommands(object):
         assert r.hincrbyfloat('a', '1', 1.2) == 3.2
 
     def test_hkeys(self, r):
-        h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
+        h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
         r.hmset('a', h)
         local_keys = list(iterkeys(h))
         remote_keys = r.hkeys('a')
@@ -1277,22 +1278,22 @@ class TestRedisCommands(object):
 
     def test_hmget(self, r):
         assert r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
-        assert r.hmget('a', 'a', 'b', 'c') == [b('1'), b('2'), b('3')]
+        assert r.hmget('a', 'a', 'b', 'c') == [b'1', b'2', b'3']
 
     def test_hmset(self, r):
-        h = {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
+        h = {b'a': b'1', b'b': b'2', b'c': b'3'}
         assert r.hmset('a', h)
         assert r.hgetall('a') == h
 
     def test_hsetnx(self, r):
         # Initially set the hash field
         assert r.hsetnx('a', '1', 1)
-        assert r.hget('a', '1') == b('1')
+        assert r.hget('a', '1') == b'1'
         assert not r.hsetnx('a', '1', 2)
-        assert r.hget('a', '1') == b('1')
+        assert r.hget('a', '1') == b'1'
 
     def test_hvals(self, r):
-        h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
+        h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
         r.hmset('a', h)
         local_vals = list(itervalues(h))
         remote_vals = r.hvals('a')
@@ -1307,25 +1308,25 @@ class TestRedisCommands(object):
     # SORT
     def test_sort_basic(self, r):
         r.rpush('a', '3', '2', '1', '4')
-        assert r.sort('a') == [b('1'), b('2'), b('3'), b('4')]
+        assert r.sort('a') == [b'1', b'2', b'3', b'4']
 
     def test_sort_limited(self, r):
         r.rpush('a', '3', '2', '1', '4')
-        assert r.sort('a', start=1, num=2) == [b('2'), b('3')]
+        assert r.sort('a', start=1, num=2) == [b'2', b'3']
 
     def test_sort_by(self, r):
         r['score:1'] = 8
         r['score:2'] = 3
         r['score:3'] = 5
         r.rpush('a', '3', '2', '1')
-        assert r.sort('a', by='score:*') == [b('2'), b('3'), b('1')]
+        assert r.sort('a', by='score:*') == [b'2', b'3', b'1']
 
     def test_sort_get(self, r):
         r['user:1'] = 'u1'
         r['user:2'] = 'u2'
         r['user:3'] = 'u3'
         r.rpush('a', '2', '3', '1')
-        assert r.sort('a', get='user:*') == [b('u1'), b('u2'), b('u3')]
+        assert r.sort('a', get='user:*') == [b'u1', b'u2', b'u3']
 
     def test_sort_get_multi(self, r):
         r['user:1'] = 'u1'
@@ -1333,7 +1334,7 @@ class TestRedisCommands(object):
         r['user:3'] = 'u3'
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', get=('user:*', '#')) == \
-            [b('u1'), b('1'), b('u2'), b('2'), b('u3'), b('3')]
+            [b'u1', b'1', b'u2', b'2', b'u3', b'3']
 
     def test_sort_get_groups_two(self, r):
         r['user:1'] = 'u1'
@@ -1341,7 +1342,7 @@ class TestRedisCommands(object):
         r['user:3'] = 'u3'
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', get=('user:*', '#'), groups=True) == \
-            [(b('u1'), b('1')), (b('u2'), b('2')), (b('u3'), b('3'))]
+            [(b'u1', b'1'), (b'u2', b'2'), (b'u3', b'3')]
 
     def test_sort_groups_string_get(self, r):
         r['user:1'] = 'u1'
@@ -1377,24 +1378,24 @@ class TestRedisCommands(object):
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', get=('user:*', 'door:*', '#'), groups=True) == \
             [
-                (b('u1'), b('d1'), b('1')),
-                (b('u2'), b('d2'), b('2')),
-                (b('u3'), b('d3'), b('3'))
+                (b'u1', b'd1', b'1'),
+                (b'u2', b'd2', b'2'),
+                (b'u3', b'd3', b'3')
         ]
 
     def test_sort_desc(self, r):
         r.rpush('a', '2', '3', '1')
-        assert r.sort('a', desc=True) == [b('3'), b('2'), b('1')]
+        assert r.sort('a', desc=True) == [b'3', b'2', b'1']
 
     def test_sort_alpha(self, r):
         r.rpush('a', 'e', 'c', 'b', 'd', 'a')
         assert r.sort('a', alpha=True) == \
-            [b('a'), b('b'), b('c'), b('d'), b('e')]
+            [b'a', b'b', b'c', b'd', b'e']
 
     def test_sort_store(self, r):
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', store='sorted_values') == 3
-        assert r.lrange('sorted_values', 0, -1) == [b('1'), b('2'), b('3')]
+        assert r.lrange('sorted_values', 0, -1) == [b'1', b'2', b'3']
 
     def test_sort_all_options(self, r):
         r['user:1:username'] = 'zeus'
@@ -1421,7 +1422,7 @@ class TestRedisCommands(object):
                      store='sorted')
         assert num == 4
         assert r.lrange('sorted', 0, 10) == \
-            [b('vodka'), b('milk'), b('gin'), b('apple juice')]
+            [b'vodka', b'milk', b'gin', b'apple juice']
 
     def test_cluster_addslots(self, mock_cluster_resp_ok):
         assert mock_cluster_resp_ok.cluster('ADDSLOTS', 1) is True
@@ -1676,7 +1677,7 @@ class TestRedisCommands(object):
         assert re.match(br'[0-9]+\-[0-9]+', message_id)
 
         # explicit message id
-        message_id = b('9999999999999999999-0')
+        message_id = b'9999999999999999999-0'
         assert message_id == r.xadd(stream, {'foo': 'bar'}, id=message_id)
 
         # with maxlen, the list evicts the first message
@@ -1741,10 +1742,10 @@ class TestRedisCommands(object):
 
         assert r.xgroup_create(stream, group, 0)
         expected = [{
-            'name': b(group),
+            'name': group.encode(),
             'consumers': 0,
             'pending': 0,
-            'last-delivered-id': b('0-0')
+            'last-delivered-id': b'0-0'
         }]
         assert r.xinfo_groups(stream) == expected
 
@@ -1763,10 +1764,10 @@ class TestRedisCommands(object):
         # automatically
         assert r.xgroup_create(stream, group, 0, mkstream=True)
         expected = [{
-            'name': b(group),
+            'name': group.encode(),
             'consumers': 0,
             'pending': 0,
-            'last-delivered-id': b('0-0')
+            'last-delivered-id': b'0-0'
         }]
         assert r.xinfo_groups(stream) == expected
 
@@ -1810,7 +1811,7 @@ class TestRedisCommands(object):
         # advance the last_delivered_id to the message_id
         r.xgroup_setid(stream, group, message_id)
         expected = [{
-            'name': b(group),
+            'name': group.encode(),
             'consumers': 0,
             'pending': 0,
             'last-delivered-id': message_id
@@ -1831,8 +1832,8 @@ class TestRedisCommands(object):
         info = r.xinfo_consumers(stream, group)
         assert len(info) == 2
         expected = [
-            {'name': b(consumer1), 'pending': 1},
-            {'name': b(consumer2), 'pending': 0},
+            {'name': consumer1.encode(), 'pending': 1},
+            {'name': consumer2.encode(), 'pending': 0},
         ]
 
         # we can't determine the idle time, so just make sure it's an int
@@ -1887,8 +1888,8 @@ class TestRedisCommands(object):
             'min': m1,
             'max': m2,
             'consumers': [
-                {'name': b(consumer1), 'pending': 1},
-                {'name': b(consumer2), 'pending': 1},
+                {'name': consumer1.encode(), 'pending': 1},
+                {'name': consumer2.encode(), 'pending': 1},
             ]
         }
         assert r.xpending(stream, group) == expected
@@ -1913,9 +1914,9 @@ class TestRedisCommands(object):
         response = r.xpending_range(stream, group)
         assert len(response) == 2
         assert response[0]['message_id'] == m1
-        assert response[0]['consumer'] == b(consumer1)
+        assert response[0]['consumer'] == consumer1.encode()
         assert response[1]['message_id'] == m2
-        assert response[1]['consumer'] == b(consumer2)
+        assert response[1]['consumer'] == consumer2.encode()
 
     @skip_if_server_version_lt('5.0.0')
     def test_xrange(self, r):
@@ -2092,16 +2093,16 @@ class TestStrictCommands(object):
     def test_strict_zadd(self, sr):
         sr.zadd('a', 1.0, 'a1', 2.0, 'a2', a3=3.0)
         assert sr.zrange('a', 0, -1, withscores=True) == \
-            [(b('a1'), 1.0), (b('a2'), 2.0), (b('a3'), 3.0)]
+            [(b'a1', 1.0), (b'a2', 2.0), (b'a3', 3.0)]
 
     def test_strict_lrem(self, sr):
         sr.rpush('a', 'a1', 'a2', 'a3', 'a1')
         sr.lrem('a', 0, 'a1')
-        assert sr.lrange('a', 0, -1) == [b('a2'), b('a3')]
+        assert sr.lrange('a', 0, -1) == [b'a2', b'a3']
 
     def test_strict_setex(self, sr):
         assert sr.setex('a', 60, '1')
-        assert sr['a'] == b('1')
+        assert sr['a'] == b'1'
         assert 0 < sr.ttl('a') <= 60
 
     def test_strict_ttl(self, sr):
@@ -2126,16 +2127,16 @@ class TestBinarySave(object):
 
     def test_binary_get_set(self, r):
         assert r.set(' foo bar ', '123')
-        assert r.get(' foo bar ') == b('123')
+        assert r.get(' foo bar ') == b'123'
 
         assert r.set(' foo\r\nbar\r\n ', '456')
-        assert r.get(' foo\r\nbar\r\n ') == b('456')
+        assert r.get(' foo\r\nbar\r\n ') == b'456'
 
         assert r.set(' \r\n\t\x07\x13 ', '789')
-        assert r.get(' \r\n\t\x07\x13 ') == b('789')
+        assert r.get(' \r\n\t\x07\x13 ') == b'789'
 
         assert sorted(r.keys('*')) == \
-            [b(' \r\n\t\x07\x13 '), b(' foo\r\nbar\r\n '), b(' foo bar ')]
+            [b' \r\n\t\x07\x13 ', b' foo\r\nbar\r\n ', b' foo bar ']
 
         assert r.delete(' foo bar ')
         assert r.delete(' foo\r\nbar\r\n ')
@@ -2143,9 +2144,9 @@ class TestBinarySave(object):
 
     def test_binary_lists(self, r):
         mapping = {
-            b('foo bar'): [b('1'), b('2'), b('3')],
-            b('foo\r\nbar\r\n'): [b('4'), b('5'), b('6')],
-            b('foo\tbar\x07'): [b('7'), b('8'), b('9')],
+            b'foo bar': [b'1', b'2', b'3'],
+            b'foo\r\nbar\r\n': [b'4', b'5', b'6'],
+            b'foo\tbar\x07': [b'7', b'8', b'9'],
         }
         # fill in lists
         for key, value in iteritems(mapping):
@@ -2197,7 +2198,7 @@ class TestBinarySave(object):
         # load up 5MB of data into a key
         data = ''.join([ascii_letters] * (5000000 // len(ascii_letters)))
         r['a'] = data
-        assert r['a'] == b(data)
+        assert r['a'] == data.encode()
 
     def test_floating_point_encoding(self, r):
         """

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import os
 import pytest
 import redis

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 import redis
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,7 +1,8 @@
+from __future__ import unicode_literals
 import pytest
 import redis
 
-from redis._compat import unichr, u, unicode
+from redis._compat import unichr, unicode
 from .conftest import _get_client
 
 
@@ -11,20 +12,20 @@ class TestEncoding(object):
         return _get_client(redis.Redis, request=request, decode_responses=True)
 
     def test_simple_encoding(self, r):
-        unicode_string = unichr(3456) + u('abcd') + unichr(3421)
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         r['unicode-string'] = unicode_string
         cached_val = r['unicode-string']
         assert isinstance(cached_val, unicode)
         assert unicode_string == cached_val
 
     def test_list_encoding(self, r):
-        unicode_string = unichr(3456) + u('abcd') + unichr(3421)
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         result = [unicode_string, unicode_string, unicode_string]
         r.rpush('a', *result)
         assert r.lrange('a', 0, -1) == result
 
     def test_object_value(self, r):
-        unicode_string = unichr(3456) + u('abcd') + unichr(3421)
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         r['unicode-string'] = Exception(unicode_string)
         cached_val = r['unicode-string']
         assert isinstance(cached_val, unicode)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 import time
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 import redis

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,8 @@
+from __future__ import unicode_literals
 import pytest
 
 import redis
-from redis._compat import b, u, unichr, unicode
+from redis._compat import unichr, unicode
 
 
 class TestPipeline(object):
@@ -12,11 +13,11 @@ class TestPipeline(object):
             assert pipe.execute() == \
                 [
                     True,
-                    b('a1'),
+                    b'a1',
                     True,
                     True,
                     2.0,
-                    [(b('z1'), 2.0), (b('z2'), 4)],
+                    [(b'z1', 2.0), (b'z2', 4)],
                 ]
 
     def test_pipeline_length(self, r):
@@ -39,9 +40,9 @@ class TestPipeline(object):
         with r.pipeline(transaction=False) as pipe:
             pipe.set('a', 'a1').set('b', 'b1').set('c', 'c1')
             assert pipe.execute() == [True, True, True]
-            assert r['a'] == b('a1')
-            assert r['b'] == b('b1')
-            assert r['c'] == b('c1')
+            assert r['a'] == b'a1'
+            assert r['b'] == b'b1'
+            assert r['c'] == b'c1'
 
     def test_pipeline_no_transaction_watch(self, r):
         r['a'] = 0
@@ -69,7 +70,7 @@ class TestPipeline(object):
             with pytest.raises(redis.WatchError):
                 pipe.execute()
 
-            assert r['a'] == b('bad')
+            assert r['a'] == b'bad'
 
     def test_exec_error_in_response(self, r):
         """
@@ -82,23 +83,23 @@ class TestPipeline(object):
             result = pipe.execute(raise_on_error=False)
 
             assert result[0]
-            assert r['a'] == b('1')
+            assert r['a'] == b'1'
             assert result[1]
-            assert r['b'] == b('2')
+            assert r['b'] == b'2'
 
             # we can't lpush to a key that's a string value, so this should
             # be a ResponseError exception
             assert isinstance(result[2], redis.ResponseError)
-            assert r['c'] == b('a')
+            assert r['c'] == b'a'
 
             # since this isn't a transaction, the other commands after the
             # error are still executed
             assert result[3]
-            assert r['d'] == b('4')
+            assert r['d'] == b'4'
 
             # make sure the pipe was restored to a working state
             assert pipe.set('z', 'zzz').execute() == [True]
-            assert r['z'] == b('zzz')
+            assert r['z'] == b'zzz'
 
     def test_exec_error_raised(self, r):
         r['c'] = 'a'
@@ -111,7 +112,7 @@ class TestPipeline(object):
 
             # make sure the pipe was restored to a working state
             assert pipe.set('z', 'zzz').execute() == [True]
-            assert r['z'] == b('zzz')
+            assert r['z'] == b'zzz'
 
     def test_parse_error_raised(self, r):
         with r.pipeline() as pipe:
@@ -125,7 +126,7 @@ class TestPipeline(object):
 
             # make sure the pipe was restored to a working state
             assert pipe.set('z', 'zzz').execute() == [True]
-            assert r['z'] == b('zzz')
+            assert r['z'] == b'zzz'
 
     def test_watch_succeed(self, r):
         r['a'] = 1
@@ -136,8 +137,8 @@ class TestPipeline(object):
             assert pipe.watching
             a_value = pipe.get('a')
             b_value = pipe.get('b')
-            assert a_value == b('1')
-            assert b_value == b('2')
+            assert a_value == b'1'
+            assert b_value == b'2'
             pipe.multi()
 
             pipe.set('c', 3)
@@ -168,7 +169,7 @@ class TestPipeline(object):
             pipe.unwatch()
             assert not pipe.watching
             pipe.get('a')
-            assert pipe.execute() == [b('1')]
+            assert pipe.execute() == [b'1']
 
     def test_transaction_callable(self, r):
         r['a'] = 1
@@ -177,9 +178,9 @@ class TestPipeline(object):
 
         def my_transaction(pipe):
             a_value = pipe.get('a')
-            assert a_value in (b('1'), b('2'))
+            assert a_value in (b'1', b'2')
             b_value = pipe.get('b')
-            assert b_value == b('2')
+            assert b_value == b'2'
 
             # silly run-once code... incr's "a" so WatchError should be raised
             # forcing this all to run again. this should incr "a" once to "2"
@@ -192,7 +193,7 @@ class TestPipeline(object):
 
         result = r.transaction(my_transaction, 'a', 'b')
         assert result == [True]
-        assert r['c'] == b('4')
+        assert r['c'] == b'4'
 
     def test_exec_error_in_no_transaction_pipeline(self, r):
         r['a'] = 1
@@ -206,10 +207,10 @@ class TestPipeline(object):
             assert unicode(ex.value).startswith('Command # 1 (LLEN a) of '
                                                 'pipeline caused error: ')
 
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
 
     def test_exec_error_in_no_transaction_pipeline_unicode_command(self, r):
-        key = unichr(3456) + u('abcd') + unichr(3421)
+        key = unichr(3456) + 'abcd' + unichr(3421)
         r[key] = 1
         with r.pipeline(transaction=False) as pipe:
             pipe.llen(key)
@@ -222,4 +223,4 @@ class TestPipeline(object):
                                'error: ') % key
             assert unicode(ex.value).startswith(expected)
 
-        assert r[key] == b('1')
+        assert r[key] == b'1'

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 import time
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,9 +1,10 @@
+from __future__ import unicode_literals
 import pytest
 import time
 
 import redis
 from redis.exceptions import ConnectionError
-from redis._compat import basestring, u, unichr, b
+from redis._compat import basestring, unichr
 
 from .conftest import _get_client
 from .conftest import skip_if_server_version_lt
@@ -39,7 +40,7 @@ def make_subscribe_test_data(pubsub, type):
             'unsub_type': 'unsubscribe',
             'sub_func': pubsub.subscribe,
             'unsub_func': pubsub.unsubscribe,
-            'keys': ['foo', 'bar', u('uni') + unichr(4456) + u('code')]
+            'keys': ['foo', 'bar', 'uni' + unichr(4456) + 'code']
         }
     elif type == 'pattern':
         return {
@@ -48,7 +49,7 @@ def make_subscribe_test_data(pubsub, type):
             'unsub_type': 'punsubscribe',
             'sub_func': pubsub.psubscribe,
             'unsub_func': pubsub.punsubscribe,
-            'keys': ['f*', 'b*', u('uni') + unichr(4456) + u('*')]
+            'keys': ['f*', 'b*', 'uni' + unichr(4456) + '*']
         }
     assert False, 'invalid subscribe type: %s' % type
 
@@ -266,7 +267,7 @@ class TestPubSubMessages(object):
 
     def test_unicode_channel_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
-        channel = u('uni') + unichr(4456) + u('code')
+        channel = 'uni' + unichr(4456) + 'code'
         channels = {channel: self.message_handler}
         p.subscribe(**channels)
         assert r.publish(channel, 'test message') == 1
@@ -275,8 +276,8 @@ class TestPubSubMessages(object):
 
     def test_unicode_pattern_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
-        pattern = u('uni') + unichr(4456) + u('*')
-        channel = u('uni') + unichr(4456) + u('code')
+        pattern = 'uni' + unichr(4456) + '*'
+        channel = 'uni' + unichr(4456) + 'code'
         p.psubscribe(**{pattern: self.message_handler})
         assert r.publish(channel, 'test message') == 1
         assert wait_for_message(p) is None
@@ -295,9 +296,9 @@ class TestPubSubMessages(object):
 class TestPubSubAutoDecoding(object):
     "These tests only validate that we get unicode values back"
 
-    channel = u('uni') + unichr(4456) + u('code')
-    pattern = u('uni') + unichr(4456) + u('*')
-    data = u('abc') + unichr(4458) + u('123')
+    channel = 'uni' + unichr(4456) + 'code'
+    pattern = 'uni' + unichr(4456) + '*'
+    data = 'abc' + unichr(4458) + '123'
 
     def make_message(self, type, channel, data, pattern=None):
         return {
@@ -365,7 +366,7 @@ class TestPubSubAutoDecoding(object):
         # test that we reconnected to the correct channel
         p.connection.disconnect()
         assert wait_for_message(p) is None  # should reconnect
-        new_data = self.data + u('new data')
+        new_data = self.data + 'new data'
         r.publish(self.channel, new_data)
         assert wait_for_message(p) is None
         assert self.message == self.make_message('message', self.channel,
@@ -383,7 +384,7 @@ class TestPubSubAutoDecoding(object):
         # test that we reconnected to the correct pattern
         p.connection.disconnect()
         assert wait_for_message(p) is None  # should reconnect
-        new_data = self.data + u('new data')
+        new_data = self.data + 'new data'
         r.publish(self.channel, new_data)
         assert wait_for_message(p) is None
         assert self.message == self.make_message('pmessage', self.channel,
@@ -407,7 +408,7 @@ class TestPubSubPubSubSubcommands(object):
         p = r.pubsub(ignore_subscribe_messages=True)
         p.subscribe('foo', 'bar', 'baz', 'quux')
         channels = sorted(r.pubsub_channels())
-        assert channels == [b('bar'), b('baz'), b('foo'), b('quux')]
+        assert channels == [b'bar', b'baz', b'foo', b'quux']
 
     @skip_if_server_version_lt('2.8.0')
     def test_pubsub_numsub(self, r):
@@ -418,7 +419,7 @@ class TestPubSubPubSubSubcommands(object):
         p3 = r.pubsub(ignore_subscribe_messages=True)
         p3.subscribe('baz')
 
-        channels = [(b('foo'), 1), (b('bar'), 2), (b('baz'), 3)]
+        channels = [(b'foo', 1), (b'bar', 2), (b'baz', 3)]
         assert channels == r.pubsub_numsub('foo', 'bar', 'baz')
 
     @skip_if_server_version_lt('2.8.0')

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,7 +1,7 @@
+from __future__ import unicode_literals
 import pytest
 
 from redis import exceptions
-from redis._compat import b
 
 
 multiply_script = """
@@ -78,7 +78,7 @@ class TestScripting(object):
         multiply(keys=['a'], args=[3], client=pipe)
         assert r.script_exists(multiply.sha) == [False]
         # [SET worked, GET 'a', result of multiple script]
-        assert pipe.execute() == [True, b('2'), 6]
+        assert pipe.execute() == [True, b'2', 6]
         # The script should have been loaded by pipe.execute()
         assert r.script_exists(multiply.sha) == [True]
         # The precalculated sha should have been the correct one
@@ -93,7 +93,7 @@ class TestScripting(object):
         multiply(keys=['a'], args=[3], client=pipe)
         assert r.script_exists(multiply.sha) == [False]
         # [SET worked, GET 'a', result of multiple script]
-        assert pipe.execute() == [True, b('2'), 6]
+        assert pipe.execute() == [True, b'2', 6]
         assert r.script_exists(multiply.sha) == [True]
 
     def test_eval_msgpack_pipeline_error_in_lua(self, r):

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 from redis import exceptions

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 from redis import exceptions

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist = {py27,py34,py35,py36}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =
-    pytest==2.9.2
-    mock==2.0.0
+    mock
+    pytest >= 2.7.0
     hiredis: hiredis >= 0.1.3
 commands = py.test {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27,py33,py34,py35,py36}-{plain,hiredis}, pycodestyle
+envlist = {py27,py33,py34,py35,py36}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py27,py33,py34,py35,py36}-{plain,hiredis}, pycodestyle
+envlist = {py27,py34,py35,py36}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =


### PR DESCRIPTION
Remove 2.6 workarounds. Update testing configurations. Use modern Python syntax where available:

* Use set literals
* Use dict comprehensions
* Use more generators
* Use `io` package for `BytesIO`
* Remove `from __future__ import with_statement`
* Use unicode literals throughout

Thanks Dustin Ingram for the original patch.

---

 This is a continuation of the work started by @di in #796. I have rebased the patch and addressed a couple other cleanups I saw. I'll happily close this PR if the other work continues.