### PR TITLE
Remove outdated distutils fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,24 @@
 #!/usr/bin/env python
 import os
 import sys
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
 
 from redis import __version__
 
-try:
-    from setuptools import setup
-    from setuptools.command.test import test as TestCommand
 
-    class PyTest(TestCommand):
-        def finalize_options(self):
-            TestCommand.finalize_options(self)
-            self.test_args = []
-            self.test_suite = True
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
 
-        def run_tests(self):
-            # import here, because outside the eggs aren't loaded
-            import pytest
-            errno = pytest.main(self.test_args)
-            sys.exit(errno)
+    def run_tests(self):
+        # import here, because outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
-except ImportError:
-
-    from distutils.core import setup
-
-    def PyTest(x):
-        x
 
 f = open(os.path.join(os.path.dirname(__file__), 'README.rst'))
 long_description = f.read()


### PR DESCRIPTION
Modern Python environments have setuptools or pip installed. The distutils fallback is unnecessary.