### PR TITLE
Feature: let lock.extend ignore the remaining ttl.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,8 +22,8 @@
       a roundtrip to the server by not having to call UNWATCH within
       Pipeline.reset(). Thanks @nickgaya, #1299/#1302
     * Add the KEEPTTL option for the SET command. Thanks @laixintao #1304/#1280
-    * Lock.extend now has a new option: keep_remaining, default to False, which
-      is identical with the old Lock.extend; When set to True, extend will set
+    * Lock.extend now has a new option: add_to_existing_ttl, default to True, which
+      is identical with the old Lock.extend; When set to False, extend will set
       lock's ttl exactly the additional time.
 * 3.4.1
     * Move the username argument in the Redis and Connection classes to the

--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,9 @@
       a roundtrip to the server by not having to call UNWATCH within
       Pipeline.reset(). Thanks @nickgaya, #1299/#1302
     * Add the KEEPTTL option for the SET command. Thanks @laixintao #1304/#1280
+    * Lock.extend now has a new option: keep_remaining, default to False, which
+      is identical with the old Lock.extend; When set to True, extend will set
+      lock's ttl exactly the additional time.
 * 3.4.1
     * Move the username argument in the Redis and Connection classes to the
       end of the argument list. This helps those poor souls that specify all

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -259,27 +259,27 @@ class Lock(object):
         ):
             raise LockNotOwnedError("Cannot release a lock" " that's no longer owned")
 
-    def extend(self, additional_time, with_remaining=True):
+    def extend(self, additional_time, keep_remaining=True):
         """
         Adds more time to an already acquired lock.
 
         ``additional_time`` can be specified as an integer or a float, both
         representing the number of seconds to add.
 
-        ``with_remaining`` indicates weather to keep the current left ttl.
+        ``keep_remaining`` indicates weather to keep the current left ttl.
         E.g. If current ``ttl name`` is 2, ``extend(name, 10)`` will result
-        ``ttl name = 12``, and ``extend(name, 10, with_remaining=False)`` will
+        ``ttl name = 12``, and ``extend(name, 10, keep_remaining=False)`` will
         result ``ttl name=10``.
         """
         if self.local.token is None:
             raise LockError("Cannot extend an unlocked lock")
         if self.timeout is None:
             raise LockError("Cannot extend a lock with no timeout")
-        return self.do_extend(additional_time, with_remaining)
+        return self.do_extend(additional_time, keep_remaining)
 
-    def do_extend(self, additional_time, with_remaining):
+    def do_extend(self, additional_time, keep_remaining):
         additional_time = int(additional_time * 1000)
-        if with_remaining:
+        if keep_remaining:
             lua_extend_script = self.lua_extend
         else:
             lua_extend_script = self.lua_extend_to

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -155,7 +155,8 @@ class Lock(object):
         if cls.lua_extend is None:
             cls.lua_extend = client.register_script(cls.LUA_EXTEND_SCRIPT)
         if cls.lua_extend_to is None:
-            cls.lua_extend_to = client.register_script(cls.LUA_EXTEND_TO_SCRIPT)
+            cls.lua_extend_to = \
+                client.register_script(cls.LUA_EXTEND_TO_SCRIPT)
         if cls.lua_reacquire is None:
             cls.lua_reacquire = \
                 client.register_script(cls.LUA_REACQUIRE_SCRIPT)
@@ -254,27 +255,27 @@ class Lock(object):
             raise LockNotOwnedError("Cannot release a lock"
                                     " that's no longer owned")
 
-    def extend(self, additional_time, with_remaining=True):
+    def extend(self, additional_time, keep_remaining=True):
         """
         Adds more time to an already acquired lock.
 
         ``additional_time`` can be specified as an integer or a float, both
         representing the number of seconds to add.
 
-        ``with_remaining`` indicates weather to keep the current left ttl.
+        ``keep_remaining`` indicates weather to keep the current left ttl.
         E.g. If current ``ttl name`` is 2, ``extend(name, 10)`` will result
-        ``ttl name = 12``, and ``extend(name, 10, with_remaining=False)`` will
+        ``ttl name = 12``, and ``extend(name, 10, keep_remaining=False)`` will
         result ``ttl name=10``.
         """
         if self.local.token is None:
             raise LockError("Cannot extend an unlocked lock")
         if self.timeout is None:
             raise LockError("Cannot extend a lock with no timeout")
-        return self.do_extend(additional_time)
+        return self.do_extend(additional_time, keep_remaining)
 
-    def do_extend(self, additional_time, with_remaining):
+    def do_extend(self, additional_time, keep_remaining):
         additional_time = int(additional_time * 1000)
-        if with_remaining:
+        if keep_remaining:
             lua_extend_script = self.lua_extend
         else:
             lua_extend_script = self.lua_extend_to
@@ -286,7 +287,9 @@ class Lock(object):
                 client=self.redis,
             )
         ):
-            raise LockNotOwnedError("Cannot extend a lock that's" " no longer owned")
+            raise LockNotOwnedError(
+                "Cannot extend a lock that's" " no longer owned"
+            )
         return True
 
     def reacquire(self):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -149,6 +149,14 @@ class TestLock(object):
         assert 16000 < r.pttl('foo') <= 20000
         lock.release()
 
+    def test_extend_lock_without_left_ttl(self, r):
+        lock = self.get_lock(r, 'foo', timeout=10)
+        assert lock.acquire(blocking=False)
+        assert 8000 < r.pttl('foo') <= 10000
+        assert lock.extend(10, keep_remaining=False)
+        assert 8000 < r.pttl('foo') <= 10000
+        lock.release()
+
     def test_extend_lock_float(self, r):
         lock = self.get_lock(r, 'foo', timeout=10.0)
         assert lock.acquire(blocking=False)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -153,7 +153,7 @@ class TestLock(object):
         lock = self.get_lock(r, 'foo', timeout=10)
         assert lock.acquire(blocking=False)
         assert 8000 < r.pttl('foo') <= 10000
-        assert lock.extend(10, keep_remaining=False)
+        assert lock.extend(10, add_to_existing_ttl=False)
         assert 8000 < r.pttl('foo') <= 10000
         lock.release()
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Lock.extend now has a new option: keep_remaining, default to False, which is identical with the old Lock.extend; When set to True, extend will set lock's ttl exactly the additional time.

A common use case would be, let's see we have 4 process and just want one to keep running, others standby. When running process is broken or offline, one of the other 3 can takeover. In order to to that, we use a lock to make sure only one prcess is running, and this process extends  lock every 8 seconds before a timeout(10 seconds).

If without the new option `keep_remaining`(not sure if it's a good arg name that makes itself clear), the `tll` will get longer and longer, failover time will be unacceptable long.

Currently there are many workarounds (see https://github.com/andymccurdy/redis-py/issues/629 for example), but I think it would be better for redis-py to support this.

close https://github.com/andymccurdy/redis-py/issues/629
