### PR TITLE
1022: Fix retry logic for StricRedis and PubSub

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2411,7 +2411,8 @@ class PubSub(object):
             return command(*args)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if not connection.retry_on_timeout and isinstance(e, TimeoutError):
+            if (not connection.retry_on_timeout and
+                    isinstance(e, TimeoutError)):
                 raise
             # Connect manually here. If the Redis server is down, this will
             # fail and raise a ConnectionError as desired.

--- a/redis/client.py
+++ b/redis/client.py
@@ -669,7 +669,7 @@ class StrictRedis(object):
             return self.parse_response(connection, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if (not connection.retry_on_timeout and
+            if not (connection.retry_on_timeout and
                     isinstance(e, TimeoutError)):
                 raise
             connection.send_command(*args)
@@ -2411,7 +2411,7 @@ class PubSub(object):
             return command(*args)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if (not connection.retry_on_timeout and
+            if not (connection.retry_on_timeout and
                     isinstance(e, TimeoutError)):
                 raise
             # Connect manually here. If the Redis server is down, this will

--- a/redis/client.py
+++ b/redis/client.py
@@ -669,7 +669,7 @@ class StrictRedis(object):
             return self.parse_response(connection, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if not connection.retry_on_timeout and isinstance(e, TimeoutError):
+            if (not connection.retry_on_timeout and isinstance(e, TimeoutError)):
                 raise
             connection.send_command(*args)
             return self.parse_response(connection, command_name, **options)

--- a/redis/client.py
+++ b/redis/client.py
@@ -669,7 +669,8 @@ class StrictRedis(object):
             return self.parse_response(connection, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if (not connection.retry_on_timeout and isinstance(e, TimeoutError)):
+            if (not connection.retry_on_timeout and
+                    isinstance(e, TimeoutError)):
                 raise
             connection.send_command(*args)
             return self.parse_response(connection, command_name, **options)


### PR DESCRIPTION
#1022 
```
----------------------------------------
Current behaviour:
----------------------------------------
Condition: retry_on_timeout-True, timeout_error-False
Result: retry
Condition: retry_on_timeout-True, timeout_error-True
Result: retry
Condition: retry_on_timeout-False, timeout_error-True
Result: not retry
Condition: retry_on_timeout-False, timeout_error-False
Result: retry
----------------------------------------
Fixed behaviour:
----------------------------------------
Condition: retry_on_timeout: True, timeout_error: False
Result: not retry
Condition: retry_on_timeout: True, timeout_error: True
Result: retry
Condition: retry_on_timeout: False, timeout_error: True
Result: not retry
Condition: retry_on_timeout: False, timeout_error: False
Result: not retry
----------------------------------------
```