### PR TITLE
Add ability to specify client_name

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -612,7 +612,7 @@ class Redis(object):
                  decode_responses=False, retry_on_timeout=False,
                  ssl=False, ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs='required', ssl_ca_certs=None,
-                 max_connections=None):
+                 max_connections=None, client_name=None):
         if not connection_pool:
             if charset is not None:
                 warnings.warn(DeprecationWarning(
@@ -631,7 +631,8 @@ class Redis(object):
                 'encoding_errors': encoding_errors,
                 'decode_responses': decode_responses,
                 'retry_on_timeout': retry_on_timeout,
-                'max_connections': max_connections
+                'max_connections': max_connections,
+                'client_name': client_name,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -425,7 +425,8 @@ else:
 
 class Connection(object):
     "Manages TCP communication to and from a Redis server"
-    description_format = "Connection<host=%(host)s,port=%(port)s,db=%(db)s,client_name=%(client_name)s>"
+    description_format = "Connection<host=%(host)s,port=%(port)s,db=%(db)s," \
+                         "client_name=%(client_name)s>"
 
     def __init__(self, host='localhost', port=6379, db=0, password=None,
                  socket_timeout=None, socket_connect_timeout=None,
@@ -762,7 +763,8 @@ class SSLConnection(Connection):
 
 
 class UnixDomainSocketConnection(Connection):
-    description_format = "UnixDomainSocketConnection<path=%(path)s,db=%(db)s,client_name=%(client_name)s>"
+    description_format = "UnixDomainSocketConnection<path=%(path)s," \
+                         "db=%(db)s,client_name=%(client_name)s>"
 
     def __init__(self, path='', db=0, password=None,
                  socket_timeout=None, encoding='utf-8',

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -65,22 +65,26 @@ class TestConnectionPool(object):
         connection_kwargs = {'host': 'localhost', 'port': 6379, 'db': 1}
         pool = self.get_pool(connection_kwargs=connection_kwargs,
                              connection_class=redis.Connection)
-        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=1,client_name=>>'
+        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=1,' \
+                   'client_name=>>'
         assert repr(pool) == expected
 
     @skip_if_server_version_lt('2.6.9')
     def test_repr_contains_db_info_tcp_wname(self):
-        connection_kwargs = {'host': 'localhost', 'port': 6379, 'db': 1, 'client_name': 'testing'}
+        connection_kwargs = {'host': 'localhost', 'port': 6379, 'db': 1,
+                             'client_name': 'testing'}
         pool = self.get_pool(connection_kwargs=connection_kwargs,
                              connection_class=redis.Connection)
-        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=1,client_name=testing>>'
+        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=1,' \
+                   'client_name=testing>>'
         assert repr(pool) == expected
 
     def test_repr_contains_db_info_unix(self):
         connection_kwargs = {'path': '/abc', 'db': 1}
         pool = self.get_pool(connection_kwargs=connection_kwargs,
                              connection_class=redis.UnixDomainSocketConnection)
-        expected = 'ConnectionPool<UnixDomainSocketConnection<path=/abc,db=1,client_name=>>'
+        expected = 'ConnectionPool<UnixDomainSocketConnection<path=/abc,' \
+                   'db=1,client_name=>>'
         assert repr(pool) == expected
 
     @skip_if_server_version_lt('2.6.9')
@@ -88,7 +92,8 @@ class TestConnectionPool(object):
         connection_kwargs = {'path': '/abc', 'db': 1, 'client_name': 'testing'}
         pool = self.get_pool(connection_kwargs=connection_kwargs,
                              connection_class=redis.UnixDomainSocketConnection)
-        expected = 'ConnectionPool<UnixDomainSocketConnection<path=/abc,db=1,client_name=testing>>'
+        expected = 'ConnectionPool<UnixDomainSocketConnection<path=/abc,' \
+                   'db=1,client_name=testing>>'
         assert repr(pool) == expected
 
 
@@ -151,13 +156,16 @@ class TestBlockingConnectionPool(object):
 
     def test_repr_contains_db_info_tcp(self):
         pool = redis.ConnectionPool(host='localhost', port=6379, db=0)
-        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=0,client_name=>>'
+        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=0,' \
+                   'client_name=>>'
         assert repr(pool) == expected
 
     @skip_if_server_version_lt('2.6.9')
     def test_repr_contains_db_info_tcp_wname(self):
-        pool = redis.ConnectionPool(host='localhost', port=6379, db=0, client_name='testing')
-        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=0,client_name=testing>>'
+        pool = redis.ConnectionPool(host='localhost', port=6379, db=0,
+                                    client_name='testing')
+        expected = 'ConnectionPool<Connection<host=localhost,port=6379,db=0,' \
+                   'client_name=testing>>'
         assert repr(pool) == expected
 
     def test_repr_contains_db_info_unix(self):
@@ -166,7 +174,8 @@ class TestBlockingConnectionPool(object):
             path='abc',
             db=0,
         )
-        expected = 'ConnectionPool<UnixDomainSocketConnection<path=abc,db=0,client_name=>>'
+        expected = 'ConnectionPool<UnixDomainSocketConnection<path=abc,db=0,' \
+                   'client_name=>>'
         assert repr(pool) == expected
 
     @skip_if_server_version_lt('2.6.9')
@@ -177,7 +186,8 @@ class TestBlockingConnectionPool(object):
             db=0,
             client_name='testing',
         )
-        expected = 'ConnectionPool<UnixDomainSocketConnection<path=abc,db=0,client_name=testing>>'
+        expected = 'ConnectionPool<UnixDomainSocketConnection<path=abc,db=0,' \
+                   'client_name=testing>>'
         assert repr(pool) == expected
 
 
@@ -533,7 +543,8 @@ class TestConnection(object):
 
     @skip_if_server_version_lt('2.6.9')
     def test_connect_from_url_tcp(self):
-        connection = redis.Redis.from_url('redis://localhost', client_name='testing')
+        connection = redis.Redis.from_url('redis://localhost',
+                                          client_name='testing')
         pool = connection.connection_pool
 
         assert re.match('(.*)<(.*)<(.*)>>', repr(pool)).groups() == (
@@ -554,7 +565,8 @@ class TestConnection(object):
 
     @skip_if_server_version_lt('2.6.9')
     def test_connect_from_url_unix(self):
-        connection = redis.Redis.from_url('unix:///path/to/socket', client_name='testing')
+        connection = redis.Redis.from_url('unix:///path/to/socket',
+                                          client_name='testing')
         pool = connection.connection_pool
 
         assert re.match('(.*)<(.*)<(.*)>>', repr(pool)).groups() == (


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ python setup.py test` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)? (DLJ - How do I enable this?)
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (DLJ - where would I document this?)

### Description of change

Adding support for specifying `client_name` (like #802) with passing tests
