### PR TITLE
Add Envy functionality

### DIFF
--- a/.envyfile
+++ b/.envyfile
@@ -1,0 +1,30 @@
+environment:
+  base:
+    image: python:3.6
+  system-packages:
+    - recipe: python-dev
+  setup-steps:
+    - name: python-deps
+      label: "Installing python dependencies"
+      type: script
+      as_user: false
+      run:
+        - "pip install --upgrade pip"
+        - "pip install tox"
+actions:
+  - name: console
+    script: 'echo "Connect to redis at redis:6379" && python'
+    help: 'Start an interactive prompt that will allow you to experiment with redis'
+  - name: test
+    script: 'tox -e py36'
+    help: 'Run the tests with python3.6'
+  - name: testall
+    script: 'tox'
+    help: 'Run the tests across all supported python versions (slow)'
+  - name: lint
+    script: 'tox -e pycodestyle'
+    help: 'Run the linter'
+services:
+  compose-file: docker-compose.yml
+network:
+  name: redis-py

--- a/.envyfile
+++ b/.envyfile
@@ -16,7 +16,7 @@ actions:
     script: 'echo "Connect to redis at redis:6379" && python'
     help: 'Start an interactive prompt that will allow you to experiment with redis'
   - name: test
-    script: 'tox -e py36'
+    script: 'tox -e py36 -- --redis-host=redis --cluster-master-host=master'
     help: 'Run the tests with python3.6'
   - name: testall
     script: 'tox'

--- a/.envyfile
+++ b/.envyfile
@@ -1,9 +1,18 @@
 environment:
-  base:
-    image: python:3.6
   system-packages:
-    - recipe: python-dev
+    - recipe: python3.6
+    - recipe: python3-pip
+    - recipe: software-properties-common
   setup-steps:
+    - name: python-versions
+      label: "Installing old python versions"
+      type: script
+      as_user: false
+      run:
+        - "add-apt-repository ppa:deadsnakes/ppa -y"
+        - "apt install python2.7 python3.5 python3.7 python3.8 -y"
+        - "ln -s /usr/bin/pip3 /usr/bin/pip"
+        - "ln -s /usr/bin/python3 /usr/bin/python"
     - name: python-deps
       label: "Installing python dependencies"
       type: script
@@ -18,8 +27,8 @@ actions:
   - name: test
     script: 'tox -e py36 -- --redis-host=redis --cluster-master-host=master'
     help: 'Run the tests with python3.6'
-  - name: testall
-    script: 'tox'
+  - name: test-all
+    script: 'tox -- --redis-host=redis --cluster-master-host=master'
     help: 'Run the tests across all supported python versions (slow)'
   - name: lint
     script: 'tox -e pycodestyle'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vagrant/.vagrant
 .cache
 .eggs
 .idea
+/.envy/

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,9 @@ or from source:
 
     $ python setup.py install
 
+If you'd like to try out redis-py with an interactive session, you can use
+`envy <https://envy-project.github.io/index.html>`_! Just run `envy up` to create your environment, and `envy console`
+will drop you into an interactive session with a redis server.
 
 Getting Started
 ---------------
@@ -869,6 +872,12 @@ that return Python iterators for convenience: `scan_iter`, `hscan_iter`,
     A 1
     B 2
     C 3
+
+Contributing
+^^^^^^^^^^^
+
+This project supports `envy <https://envy-project.github.io/index.html>`_, a tool
+to isolate and manage your dev environment. Setup is as easy as `envy up`!
 
 Author
 ^^^^^^

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.5"
+services:
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+  master:
+    image: redis
+    expose:
+      - "6379"
+  slave1:
+    image: redis
+    expose:
+      - "6379"
+  slave2:
+    image: redis
+    expose:
+      - "6379"
+networks:
+  default:
+    name: redis-py

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -30,12 +30,12 @@ class TestMultiprocessing(object):
             request=request,
             single_connection_client=False)
 
-    def test_close_connection_in_child(self):
+    def test_close_connection_in_child(self, redis_host, redis_port):
         """
         A connection owned by a parent and closed by a child doesn't
         destroy the file descriptors so a parent can still use it.
         """
