### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,3 @@ exclude = .venv,.tox,dist,docs,build,*.egg
 
 [bdist_wheel]
 universal = 1
-
-[metadata]
-license_file = LICENSE


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is
deprecated.

The wheel will continue to include LICENSE, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
https://wheel.readthedocs.io/en/stable/news.html