### PR TITLE
Fix parsing for INFO keys that include ':'

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -114,7 +114,8 @@ def parse_info(response):
     for line in response.splitlines():
         if line and not line.startswith('#'):
             if line.find(':') != -1:
-                key, value = line.split(':', 1)
+                # support keys that include ':' by using rsplit
+                key, value = line.rsplit(':', 1)
                 info[key] = get_value(value)
             else:
                 # if the line isn't splittable, append it to the "__raw__" key


### PR DESCRIPTION
As of https://github.com/antirez/redis/commit/a81a92ca2ceba364f4bb51efde9284d939e7ff47 (first included in Redis 4), there is a new 'host:' pseudo-command. This caused the addition of an INFO commandstat key 'cmdstat_host:', which results in incorrect parsing of the INFO command into a Python dict by the `client.parse_info` function.

Before fix:
`{
...
'cmdstat_host': {':calls': 6, 'usec': 601, 'usec_per_call': 100.17}
...
}`

After fix:
`{
...
'cmdstat_host:': {'calls': 6, 'usec': 601, 'usec_per_call': 100.17}
...
}`