### PR TITLE
Fail gracefully with a default return value when 0 keys are are provided to a command expecting at least 1 key

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -427,6 +427,7 @@ class TestRedisCommands(object):
         assert set(r.keys(pattern='test*')) == keys
 
     def test_mget(self, r):
+        assert r.mget([]) == []
         assert r.mget(['a', 'b']) == [None, None]
         r['a'] = '1'
         r['b'] = '2'

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -114,13 +114,27 @@ class TestPipeline(object):
             assert pipe.set('z', 'zzz').execute() == [True]
             assert r['z'] == b('zzz')
 
-    def test_command_with_on_error_option_returns_default_value(self, r):
+    def test_transaction_with_empty_error_command(self, r):
         """
-        Commands with custom ON_ERROR functionality return their default
+        Commands with custom EMPTY_ERROR functionality return their default
         values in the pipeline no matter the raise_on_error preference
         """
         for error_switch in (True, False):
             with r.pipeline() as pipe:
+                pipe.set('a', 1).mget([]).set('c', 3)
+                result = pipe.execute(raise_on_error=error_switch)
+
+                assert result[0]
+                assert result[1] == []
+                assert result[2]
+
+    def test_pipeline_with_empty_error_command(self, r):
+        """
+        Commands with custom EMPTY_ERROR functionality return their default
+        values in the pipeline no matter the raise_on_error preference
+        """
+        for error_switch in (True, False):
+            with r.pipeline(transaction=False) as pipe:
                 pipe.set('a', 1).mget([]).set('c', 3)
                 result = pipe.execute(raise_on_error=error_switch)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -114,6 +114,20 @@ class TestPipeline(object):
             assert pipe.set('z', 'zzz').execute() == [True]
             assert r['z'] == b('zzz')
 
+    def test_command_with_on_error_option_returns_default_value(self, r):
+        """
+        Commands with custom ON_ERROR functionality return their default
+        values in the pipeline no matter the raise_on_error preference
+        """
+        for error_switch in (True, False):
+            with r.pipeline() as pipe:
+                pipe.set('a', 1).mget([]).set('c', 3)
+                result = pipe.execute(raise_on_error=error_switch)
+
+                assert result[0]
+                assert result[1] == []
+                assert result[2]
+
     def test_parse_error_raised(self, r):
         with r.pipeline() as pipe:
             # the zrem is invalid because we don't pass any keys to it


### PR DESCRIPTION
This is an alternative implementation to #941 

Some commands like `MGET`, `DEL`, etc. accept 1 or more keys but fail if the user supplies 0 keys. From a user point of view, it would be nice if these commands simply returned an empty value when called with 0 keys. For example, `MGET` could return an empty list and `DEL` could return 0 indicating 0 keys were deleted. However, commands cannot simply return an empty value because of how they interact with pipelines.

This PR introduces a well named option `EMPTY_ERROR`. If a command detects one of these 0-key scenarios, it can pass the `EMPTY_ERROR` option with the default value that should be returned to the application. This includes the plumbing to work with pipelines.

Currently only `MGET` is implemented as an example. Other commands like `DEL` should also get this functionality if merged.

The question we need to answer is should we actually do this.