-        conn = Connection()
+        conn = Connection(host=redis_host, port=redis_port)
         conn.send_command('ping')
         assert conn.read_response() == b'PONG'
 
@@ -56,12 +56,12 @@ class TestMultiprocessing(object):
         conn.send_command('ping')
         assert conn.read_response() == b'PONG'
 
-    def test_close_connection_in_parent(self):
+    def test_close_connection_in_parent(self, redis_host, redis_port):
         """
         A connection owned by a parent is unusable by a child if the parent
         (the owning process) closes the connection.
         """
-        conn = Connection()
+        conn = Connection(host=redis_host, port=redis_port)
         conn.send_command('ping')
         assert conn.read_response() == b'PONG'
 
@@ -84,13 +84,13 @@ class TestMultiprocessing(object):
         assert proc.exitcode == 0
 
     @pytest.mark.parametrize('max_connections', [1, 2, None])
-    def test_pool(self, max_connections):
+    def test_pool(self, redis_host, redis_port, max_connections):
         """
         A child will create its own connections when using a pool created
         by a parent.
         """
-        pool = ConnectionPool.from_url('redis://localhost',
-                                       max_connections=max_connections)
+        url = 'redis://{}:{}'.format(redis_host, redis_port)
+        pool = ConnectionPool.from_url(url, max_connections=max_connections)
 
         conn = pool.get_connection('ping')
         main_conn_pid = conn.pid
@@ -119,13 +119,13 @@ class TestMultiprocessing(object):
             assert conn.read_response() == b'PONG'
 
     @pytest.mark.parametrize('max_connections', [1, 2, None])
-    def test_close_pool_in_main(self, max_connections):
+    def test_close_pool_in_main(self, redis_host, redis_port, max_connections):
         """
         A child process that uses the same pool as its parent isn't affected
         when the parent disconnects all connections within the pool.
         """
-        pool = ConnectionPool.from_url('redis://localhost',
-                                       max_connections=max_connections)
+        url = 'redis://{}:{}'.format(redis_host, redis_port)
+        pool = ConnectionPool.from_url(url, max_connections=max_connections)
 
         conn = pool.get_connection('ping')
         assert conn.send_command('ping') is None


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Hello!
​
We (@magmastonealex, @omstrumpf, @gbateman, @Tim-Willard) have been working on a tool called ENVy.
​
ENVy is an environment manager to make working on disparate projects easier. You don't need to worry about what a system package is called on your Linux distribution, or figure out how to build for Mac from scratch.

​Setup with ENVy is as simple as typing `envy up` for any project you want to work on. Running `envy nuke` removes all traces of that environment.
With ENVy, you don't need to hunt down a lint command or ask how you run the tests. `envy -h` shows you all the commands you can run - or just jump into a shell with `envy shell`.
​
You can read more about ENVy [here](http://envy-project.github.io/), but the short version is that we think it'll make it easier for contributors to help out.
​
This PR adds an `ENVyfile`, the file that describes a development environment and contains the commands to run. We used redis-py while developing in order to test ENVy, and we hoped you'd consider committing this file to help out casual contributors.

While redis-py doesn't have a particularly complex setup guide, setting up a redis cluster to test on is non-trivial. This is especially true if contributors want to run the tests under all the python versions that tox demands. The envyfile provided here starts up a dockerized redis cluster which works out of the box. The cluster is similar to the one under Vagrant, and can be used to run the tests.
 * `envy console` will drop contributors into a python session inside the development container with a helpful message on how to connect to the basic redis instance. This can be used as an interactive session for new users who want to try out redis-py, and as a full development environment for contributors.
 * `envy test` runs the tox tests under python3.6
 * `envy test-all` runs the tox tests under all specified python versions
 * `envy lint` runs the tox linter

Since envy doesn't run the redis instances on localhost, I had to modify the tests slightly to allow the hostnames / ports of redis instances to be passed in. I kept the defaults the same though, so everything will still work under Vagrant as normal.

Note that currently the first `envy up` may take a few minutes, because envy needs to manually install all the python versions that your tox tests demand. This process can be sped up by uploading a base image that already contains the python versions that you need, or using an existing image like [this one](https://hub.docker.com/r/shimizukawa/python-all).

Please let us know what you think!