### PR TITLE
 Allow pings in PubSub

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2521,6 +2521,7 @@ class PubSub(object):
         """
         Ping the Redis server
         """
+        message = '' if message is None else message
         return self.execute_command('PING', message)
 
     def handle_message(self, response, ignore_subscribe_messages=False):

--- a/redis/client.py
+++ b/redis/client.py
@@ -2517,6 +2517,12 @@ class PubSub(object):
             return self.handle_message(response, ignore_subscribe_messages)
         return None
 
+    def ping(self):
+        """
+        Ping the Redis server
+        """
+        return self.execute_command('PING')
+
     def handle_message(self, response, ignore_subscribe_messages=False):
         """
         Parses a pub/sub message. If the channel or pattern was subscribed to
@@ -2530,6 +2536,13 @@ class PubSub(object):
                 'pattern': response[1],
                 'channel': response[2],
                 'data': response[3]
+            }
+        elif message_type == 'pong':
+            message = {
+                'type': message_type,
+                'pattern': None,
+                'channel': None,
+                'data': response[1]
             }
         else:
             message = {

--- a/redis/client.py
+++ b/redis/client.py
@@ -2517,11 +2517,11 @@ class PubSub(object):
             return self.handle_message(response, ignore_subscribe_messages)
         return None
 
-    def ping(self):
+    def ping(self, message=None):
         """
         Ping the Redis server
         """
-        return self.execute_command('PING')
+        return self.execute_command('PING', message)
 
     def handle_message(self, response, ignore_subscribe_messages=False):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -2574,7 +2574,7 @@ class PubSub(object):
             if handler:
                 handler(message)
                 return None
-        else:
+        elif message_type != 'pong':
             # this is a subscribe/unsubscribe message. ignore if we don't
             # want them
             if ignore_subscribe_messages or self.ignore_subscribe_messages:

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -27,7 +27,7 @@ def make_message(type, channel, data, pattern=None):
     return {
         'type': type,
         'pattern': pattern and pattern.encode('utf-8') or None,
-        'channel': channel.encode('utf-8'),
+        'channel': channel and channel.encode('utf-8') or None,
         'data': data.encode('utf-8') if isinstance(data, basestring) else data
     }
 
@@ -427,3 +427,15 @@ class TestPubSubPubSubSubcommands(object):
         p = r.pubsub(ignore_subscribe_messages=True)
         p.psubscribe('*oo', '*ar', 'b*z')
         assert r.pubsub_numpat() == 3
+
+
+class TestPubSubPings(object):
+
+    @skip_if_server_version_lt('3.0.0')
+    def test_send_pubsub_ping(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        p.subscribe('foo')
+        p.ping()
+        assert wait_for_message(p) == make_message(type='pong', channel=None,
+                                                 data='',
+                                                 pattern=None)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -439,3 +439,12 @@ class TestPubSubPings(object):
         assert wait_for_message(p) == make_message(type='pong', channel=None,
                                                    data='',
                                                    pattern=None)
+
+    @skip_if_server_version_lt('3.0.0')
+    def test_send_pubsub_ping_message(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        p.subscribe('foo')
+        p.ping(message='hello world')
+        assert wait_for_message(p) == make_message(type='pong', channel=None,
+                                                   data='hello world',
+                                                   pattern=None)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -437,5 +437,5 @@ class TestPubSubPings(object):
         p.subscribe('foo')
         p.ping()
         assert wait_for_message(p) == make_message(type='pong', channel=None,
-                                                 data='',
-                                                 pattern=None)
+                                                   data='',
+                                                   pattern=None)


### PR DESCRIPTION
According to https://redis.io/topics/pubsub, “The commands that are allowed in the context of a subscribed client are SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE, PUNSUBSCRIBE, PING and QUIT.”

According to https://redis.io/commands/ping, “If the client is subscribed to a channel or a pattern, it will instead return a multi-bulk with a "pong" in the first position and an empty bulk in the second position, unless an argument is provided in which case it returns a copy of the argument.”

The motivation for this is as follows:
We use redis-py in production for caching, key-value storage and pubsub. Some of our uses of pubsub are very sparse - publishers could potentially only publish every 3 days. We find, in about 1 out of 20 instances where this happens, that subscribers "stop listening" to a channel. Inspecting the local network we can see the channels are open but inspecting redis, it no longer is aware of these subscribers. Our hypothesis on this is that the connection has failed but since these instances of PubSub only subscribe and listen, nothing triggers the "reconnect" mechanism (and so `PubSub.on_connect` is never called). Redis recently (v3) implemented PINGs whilst subscribed which would give us the ability to routinely check the connection is still alive and reconnect if needed.