### PR TITLE
Fixes a KeyError in empty `options` dict at sort's return

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -220,7 +220,7 @@ def sort_return_tuples(response, **options):
     If ``groups`` is specified, return the response as a list of
     n-element tuples with n being the value found in options['groups']
     """
-    if not response or not options['groups']:
+    if not response or not options.get('groups'):
         return response
     n = options['groups']
     return list(izip(*[response[i::n] for i in range(n)]))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1375,6 +1375,11 @@ class TestRedisCommands(object):
         assert r.lrange('sorted', 0, 10) == \
             [b('vodka'), b('milk'), b('gin'), b('apple juice')]
 
+    def test_sort_issue_924(self, r):
+        # Tests for issue https://github.com/andymccurdy/redis-py/issues/924
+        r.execute_command('SADD', 'issue#924', 1)
+        r.execute_command('SORT', 'issue#924')
+
     def test_cluster_addslots(self, mock_cluster_resp_ok):
         assert mock_cluster_resp_ok.cluster('ADDSLOTS', 1) is True
 


### PR DESCRIPTION
Fixes #924 

Interestingly, this surfaces when using raw commands and doesn't reproduce when using the 'redis.sort()' function.