### PR TITLE
Drop support for end-of-life Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
       env: TOXENV=py27-plain
     - python: 2.7
       env: TOXENV=py27-hiredis
-    - python: 3.4
-      env: TOXENV=py34-plain
-    - python: 3.4
-      env: TOXENV=py34-hiredis
     - python: 3.5
       env: TOXENV=py35-plain
     - python: 3.5

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
       This is a convenient way to test if any of the watched keys changed
       without actually running any other commands. Thanks @brianmaissy.
       #1233, #1234
+    * Removed support for end of life Python 3.4.
 * 3.3.11
     * Further fix for the SSLError -> TimeoutError mapping to work
       on obscure releases of Python 2.7.

--- a/README.rst
+++ b/README.rst
@@ -71,8 +71,7 @@ provide an upgrade path for users migrating from 2.X to 3.0.
 Python Version Support
 ^^^^^^^^^^^^^^^^^^^^^^
 
-redis-py 3.0 now supports Python 2.7 and Python 3.4+. Python 2.6 and 3.3
-support has been dropped.
+redis-py 3.0 supports Python 2.7 and Python 3.5+.
 
 
 Client Classes: Redis and StrictRedis

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     keywords=['Redis', 'key-value store'],
     license='MIT',
     packages=['redis'],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     extras_require={
         'hiredis': [
             "hiredis>=0.1.3",
@@ -39,7 +39,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = {py27,py34,py35,py36,py37,py38}-{plain,hiredis}, pycodestyle
+envlist = {py27,py35,py36,py37,py38}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.4 has been EOL since 2019-03-18.

Removing from the test matrix helps reduce testing resources.

For additional details on unsupported Python versions, see:

https://devguide.python.org/devcycle/#end-of-life-branches