### PR TITLE
Remove Queue package workarounds for older unsupported Pythons

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -172,27 +172,5 @@ else:
 
 try:  # Python 3
     from queue import LifoQueue, Empty, Full
-except ImportError:
-    from Queue import Empty, Full
-    try:  # Python 2.6 - 2.7
-        from Queue import LifoQueue
-    except ImportError:  # Python 2.5
-        from Queue import Queue
-        # From the Python 2.7 lib. Python 2.5 already extracted the core
-        # methods to aid implementating different queue organisations.
-
-        class LifoQueue(Queue):
-            "Override queue methods to implement a last-in first-out queue."
-
-            def _init(self, maxsize):
-                self.maxsize = maxsize
-                self.queue = []
-
-            def _qsize(self, len=len):
-                return len(self.queue)
-
-            def _put(self, item):
-                self.queue.append(item)
-
-            def _get(self):
-                return self.queue.pop()
+except ImportError:  # Python 2
+    from Queue import LifoQueue, Empty, Full


### PR DESCRIPTION
Python 2.5 is neither supported nor tested by redis-py. Can remove
workaround.