### PR TITLE
Remove not using input parameter at connection.py

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1066,7 +1066,7 @@ class ConnectionPool(object):
                     return
                 self.reset()
 
-    def get_connection(self, command_name, *keys, **options):
+    def get_connection(self, *keys, **options):
         "Get a connection from the pool"
         self._checkpid()
         try:
@@ -1195,7 +1195,7 @@ class BlockingConnectionPool(ConnectionPool):
         self._connections.append(connection)
         return connection
 
-    def get_connection(self, command_name, *keys, **options):
+    def get_connection(self, *keys, **options):
         """
         Get a connection, blocking for ``self.timeout`` until a connection
         is available from the pool.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

- remove 'command_name' at get_connection@ConnectionPool
  -> get_connection(self, command_name, *keys, **kwargs) => get_connection(self, *keys, **kwargs)
- remove 'command_name' at get_connection@BlockingConnectionPool
  -> get_connection(self, command_name, *keys, **kwargs) => get_connection(self, *keys, **kwargs)
