### PR TITLE
Improve Redis.hmset() warning message

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3026,7 +3026,12 @@ class Redis(object):
         Set key to value within hash ``name`` for each corresponding
         key and value from the ``mapping`` dict.
         """
-        warnings.warn(DeprecationWarning('Use hset'))
+        warnings.warn(
+            '%s.hmset() is deprecated. Use %s.hset() instead.'
+            % (self.__class__.__name__, self.__class__.__name__),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not mapping:
             raise DataError("'hmset' with 'mapping' of length 0")
         items = []

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -59,6 +59,9 @@ class TestResponseCallbacks(object):
 
 
 class TestRedisCommands(object):
+    hmset_warning = (
+        r'^Redis\.hmset\(\) is deprecated\. Use Redis\.hset\(\) instead\.$'
+    )
 
     def test_command_on_invalid_key_type(self, r):
         r.lpush('a', '1')
@@ -1102,7 +1105,8 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.8.0')
     def test_hscan(self, r):
-        r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         cursor, dic = r.hscan('a')
         assert cursor == 0
         assert dic == {b'a': b'1', b'b': b'2', b'c': b'3'}
@@ -1111,7 +1115,8 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.8.0')
     def test_hscan_iter(self, r):
-        r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         dic = dict(r.hscan_iter('a'))
         assert dic == {b'a': b'1', b'b': b'2', b'c': b'3'}
         dic = dict(r.hscan_iter('a', match='a'))
@@ -1587,7 +1592,8 @@ class TestRedisCommands(object):
 
     # HASH COMMANDS
     def test_hget_and_hset(self, r):
-        r.hmset('a', mapping={'1': 1, '2': 2, '3': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', mapping={'1': 1, '2': 2, '3': 3})
         assert r.hget('a', '1') == b'1'
         assert r.hget('a', '2') == b'2'
         assert r.hget('a', '3') == b'3'
@@ -1619,20 +1625,23 @@ class TestRedisCommands(object):
             r.hset("x")
 
     def test_hdel(self, r):
-        r.hmset('a', {'1': 1, '2': 2, '3': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', {'1': 1, '2': 2, '3': 3})
         assert r.hdel('a', '2') == 1
         assert r.hget('a', '2') is None
         assert r.hdel('a', '1', '3') == 2
         assert r.hlen('a') == 0
 
     def test_hexists(self, r):
-        r.hmset('a', {'1': 1, '2': 2, '3': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', {'1': 1, '2': 2, '3': 3})
         assert r.hexists('a', '1')
         assert not r.hexists('a', '4')
 
     def test_hgetall(self, r):
         h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
-        r.hmset('a', h)
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', h)
         assert r.hgetall('a') == h
 
     def test_hincrby(self, r):
@@ -1648,22 +1657,26 @@ class TestRedisCommands(object):
 
     def test_hkeys(self, r):
         h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
-        r.hmset('a', h)
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', h)
         local_keys = list(iterkeys(h))
         remote_keys = r.hkeys('a')
         assert (sorted(local_keys) == sorted(remote_keys))
 
     def test_hlen(self, r):
-        r.hmset('a', {'1': 1, '2': 2, '3': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', {'1': 1, '2': 2, '3': 3})
         assert r.hlen('a') == 3
 
     def test_hmget(self, r):
-        assert r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            assert r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         assert r.hmget('a', 'a', 'b', 'c') == [b'1', b'2', b'3']
 
     def test_hmset(self, r):
         h = {b'a': b'1', b'b': b'2', b'c': b'3'}
-        assert r.hmset('a', h)
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            assert r.hmset('a', h)
         assert r.hgetall('a') == h
 
     def test_hsetnx(self, r):
@@ -1675,14 +1688,16 @@ class TestRedisCommands(object):
 
     def test_hvals(self, r):
         h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
-        r.hmset('a', h)
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', h)
         local_vals = list(itervalues(h))
         remote_vals = r.hvals('a')
         assert sorted(local_vals) == sorted(remote_vals)
 
     @skip_if_server_version_lt('3.2.0')
     def test_hstrlen(self, r):
-        r.hmset('a', {'1': '22', '2': '333'})
+        with pytest.warns(DeprecationWarning, match=self.hmset_warning):
+            r.hmset('a', {'1': '22', '2': '333'})
         assert r.hstrlen('a', '1') == 2
         assert r.hstrlen('a', '2') == 3
 


### PR DESCRIPTION
It now describe what is deprecated and displays for the callers line by using `stacklevel=2`.

The warning is now tested and not emitted during normal test runs.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- <s>Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?</s> N/A