### PR TITLE
Fix a bug in parsing the response for CLUSTER SLAVES as a list instead of a raw string

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -427,6 +427,14 @@ def parse_cluster_nodes(response, **options):
         raw_lines = response.splitlines()
     return dict(_parse_node_line(line) for line in raw_lines)
 
+def parse_cluster_nodes_list(response, **options):
+    result = {}
+    if isinstance(response, list):
+        for r in response:
+            result.update(parse_cluster_nodes(r))
+    else:
+        raise DataError("CLUSTER SLAVES response type must be a list")
+    return result
 
 def parse_georadius_generic(response, **options):
     if options['store'] or options['store_dist']:
@@ -547,7 +555,7 @@ class Redis(object):
             'CLUSTER SAVECONFIG': bool_ok,
             'CLUSTER SET-CONFIG-EPOCH': bool_ok,
             'CLUSTER SETSLOT': bool_ok,
-            'CLUSTER SLAVES': parse_cluster_nodes,
+            'CLUSTER SLAVES': parse_cluster_nodes_list,
             'CONFIG GET': parse_config_get,
             'CONFIG RESETSTAT': bool_ok,
             'CONFIG SET': bool_ok,


### PR DESCRIPTION
Currently in Redis, the server response for CLUSTER SLAVES command is inconsistent with that of CLUSTER NODES command. CLUSTER NODES command returns a single String response that is delimited with newline char, but CLUSTER SLAVES returns a bulk list of strings. The redis-py client is applying the same logic to parse the responses for both calls and erroring out when invoking r.cluster('SLAVES') API. See the test results below. 

--- Before the fix ---

>>> import redis
>>> r = redis.Redis(host='localhost', port=6379, db=0)
>>> r.cluster('SLAVES', '06b3f7e19c9e34bd859421746ba0e05b95e0f9f9')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "redis/client.py", line 2806, in cluster
    return self.execute_command('CLUSTER %s' % cluster_arg.upper(), *args)
  File "redis/client.py", line 839, in execute_command
    return self.parse_response(conn, command_name, **options)
  File "redis/client.py", line 859, in parse_response
    return self.response_callbacks[command_name](response, **options)
  File "redis/client.py", line 424, in parse_cluster_nodes
    response = nativestr(response)
  File "redis/_compat.py", line 90, in nativestr
    return x if isinstance(x, str) else x.encode('utf-8', 'replace')
AttributeError: 'list' object has no attribute 'encode'


--- After the fix ---

>>> import redis
>>> r = redis.Redis(host='localhost', port=6379, db=0)
>>> r.cluster('SLAVES', '06b3f7e19c9e34bd859421746ba0e05b95e0f9f9')
{u'127.0.0.1:6380@16380': {u'last_pong_rcvd': u'1566867909239', u'epoch': u'1', u'node_id': u'921db10c7a46b5b0f78fb79296bab603a6d25bd0', u'flags': u'slave', u'last_ping_sent': u'0', u'connected': True, u'slots': [], u'master_id': u'06b3f7e19c9e34bd859421746ba0e05b95e0f9f9'}}