### PR TITLE
Fix parse_cluster_nodes for python3

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -282,6 +282,9 @@ def parse_slowlog_get(response, **options):
 
 
 def parse_cluster_info(response, **options):
+    import sys
+    if sys.version_info >= (3, 0):
+        response = response.decode('utf-8')
     return dict([line.split(':') for line in response.splitlines() if line])
 
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -284,7 +284,10 @@ def parse_slowlog_get(response, **options):
 def parse_cluster_info(response, **options):
     import sys
     if sys.version_info >= (3, 0):
-        response = response.decode('utf-8')
+        try:
+           response = response.decode('utf-8')
+         except AttributeError:
+           pass
     return dict([line.split(':') for line in response.splitlines() if line])
 
 
@@ -309,7 +312,10 @@ def _parse_node_line(line):
 def parse_cluster_nodes(response, **options):
     import sys
     if sys.version_info >= (3, 0):
-        response = response.decode('utf-8')
+        try:
+            response = response.decode('utf-8')
+        except AttributeError:
+            pass
         
     raw_lines = response
     if isinstance(response, basestring):

--- a/redis/client.py
+++ b/redis/client.py
@@ -304,6 +304,10 @@ def _parse_node_line(line):
 
 
 def parse_cluster_nodes(response, **options):
+    import sys
+    if sys.version_info >= (3, 0):
+        response = response.decode('utf-8')
+        
     raw_lines = response
     if isinstance(response, basestring):
         raw_lines = response.splitlines()


### PR DESCRIPTION
Command is not compatible with python3 and rises error below.

Traceback (most recent call last):
  File "redis-cluster.py", line 137, in <module>
    forget_failed_nodes()
  File "redis-cluster.py", line 119, in forget_failed_nodes
    nodes = rediscon.execute_command(f'CLUSTER NODES')
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 669, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 683, in parse_response
    return self.response_callbacks[command_name](response, **options)
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 310, in parse_cluster_nodes
    return dict([_parse_node_line(line) for line in raw_lines])
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 310, in <listcomp>
    return dict([_parse_node_line(line) for line in raw_lines])
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 289, in _parse_node_line
    line_items = line.split(' ')
AttributeError: 'int' object has no attribute 'split'