### PR TITLE
Unregister socket from ready_poller

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -581,6 +581,8 @@ class Connection(object):
         self._parser.on_disconnect()
         if self._sock is None:
             return
+        self._selector.close()
+        self._selector = None
         try:
             if os.getpid() == self.pid:
                 self._sock.shutdown(socket.SHUT_RDWR)

--- a/redis/selector.py
+++ b/redis/selector.py
@@ -131,7 +131,7 @@ if hasattr(select, 'poll'):
             """
             for poller in (self.read_poller, self.ready_poller):
                 try:
-                    self.read_poller.unregister(self.sock)
+                    poller.unregister(self.sock)
                 except (KeyError, ValueError):
                     # KeyError is raised if somehow the socket was not
                     #   registered


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ python setup.py test` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

It looks like there was a typo in PollSelector.close that made it
unregister from the read_poller twice instead of once from each poller.

This code was never actually executed, because Connection.disconnect didn't close the poller. I added that so that the modified code gets tested.