### PR TITLE
check exception.args rather than exception.message

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -98,7 +98,8 @@ if sys.version_info[0] < 3:
             try:
                 return func(*args, **kwargs)
             except _SSLError as e:
-                if any(x in e.message for x in _EXPECTED_SSL_TIMEOUT_MESSAGES):
+                message = len(e.args) == 1 and unicode(e.args[0]) or ''
+                if any(x in message for x in _EXPECTED_SSL_TIMEOUT_MESSAGES):
                     # Raise socket.timeout for compatibility with Python 3.
                     raise socket.timeout(*e.args)
                 raise


### PR DESCRIPTION
@harpener @zbristow Let me know if this makes sense to you guys. This is the same logic that the deprecated `message` property uses.