### PR TITLE
Handling with redis auth error

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -559,7 +559,12 @@ class Connection(object):
         # if a password is specified, authenticate
         if self.password:
             self.send_command('AUTH', self.password)
-            if nativestr(self.read_response()) != 'OK':
+            try:
+                response = self.read_response()
+            except ResponseError as error:
+                raise AuthenticationError(str(error))
+
+            if nativestr(response) != 'OK':
                 raise AuthenticationError('Invalid Password')
 
         # if a database is specified, switch to it


### PR DESCRIPTION
Improving error handler in redis auth.

When a auth error occur, should raise an AuthenticationError
I think ResponseError is too much generic for this scenario.

Response error example: "Client sent AUTH, but no password is set"