### PR TITLE
Change order of tasks in connection reset

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1084,10 +1084,11 @@ class ConnectionPool(object):
         )
 
     def reset(self):
-        self.pid = os.getpid()
         self._created_connections = 0
         self._available_connections = []
         self._in_use_connections = set()
+        # Setting the pid signals, that we have done all the work here.
+        self.pid = os.getpid()
         self._check_lock = threading.Lock()
 
     def _checkpid(self):


### PR DESCRIPTION
This fixes a race condition, where a task can be returned an old
connection instead of waiting, while another one already started the reset.

Thanks for the analysis done by @yht804421715 and @gmbnomis .

fixes #1138

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] <s>Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?</s>

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
