### PR TITLE
Fix parsing max_connections URL query string parameter

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -779,7 +779,8 @@ URL_QUERY_ARGUMENT_PARSERS = {
     'socket_timeout': float,
     'socket_connect_timeout': float,
     'socket_keepalive': to_bool,
-    'retry_on_timeout': to_bool
+    'retry_on_timeout': to_bool,
+    'max_connections': int,
 }
 
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -240,7 +240,7 @@ class TestConnectionPoolURLParsing(object):
     def test_extra_typed_querystring_options(self):
         pool = redis.ConnectionPool.from_url(
             'redis://localhost/2?socket_timeout=20&socket_connect_timeout=10'
-            '&socket_keepalive=&retry_on_timeout=Yes'
+            '&socket_keepalive=&retry_on_timeout=Yes&max_connections=10'
         )
 
         assert pool.connection_class == redis.Connection
@@ -253,6 +253,7 @@ class TestConnectionPoolURLParsing(object):
             'retry_on_timeout': True,
             'password': None,
         }
+        assert pool.max_connections == 10
 
     def test_boolean_parsing(self):
         for expected, value in (


### PR DESCRIPTION
Previously ConnectionPool.from_url kept it as a string, causing a 'ValueError:
"max_connections" must be a positive integer'.