### PR TITLE
Don't send DISCARD after ExecAbortError in pipeline

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3898,8 +3898,6 @@ class Pipeline(Redis):
         try:
             response = self.parse_response(connection, '_')
         except ExecAbortError:
-            if self.explicit_transaction:
-                self.immediate_execute_command('DISCARD')
             if errors:
                 raise errors[0][1]
             raise sys.exc_info()[1]


### PR DESCRIPTION
### Description of change

Don't send `DISCARD` after `ExecAbortError` when executing a `MULTI`/`EXEC` transaction in the `Pipeline` class.

The `EXECABORT` error type was added in Redis 2.6.5 and is returned from an `EXEC` command to indicate that the transaction was aborted due to an invalid command.  It is not necessary to call `DISCARD` after this error, and doing so causes a "DISCARD without MULTI" error.

Fixes #1300 

### Pull Request check-list

<!--_Please make sure to review and check all of these items:_-->

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!--_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._-->