### PR TITLE
Add custom object hook

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -117,6 +117,9 @@ class Encoder(object):
         elif isinstance(value, (int, long)):
             # python 2 repr() on longs is '123L', so use str() instead
             value = str(value).encode()
+        elif hasattr(value, 'to_bytes'):
+            # Provide hook for custom objects to convert themselves to bytes.
+            value = self.encode(value.to_bytes())
         elif not isinstance(value, basestring):
             # a value we don't know how to deal with. throw an error
             typename = type(value).__name__

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -6,6 +6,17 @@ from redis._compat import unichr, unicode
 from .conftest import _get_client
 
 
+class CustomKey(object):
+    prefix = ':'
+
+    def __init__(self, key):
+        super(CustomKey, self).__init__()
+        self.key = self.prefix + key
+
+    def to_bytes(self):
+        return self.key
+
+
 class TestEncoding(object):
     @pytest.fixture()
     def r(self, request):
@@ -23,6 +34,10 @@ class TestEncoding(object):
         result = [unicode_string, unicode_string, unicode_string]
         r.rpush('a', *result)
         assert r.lrange('a', 0, -1) == result
+
+    def test_custom_object_encoding(self, r):
+        r.set(CustomKey('a'), 'a')
+        assert r.get(':a') == 'a'
 
 
 class TestCommandsAndTokensArentEncoded(object):


### PR DESCRIPTION
### Background

[django-redis-cache](https://github.com/sebleier/django-redis-cache) uses a custom cache key that stores an original key along with a versioned key.  redis-py < 3.0 would just call the `__unicode__` method on the object and the custom key would be returned.  Now redis-py looks like it discriminates a little more on what can be encoded.

### Changes

This pull request will add a hook for objects to define their own `to_bytes` method, which will allow themselves to convert into a data type otherwise supported by the `Encoder`.  It seems to me that you can either use the built-in `__str__` method of an object or use a custom method to convert to a supported datatype.  The former might be a little too aggressive in converting data types into strings, since most objects have a `__str__` method and we would lose the ability to discriminate against unknown objects.  This implementation forces custom objects to fulfill a contract, where they will reduce themselves into an appropriate data type when `to_bytes` is called.


### Testing

I added a test to exercise encoding a custom object.  The test fails before 792b77d is applied and passes afterwards.
