### PR TITLE
Fix spelling in docstring

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2265,7 +2265,7 @@ class Redis(object):
         If ``number`` is None, returns a random member of set ``name``.
 
         If ``number`` is supplied, returns a list of ``number`` random
-        memebers of set ``name``. Note this is only available when running
+        members of set ``name``. Note this is only available when running
         Redis 2.6+.
         """
         args = (number is not None) and [number] or []


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This fixes a minor spelling mistake in the docstring of `srandmember`, by removing the extra _"e"_ in _"members"_.