### PR TITLE
Use IPPROTO_TCP constant instead of SOL_TCP constant

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -529,7 +529,7 @@ class Connection(object):
                 if self.socket_keepalive:
                     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                     for k, v in iteritems(self.socket_keepalive_options):
-                        sock.setsockopt(socket.SOL_TCP, k, v)
+                        sock.setsockopt(socket.IPPROTO_TCP, k, v)
 
                 # set the socket_connect_timeout before we connect
                 sock.settimeout(self.socket_connect_timeout)


### PR DESCRIPTION

### Description of change
use socket.IPPROTO_TCP instead of SOL_TCP for compatible with jython 2.7.0

```python
Jython 2.7.0 (default:9987c746f838, Apr 29 2015, 02:25:11)
[Java HotSpot(TM) 64-Bit Server VM (Oracle Corporation)] on java1.8.0_181
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.SOL_TCP
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'SOL_TCP'
```
see also https://github.com/andymccurdy/redis-py/pull/124/files