### PR TITLE
Add ZPOPMIN and ZPOPMAX commands

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -215,6 +215,13 @@ def zset_score_pairs(response, **options):
     return list(izip(it, imap(score_cast_func, it)))
 
 
+def zset_score_pairs_always(response, **options):
+    "Return the response as a list of (value, score) pairs"
+    score_cast_func = options.get('score_cast_func', float)
+    it = iter(response)
+    return list(izip(it, imap(score_cast_func, it)))
+
+
 def sort_return_tuples(response, **options):
     """
     If ``groups`` is specified, return the response as a list of
@@ -394,6 +401,7 @@ class StrictRedis(object):
             'ZRANGE ZRANGEBYSCORE ZREVRANGE ZREVRANGEBYSCORE',
             zset_score_pairs
         ),
+        string_keys_to_dict('ZPOPMAX ZPOPMIN', zset_score_pairs_always),
         string_keys_to_dict('ZRANK ZREVRANK', int_or_none),
         string_keys_to_dict('BGREWRITEAOF BGSAVE', lambda r: True),
         {
@@ -1934,6 +1942,20 @@ class StrictRedis(object):
             pieces.append(Token.get_token('AGGREGATE'))
             pieces.append(aggregate)
         return self.execute_command(*pieces)
+
+    def zpopmax(self, name, amount=1):
+        """
+        Remove and return up to ``amount`` members with the highest scores from
+        the sorted set ``name``
+        """
+        return self.execute_command('ZPOPMAX', name, amount)
+
+    def zpopmin(self, name, amount=1):
+        """
+        Remove and return up to ``amount`` members with the lowest scores from
+        the sorted set ``name``
+        """
+        return self.execute_command('ZPOPMIN', name, amount)
 
     # HYPERLOGLOG COMMANDS
     def pfadd(self, name, *values):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1139,6 +1139,22 @@ class TestRedisCommands(object):
         assert r.zrange('d', 0, -1, withscores=True) == \
             [(b('a2'), 5), (b('a4'), 12), (b('a3'), 20), (b('a1'), 23)]
 
+    @skip_if_server_version_lt('5.0.0')
+    def test_zpopmax(self, r):
+        r.zadd('a', a=4, b=3, c=2, d=1)
+        assert r.zpopmax('a') == [b('a')]
+        assert r.zpopmax('a', 2) == [b('b'), b('c')]
+        assert r.zpopmax('a', 2) == [b('d')]
+        assert r.zpopmax('a') == []
+
+    @skip_if_server_version_lt('5.0.0')
+    def test_zpopmin(self, r):
+        r.zadd('a', a=1, b=2, c=3, d=4)
+        assert r.zpopmin('a') == [b('a')]
+        assert r.zpopmin('a', 2) == [b('b'), b('c')]
+        assert r.zpopmin('a', 2) == [b('d')]
+        assert r.zpopmin('a') == []
+
     # HYPERLOGLOG TESTS
     @skip_if_server_version_lt('2.8.9')
     def test_pfadd(self, r):


### PR DESCRIPTION
[Redis 5.0.0](https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES) adds two new commands for working on sorted sets: [ZPOPMAX](https://redis.io/commands/zpopmax) and [ZPOPMIN](https://redis.io/commands/zpopmin). This PR adds support for the two commands and some corresponding test coverage.

I added `zset_score_pairs_always` because ZPOP* always return score/value pairs even without the `WITHSCORES` option. Please feel free to rename it if you can think of a better name.

Many thanks