### PR TITLE
handle select.error interrupt system call exception in python 2

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -15,7 +15,7 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
     import time
     import errno
 
-    from select import select as _select
+    from select import select as _select, error as _select_error
 
     def select(rlist, wlist, xlist, timeout):
         while True:
@@ -25,6 +25,10 @@ if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
                 # Python 2 does not define InterruptedError, instead
                 # try to catch an OSError with errno == EINTR == 4.
                 if getattr(e, 'errno', None) == getattr(errno, 'EINTR', 4):
+                    continue
+                raise
+            except _select_error as e:
+                if e.args[0] == errno.EINTR:
                     continue
                 raise
 


### PR DESCRIPTION
In python 3.3+, `select.error` is an alias of `OSError`, however in python 2 it's just it's own unrelated class:
```
$ python
Python 2.7.12 (default, Nov 20 2017, 18:23:56) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import select; select.error
<class 'select.error'>

$ python3
Python 3.5.2 (default, Nov 23 2017, 16:37:01) 
>>> import select; select.error
<class 'OSError'>
```
Additionally, a python2 `select.error` doesn't have the `errno` attribute, so the if statement checking for EINTR won't work either. Because of this, the existing exception handling won't catch when a select.error is thrown in python 2.7. 

This adds an additional except clause for that case, borrowed from an older version of the code. So `InterruptedError`, `OSError`, and `select.error` versions of a interrupted system call should be handled correctly.