### PR TITLE
Note that redis-py does not support Cluster Mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -815,6 +815,12 @@ that return Python iterators for convenience: `scan_iter`, `hscan_iter`,
     B 2
     C 3
 
+Cluster Mode
+^^^^^^^^^^^^
+
+redis-py does not currently support `Cluster Mode
+<https://redis.io/topics/cluster-tutorial>`_.
+
 Author
 ^^^^^^
 


### PR DESCRIPTION
### Description of change

Adds a note in `README.rst`.

### Background

A cluster set up via AWS Elasticache for Redis will not work well with a redis-py client:

```python
>>> import redis 
...  
... r = redis.Redis("myclustername.abcdef.clustercfg.xxxx.cache.amazonaws.com")                                                                                                                                                                                  
>>> r                                                                                                                                                                                                                                                        
Redis<ConnectionPool<Connection<host=myclustername.abcdef.clustercfg.xxxx.cache.amazonaws.com,port=6379,db=0>>>
>>> r.set("foo", "bar")                                                                                                                                                                                                                                      
Traceback (most recent call last):
  File "<ipython-input-3-9b91a39c5b0e>", line 1, in <module>
    r.set("foo", "bar")
  File "...redis/client.py", line 1451, in set
    return self.execute_command('SET', *pieces)
  File "...redis/client.py", line 775, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "...redis/client.py", line 789, in parse_response
    response = connection.read_response()
  File "...redis/connection.py", line 642, in read_response
    raise response
ResponseError: MOVED 12182 XX.XX.XX.XX:6379

>>> r.set("baz", "bing")                                                                                                                                                                                                                                     
Traceback (most recent call last):
  File "<ipython-input-4-9838c9152ede>", line 1, in <module>
    r.set("baz", "bing")
  File "...redis/client.py", line 1451, in set
    return self.execute_command('SET', *pieces)
  File "...redis/client.py", line 775, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "...redis/client.py", line 789, in parse_response
    response = connection.read_response()
  File "...redis/connection.py", line 642, in read_response
    raise response
ResponseError: MOVED 4813 XX.XX.XX.XX:6379
```
