### PR TITLE
Fix: zadd raises unhandled exception - fixes #954

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -367,7 +367,7 @@ class StrictRedis(object):
             'SETBIT SETRANGE SINTERSTORE SREM STRLEN SUNIONSTORE ZADD ZCARD '
             'ZLEXCOUNT ZREM ZREMRANGEBYLEX ZREMRANGEBYRANK ZREMRANGEBYSCORE '
             'GEOADD',
-            int
+            int_or_none
         ),
         string_keys_to_dict(
             'INCRBYFLOAT HINCRBYFLOAT GEODIST',
@@ -1688,11 +1688,10 @@ class StrictRedis(object):
         redis.zadd('my-key', 1.1, 'name1', 2.2, 'name2', name3=3.3, name4=4.4)
         """
         pieces = []
-        if args:
-            if len(args) % 2 != 0:
-                raise RedisError("ZADD requires an equal number of "
-                                 "values and scores")
-            pieces.extend(args)
+        if args and len(args) % 2 != 0:
+            raise RedisError("ZADD requires an equal number of "
+                             "values and scores")
+        pieces.extend(args)
         for pair in iteritems(kwargs):
             pieces.append(pair[1])
             pieces.append(pair[0])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -918,7 +918,7 @@ class TestRedisCommands(object):
 
         r.zadd('a', 'nx', 'INCR', a1=10)
         r.zadd('a', 'nx', 'INCR', a1=10)
-        assert r.zrange('a', 0, -1, withscores=True) == [('a1', 10.0)]
+        assert r.zrange('a', 0, -1, withscores=True) == [(b'a1', 10.0)]
 
     def test_zcard(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -912,6 +912,14 @@ class TestRedisCommands(object):
         r.zadd('a', a1=1, a2=2, a3=3)
         assert r.zrange('a', 0, -1) == [b('a1'), b('a2'), b('a3')]
 
+    def test_zadd_with_options(self, r):
+        r.zadd('a', 'xx', 'INCR', a1=10)
+        assert r.zrange('a', 0, -1) == []
+
+        r.zadd('a', 'nx', 'INCR', a1=10)
+        r.zadd('a', 'nx', 'INCR', a1=10)
+        assert r.zrange('a', 0, -1, withscores=True) == [('a1', 10.0)]
+
     def test_zcard(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
         assert r.zcard('a') == 3


### PR DESCRIPTION
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'