### PR TITLE
lock.py: do not raise error on large sleep

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -124,8 +124,6 @@ class Lock(object):
         self.thread_local = bool(thread_local)
         self.local = threading.local() if self.thread_local else dummy()
         self.local.token = None
-        if self.timeout and self.sleep > self.timeout:
-            raise LockError("'sleep' must be less than 'timeout'")
         self.register_scripts()
 
     def register_scripts(self):
@@ -184,7 +182,7 @@ class Lock(object):
                 return True
             if not blocking:
                 return False
-            if stop_trying_at is not None and mod_time.time() > stop_trying_at:
+            if stop_trying_at is not None and mod_time.time() + sleep > stop_trying_at:
                 return False
             mod_time.sleep(sleep)
 

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -182,7 +182,8 @@ class Lock(object):
                 return True
             if not blocking:
                 return False
-            if stop_trying_at is not None and mod_time.time() + sleep > stop_trying_at:
+            next_try_at = mod_time.time() + sleep
+            if stop_trying_at is not None and next_try_at > stop_trying_at:
                 return False
             mod_time.sleep(sleep)
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -91,10 +91,12 @@ class TestLock(object):
     def test_blocking_timeout(self, r):
         lock1 = self.get_lock(r, 'foo')
         assert lock1.acquire(blocking=False)
-        lock2 = self.get_lock(r, 'foo', blocking_timeout=0.2)
+        sleep = 0.05
+        lock2 = self.get_lock(r, 'foo', sleep=sleep, blocking_timeout=0.2)
         start = time.time()
         assert not lock2.acquire()
-        assert (time.time() - start) > 0.2
+        # If we slept, last try would be after blocking_timeout
+        assert (time.time() - start) > 0.2 - sleep
         lock1.release()
 
     def test_context_manager(self, r):
@@ -110,10 +112,15 @@ class TestLock(object):
             with self.get_lock(r, 'foo', blocking_timeout=0.1):
                 pass
 
-    def test_high_sleep_raises_error(self, r):
-        "If sleep is higher than timeout, it should raise an error"
-        with pytest.raises(LockError):
-            self.get_lock(r, 'foo', timeout=1, sleep=2)
+    def test_high_sleep_small_blocking_timeout(self, r):
+        lock1 = self.get_lock(r, 'foo')
+        assert lock1.acquire(blocking=False)
+        sleep = 60
+        lock2 = self.get_lock(r, 'foo', sleep=sleep, blocking_timeout=1)
+        start = time.time()
+        assert not lock2.acquire()
+        assert (time.time() - start) < 1
+        lock1.release()
 
     def test_releasing_unlocked_lock_raises_error(self, r):
         lock = self.get_lock(r, 'foo')


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

I do not see why `sleep` should be smaller than `timeout`: I can be perfectly fine with waiting a long time (`sleep`) to acquire a lock for doing something that will be done in a short time (`timeout` only applies once the lock is acquired).
On the other hand I could see why `sleep` should be smaller than `blocking_timeout`. I suggest another solution: do not sleep if blocking_timeout will have expired when you wake up.
