### PR TITLE
Prevent unclosed connections on timeout/connect error (ResourceWarning)

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -669,7 +669,8 @@ class StrictRedis(object):
             return self.parse_response(connection, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if not connection.retry_on_timeout and isinstance(e, TimeoutError):
+            if not (connection.retry_on_timeout and
+                    isinstance(e, TimeoutError)):
                 raise
             connection.send_command(*args)
             return self.parse_response(connection, command_name, **options)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -333,6 +333,7 @@ class HiredisParser(BaseParser):
         if not HIREDIS_AVAILABLE:
             raise RedisError("Hiredis is not installed")
         self.socket_read_size = socket_read_size
+        self._sock = None
 
         if HIREDIS_USE_BYTE_BUFFER:
             self._buffer = bytearray(socket_read_size)
@@ -360,7 +361,9 @@ class HiredisParser(BaseParser):
         self._next_response = False
 
     def on_disconnect(self):
-        self._sock = None
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
         self._reader = None
         self._next_response = False
 


### PR DESCRIPTION
This patch addresses two potential cases of `ResourceWarning` (e.g. when running interpreter with `-W all` argument) due to socket errors.

1. Fix retry behaviour (`retry_on_timeout`): Previously if retries were not enabled, a retry would still be performed **unless** the exception was `TimeoutError`.
2. When using hiredis module, the socket would not be closed when encountering an exception (e.g. disconnected from server or inability to connect)

**Note**: This does **not** address lack of tidy-up if retries are enabled, where the [retry performs an attempt without a try-except block](https://github.com/andymccurdy/redis-py/blob/3edccee4a18197da0436a6d2d33269190d07ed54/redis/client.py#L674-L675) (unlike the initial attempt).