### PR TITLE
Add equality test on Redis client and conn pool

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -707,6 +707,9 @@ class Redis(object):
     def __repr__(self):
         return "%s<%s>" % (type(self).__name__, repr(self.connection_pool))
 
+    def __eq__(self, other):
+        return self.connection_pool == other.connection_pool
+
     def set_response_callback(self, command, callback):
         "Set a custom Response Callback"
         self.response_callbacks[command] = callback

--- a/redis/client.py
+++ b/redis/client.py
@@ -708,7 +708,10 @@ class Redis(object):
         return "%s<%s>" % (type(self).__name__, repr(self.connection_pool))
 
     def __eq__(self, other):
-        return self.connection_pool == other.connection_pool
+        return (
+            isinstance(other, self.__class__)
+            and self.connection_pool == other.connection_pool
+        )
 
     def set_response_callback(self, command, callback):
         "Set a custom Response Callback"

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1044,6 +1044,9 @@ class ConnectionPool(object):
             repr(self.connection_class(**self.connection_kwargs)),
         )
 
+    def __eq__(self, other):
+        return self.connection_kwargs == other.connection_kwargs
+
     def reset(self):
         self.pid = os.getpid()
         self._created_connections = 0

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1045,7 +1045,10 @@ class ConnectionPool(object):
         )
 
     def __eq__(self, other):
-        return self.connection_kwargs == other.connection_kwargs
+        return (
+            isinstance(other, self.__class__)
+            and self.connection_kwargs == other.connection_kwargs
+        )
 
     def reset(self):
         self.pid = os.getpid()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,10 @@ class TestClient(object):
         r2 = redis.Redis.from_url('redis://localhost:6379/9')
         assert r1 == r2
 
+    def test_clients_unequal_if_different_types(self):
+        r = redis.Redis.from_url('redis://localhost:6379/9')
+        assert r != 0
+
     def test_clients_unequal_if_different_hosts(self):
         r1 = redis.Redis.from_url('redis://localhost:6379/9')
         r2 = redis.Redis.from_url('redis://127.0.0.1:6379/9')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,23 @@
+import redis
+
+
+class TestClient(object):
+    def test_client_equality(self):
+        r1 = redis.Redis.from_url('redis://localhost:6379/9')
+        r2 = redis.Redis.from_url('redis://localhost:6379/9')
+        assert r1 == r2
+
+    def test_clients_unequal_if_different_hosts(self):
+        r1 = redis.Redis.from_url('redis://localhost:6379/9')
+        r2 = redis.Redis.from_url('redis://127.0.0.1:6379/9')
+        assert r1 != r2
+
+    def test_clients_unequal_if_different_ports(self):
+        r1 = redis.Redis.from_url('redis://localhost:6379/9')
+        r2 = redis.Redis.from_url('redis://localhost:6380/9')
+        assert r1 != r2
+
+    def test_clients_unequal_if_different_dbs(self):
+        r1 = redis.Redis.from_url('redis://localhost:6379/9')
+        r2 = redis.Redis.from_url('redis://localhost:6380/10')
+        assert r1 != r2

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -77,6 +77,41 @@ class TestConnectionPool(object):
         expected = 'ConnectionPool<UnixDomainSocketConnection<path=/abc,db=1>>'
         assert repr(pool) == expected
 
+    def test_pool_equality(self):
+        connection_kwargs = {'host': 'localhost', 'port': 6379, 'db': 1}
+        pool1 = self.get_pool(connection_kwargs=connection_kwargs,
+                              connection_class=redis.Connection)
+        pool2 = self.get_pool(connection_kwargs=connection_kwargs,
+                              connection_class=redis.Connection)
+        assert pool1 == pool2
+
+    def test_pools_unequal_if_different_hosts(self):
+        connection_kwargs1 = {'host': 'localhost', 'port': 6379, 'db': 1}
+        connection_kwargs2 = {'host': '127.0.0.1', 'port': 6379, 'db': 1}
+        pool1 = self.get_pool(connection_kwargs=connection_kwargs1,
+                              connection_class=redis.Connection)
+        pool2 = self.get_pool(connection_kwargs=connection_kwargs2,
+                              connection_class=redis.Connection)
+        assert pool1 != pool2
+
+    def test_pools_unequal_if_different_ports(self):
+        connection_kwargs1 = {'host': 'localhost', 'port': 6379, 'db': 1}
+        connection_kwargs2 = {'host': 'localhost', 'port': 6380, 'db': 1}
+        pool1 = self.get_pool(connection_kwargs=connection_kwargs1,
+                              connection_class=redis.Connection)
+        pool2 = self.get_pool(connection_kwargs=connection_kwargs2,
+                              connection_class=redis.Connection)
+        assert pool1 != pool2
+
+    def test_pools_unequal_if_different_dbs(self):
+        connection_kwargs1 = {'host': 'localhost', 'port': 6379, 'db': 1}
+        connection_kwargs2 = {'host': 'localhost', 'port': 6379, 'db': 2}
+        pool1 = self.get_pool(connection_kwargs=connection_kwargs1,
+                              connection_class=redis.Connection)
+        pool2 = self.get_pool(connection_kwargs=connection_kwargs2,
+                              connection_class=redis.Connection)
+        assert pool1 != pool2
+
 
 class TestBlockingConnectionPool(object):
     def get_pool(self, connection_kwargs=None, max_connections=10, timeout=20):

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -85,6 +85,12 @@ class TestConnectionPool(object):
                               connection_class=redis.Connection)
         assert pool1 == pool2
 
+    def test_pools_unequal_if_different_types(self):
+        connection_kwargs = {'host': 'localhost', 'port': 6379, 'db': 1}
+        pool = self.get_pool(connection_kwargs=connection_kwargs,
+                             connection_class=redis.Connection)
+        assert pool != 0
+
     def test_pools_unequal_if_different_hosts(self):
         connection_kwargs1 = {'host': 'localhost', 'port': 6379, 'db': 1}
         connection_kwargs2 = {'host': '127.0.0.1', 'port': 6379, 'db': 1}


### PR DESCRIPTION
Currently, there's no `__eq__()` method defined on the `Redis` or
`ConnectionPool` classes.  Therefore, no two instances of either of
these classes will ever be equal.

I have a use case where it would be nice for one Redis client instance
to be equal to another if they have the same connection kwargs; that is,
if they're connected to the same Redis database.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ python setup.py test` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Add an `__eq__()` method on the `Redis` and `ConnectionPool` classes that return true if they have the same connection kwargs; that is, if they're connected to the same Redis database.