### PR TITLE
pubsub: handle disconnection while checking if we are connected

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3439,8 +3439,12 @@ class PubSub(object):
 
         self.check_health()
 
-        if not block and not conn.can_read(timeout=timeout):
-            return None
+        try:
+            if not block and not conn.can_read(timeout=timeout):
+                return None
+        except ConnectionError:
+            conn.disconnect()
+            conn.connect()
         response = self._execute(conn, conn.read_response)
 
         if conn.health_check_interval and \


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

After upgrade from redis-py 2.x to 3.3.11, I was getting these tracebacks in a loop:

```
2020-01-06 15:32:36,519 ERROR Problem reading redis queues
Traceback (most recent call last):
  File "/code/molly/pricefeed/pubsubutils.py", line 217, in run
    msg = self.pubsub.get_message()
  File "/env/lib/python3.6/site-packages/redis/client.py", line 3297, in get_message
    response = self.parse_response(block=False, timeout=timeout)
  File "/env/lib/python3.6/site-packages/redis/client.py", line 3183, in parse_response
    if not block and not conn.can_read(timeout=timeout):
  File "/env/lib/python3.6/site-packages/redis/connection.py", line 695, in can_read
    return self._parser.can_read(timeout)
  File "/env/lib/python3.6/site-packages/redis/connection.py", line 404, in can_read
    raise_on_timeout=False)
  File "/env/lib/python3.6/site-packages/redis/connection.py", line 416, in read_from_socket
    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
redis.exceptions.ConnectionError: Connection closed by server.
```

I monkey patched it in my app, but this PR should do something equivalent upstream.

The problem is that I was getting ConnectionError in `conn.can_read(timeout=timeout)`, and there is no code to handle it. parse_response does handle this error, but later, when it calls `self._execute()`.

Because the exception is not handled, the system doesn't recover from the disconnection, on its own.  With the patch, it will recover on its own.