### PR TITLE
Don't destroy data in GEORADIUS commands

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -378,6 +378,17 @@ def parse_cluster_nodes(response, **options):
     return dict(_parse_node_line(line) for line in raw_lines)
 
 
+def text_or_binary(response):
+    """
+    Return the response as text data if possible (decoded as utf-8), otherwise
+    return it unmodified.
+    """
+    try:
+        return response.decode('utf-8')
+    except UnicodeDecodeError:
+        return response
+
+
 def parse_georadius_generic(response, **options):
     if options['store'] or options['store_dist']:
         # `store` and `store_diff` cant be combined
@@ -392,7 +403,7 @@ def parse_georadius_generic(response, **options):
     if not options['withdist'] and not options['withcoord']\
             and not options['withhash']:
         # just a bunch of places
-        return [nativestr(r) for r in response_list]
+        return [text_or_binary(r) for r in response_list]
 
     cast = {
         'withdist': float,
@@ -402,7 +413,7 @@ def parse_georadius_generic(response, **options):
 
     # zip all output results with each casting functino to get
     # the properly native Python value.
-    f = [nativestr]
+    f = [text_or_binary]
     f += [cast[o] for o in ['withdist', 'withhash', 'withcoord'] if options[o]]
     return [
         list(map(lambda fv: fv[0](fv[1]), zip(f, r))) for r in response_list

--- a/redis/client.py
+++ b/redis/client.py
@@ -378,17 +378,6 @@ def parse_cluster_nodes(response, **options):
     return dict(_parse_node_line(line) for line in raw_lines)
 
 
-def text_or_binary(response):
-    """
-    Return the response as text data if possible (decoded as utf-8), otherwise
-    return it unmodified.
-    """
-    try:
-        return response.decode('utf-8')
-    except UnicodeDecodeError:
-        return response
-
-
 def parse_georadius_generic(response, **options):
     if options['store'] or options['store_dist']:
         # `store` and `store_diff` cant be combined
@@ -403,7 +392,7 @@ def parse_georadius_generic(response, **options):
     if not options['withdist'] and not options['withcoord']\
             and not options['withhash']:
         # just a bunch of places
-        return [text_or_binary(r) for r in response_list]
+        return response_list
 
     cast = {
         'withdist': float,
@@ -413,7 +402,7 @@ def parse_georadius_generic(response, **options):
 
     # zip all output results with each casting functino to get
     # the properly native Python value.
-    f = [text_or_binary]
+    f = [lambda x: x]
     f += [cast[o] for o in ['withdist', 'withhash', 'withcoord'] if options[o]]
     return [
         list(map(lambda fv: fv[0](fv[1]), zip(f, r))) for r in response_list

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1656,7 +1656,7 @@ class TestRedisCommands(object):
                  (2.1873744593677, 41.406342043777, b'\x80place2')
 
         r.geoadd('barcelona', *values)
-        assert r.georadius('barcelona', 2.191, 41.433, 1000) == ['place1']
+        assert r.georadius('barcelona', 2.191, 41.433, 1000) == [b'place1']
         assert r.georadius('barcelona', 2.187, 41.406, 1000) == [b'\x80place2']
 
     @skip_if_server_version_lt('3.2.0')
@@ -1674,7 +1674,7 @@ class TestRedisCommands(object):
 
         r.geoadd('barcelona', *values)
         assert r.georadius('barcelona', 2.191, 41.433, 1, unit='km') ==\
-            ['place1']
+            [b'place1']
 
     @skip_if_server_version_lt('3.2.0')
     def test_georadius_with(self, r):
@@ -1687,17 +1687,17 @@ class TestRedisCommands(object):
         # function.
         assert r.georadius('barcelona', 2.191, 41.433, 1, unit='km',
                            withdist=True, withcoord=True, withhash=True) ==\
-            [['place1', 0.0881, 3471609698139488,
+            [[b'place1', 0.0881, 3471609698139488,
               (2.19093829393386841, 41.43379028184083523)]]
 
         assert r.georadius('barcelona', 2.191, 41.433, 1, unit='km',
                            withdist=True, withcoord=True) ==\
-            [['place1', 0.0881,
+            [[b'place1', 0.0881,
               (2.19093829393386841, 41.43379028184083523)]]
 
         assert r.georadius('barcelona', 2.191, 41.433, 1, unit='km',
                            withhash=True, withcoord=True) ==\
-            [['place1', 3471609698139488,
+            [[b'place1', 3471609698139488,
               (2.19093829393386841, 41.43379028184083523)]]
 
         # test no values.
@@ -1711,7 +1711,7 @@ class TestRedisCommands(object):
 
         r.geoadd('barcelona', *values)
         assert r.georadius('barcelona', 2.191, 41.433, 3000, count=1) ==\
-            ['place1']
+            [b'place1']
 
     @skip_if_server_version_lt('3.2.0')
     def test_georadius_sort(self, r):
@@ -1720,9 +1720,9 @@ class TestRedisCommands(object):
 
         r.geoadd('barcelona', *values)
         assert r.georadius('barcelona', 2.191, 41.433, 3000, sort='ASC') ==\
-            ['place1', 'place2']
+            [b'place1', b'place2']
         assert r.georadius('barcelona', 2.191, 41.433, 3000, sort='DESC') ==\
-            ['place2', 'place1']
+            [b'place2', b'place1']
 
     @skip_if_server_version_lt('3.2.0')
     def test_georadius_store(self, r):
@@ -1751,15 +1751,15 @@ class TestRedisCommands(object):
 
         r.geoadd('barcelona', *values)
         assert r.georadiusbymember('barcelona', 'place1', 4000) ==\
-            [b'\x80place2', 'place1']
-        assert r.georadiusbymember('barcelona', 'place1', 10) == ['place1']
+            [b'\x80place2', b'place1']
+        assert r.georadiusbymember('barcelona', 'place1', 10) == [b'place1']
 
         assert r.georadiusbymember('barcelona', 'place1', 4000,
                                    withdist=True, withcoord=True,
                                    withhash=True) ==\
             [[b'\x80place2', 3067.4157, 3471609625421029,
                 (2.187376320362091, 41.40634178640635)],
-             ['place1', 0.0, 3471609698139488,
+             [b'place1', 0.0, 3471609698139488,
                  (2.1909382939338684, 41.433790281840835)]]
 
     @skip_if_server_version_lt('5.0.0')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1653,10 +1653,11 @@ class TestRedisCommands(object):
     @skip_if_server_version_lt('3.2.0')
     def test_georadius(self, r):
         values = (2.1909389952632, 41.433791470673, 'place1') +\
-                 (2.1873744593677, 41.406342043777, 'place2')
+                 (2.1873744593677, 41.406342043777, b'\x80place2')
 
         r.geoadd('barcelona', *values)
         assert r.georadius('barcelona', 2.191, 41.433, 1000) == ['place1']
+        assert r.georadius('barcelona', 2.187, 41.406, 1000) == [b'\x80place2']
 
     @skip_if_server_version_lt('3.2.0')
     def test_georadius_no_values(self, r):
@@ -1746,17 +1747,17 @@ class TestRedisCommands(object):
     @skip_if_server_version_lt('3.2.0')
     def test_georadiusmember(self, r):
         values = (2.1909389952632, 41.433791470673, 'place1') +\
-                 (2.1873744593677, 41.406342043777, 'place2')
+                 (2.1873744593677, 41.406342043777, b'\x80place2')
 
         r.geoadd('barcelona', *values)
         assert r.georadiusbymember('barcelona', 'place1', 4000) ==\
-            ['place2', 'place1']
+            [b'\x80place2', 'place1']
         assert r.georadiusbymember('barcelona', 'place1', 10) == ['place1']
 
         assert r.georadiusbymember('barcelona', 'place1', 4000,
                                    withdist=True, withcoord=True,
                                    withhash=True) ==\
-            [['place2', 3067.4157, 3471609625421029,
+            [[b'\x80place2', 3067.4157, 3471609625421029,
                 (2.187376320362091, 41.40634178640635)],
              ['place1', 0.0, 3471609698139488,
                  (2.1909382939338684, 41.433790281840835)]]


### PR DESCRIPTION
Re: https://github.com/andymccurdy/redis-py/issues/1082, this PR changes how the responses for `georadius` and `georadiusbymember` are handled, such that they don't destroy information when the "member" contains non-unicode data.