### PR TITLE
Add missing UnixDomainSocketConnection._buffer_cutoff

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -759,6 +759,7 @@ class UnixDomainSocketConnection(Connection):
             'db': self.db,
         }
         self._connect_callbacks = []
+        self._buffer_cutoff = 6000
 
     def _connect(self):
         "Create a Unix domain socket connection"


### PR DESCRIPTION
Without this using `unix_socket_path` will fail:

    AttributeError: 'UnixDomainSocketConnection' object has no attribute '_buffer_cutoff'

Fixes #1067