### PR TITLE
Updating acl setuser to include hashes

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1014,7 +1014,7 @@ class Redis(object):
                 if len(password) == 64:
                     pieces.append('!%s' % password)
                 else:
-                	pieces.append('<%s' % password)
+                    pieces.append('<%s' % password)
 
         if add_passwords:
             # as most users will have only one password, allow add_passwords
@@ -1024,7 +1024,7 @@ class Redis(object):
                 if len(password) == 64:
                     pieces.append('#%s' % password)
                 else:
-                	pieces.append('>%s' % password)
+                	  pieces.append('>%s' % password)
 
         if nopass:
             pieces.append(b'nopass')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -129,6 +129,7 @@ class TestRedisCommands(object):
         # test all args
         assert r.acl_setuser(username, enabled=True, reset=True,
                              add_passwords=['pass1', 'pass2'],
+                             add_hashes=['5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8', '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'],
                              categories=['+@set', '+@hash', '-@geo'],
                              commands=['+get', '+mget', '-hset'],
                              keys=['cache:*', 'objects:*'])
@@ -138,11 +139,12 @@ class TestRedisCommands(object):
         assert acl['enabled'] is True
         assert acl['flags'] == ['on']
         assert set(acl['keys']) == set([b'cache:*', b'objects:*'])
-        assert len(acl['passwords']) == 2
+        assert len(acl['passwords']) == 4
 
         # test reset=False keeps existing ACL and applies new ACL on top
         assert r.acl_setuser(username, enabled=True, reset=True,
                              add_passwords=['pass1'],
+                             add_hashes=['5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'],
                              categories=['+@set'],
                              commands=['+set'],
                              keys=['cache:*'])
@@ -157,14 +159,16 @@ class TestRedisCommands(object):
         assert acl['enabled'] is True
         assert acl['flags'] == ['on']
         assert set(acl['keys']) == set([b'cache:*', b'objects:*'])
-        assert len(acl['passwords']) == 2
+        assert len(acl['passwords']) == 3
 
-        # test remove_passwords
+        # test remove_passwords and remove_hashes
         assert r.acl_setuser(username, enabled=True, reset=True,
-                             add_passwords=['pass1', 'pass2'])
-        assert len(r.acl_getuser(username)['passwords']) == 2
+                             add_passwords=['pass1', 'pass2'],
+                             add_hashes=['5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'])
+        assert len(r.acl_getuser(username)['passwords']) == 3
         assert r.acl_setuser(username, enabled=True,
-                             remove_passwords=['pass2'])
+                             remove_passwords=['pass2'],
+                             remove_hashes=['5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'])
         assert len(r.acl_getuser(username)['passwords']) == 1
 
     @skip_if_server_version_lt('6.0.0')


### PR DESCRIPTION
@andymccurdy, Adding the ability to remove and add hashes to ACLs. Let me know if you have any objections to the implementation. I still have to write the tests. I think this will be valuable for users who will not want to ever share cleartext passwords.