### PR TITLE
Support memoryview encoding/decoding as a no-op, calling tobytes() on…

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -775,9 +775,8 @@ class Connection(object):
             # to avoid large string mallocs, chunk the command into the
             # output list if we're sending large values or memoryviews
             arg_length = len(arg)
-            if len(buff) > buffer_cutoff \
-                or arg_length > buffer_cutoff \
-                or isinstance(arg, memoryview):
+            if (len(buff) > buffer_cutoff or arg_length > buffer_cutoff
+                    or isinstance(arg, memoryview)):
                 buff = SYM_EMPTY.join(
                     (buff, SYM_DOLLAR, str(arg_length).encode(), SYM_CRLF))
                 output.append(buff)
@@ -800,9 +799,8 @@ class Connection(object):
         for cmd in commands:
             for chunk in self.pack_command(*cmd):
                 chunklen = len(chunk)
-                if buffer_length > buffer_cutoff \
-                    or chunklen > buffer_cutoff \
-                    or isinstance(chunk, memoryview):
+                if (buffer_length > buffer_cutoff or chunklen > buffer_cutoff
+                        or isinstance(chunk, memoryview)):
                     output.append(SYM_EMPTY.join(pieces))
                     buffer_length = 0
                     pieces = []

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -805,7 +805,7 @@ class Connection(object):
                     buffer_length = 0
                     pieces = []
 
-                if chunklen > self._buffer_cutoff:
+                if chunklen > buffer_cutoff or isinstance(chunk, memoryview):
                     output.append(chunk)
                 else:
                     pieces.append(chunk)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -103,7 +103,7 @@ class Encoder(object):
 
     def encode(self, value):
         "Return a bytestring or bytes-like representation of the value"
-        if isinstance(value, bytes) or isinstance(value, memoryview):
+        if isinstance(value, (bytes, memoryview)):
             return value
         elif isinstance(value, bool):
             # special case bool since it is a subclass of int
@@ -125,7 +125,7 @@ class Encoder(object):
 
     def decode(self, value, force=False):
         "Return a unicode string from the bytes-like representation"
-        if (self.decode_responses or force):
+        if self.decode_responses or force:
             if isinstance(value, memoryview):
                 value = value.tobytes()
             if isinstance(value, bytes):

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -75,8 +75,12 @@ class TestEncodingErrors(object):
 class TestMemoryviewsAreNotPacked(object):
     c = Connection()
     arg = memoryview(b'some_arg')
-    cmd = c.pack_command('SOME_COMMAND', arg)
+    arg_list = ['SOME_COMMAND', arg]
+    cmd = c.pack_command(*arg_list)
     assert cmd[1] is arg
+    cmds = c.pack_commands([arg_list, arg_list])
+    assert cmds[1] is arg
+    assert cmds[3] is arg
 
 
 class TestCommandsAreNotEncoded(object):

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -14,7 +14,11 @@ class TestEncoding(object):
 
     @pytest.fixture()
     def r_no_decode(self, request):
-        return _get_client(redis.Redis, request=request, decode_responses=False)
+        return _get_client(
+            redis.Redis,
+            request=request,
+            decode_responses=False,
+        )
 
     def test_simple_encoding(self, r, r_no_decode):
         unicode_string = unichr(3456) + 'abcd' + unichr(3421)
@@ -60,11 +64,13 @@ class TestEncodingErrors(object):
         r.set('a', b'foo\xff')
         assert r.get('a') == 'foo\ufffd'
 
+
 class TestMemoryviewsAreNotPacked(object):
     c = Connection()
     arg = memoryview(b'some_arg')
     cmd = c.pack_command('SOME_COMMAND', arg)
     assert cmd[1] is arg
+
 
 class TestCommandsAreNotEncoded(object):
     @pytest.fixture()

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -3,6 +3,7 @@ import pytest
 import redis
 
 from redis._compat import unichr, unicode
+from redis.connection import Connection
 from .conftest import _get_client
 
 
@@ -59,6 +60,11 @@ class TestEncodingErrors(object):
         r.set('a', b'foo\xff')
         assert r.get('a') == 'foo\ufffd'
 
+class TestMemoryviewsAreNotPacked(object):
+    c = Connection()
+    arg = memoryview(b'some_arg')
+    cmd = c.pack_command('SOME_COMMAND', arg)
+    assert cmd[1] is arg
 
 class TestCommandsAreNotEncoded(object):
     @pytest.fixture()

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -20,29 +20,36 @@ class TestEncoding(object):
             decode_responses=False,
         )
 
-    def test_simple_encoding(self, r, r_no_decode):
+    def test_simple_encoding(self, r_no_decode):
         unicode_string = unichr(3456) + 'abcd' + unichr(3421)
-        r['unicode-string'] = unicode_string
-        cached_val = r['unicode-string']
-        assert isinstance(cached_val, unicode)
-        assert unicode_string == cached_val
         r_no_decode['unicode-string'] = unicode_string.encode('utf-8')
         cached_val = r_no_decode['unicode-string']
         assert isinstance(cached_val, bytes)
         assert unicode_string == cached_val.decode('utf-8')
 
-    def test_memoryview_encoding(self, r, r_no_decode):
+    def test_simple_encoding_decoding(self, r):
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
+        r['unicode-string'] = unicode_string
+        cached_val = r['unicode-string']
+        assert isinstance(cached_val, unicode)
+        assert unicode_string == cached_val
+
+    def test_memoryview_encoding(self, r_no_decode):
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
+        unicode_string_view = memoryview(unicode_string.encode('utf-8'))
+        r_no_decode['unicode-string-memoryview'] = unicode_string_view
+        cached_val = r_no_decode['unicode-string-memoryview']
+        # The cached value won't be a memoryview because it's a copy from Redis
+        assert isinstance(cached_val, bytes)
+        assert unicode_string == cached_val.decode('utf-8')
+
+    def test_memoryview_encoding_decoding(self, r):
         unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         unicode_string_view = memoryview(unicode_string.encode('utf-8'))
         r['unicode-string-memoryview'] = unicode_string_view
         cached_val = r['unicode-string-memoryview']
         assert isinstance(cached_val, unicode)
         assert unicode_string == cached_val
-        r_no_decode['unicode-string-memoryview'] = unicode_string_view
-        cached_val = r_no_decode['unicode-string-memoryview']
-        # The cached value won't be a memoryview because it's a copy from Redis
-        assert isinstance(cached_val, bytes)
-        assert unicode_string == cached_val.decode('utf-8')
 
     def test_list_encoding(self, r):
         unicode_string = unichr(3456) + 'abcd' + unichr(3421)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -29,6 +29,16 @@ class TestPipeline(object):
                     [(b'z1', 2.0), (b'z2', 4)],
                 ]
 
+    def test_pipeline_memoryview(self, r):
+        with r.pipeline() as pipe:
+            (pipe.set('a', memoryview(b'a1'))
+                 .get('a'))
+            assert pipe.execute() == \
+                [
+                    True,
+                    b'a1',
+                ]
+
     def test_pipeline_length(self, r):
         with r.pipeline() as pipe:
             # Initially empty.


### PR DESCRIPTION
…ly when decode_responses=True

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Supports passing memoryviews to redis-py as first outlined in #1265 and discussed further in #1266 
