### PR TITLE
GEOHASH response may contain None elements

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -244,6 +244,12 @@ def int_or_none(response):
     return int(response)
 
 
+def string_or_none(response):
+    if response is None:
+        return None
+    return nativestr(response)
+
+
 def parse_stream_list(response):
     if response is None:
         return None
@@ -508,7 +514,7 @@ class Redis(object):
             'CONFIG RESETSTAT': bool_ok,
             'CONFIG SET': bool_ok,
             'DEBUG OBJECT': parse_debug_object,
-            'GEOHASH': lambda r: list(map(nativestr, r)),
+            'GEOHASH': lambda r: list(map(string_or_none, r)),
             'GEOPOS': lambda r: list(map(lambda ll: (float(ll[0]),
                                          float(ll[1]))
                                          if ll is not None else None, r)),


### PR DESCRIPTION
fixes the following exception:
```
In [5]: r.geohash('Sicily', 'not_a_member')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-2a78bddb7b0d> in <module>()
----> 1 r.geohash('Sicily', 'not_a_member')

/home/ninja/work/oss/redis-py/redis/client.pyc in geohash(self, name, *values)
   2813         the specified key identified by the ``name`` argument.
   2814         """
-> 2815         return self.execute_command('GEOHASH', name, *values)
   2816 
   2817     def geopos(self, name, *values):

/home/ninja/work/oss/redis-py/redis/client.pyc in execute_command(self, *args, **options)
    765         try:
    766             connection.send_command(*args)
--> 767             return self.parse_response(connection, command_name, **options)
    768         except (ConnectionError, TimeoutError) as e:
    769             connection.disconnect()

/home/ninja/work/oss/redis-py/redis/client.pyc in parse_response(self, connection, command_name, **options)
    784             raise
    785         if command_name in self.response_callbacks:
--> 786             return self.response_callbacks[command_name](response, **options)
    787         return response
    788 

/home/ninja/work/oss/redis-py/redis/client.pyc in <lambda>(r)
    509             'CONFIG SET': bool_ok,
    510             'DEBUG OBJECT': parse_debug_object,
--> 511             'GEOHASH': lambda r: list(map(nativestr if r is not None else None, r)),
    512             'GEOPOS': lambda r: list(map(lambda ll: (float(ll[0]),
    513                                          float(ll[1]))

/home/ninja/work/oss/redis-py/redis/_compat.pyc in nativestr(x)
    102     def nativestr(x):
--> 103         return x if isinstance(x, str) else x.encode('utf-8', 'replace')
    104 
    105     def next(x):

AttributeError: 'NoneType' object has no attribute 'encode'
```