### PR TITLE
Implement Lock.locked() check, as threading.Lock does

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -127,6 +127,11 @@ class Lock(object):
             return True
         return False
 
+    def locked(self):
+        if self.redis.get(self.name) is not None:
+            return True
+        return False
+
     def release(self):
         "Releases the already acquired lock"
         expected_token = self.local.token

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -15,7 +15,9 @@ class TestLock(object):
 
     def test_lock(self, sr):
         lock = self.get_lock(sr, 'foo')
+        assert lock.locked() is False
         assert lock.acquire(blocking=False)
+        assert lock.locked() is True
         assert sr.get('foo') == lock.local.token
         assert sr.ttl('foo') == -1
         lock.release()
@@ -56,6 +58,7 @@ class TestLock(object):
         # blocking_timeout prevents a deadlock if the lock can't be acquired
         # for some reason
         with self.get_lock(sr, 'foo', blocking_timeout=0.2) as lock:
+            assert lock.locked() is True
             assert sr.get('foo') == lock.local.token
         assert sr.get('foo') is None
 


### PR DESCRIPTION
`threading.Lock` have a way to check if it is locked right now.

Implemented by checking if the `Lock.name` key is present in the redis.