### PR TITLE
Adds `sync` flag to flushdb and flushall

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -841,27 +841,27 @@ class StrictRedis(object):
         "Echo the string back from the server"
         return self.execute_command('ECHO', value)
 
-    def flushall(self, sync=True):
+    def flushall(self, asynchronous=False):
         """
         Delete all keys in all databases on the current host.
 
-        ``sync`` indicates whether the operation is executed
-        synchronously by the server.
+        ``asynchronous`` indicates whether the operation is
+        executed asynchronously by the server.
         """
         args = []
-        if not sync:
+        if not asynchronous:
             args.append(Token.get_token('ASYNC'))
         return self.execute_command('FLUSHALL', *args)
 
-    def flushdb(self, sync=True):
+    def flushdb(self, asynchronous=False):
         """
         Delete all keys in the current database.
 
-        ``sync`` indicates whether the operation is executed
-        synchronously by the server.
+        ``asynchronous`` indicates whether the operation is
+        executed asynchronously by the server.
         """
         args = []
-        if not sync:
+        if not asynchronous:
             args.append(Token.get_token('ASYNC'))
         return self.execute_command('FLUSHDB', *args)
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -841,13 +841,29 @@ class StrictRedis(object):
         "Echo the string back from the server"
         return self.execute_command('ECHO', value)
 
-    def flushall(self):
-        "Delete all keys in all databases on the current host"
-        return self.execute_command('FLUSHALL')
+    def flushall(self, sync=True):
+        """
+        Delete all keys in all databases on the current host.
 
-    def flushdb(self):
-        "Delete all keys in the current database"
-        return self.execute_command('FLUSHDB')
+        ``sync`` indicates whether the operation is executed
+        synchronously by the server.
+        """
+        args = []
+        if not sync:
+            args.append(Token.get_token('ASYNC'))
+        return self.execute_command('FLUSHALL', *args)
+
+    def flushdb(self, sync=True):
+        """
+        Delete all keys in the current database.
+
+        ``sync`` indicates whether the operation is executed
+        synchronously by the server.
+        """
+        args = []
+        if not sync:
+            args.append(Token.get_token('ASYNC'))
+        return self.execute_command('FLUSHDB', *args)
 
     def swapdb(self, first, second):
         "Swap two databases"


### PR DESCRIPTION
Uses sync as async is a keyword. Defaults to Redis pre v4 behavior.

Signed-off-by: Itamar Haber <itamar@redislabs.com>