### PR TITLE
Fix issue #1140 - reconnect on ConnectionError while executing command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -809,8 +809,7 @@ class Redis(object):
             return self.parse_response(connection, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if not (connection.retry_on_timeout and
-                    isinstance(e, TimeoutError)):
+            if not connection.retry_on_timeout and isinstance(e, TimeoutError):
                 raise
             connection.send_command(*args)
             return self.parse_response(connection, command_name, **options)
@@ -3098,8 +3097,7 @@ class PubSub(object):
             return command(*args)
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
-            if not (connection.retry_on_timeout and
-                    isinstance(e, TimeoutError)):
+            if not connection.retry_on_timeout and isinstance(e, TimeoutError):
                 raise
             # Connect manually here. If the Redis server is down, this will
             # fail and raise a ConnectionError as desired.


### PR DESCRIPTION
### Description of change

Fix issue #1140 - which was caused by mistake made in commit: https://github.com/andymccurdy/redis-py/commit/7860995ce4226ee0ca82d2eefa4b8bd5c3943a75
where logic was totally changed by moving parenthesis. After mentioned change client **dont** reconnect to redis server if any ConnectionError was raised while command was executing - this PR reverts this bug.
