### PR TITLE
readme link badge to docs and pypi (#1021)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ The Python interface to the Redis key-value store.
 
 .. image:: https://secure.travis-ci.org/andymccurdy/redis-py.png?branch=master
         :target: http://travis-ci.org/andymccurdy/redis-py
+.. image:: https://readthedocs.org/projects/redis-py/badge/?version=latest&style=flat
+        :target: https://redis-py.readthedocs.io/en/latest/
+.. image:: https://badge.fury.io/py/redis.svg
+        :target: https://pypi.org/project/redis/
 
 Installation
 ------------


### PR DESCRIPTION
Hi!
As requested in issue #1021, created link to pypi and docs.
They come in green by default.
