### PR TITLE
Stop hiding errors that occur inside __del__ methods

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3370,13 +3370,10 @@ class PubSub(object):
         self.reset()
 
     def __del__(self):
-        try:
-            # if this object went out of scope prior to shutting down
-            # subscriptions, close the connection manually before
-            # returning it to the connection pool
-            self.reset()
-        except Exception:
-            pass
+        # if this object went out of scope prior to shutting down
+        # subscriptions, close the connection manually before
+        # returning it to the connection pool
+        self.reset()
 
     def reset(self):
         if self.connection:
@@ -3725,10 +3722,7 @@ class Pipeline(Redis):
         self.reset()
 
     def __del__(self):
-        try:
-            self.reset()
-        except Exception:
-            pass
+        self.reset()
 
     def __len__(self):
         return len(self.command_stack)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -288,10 +288,7 @@ class PythonParser(BaseParser):
         self._buffer = None
 
     def __del__(self):
-        try:
-            self.on_disconnect()
-        except Exception:
-            pass
+        self.on_disconnect()
 
     def on_connect(self, connection):
         "Called when the socket connects"
@@ -370,10 +367,7 @@ class HiredisParser(BaseParser):
             self._buffer = bytearray(socket_read_size)
 
     def __del__(self):
-        try:
-            self.on_disconnect()
-        except Exception:
-            pass
+        self.on_disconnect()
 
     def on_connect(self, connection):
         self._sock = connection._sock
@@ -533,10 +527,7 @@ class Connection(object):
         return pieces
 
     def __del__(self):
-        try:
-            self.disconnect()
-        except Exception:
-            pass
+        self.disconnect()
 
     def register_connect_callback(self, callback):
         self._connect_callbacks.append(callback)


### PR DESCRIPTION
If an exception occurs inside the `__del__` method, it should be reported to the developer. Not doing so could hide bugs.

Python automatically handles exceptions inside `__del__` methods, for example:

    class A:
        def __del__(self):
            1 / 0

    A()
    print("after del")

Results in the output:

    $ python3 ~/blah.py
    Exception ignored in: <function A.__del__ at 0x7fbbf2bbfc20>
    Traceback (most recent call last):
      File "/home/jon/test.py", line 3, in __del__
        1 / 0
    ZeroDivisionError: division by zero
    after del

From this example, we can see the bug was not hidden and the code after `__del__` still executed.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- <s>[ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?</s> N/A

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._