### PR TITLE
Fix race condition in redis.lock.Lock.release

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -142,6 +142,7 @@ class Lock(object):
             lock_value = pipe.get(name)
             if lock_value != expected_token:
                 raise LockError("Cannot release a lock that's no longer owned")
+            pipe.multi()
             pipe.delete(name)
 
         self.redis.transaction(execute_release, name)


### PR DESCRIPTION
The release code wasn't using transaction correctly. It calls `watch`,
which puts the pipeline into immediate execution mode, checks the
current value of the key, then deletes it. At no stage does it call
`multi` to put it back into pipeline mode. As a result, the command
stack is empty and so no MULTI/EXEC is done, and the watch has no
effect.

This leads to a race condition when using expiring locks:

- Client 1 acquires the lock, with a timeout
- Client 1 calls release()
- Client 1 watches the key
- Client 1 gets the key, sees that it is still correct
- Client 1's timeout expires, so the key disappears
- Client 2 acquires the lock
- Client 1 deletes the key
- Client 3 also acquires the lock

Now client 3 has stolen the lock from under client 2.