### PR TITLE
Support memoryview encoding (as a no-op)

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -92,7 +92,7 @@ SENTINEL = object()
 
 
 class Encoder(object):
-    "Encode strings to bytes and decode bytes to strings"
+    "Encode strings to bytes-like and decode bytes-like to strings"
 
     def __init__(self, encoding, encoding_errors, decode_responses):
         self.encoding = encoding
@@ -100,8 +100,8 @@ class Encoder(object):
         self.decode_responses = decode_responses
 
     def encode(self, value):
-        "Return a bytestring representation of the value"
-        if isinstance(value, bytes):
+        "Return a bytestring or bytes-like representation of the value"
+        if isinstance(value, bytes) or isinstance(value, memoryview):
             return value
         elif isinstance(value, bool):
             # special case bool since it is a subclass of int
@@ -122,7 +122,7 @@ class Encoder(object):
         return value
 
     def decode(self, value, force=False):
-        "Return a unicode string from the byte representation"
+        "Return a unicode string from the bytes-like representation"
         if (self.decode_responses or force) and isinstance(value, bytes):
             value = value.decode(self.encoding, self.encoding_errors)
         return value

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -738,6 +738,12 @@ class Connection(object):
             raise response
         return response
 
+    def _maybe_to_bytes(self, arg):
+        if isinstance(arg, memoryview):
+            return arg.tobytes()
+        else:
+            return arg
+
     def pack_command(self, *args):
         "Pack a series of arguments into the Redis protocol"
         output = []
@@ -767,7 +773,7 @@ class Connection(object):
             else:
                 buff = SYM_EMPTY.join(
                     (buff, SYM_DOLLAR, str(arg_length).encode(),
-                     SYM_CRLF, arg, SYM_CRLF))
+                     SYM_CRLF, self._maybe_to_bytes(arg), SYM_CRLF))
         output.append(buff)
         return output
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2399,6 +2399,19 @@ class TestRedisCommands(object):
         # xread starting at the last message returns an empty list
         assert r.xread(streams={stream: m2}) == []
 
+        # memoryviews
+        m3 = r.xadd(stream, {'boom': memoryview(b'bop')})
+        expected = [
+            [
+                stream.encode(),
+                [
+                    get_stream_message(r, stream, m3),
+                ]
+            ]
+        ]
+
+        assert r.xread(streams={stream: m2}) == expected
+
     @skip_if_server_version_lt('5.0.0')
     def test_xreadgroup(self, r):
         stream = 'stream'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [(not sure) ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Supports passing memoryviews to redis-py as outlined in #1265 