### PR TITLE
Fix SSL read timeouts in Python 2.7

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -3,6 +3,19 @@ import errno
 import socket
 import sys
 
+
+def sendall(sock, *args, **kwargs):
+    return sock.sendall(*args, **kwargs)
+
+
+def shutdown(sock, *args, **kwargs):
+    return sock.shutdown(*args, **kwargs)
+
+
+def ssl_wrap_socket(context, sock, *args, **kwargs):
+    return context.wrap_socket(sock, *args, **kwargs)
+
+
 # For Python older than 3.5, retry EINTR.
 if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and
                                sys.version_info[1] < 5):
@@ -73,13 +86,19 @@ if sys.version_info[0] < 3:
             """A replacement in case ssl.SSLError is not available."""
             pass
 
+    _EXPECTED_SSL_TIMEOUT_MESSAGES = (
+        "The handshake operation timed out",
+        "The read operation timed out",
+        "The write operation timed out",
+    )
+
     def _handle_ssl_timeout(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
             except _SSLError as e:
-                if e.args[0] == "The read operation timed out":
+                if any(x in e.args[0] for x in _EXPECTED_SSL_TIMEOUT_MESSAGES):
                     # Raise socket.timeout for compatibility with Python 3.
                     raise socket.timeout(*e.args)
                 raise
@@ -87,6 +106,9 @@ if sys.version_info[0] < 3:
 
     recv = _handle_ssl_timeout(recv)
     recv_into = _handle_ssl_timeout(recv_into)
+    sendall = _handle_ssl_timeout(sendall)
+    shutdown = _handle_ssl_timeout(shutdown)
+    ssl_wrap_socket = _handle_ssl_timeout(ssl_wrap_socket)
 
 if sys.version_info[0] < 3:
     from urllib import unquote


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `$ python setup.py test` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

The ssl module in Python 2.7 raises timeouts as ssl.SSLError instead of socket.timeout. When these timeouts are encountered, the error will be re-raised as socket.timeout so it is handled appropriately by the connection.

This issue was discovered when using Redis as a result backend for [Celery](http://www.celeryproject.org/). When celery was waiting for results in Redis, its connection would time out causing the operation to fail. This only occurred when using secure connections; it works fine with non-secure connections.