### PR TITLE
Pipeline.execute() doesn't short-circuit on empty command stack if it is watching keys

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3670,7 +3670,7 @@ class Pipeline(Redis):
     def execute(self, raise_on_error=True):
         "Execute all the commands in the current pipeline"
         stack = self.command_stack
-        if not stack:
+        if not stack and not self.watching:
             return []
         if self.scripts:
             self.load_scripts()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -191,6 +191,19 @@ class TestPipeline(object):
 
             assert not pipe.watching
 
+    def test_watch_failure_in_empty_transaction(self, r):
+        r['a'] = 1
+        r['b'] = 2
+
+        with r.pipeline() as pipe:
+            pipe.watch('a', 'b')
+            r['b'] = 3
+            pipe.multi()
+            with pytest.raises(redis.WatchError):
+                pipe.execute()
+
+            assert not pipe.watching
+
     def test_unwatch(self, r):
         r['a'] = 1
         r['b'] = 2


### PR DESCRIPTION
Pipeline.execute() no longer short-circuits on empty command stack (eturns an empty list without running EXEC) if it is watching keys.

Closes #1233