### PR TITLE
Remove from __future__ import with_statement

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from itertools import chain
 import datetime
 import sys

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from distutils.version import StrictVersion
 from itertools import chain
 import os

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import binascii
 import datetime
 import pytest

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import os
 import pytest
 import redis

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 from redis._compat import unichr, u, unicode

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 import time
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 import redis

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 import time
 

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 from redis import exceptions

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import pytest
 
 from redis import exceptions


### PR DESCRIPTION
All supported Python versions support the with statement.

Available since 2.5.

https://docs.python.org/3/whatsnew/2.5.html#pep-343-the-with-statement