### PR TITLE
Clear pipeline watch state after exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vagrant/.vagrant
 .cache
 .eggs
 .idea
+.coverage

--- a/redis/client.py
+++ b/redis/client.py
@@ -3904,6 +3904,9 @@ class Pipeline(Redis):
                 raise errors[0][1]
             raise sys.exc_info()[1]
 
+        # EXEC clears any watched keys
+        self.watching = False
+
         if response is None:
             raise WatchError("Watched variable changed.")
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -17,7 +17,7 @@ def wait_for_command(client, monitor, command):
             return None
 
 
-class TestPipeline(object):
+class TestMonitor(object):
     @skip_if_server_version_lt('5.0.0')
     def test_wait_command_not_found(self, r):
         "Make sure the wait_for_command func works when command is not found"

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,31 +1,15 @@
 from __future__ import unicode_literals
 from redis._compat import unicode
-from .conftest import skip_if_server_version_lt
-
-
-def wait_for_command(client, monitor, command):
-    # issue a command with a key name that's local to this process.
-    # if we find a command with our key before the command we're waiting
-    # for, something went wrong
-    key = '__REDIS-PY-%s__' % str(client.client_id())
-    client.get(key)
-    while True:
-        monitor_response = monitor.next_command()
-        if command in monitor_response['command']:
-            return monitor_response
-        if key in monitor_response['command']:
-            return None
+from .conftest import  wait_for_command
 
 
 class TestMonitor(object):
-    @skip_if_server_version_lt('5.0.0')
     def test_wait_command_not_found(self, r):
         "Make sure the wait_for_command func works when command is not found"
         with r.monitor() as m:
             response = wait_for_command(r, m, 'nothing')
             assert response is None
 
-    @skip_if_server_version_lt('5.0.0')
     def test_response_values(self, r):
         with r.monitor() as m:
             r.ping()
@@ -37,14 +21,12 @@ class TestMonitor(object):
             assert isinstance(response['client_port'], unicode)
             assert response['command'] == 'PING'
 
-    @skip_if_server_version_lt('5.0.0')
     def test_command_with_quoted_key(self, r):
         with r.monitor() as m:
             r.get('foo"bar')
             response = wait_for_command(r, m, 'GET foo"bar')
             assert response['command'] == 'GET foo"bar'
 
-    @skip_if_server_version_lt('5.0.0')
     def test_command_with_binary_data(self, r):
         with r.monitor() as m:
             byte_string = b'foo\x92'
@@ -52,7 +34,6 @@ class TestMonitor(object):
             response = wait_for_command(r, m, 'GET foo\\x92')
             assert response['command'] == 'GET foo\\x92'
 
-    @skip_if_server_version_lt('5.0.0')
     def test_lua_script(self, r):
         with r.monitor() as m:
             script = 'return redis.call("GET", "foo")'

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from redis._compat import unicode
-from .conftest import  wait_for_command
+from .conftest import wait_for_command
 
 
 class TestMonitor(object):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,8 +3,7 @@ import pytest
 
 import redis
 from redis._compat import unichr, unicode
-from .conftest import skip_if_server_version_lt
-from .test_monitor import wait_for_command
+from .conftest import wait_for_command
 
 
 class TestPipeline(object):
@@ -230,7 +229,6 @@ class TestPipeline(object):
             pipe.get('a')
             assert pipe.execute() == [b'1']
 
-    @skip_if_server_version_lt('5.0.0')
     def test_watch_exec_no_unwatch(self, r):
         r['a'] = 1
         r['b'] = 2

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -249,6 +249,20 @@ class TestPipeline(object):
             unwatch_command = wait_for_command(r, m, 'UNWATCH')
             assert unwatch_command is None, "should not send UNWATCH"
 
+    def test_watch_reset_unwatch(self, r):
+        r['a'] = 1
+
+        with r.monitor() as m:
+            with r.pipeline() as pipe:
+                pipe.watch('a')
+                assert pipe.watching
+                pipe.reset()
+                assert not pipe.watching
+
+            unwatch_command = wait_for_command(r, m, 'UNWATCH')
+            assert unwatch_command is not None
+            assert unwatch_command['command'] == 'UNWATCH'
+
     def test_transaction_callable(self, r):
         r['a'] = 1
         r['b'] = 2


### PR DESCRIPTION
### Description of change

Set `Pipeline.watching` to false after executing a transaction to prevent an unnecessary `UNWATCH` command when resetting pipeline state.

Fixes #1299

### Pull Request check-list

<!--_Please make sure to review and check all of these items:_-->

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!--_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._-->