### PR TITLE
Make hset support multiple field/value pairs.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@
       in 3.4.0. This ended up being a bad idea as two separate connection
       pools be considered equal yet manage a completely separate set of
       connections.
+    * HSET command now can accept multiple pairs. HMSET has been marked as 
+      deprecated now. Thanks to @laixintao #1271
 * 3.4.0
     * Allow empty pipelines to be executed if there are WATCHed keys.
       This is a convenient way to test if any of the watched keys changed

--- a/redis/client.py
+++ b/redis/client.py
@@ -3024,6 +3024,7 @@ class Redis(object):
         Set key to value within hash ``name`` for each corresponding
         key and value from the ``mapping`` dict.
         """
+        warnings.warn(DeprecationWarning('Use hset'))
         if not mapping:
             raise DataError("'hmset' with 'mapping' of length 0")
         items = []

--- a/redis/client.py
+++ b/redis/client.py
@@ -2999,7 +2999,8 @@ class Redis(object):
     def hset(self, name, key=None, value=None, mapping=None):
         """
         Set ``key`` to ``value`` within hash ``name``,
-        Use kwargs to set multiple key/value pairs for a hash ``name``.
+        Use ``mappings`` keyword args to set multiple key/value pairs
+        for a hash ``name``.
         Returns the number of fields that were added.
         """
         if not key and not mapping:

--- a/redis/client.py
+++ b/redis/client.py
@@ -2996,12 +2996,21 @@ class Redis(object):
         "Return the number of elements in hash ``name``"
         return self.execute_command('HLEN', name)
 
-    def hset(self, name, key, value):
+    def hset(self, name, key=None, value=None, **pairs):
         """
         Set ``key`` to ``value`` within hash ``name``
         Returns 1 if HSET created a new field, otherwise 0
         """
-        return self.execute_command('HSET', name, key, value)
+        if not key and not pairs:
+            raise DataError("'hset' with no key value pairs")
+        items = []
+        if key:
+            items.extend((key, value))
+        if pairs:
+            for pair in iteritems(pairs):
+                items.extend(pair)
+
+        return self.execute_command('HSET', name, *items)
 
     def hsetnx(self, name, key, value):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -2999,7 +2999,7 @@ class Redis(object):
     def hset(self, name, key=None, value=None, mapping=None):
         """
         Set ``key`` to ``value`` within hash ``name``,
-        Use kwargs to set multiple key/value paris for a hash ``name``.
+        Use kwargs to set multiple key/value pairs for a hash ``name``.
         Returns the number of fields that were added.
         """
         if not key and not mapping:

--- a/redis/client.py
+++ b/redis/client.py
@@ -2998,7 +2998,8 @@ class Redis(object):
 
     def hset(self, name, key=None, value=None, **pairs):
         """
-        Set ``key`` to ``value`` within hash ``name``
+        Set ``key`` to ``value`` within hash ``name``,
+        Use kwargs to set multiple key/value paris for a hash ``name``.
         Returns 1 if HSET created a new field, otherwise 0
         """
         if not key and not pairs:

--- a/redis/client.py
+++ b/redis/client.py
@@ -2996,19 +2996,19 @@ class Redis(object):
         "Return the number of elements in hash ``name``"
         return self.execute_command('HLEN', name)
 
-    def hset(self, name, key=None, value=None, **pairs):
+    def hset(self, name, key=None, value=None, mapping=None):
         """
         Set ``key`` to ``value`` within hash ``name``,
         Use kwargs to set multiple key/value paris for a hash ``name``.
-        Returns 1 if HSET created a new field, otherwise 0
+        Returns the number of fields that were added.
         """
-        if not key and not pairs:
+        if not key and not mapping:
             raise DataError("'hset' with no key value pairs")
         items = []
         if key:
             items.extend((key, value))
-        if pairs:
-            for pair in iteritems(pairs):
+        if mapping:
+            for pair in mapping.items():
                 items.extend(pair)
 
         return self.execute_command('HSET', name, *items)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1603,6 +1603,21 @@ class TestRedisCommands(object):
         # key inside of hash that doesn't exist returns null value
         assert r.hget('a', 'b') is None
 
+    def test_hset_with_multi_key_values(self, r):
+        r.hset('a', **{'1': 1, '2': 2, '3': 3})
+        assert r.hget('a', '1') == b'1'
+        assert r.hget('a', '2') == b'2'
+        assert r.hget('a', '3') == b'3'
+
+        r.hset('b', "foo", "bar", **{'1': 1, '2': 2})
+        assert r.hget('b', '1') == b'1'
+        assert r.hget('b', '2') == b'2'
+        assert r.hget('b', 'foo') == b'bar'
+
+        r.hset("c", a="9", b="0")
+        assert r.hget('c', 'a') == b'9'
+        assert r.hget('c', 'b') == b'0'
+
     def test_hdel(self, r):
         r.hmset('a', {'1': 1, '2': 2, '3': 3})
         assert r.hdel('a', '2') == 1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1587,7 +1587,7 @@ class TestRedisCommands(object):
 
     # HASH COMMANDS
     def test_hget_and_hset(self, r):
-        r.hmset('a', {'1': 1, '2': 2, '3': 3})
+        r.hmset('a', mapping={'1': 1, '2': 2, '3': 3})
         assert r.hget('a', '1') == b'1'
         assert r.hget('a', '2') == b'2'
         assert r.hget('a', '3') == b'3'
@@ -1604,19 +1604,19 @@ class TestRedisCommands(object):
         assert r.hget('a', 'b') is None
 
     def test_hset_with_multi_key_values(self, r):
-        r.hset('a', **{'1': 1, '2': 2, '3': 3})
+        r.hset('a', mapping={'1': 1, '2': 2, '3': 3})
         assert r.hget('a', '1') == b'1'
         assert r.hget('a', '2') == b'2'
         assert r.hget('a', '3') == b'3'
 
-        r.hset('b', "foo", "bar", **{'1': 1, '2': 2})
+        r.hset('b', "foo", "bar", mapping={'1': 1, '2': 2})
         assert r.hget('b', '1') == b'1'
         assert r.hget('b', '2') == b'2'
         assert r.hget('b', 'foo') == b'bar'
 
-        r.hset("c", a="9", b="0")
-        assert r.hget('c', 'a') == b'9'
-        assert r.hget('c', 'b') == b'0'
+    def test_hset_without_data(self, r):
+        with pytest.raises(exceptions.DataError):
+            r.hset("x")
 
     def test_hdel(self, r):
         r.hmset('a', {'1': 1, '2': 2, '3': 3})


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

1. `hset` accept multiple field/value s now.
2. `hmset` marked as deprecated.

close https://github.com/andymccurdy/redis-py/issues/1269