### PR TITLE
when decoding a byte stream of pickled data, return the byte stream..…

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -129,7 +129,11 @@ class Encoder(object):
     def decode(self, value, force=False):
         "Return a unicode string from the byte representation"
         if (self.decode_responses or force) and isinstance(value, bytes):
-            value = value.decode(self.encoding, self.encoding_errors)
+            try:
+                value = value.decode(self.encoding, self.encoding_errors)
+            except ValueError:
+                # Ignore encoding and return bytes
+                pass
         return value
 
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+
+import pickle
 import pytest
 import redis
 
@@ -23,6 +25,19 @@ class TestEncoding(object):
         result = [unicode_string, unicode_string, unicode_string]
         r.rpush('a', *result)
         assert r.lrange('a', 0, -1) == result
+
+
+class TestDecoding(object):
+    @pytest.fixture()
+    def r(self, request):
+        rdb = redis.StrictRedis
+        return _get_client(rdb, request=request, decode_responses=True)
+
+    def test_byte_stream_decoding(self, r):
+        expected = pickle.dumps(dict(hello='world'))
+        r.set('pickled-data', expected)
+        actual = r.get('pickled-data')
+        assert actual == expected
 
 
 class TestCommandsAndTokensArentEncoded(object):


### PR DESCRIPTION
…. this makes the behavior consistent whether we're using PythonParser or HiredisParser

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ python setup test` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

when decoding a byte stream of pickled data, return the byte stream... this makes the behavior consistent whether we're using PythonParser or HiredisParser

this commit fixes #1006  #772  