### PR TITLE
Test Python 3.7 in Travis CI and document in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 cache: pip
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"
@@ -21,5 +22,6 @@ matrix:
   include:
     - python: "2.7"
       env: TEST_PEP8=1
-    - python: "3.6"
+    - python: "3.7"
+      dist: xenial
       env: TEST_PEP8=1

--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py26,py27,py32,py33,py34,py35,py36}-{plain,hiredis}, pep8
+envlist = {py26,py27,py32,py33,py34,py35,py36,py37}-{plain,hiredis}, pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.7 is out since 2018-06-27. 
I suggest we support it and run tests in travis CI using it.