### PR TITLE
__enter__ will raise LockError if failed to acquire lock

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -79,10 +79,9 @@ class Lock(object):
             raise LockError("'sleep' must be less than 'timeout'")
 
     def __enter__(self):
-        # force blocking, as otherwise the user would have to check whether
-        # the lock was actually acquired or not.
-        self.acquire(blocking=True)
-        return self
+        if self.acquire(blocking=True):
+            return self
+        raise LockError("Cannot acquire lock")
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.release()


### PR DESCRIPTION
#621

1. It is easy to forget to check whether the lock is acquired(test `lock.local.token` value).
2. `Lock.__exit__` method always raise `LockError("Cannot release an unlocked lock")` if lock is not acquired.
3. If we want to use the origin version of `redis.lock`, we must check lock status in the `with statement suite` and wrapper a `try statement` outside the `with statement`.
like codes below:
```python
def foo(start, end):
    return_value = 0, ""
    try:
        for i in range(start, end):
            with redis_client.lock(str(i), blocking_timeout=2) as lock:
                if lock.local.token is None:
                    return_value = -1, "can not acquire {} lock".format(i)
                    return
     except LockError:
         return return_value
     # do other stuff
     return_value = 0, "success"
     return return_value
```
4. I suppose it is better to check wether lock is acquired in the `Lock.__enter__` method and raise `LockError` if necessary