### PR TITLE
Support for bitfields

### DIFF
--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -1,4 +1,4 @@
-from redis.client import Redis, StrictRedis
+from redis.client import Redis, StrictRedis, BitField
 from redis.connection import (
     BlockingConnectionPool,
     ConnectionPool,
@@ -30,5 +30,5 @@ __all__ = [
     'Connection', 'SSLConnection', 'UnixDomainSocketConnection', 'from_url',
     'AuthenticationError', 'BusyLoadingError', 'ConnectionError', 'DataError',
     'InvalidResponse', 'PubSubError', 'ReadOnlyError', 'RedisError',
-    'ResponseError', 'TimeoutError', 'WatchError'
+    'ResponseError', 'TimeoutError', 'WatchError', 'BitField',
 ]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1649,6 +1649,13 @@ class TestRedisCommands(object):
              ['place1', 0.0, 3471609698139488,
                  (2.1909382939338684, 41.433790281840835)]]
 
+    # BITFIELD COMMAND
+    @skip_if_server_version_lt('3.2.0')
+    def test_bitfield(self, r):
+        # TBD
+        pass
+
+    # STREAM COMMANDS
     @skip_if_server_version_lt('5.0.0')
     def test_xack(self, r):
         stream = 'stream'


### PR DESCRIPTION
WIP - addresses #926 

```python
from redis import StrictRedis, BitField

r = StrictRedis()

r.delete('bfchain')
b = r.bitfield('bfchain').set(8, 0, 1).get(8, 0)
print(b.execute())  # [0, 1]

for i in range(2):
    name = 'bfex{}'.format(i)
    r.delete(name)
    b = BitField()
    b.set(4, 0, i+1)
    b.incrby(2, 1, 2, positional=True)
    print(b.execute(client=r, name=name))  # [0, 3] and [0, 0]

r.delete('bfctx')
with r.bitfield('bfctx') as b:
    b.set(2, 0, 3, signed=False)
    b.overflow(fail=True)
    b.incrby(2, 0, 2)
    print(b.execute())  # [0, None]

```

Signed-off-by: Itamar Haber <itamar@redislabs.com>