### PR TITLE
Fix SSL regression introduced in 3.3.9

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -98,7 +98,7 @@ if sys.version_info[0] < 3:
             try:
                 return func(*args, **kwargs)
             except _SSLError as e:
-                if any(x in e.args[0] for x in _EXPECTED_SSL_TIMEOUT_MESSAGES):
+                if any(x in e.message for x in _EXPECTED_SSL_TIMEOUT_MESSAGES):
                     # Raise socket.timeout for compatibility with Python 3.
                     raise socket.timeout(*e.args)
                 raise


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `$ python setup.py test` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

The wrapper introduced to handle SSL timeout errors in Python 2.7 incorrectly assumed that instances of SSLError would always have a string as the first element in their args. The safer approach is to check the message attribute on the error.

This was caught when the `ssl` module raised an error that contained an errno as it's first element, which was not seen in my original testing. I've confirmed that this patch preserves the timeout handling and fixes the regression.