### PR TITLE
Remove unnecessary compat shim for 'bytes'

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -112,7 +112,6 @@ if sys.version_info[0] < 3:
     xrange = xrange
     basestring = basestring
     unicode = unicode
-    bytes = str
     long = long
 else:
     from urllib.parse import parse_qs, unquote, urlparse
@@ -142,7 +141,6 @@ else:
     basestring = str
     unicode = str
     safe_unicode = str
-    bytes = bytes
     long = int
 
 try:  # Python 3

--- a/redis/client.py
+++ b/redis/client.py
@@ -7,7 +7,7 @@ import time
 import threading
 import time as mod_time
 import hashlib
-from redis._compat import (basestring, bytes, imap, iteritems, iterkeys,
+from redis._compat import (basestring, imap, iteritems, iterkeys,
                            itervalues, izip, long, nativestr, safe_unicode)
 from redis.connection import (ConnectionPool, UnixDomainSocketConnection,
                               SSLConnection, Token)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     ssl_available = False
 
-from redis._compat import (xrange, imap, byte_to_chr, unicode, bytes, long,
+from redis._compat import (xrange, imap, byte_to_chr, unicode, long,
                            nativestr, basestring, iteritems,
                            LifoQueue, Empty, Full, urlparse, parse_qs,
                            recv, recv_into, select, unquote)


### PR DESCRIPTION
Both Python 2.7 & Python 3 have the types bytes. On Python 2.7, it is an alias for the type `str`, same as what was previously defined in `_compat.py`.