### PR TITLE
Fix #1116 - trimmed stream causes exception on xreadgroup with id 0

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -191,6 +191,8 @@ def parse_sentinel_get_master(response):
 
 def pairs_to_dict(response, decode_keys=False):
     "Create a dict given a list of key/value pairs"
+    if response is None:
+        return {}
     if decode_keys:
         # the iter form is faster, but I don't know how to make that work
         # with a nativestr() map

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2205,6 +2205,22 @@ class TestRedisCommands(object):
         # xread starting after the last message returns an empty message list
         assert r.xreadgroup(group, consumer, streams={stream: '>'}) == expected
 
+        r.xgroup_destroy(stream, group)
+        r.xgroup_create(stream, group, '0')
+        # delete all the messages in the stream
+        expected = [
+            [
+                stream.encode(),
+                [
+                    (m1, {}),
+                    (m2, {}),
+                ]
+            ]
+        ]
+        r.xreadgroup(group, consumer, streams={stream: '>'})
+        r.xtrim(stream, 0)
+        assert r.xreadgroup(group, consumer, streams={stream: '0'}) == expected
+
     @skip_if_server_version_lt('5.0.0')
     def test_xrevrange(self, r):
         stream = 'stream'


### PR DESCRIPTION
This PR solves de exception by returning an empty dictionary if the group being converted from pairs to dict is None.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ python setup test` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

If a pending message from a consumer group gets deleted before it's acked, the next time you receive it when reading the messages via XREADGROUP with message id 0 it returns a (nil) instead of a list key/value pairs. This causes the library to thrown an exception.
The fix is to return an empty dict if the response is None in the pairs_to_dict function.
