### PR TITLE
Pass encoding_errors setting to hiredis (>=1.0.0)

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -41,6 +41,8 @@ if HIREDIS_AVAILABLE:
         hiredis_version >= StrictVersion('0.1.3')
     HIREDIS_SUPPORTS_BYTE_BUFFER = \
         hiredis_version >= StrictVersion('0.1.4')
+    HIREDIS_SUPPORTS_ENCODING_ERRORS = \
+        hiredis_version >= StrictVersion('1.0.0')
 
     if not HIREDIS_SUPPORTS_BYTE_BUFFER:
         msg = ("redis-py works best with hiredis >= 0.1.4. You're running "
@@ -355,6 +357,8 @@ class HiredisParser(BaseParser):
 
         if connection.encoder.decode_responses:
             kwargs['encoding'] = connection.encoder.encoding
+        if HIREDIS_SUPPORTS_ENCODING_ERRORS:
+            kwargs['errors'] = connection.encoder.encoding_errors
         self._reader = hiredis.Reader(**kwargs)
         self._next_response = False
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -25,6 +25,20 @@ class TestEncoding(object):
         assert r.lrange('a', 0, -1) == result
 
 
+class TestEncodingErrors(object):
+    def test_ignore(self, request):
+        r = _get_client(redis.Redis, request=request, decode_responses=True,
+                        encoding_errors='ignore')
+        r.set('a', b'foo\xff')
+        assert r.get('a') == 'foo'
+
+    def test_replace(self, request):
+        r = _get_client(redis.Redis, request=request, decode_responses=True,
+                        encoding_errors='replace')
+        r.set('a', b'foo\xff')
+        assert r.get('a') == 'foo\ufffd'
+
+
 class TestCommandsAndTokensArentEncoded(object):
     @pytest.fixture()
     def r(self, request):


### PR DESCRIPTION
Fixes #1161

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ python setup.py test` pass with this change (including linting)?
- [X] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)? [Link](https://travis-ci.org/candlerb/redis-py/builds/523025256)
- [X] Is the new or changed code fully tested?
- [X] (N/A) Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Behaviour of `encoding_errors` varies depending on whether hiredis is present or not (#1161)

This PR:

* Adds tests for `decode_responses=True` with `encoding_errors='ignore'` and `encoding_errors='replace'`
* Passes the relevant option to hiredis-py, if the version is 1.0.0+

NOTE: the new tests will likely fail if an older version of hiredis-py is installed.  I would argue that these tests *should* fail: if you install an older version of hiredis and set `decode_responses=True` then you get bad behaviour (specifically, non-decodable UTF-8 data was being returned as `bytes` instead of `str`). The failing test cases will accurately reflect this problem.