### PR TITLE
Add `redis.sentinel.Sentinel` module documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,3 +21,6 @@ Contents:
 
 .. automodule:: redis
    :members:
+
+.. automodule:: redis.sentinel
+   :members:


### PR DESCRIPTION
Added module documentation for `redis.sentinel`

### Pull Request check-list

The change is documentation only so no testable code has been added.

### Description of change

The parameters for `Sentinel` are not documented anywhere else so besides looking through the source, this seems the best solution to document `redis.sentinel.Sentinel`.
