### PR TITLE
Pass generators to dict() and tuple() instead of coercing to a list

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -71,7 +71,7 @@ def parse_debug_object(response):
     # prefixed with a name
     response = nativestr(response)
     response = 'type:' + response
-    response = dict([kv.split(':') for kv in response.split()])
+    response = dict(kv.split(':') for kv in response.split())
 
     # parse some expected int values from the string response
     # note: this cmd isn't spec'd so these may not appear in all redis versions
@@ -246,7 +246,7 @@ def parse_client_list(response, **options):
     clients = []
     for c in nativestr(response).splitlines():
         # Values might contain '='
-        clients.append(dict([pair.split('=', 1) for pair in c.split(' ')]))
+        clients.append(dict(pair.split('=', 1) for pair in c.split(' ')))
     return clients
 
 
@@ -282,7 +282,7 @@ def parse_slowlog_get(response, **options):
 
 
 def parse_cluster_info(response, **options):
-    return dict([line.split(':') for line in response.splitlines() if line])
+    return dict(line.split(':') for line in response.splitlines() if line)
 
 
 def _parse_node_line(line):
@@ -307,7 +307,7 @@ def parse_cluster_nodes(response, **options):
     raw_lines = response
     if isinstance(response, basestring):
         raw_lines = response.splitlines()
-    return dict([_parse_node_line(line) for line in raw_lines])
+    return dict(_parse_node_line(line) for line in raw_lines)
 
 
 def parse_georadius_generic(response, **options):
@@ -2439,7 +2439,7 @@ class PubSub(object):
         """
         encode = self.encoder.encode
         decode = self.encoder.decode
-        return dict([(decode(encode(k)), v) for k, v in iteritems(data)])
+        return dict((decode(encode(k)), v) for k, v in iteritems(data))
 
     def psubscribe(self, *args, **kwargs):
         """

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -640,8 +640,8 @@ class Connection(object):
         # to prevent them from being encoded.
         command = args[0]
         if ' ' in command:
-            args = tuple([Token.get_token(s)
-                          for s in command.split()]) + args[1:]
+            args = tuple(Token.get_token(s)
+                         for s in command.split()) + args[1:]
         else:
             args = (Token.get_token(command),) + args[1:]
 

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -171,10 +171,11 @@ class Sentinel(object):
         # if sentinel_kwargs isn't defined, use the socket_* options from
         # connection_kwargs
         if sentinel_kwargs is None:
-            sentinel_kwargs = dict([(k, v)
-                                    for k, v in iteritems(connection_kwargs)
-                                    if k.startswith('socket_')
-                                    ])
+            sentinel_kwargs = dict(
+                (k, v)
+                for k, v in iteritems(connection_kwargs)
+                if k.startswith('socket_')
+            )
         self.sentinel_kwargs = sentinel_kwargs
 
         self.sentinels = [StrictRedis(hostname, port, **self.sentinel_kwargs)


### PR DESCRIPTION
Avoids storing temporary lists in memory.