### PR TITLE
Add an Event parameter to PubSubWorkerThread and run_in_thread so

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3338,6 +3338,7 @@ class PubSubWorkerThread(threading.Thread):
         # and returns the connection to the pool.
         self._running.clear()
 
+
 class Pipeline(Redis):
     """
     Pipelines provide a way to transmit multiple commands to the Redis server


### PR DESCRIPTION
that the PubSubWorkerThread can be reliably stopped.

The existing mechanism is left in place so that there is no API change.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ python setup.py test` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Please let me know what you think of the change. If I should make any other adjustments or tests. I don't mind to rework the Class and API further, but did not want introduce any significant changes.

#1194
