### PR TITLE
Improve formatting of docs

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2525,14 +2525,14 @@ class StrictRedis(object):
     def geohash(self, name, *values):
         """
         Return the geo hash string for each item of ``values`` members of
-        the specified key identified by the ``name``argument.
+        the specified key identified by the ``name`` argument.
         """
         return self.execute_command('GEOHASH', name, *values)
 
     def geopos(self, name, *values):
         """
         Return the positions of each item of ``values`` as members of
-        the specified key identified by the ``name``argument. Each position
+        the specified key identified by the ``name`` argument. Each position
         is represented by the pairs lon and lat.
         """
         return self.execute_command('GEOPOS', name, *values)


### PR DESCRIPTION
I've only made two minor changes for now, but there a few more changes I'd like to discuss:

* Change the docs for `xclaim` (line 1785) from this:
  ```
  Changes the ownership of a pending message.
  name: name of the stream.
  groupname: name of the consumer group.
  consumername: name of a consumer that claims the message.
  min_idle_time: filter messages that were idle less than this amount of
  milliseconds
  message_ids: non-empty list or tuple of message IDs to claim
  idle: optional. Set the idle time (last time it was delivered) of the
   message in ms
  time: optional integer. This is the same as idle but instead of a
   relative amount of milliseconds, it sets the idle time to a specific
   Unix time (in milliseconds).
  retrycount: optional integer. set the retry counter to the specified
   value. This counter is incremented every time a message is delivered
   again.
  force: optional boolean, false by default. Creates the pending message
   entry in the PEL even if certain specified IDs are not already in the
   PEL assigned to a different client.
  justid: optional boolean, false by default. Return just an array of IDs
   of messages successfully claimed, without returning the actual message
  ```
  to this:
  ```
  Changes the ownership of a pending message.
  
  ``name``: name of the stream.
  
  ``groupname``: name of the consumer group.
  
  ``consumername``: name of a consumer that claims the message.
  
  ``min_idle_time``: filter messages that were idle less than this amount of
  milliseconds
  
  ``message_ids``: non-empty list or tuple of message IDs to claim
  
  ``idle``: optional. Set the idle time (last time it was delivered) of the
  message in ms.
  
  ``time``: optional integer. This is the same as idle but instead of a
  relative amount of milliseconds, it sets the idle time to a specific
  Unix time (in milliseconds).
  
  ``retrycount``: optional integer. set the retry counter to the specified
  value. This counter is incremented every time a message is delivered
  again.
  
  ``force``: optional boolean, false by default. Creates the pending message
  entry in the PEL even if certain specified IDs are not already in the
  PEL assigned to a different client.
  
  ``justid``: optional boolean, false by default. Return just an array of IDs
   of messages successfully claimed, without returning the actual message.
  ```
  Similar changes would need to be made for docs of other functions which haven't been formatted yet.

* Fix the formatting of an external link [here](https://redis-py.readthedocs.io/en/latest/#redis.StrictRedis.from_url):
  ![screenshot from 2018-11-01 12-41-38](https://user-images.githubusercontent.com/11466676/47837885-94dab800-ddd3-11e8-921d-e1c5838179c9.png)
  I've tried to fix it but can't work out how an inline code element can be inside a link.