### PR TITLE
Fix handling for empty arguments in commands that throw server-side error

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -427,6 +427,7 @@ class TestRedisCommands(object):
         assert set(r.keys(pattern='test*')) == keys
 
     def test_mget(self, r):
+        assert r.mget([]) == []
         assert r.mget(['a', 'b']) == [None, None]
         r['a'] = '1'
         r['b'] = '2'

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,6 +10,7 @@ class TestPipeline(object):
         with r.pipeline() as pipe:
             pipe.set('a', 'a1').get('a').zadd('z', z1=1).zadd('z', z2=4)
             pipe.zincrby('z', 'z1').zrange('z', 0, 5, withscores=True)
+            pipe.mget([])
             assert pipe.execute() == \
                 [
                     True,
@@ -18,6 +19,7 @@ class TestPipeline(object):
                     True,
                     2.0,
                     [(b('z1'), 2.0), (b('z2'), 4)],
+                    [],
                 ]
 
     def test_pipeline_length(self, r):
@@ -38,8 +40,8 @@ class TestPipeline(object):
 
     def test_pipeline_no_transaction(self, r):
         with r.pipeline(transaction=False) as pipe:
-            pipe.set('a', 'a1').set('b', 'b1').set('c', 'c1')
-            assert pipe.execute() == [True, True, True]
+            pipe.set('a', 'a1').set('b', 'b1').set('c', 'c1').mget([])
+            assert pipe.execute() == [True, True, True, []]
             assert r['a'] == b('a1')
             assert r['b'] == b('b1')
             assert r['c'] == b('c1')


### PR DESCRIPTION
Sometimes you pass an array to mget as an input, if the array is empty, instead of returning an empty array, mget throws an exception from the server (rightfully so) but it's not very pythonic.

I have lots of places in the code which call mget with an array that might or might not be empty, since in the end i just iterate over the result, adding an if not empty check before each mget call is superfluous (and if someone really wants to check it, he can).