### PR TITLE
Unify tox and Travis test matrix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 _Please make sure to review and check all of these items:_
 
-- [ ] Does `$ python setup.py test` pass with this change (including linting)?
+- [ ] Does `$ tox` pass with this change (including linting)?
 - [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
 - [ ] Is the new or changed code fully tested?
 - [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,38 @@
-dist: xenial
-sudo: false
 language: python
 cache: pip
-python:
-  - 3.8
-  - 3.7
-  - 3.6
-  - 3.5
-  - 3.4
-  - 2.7
+matrix:
+  include:
+    - env: TOXENV=pycodestyle
+    - python: 2.7
+      env: TOXENV=py27-plain
+    - python: 2.7
+      env: TOXENV=py27-hiredis
+    - python: 3.4
+      env: TOXENV=py34-plain
+    - python: 3.4
+      env: TOXENV=py34-hiredis
+    - python: 3.5
+      env: TOXENV=py35-plain
+    - python: 3.5
+      env: TOXENV=py35-hiredis
+    - python: 3.6
+      env: TOXENV=py36-plain
+    - python: 3.6
+      env: TOXENV=py36-hiredis
+    - python: 3.7
+      env: TOXENV=py37-plain
+    - python: 3.7
+      env: TOXENV=py37-hiredis
+    - python: 3.8
+      env: TOXENV=py38-plain
+    - python: 3.8
+      env: TOXENV=py38-hiredis
 before_install:
   - wget http://download.redis.io/releases/redis-5.0.3.tar.gz && mkdir redis_install && tar -xvzf redis-5.0.3.tar.gz -C redis_install && cd redis_install/redis-5.0.3 && make && src/redis-server --daemonize yes && cd ../..
   - redis-cli info
-env:
-  - TEST_HIREDIS=0
-  - TEST_HIREDIS=1
 install:
-  - pip install -e .
-  - "if [[ $TEST_PYCODESTYLE == '1' ]]; then pip install pycodestyle; fi"
-  - "if [[ $TEST_HIREDIS == '1' ]]; then pip install hiredis; fi"
-  - "if [[ $TEST_PYCODESTYLE != '1' ]]; then pip install codecov coverage; fi"
-script: "if [[ $TEST_PYCODESTYLE == '1' ]]; then pycodestyle --repeat --show-source --exclude=.venv,.tox,dist,docs,build,*.egg,redis_install .; else coverage run setup.py test; fi"
+  - pip install codecov tox
+script:
+  - tox
 after_success:
-  - "if [[ $TEST_PYCODESTYLE != '1' ]]; then codecov; fi"
-matrix:
-  include:
-    - python: 2.7
-      env: TEST_PYCODESTYLE=1
-    - python: 3.8
-      env: TEST_PYCODESTYLE=1
+  - "if [[ $TOXENV != 'pycodestyle' ]]; then codecov; fi"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pycodestyle]
 show-source = 1
-exclude = .venv,.tox,dist,docs,build,*.egg
+exclude = .venv,.tox,dist,docs,build,*.egg,redis_install
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,8 @@
 #!/usr/bin/env python
 import os
-import sys
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 from redis import __version__
-
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, because outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 f = open(os.path.join(os.path.dirname(__file__), 'README.rst'))
@@ -44,11 +29,6 @@ setup(
             "hiredis>=0.1.3",
         ],
     },
-    tests_require=[
-        'mock',
-        'pytest>=2.7.0',
-    ],
-    cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ envlist = {py27,py34,py35,py36,py37,py38}-{plain,hiredis}, pycodestyle
 
 [testenv]
 deps =
+    coverage
     mock
     pytest >= 2.7.0
 extras =
     hiredis: hiredis
-commands = py.test {posargs}
+commands = {envpython} -m coverage run -m pytest {posargs}
 
 [testenv:pycodestyle]
 basepython = python3.6


### PR DESCRIPTION
tox can now always be used as the test entry point and allows for
contributors to easily test the full test matrix locally.

Starting with setuptools v41.5.0 (27 Oct 2019) the `setup.py test`
command is formally deprecated. It now emits a warning on use. Prior to
this version, it use was discouraged by the setuptools developers.

Now, always use tox as the one true testing entry point. It handles
multiple version of Python and Redis.

The Travis CI configuration was reworked to use tox to install
dependencies and run tests in the same manner that contributors would do
locally.
