### PR TITLE
Move to more explicit, deterministic resource management

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -881,9 +881,7 @@ class Redis(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
-
-    def __del__(self):
-        self.close()
+        self.connection_pool.disconnect()
 
     def close(self):
         conn = self.connection
@@ -3410,12 +3408,6 @@ class PubSub(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.reset()
 
-    def __del__(self):
-        # if this object went out of scope prior to shutting down
-        # subscriptions, close the connection manually before
-        # returning it to the connection pool
-        self.reset()
-
     def reset(self):
         if self.connection:
             self.connection.disconnect()
@@ -3760,9 +3752,6 @@ class Pipeline(Redis):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.reset()
-
-    def __del__(self):
         self.reset()
 
     def __len__(self):

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -44,24 +44,24 @@ class TestConnectionPool(object):
         assert connection.kwargs == connection_kwargs
 
     def test_multiple_connections(self):
-        pool = self.get_pool()
-        c1 = pool.get_connection('_')
-        c2 = pool.get_connection('_')
-        assert c1 != c2
+        with self.get_pool() as pool:
+            c1 = pool.get_connection('_')
+            c2 = pool.get_connection('_')
+            assert c1 != c2
 
     def test_max_connections(self):
-        pool = self.get_pool(max_connections=2)
-        pool.get_connection('_')
-        pool.get_connection('_')
-        with pytest.raises(redis.ConnectionError):
+        with self.get_pool(max_connections=2) as pool:
             pool.get_connection('_')
+            pool.get_connection('_')
+            with pytest.raises(redis.ConnectionError):
+                pool.get_connection('_')
 
     def test_reuse_previously_released_connection(self):
-        pool = self.get_pool()
-        c1 = pool.get_connection('_')
-        pool.release(c1)
-        c2 = pool.get_connection('_')
-        assert c1 == c2
+        with self.get_pool() as pool:
+            c1 = pool.get_connection('_')
+            pool.release(c1)
+            c2 = pool.get_connection('_')
+            assert c1 == c2
 
     def test_repr_contains_db_info_tcp(self):
         connection_kwargs = {

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -154,13 +154,14 @@ def test_discover_slaves(cluster, sentinel):
 
 
 def test_master_for(cluster, sentinel):
-    master = sentinel.master_for('mymaster', db=9)
-    assert master.ping()
-    assert master.connection_pool.master_address == ('127.0.0.1', 6379)
+    with sentinel.master_for('mymaster', db=9) as master:
+        assert master.ping()
+        assert master.connection_pool.master_address == ('127.0.0.1', 6379)
 
     # Use internal connection check
-    master = sentinel.master_for('mymaster', db=9, check_connection=True)
-    assert master.ping()
+    with sentinel.master_for('mymaster', db=9,
+                             check_connection=True) as master:
+        assert master.ping()
 
 
 def test_slave_for(cluster, sentinel):
@@ -168,8 +169,8 @@ def test_slave_for(cluster, sentinel):
         {'ip': '127.0.0.1', 'port': 6379,
          'is_odown': False, 'is_sdown': False},
     ]
-    slave = sentinel.slave_for('mymaster', db=9)
-    assert slave.ping()
+    with sentinel.slave_for('mymaster', db=9) as slave:
+        assert slave.ping()
 
 
 def test_slave_for_slave_not_found_error(cluster, sentinel):


### PR DESCRIPTION
This removes `__del__` methods. Now, mishandled resource management will emit a `ResourceWarning`. These warnings should not be ignored. They highlight code that are not closing resources explicitly nor deterministically. Library users should use `.close()`, `.disconnect()` or
context managers to resolve these warnings.

This follows the Python semantics of resources such as file objects and sockets. For example:

    $ python3 -W always
    >>> f = open('/tmp/foo', 'w')
    >>> del f
    __main__:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/foo' mode='w' encoding='UTF-8'>
    ResourceWarning: Enable tracemalloc to get the object allocation traceback

Even with these warnings, the resources are still closed by Python when their reference count goes to zero, but now library users can notice the mishandling and fix it.

The previous use of `__del__` comes with a number of warnings. For example, CPython does not guarantee `__del__` is called on exit:

https://docs.python.org/3/reference/datamodel.html#object.__del__

> It is not guaranteed that `__del__()` methods are called for objects that still exist when the interpreter exits.

There are other warnings with using `__del__()`:

> Warning
>
> Due to the precarious circumstances under which `__del__()` methods are invoked, exceptions that occur during their execution are ignored, and a warning is printed to sys.stderr instead. In particular:
>
> `__del__()` can be invoked when arbitrary code is being executed, including from any arbitrary thread. If `__del__()` needs to take a lock or invoke any other blocking resource, it may deadlock as the resource may already be taken by the code that gets interrupted to execute `__del__()`.
>
> `__del__()` can be executed during interpreter shutdown. As a consequence, the global variables it needs to access (including other modules) may already have been deleted or set to `None`. Python guarantees that globals whose name begins with a single underscore are deleted from their module before other globals are deleted; if no other references to such globals exist, this may help in assuring that imported modules are still available at the time when the `__del__()` method is called.

All warnings emitted during tests have been cleaned up.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
