### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+dist: xenial
+sudo: false
 language: python
 cache: pip
 python:
+  - 3.7
   - 3.6
   - 3.5
   - 3.4
@@ -20,15 +23,5 @@ matrix:
   include:
     - python: 2.7
       env: TEST_PYCODESTYLE=1
-    - python: 3.6
+    - python: 3.7
       env: TEST_PYCODESTYLE=1
-    # python 3.7 has to be specified manually in the matrix
-    # https://github.com/travis-ci/travis-ci/issues/9815
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: TEST_HIREDIS=0
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: TEST_HIREDIS=1

--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = {py27,py34,py35,py36}-{plain,hiredis}, pycodestyle
+envlist = {py27,py34,py35,py36,py37}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release

Add Python 3.7 to tox.ini and setup.py as well.