### PR TITLE
Add support for specifying the token when acquiring a lock

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -193,17 +193,18 @@ class Lock(object):
             return True
         return False
 
-    def locked(self, current=False):
+    def locked(self):
         """
         Returns True if this key is locked by any process, otherwise False.
-
-        ``current`` specifies if the lock check needs to be this lock
         """
-        value = self.redis.get(self.name)
-        if current:
-            return self.local.token is not None and value == self.local.token
-        else:
-            return value is not None
+        return self.redis.get(self.name) is not None
+
+    def owned(self):
+        """
+        Returns True if this key is locked by this lock, otherwise False.
+        """
+        return self.local.token is not None and \
+               self.redis.get(self.name) == self.local.token
 
     def release(self):
         "Releases the already acquired lock"

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -193,7 +193,7 @@ class Lock(object):
         """
         Returns True if this key is locked by any process, otherwise False.
         """
-        return self.redis.get(self.name) is not None
+        return self.local.token is not None and self.redis.get(self.name) == self.local.token
 
     def release(self):
         "Releases the already acquired lock"

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -149,7 +149,7 @@ class Lock(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.release()
 
-    def acquire(self, blocking=None, blocking_timeout=None):
+    def acquire(self, blocking=None, blocking_timeout=None, token=None):
         """
         Use Redis to hold a shared, distributed lock named ``name``.
         Returns True once the lock is acquired.
@@ -159,9 +159,13 @@ class Lock(object):
 
         ``blocking_timeout`` specifies the maximum number of seconds to
         wait trying to acquire the lock.
+
+        ``token`` specifies the value of the key used. Should have a unique
+        component to it when acquiring a lock with the same name.
         """
         sleep = self.sleep
-        token = uuid.uuid1().hex.encode()
+        if token is None:
+            token = uuid.uuid1().hex.encode()
         if blocking is None:
             blocking = self.blocking
         if blocking_timeout is None:

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -193,11 +193,17 @@ class Lock(object):
             return True
         return False
 
-    def locked(self):
+    def locked(self, current=False):
         """
         Returns True if this key is locked by any process, otherwise False.
+
+        ``current`` specifies if the lock check needs to be this lock
         """
-        return self.local.token is not None and self.redis.get(self.name) == self.local.token
+        value = self.redis.get(self.name)
+        if current:
+            return self.local.token is not None and value == self.local.token
+        else:
+            return value is not None
 
     def release(self):
         "Releases the already acquired lock"

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -36,18 +36,23 @@ class TestLock(object):
         lock.release()
         assert lock.locked() is False
 
-        # Original lock should always return false for locked(), especially
-        # when a new lock is acquired
+    def test_owned(self, r):
+        lock = self.get_lock(r, 'foo')
+        assert lock.owned() is False
+        lock.acquire(blocking=False)
+        assert lock.owned() is True
+        lock.release()
+        assert lock.owned() is False
+
         lock2 = self.get_lock(r, 'foo')
-        assert lock.locked() is False
-        assert lock2.locked() is False
+        assert lock.owned() is False
+        assert lock2.owned() is False
         lock2.acquire(blocking=False)
-        assert lock.locked() is True
-        assert lock.locked(True) is False
-        assert lock2.locked() is True
+        assert lock.owned() is False
+        assert lock2.owned() is True
         lock2.release()
-        assert lock.locked() is False
-        assert lock2.locked() is False
+        assert lock.owned() is False
+        assert lock2.owned() is False
 
     def test_competing_locks(self, r):
         lock1 = self.get_lock(r, 'foo')

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -18,6 +18,16 @@ class TestLock(object):
         lock.release()
         assert r.get('foo') is None
 
+    def test_lock_token(self, r):
+        lock = self.get_lock(r, 'foo')
+        assert lock.acquire(blocking=False, token='test')
+        assert r.get('foo') == b'test'
+        assert lock.local.token == 'test'
+        assert r.ttl('foo') == -1
+        lock.release()
+        assert r.get('foo') is None
+        assert lock.local.token is None
+
     def test_locked(self, r):
         lock = self.get_lock(r, 'foo')
         assert lock.locked() is False

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -42,7 +42,8 @@ class TestLock(object):
         assert lock.locked() is False
         assert lock2.locked() is False
         lock2.acquire(blocking=False)
-        assert lock.locked() is False
+        assert lock.locked() is True
+        assert lock.locked(True) is False
         assert lock2.locked() is True
         lock2.release()
         assert lock.locked() is False

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -26,6 +26,18 @@ class TestLock(object):
         lock.release()
         assert lock.locked() is False
 
+        # Original lock should always return false for locked(), especially
+        # when a new lock is acquired
+        lock2 = self.get_lock(r, 'foo')
+        assert lock.locked() is False
+        assert lock2.locked() is False
+        lock2.acquire(blocking=False)
+        assert lock.locked() is False
+        assert lock2.locked() is True
+        lock2.release()
+        assert lock.locked() is False
+        assert lock2.locked() is False
+
     def test_competing_locks(self, r):
         lock1 = self.get_lock(r, 'foo')
         lock2 = self.get_lock(r, 'foo')


### PR DESCRIPTION
- [X] Does `$ python setup test` pass with this change (including linting)? (pytest passes but I'm not sure how to run the linting)
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)? (I don't know how to do this)
- [X] Is the new or changed code fully tested? (Added test for the bug fix and the new feature)
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (I updated the documentation of the function and didn't see anything else that I'm supposed to do)

### Description of change
*  Allowed `token` to be specified in `Lock.acquire()`
* Fixed `Lock.locked()` to verify the value of the token