### PR TITLE
Extend lock error for not owned special case

### DIFF
--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -58,3 +58,8 @@ class LockError(RedisError, ValueError):
     # NOTE: For backwards compatability, this class derives from ValueError.
     # This was originally chosen to behave like threading.Lock.
     pass
+
+
+class LockErrorNotOwned(LockError):
+    "Error related to lock that may have been owned being lost."
+    pass

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -1,7 +1,7 @@
 import threading
 import time as mod_time
 import uuid
-from redis.exceptions import LockError
+from redis.exceptions import LockError, LockErrorNotOwned
 from redis.utils import dummy
 
 
@@ -190,7 +190,8 @@ class Lock(object):
         if not bool(self.lua_release(keys=[self.name],
                                      args=[expected_token],
                                      client=self.redis)):
-            raise LockError("Cannot release a lock that's no longer owned")
+            raise LockErrorNotOwned("Cannot release a lock"
+                                    " that's no longer owned")
 
     def extend(self, additional_time):
         """
@@ -210,5 +211,6 @@ class Lock(object):
         if not bool(self.lua_extend(keys=[self.name],
                                     args=[self.local.token, additional_time],
                                     client=self.redis)):
-            raise LockError("Cannot extend a lock that's no longer owned")
+            raise LockErrorNotOwned("Cannot extend a lock that's"
+                                    " no longer owned")
         return True

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 
-from redis.exceptions import LockError
+from redis.exceptions import LockError, LockErrorNotOwned
 from redis.lock import Lock
 
 
@@ -85,7 +85,7 @@ class TestLock(object):
         lock.acquire(blocking=False)
         # manually change the token
         r.set('foo', 'a')
-        with pytest.raises(LockError):
+        with pytest.raises(LockErrorNotOwned):
             lock.release()
         # even though we errored, the token is still cleared
         assert lock.local.token is None
@@ -119,10 +119,10 @@ class TestLock(object):
         lock.release()
 
     def test_extending_lock_no_longer_owned_raises_error(self, r):
-        lock = self.get_lock(r, 'foo')
+        lock = self.get_lock(r, 'foo', timeout=10)
         assert lock.acquire(blocking=False)
         r.set('foo', 'a')
-        with pytest.raises(LockError):
+        with pytest.raises(LockErrorNotOwned):
             lock.extend(10)
 
 


### PR DESCRIPTION
Using the locking routines, it is useful to be able to
distingush a generic lock error from a one that is related
to the lock not being owned anymore (without doing string
checks); this allows say a lock extension thread to attempt
to re-acquire the lock in this case (vs just dying).