### PR TITLE
Adding a NOSAVE option to the SHUTDOWN command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -822,12 +822,12 @@ class StrictRedis(object):
         "Returns a list of slaves for ``service_name``"
         return self.execute_command('SENTINEL SLAVES', service_name)
 
-    def shutdown(self, option=None):
+    def shutdown(self, save=True):
         "Shutdown the server"
         try:
             args = ['SHUTDOWN']
-            if option is not None:
-                args.append(option)
+            if not save:
+                args.append('NOSAVE')
             self.execute_command(*args)
         except ConnectionError:
             # a ConnectionError here is expected

--- a/redis/client.py
+++ b/redis/client.py
@@ -822,10 +822,13 @@ class StrictRedis(object):
         "Returns a list of slaves for ``service_name``"
         return self.execute_command('SENTINEL SLAVES', service_name)
 
-    def shutdown(self):
+    def shutdown(self, option=None):
         "Shutdown the server"
         try:
-            self.execute_command('SHUTDOWN')
+            args = ['SHUTDOWN']
+            if option is not None:
+                args.append(option)
+            self.execute_command(*args)
         except ConnectionError:
             # a ConnectionError here is expected
             return

--- a/redis/client.py
+++ b/redis/client.py
@@ -823,9 +823,11 @@ class StrictRedis(object):
         return self.execute_command('SENTINEL SLAVES', service_name)
 
     def shutdown(self, save=False, nosave=False):
-        """Shutdown the Redis server.  If Redis has persistence configured, data will be flushed before shutdown.  If
-        the "save" option is set, a data flush will be attempted even if there is no persistence configured.  If the
-        "nosave" option is set, no data flush will be attempted.  The "save" and "nosave" options cannot both be set.
+        """Shutdown the Redis server.  If Redis has persistence configured,
+        data will be flushed before shutdown.  If the "save" option is set,
+        a data flush will be attempted even if there is no persistence
+        configured.  If the "nosave" option is set, no data flush will be
+        attempted.  The "save" and "nosave" options cannot both be set.
         """
         if save and nosave:
             raise RedisError('SHUTDOWN save and nosave cannot both be set')

--- a/redis/client.py
+++ b/redis/client.py
@@ -822,12 +822,19 @@ class StrictRedis(object):
         "Returns a list of slaves for ``service_name``"
         return self.execute_command('SENTINEL SLAVES', service_name)
 
-    def shutdown(self, save=True):
-        "Shutdown the server"
+    def shutdown(self, save=False, nosave=False):
+        """Shutdown the Redis server.  If Redis has persistence configured, data will be flushed before shutdown.  If
+        the "save" option is set, a data flush will be attempted even if there is no persistence configured.  If the
+        "nosave" option is set, no data flush will be attempted.  The "save" and "nosave" options cannot both be set.
+        """
+        if save and nosave:
+            raise RedisError('SHUTDOWN save and nosave cannot both be set')
+        args = ['SHUTDOWN']
+        if save:
+            args.append('SAVE')
+        if nosave:
+            args.append('NOSAVE')
         try:
-            args = ['SHUTDOWN']
-            if not save:
-                args.append('NOSAVE')
             self.execute_command(*args)
         except ConnectionError:
             # a ConnectionError here is expected

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -126,34 +126,6 @@ class TestRedisCommands(object):
     def test_ping(self, r):
         assert r.ping()
 
-    def test_shutdown(self, r):
-        r.shutdown()
-        # Attempt to ping the server after the shutdown.  The library should
-        #    reconnect, but will return a connection error for the next couple
-        #    of attempts.  This loop will reattempt a ping until a success or
-        #    one second timeout.
-        for i in range(10):
-            try:
-                r.ping()
-                break
-            except:
-                time.sleep(0.1)
-        assert r.ping()
-
-    def test_shutdown_nosave(self, r):
-        r.shutdown(save=False)
-        # Attempt to ping the server after the shutdown.  The library should
-        #    reconnect, but will return a connection error for the next couple
-        #    of attempts.  This loop will reattempt a ping until a success or
-        #    one second timeout.
-        for i in range(10):
-            try:
-                r.ping()
-                break
-            except:
-                time.sleep(0.1)
-        assert r.ping()
-
     def test_slowlog_get(self, r, slowlog):
         assert r.slowlog_reset()
         unicode_string = unichr(3456) + u('abcd') + unichr(3421)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -126,6 +126,34 @@ class TestRedisCommands(object):
     def test_ping(self, r):
         assert r.ping()
 
+    def test_shutdown(self, r):
+        r.shutdown()
+        # Attempt to ping the server after the shutdown.  The library should
+        #    reconnect, but will return a connection error for the next couple
+        #    of attempts.  This loop will reattempt a ping until a success or
+        #    one second timeout.
+        for i in range(10):
+            try:
+                r.ping()
+                break
+            except:
+                time.sleep(0.1)
+        assert r.ping()
+
+    def test_shutdown_nosave(self, r):
+        r.shutdown(save=False)
+        # Attempt to ping the server after the shutdown.  The library should
+        #    reconnect, but will return a connection error for the next couple
+        #    of attempts.  This loop will reattempt a ping until a success or
+        #    one second timeout.
+        for i in range(10):
+            try:
+                r.ping()
+                break
+            except:
+                time.sleep(0.1)
+        assert r.ping()
+
     def test_slowlog_get(self, r, slowlog):
         assert r.slowlog_reset()
         unicode_string = unichr(3456) + u('abcd') + unichr(3421)


### PR DESCRIPTION
Fixes #1041 

Adding a NOSAVE option to the shutdown command.

~~Also added tests for the shutdown command and for the shutdown command with the NOSAVE option.  They're simple tests, but they wait for reconnection so other tests don't fail.~~

Reverted the tests back out as the Redis server doesn't recover on TravisCI.