### PR TITLE
Redis client get method EMTPY_RESPONSE in comment.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1336,7 +1336,8 @@ class Redis(object):
 
     def get(self, name):
         """
-        Return the value at key ``name``, or None if the key doesn't exist
+        Return the value at key ``name``, or None if the key doesn't exist,
+        or "EMPTY_RESPONSE" string on timeout.
         """
         return self.execute_command('GET', name)
 


### PR DESCRIPTION
Edit Redis client get method comment to accurately describe return value.

Multiple cases were encountered on production servers where Redis was returning 'EMPTY_RESPONSE' instead of None, which was not expected, and resulted in exceptions. Changes were made to our Redis wrapper to expect this, but the base client library comments still did not accurately describe the values that could be returned. This change amends the comments to describe that get method can either return you the value, None, _or_ the EMPTY_RESPONSE string.

This change should help future developers understand that the get method can return them a value that is neither their stored value or None.