### PR TITLE
Use tox "extras" option to install package extras

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-minversion = 1.8
+minversion = 2.4
 envlist = {py27,py34,py35,py36,py37}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =
     mock
     pytest >= 2.7.0
-    hiredis: hiredis >= 0.1.3
+extras =
+    hiredis: hiredis
 commands = py.test {posargs}
 
 [testenv:pycodestyle]


### PR DESCRIPTION
For details, see:

https://tox.readthedocs.io/en/latest/config.html#conf-extras

Removes the need to duplicate the version string in tox.ini. Allow setup.py to be the single source of truth.