### PR TITLE
Use setuptools setup.cfg declarative configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,37 @@
+[metadata]
+name = redis
+version = attr: redis.__version__
+description = Python client for Redis key-value store
+long_description = file: README.rst
+url = https://github.com/andymccurdy/redis-py
+author = Andy McCurdy
+author_email = sedrik@gmail.com
+maintainer = Andy McCurdy
+maintainer_email = sedrik@gmail.com
+keywords = Redis, key-value store
+license = MIT
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+packages = redis
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+
+[options.extras_require]
+hiredis = hiredis>=0.1.3
+
 [pycodestyle]
 show-source = 1
 exclude = .venv,.tox,dist,docs,build,*.egg,redis_install

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,4 @@
 #!/usr/bin/env python
-import os
 from setuptools import setup
 
-from redis import __version__
-
-
-f = open(os.path.join(os.path.dirname(__file__), 'README.rst'))
-long_description = f.read()
-f.close()
-
-setup(
-    name='redis',
-    version=__version__,
-    description='Python client for Redis key-value store',
-    long_description=long_description,
-    long_description_content_type='text/x-rst',
-    url='https://github.com/andymccurdy/redis-py',
-    author='Andy McCurdy',
-    author_email='sedrik@gmail.com',
-    maintainer='Andy McCurdy',
-    maintainer_email='sedrik@gmail.com',
-    keywords=['Redis', 'key-value store'],
-    license='MIT',
-    packages=['redis'],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-    extras_require={
-        'hiredis': [
-            "hiredis>=0.1.3",
-        ],
-    },
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ]
-)
+setup()


### PR DESCRIPTION
For details on this feature, see:
https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

Setuptools allows using setup.cfg as a configuration file to define the
package metadata and options. This approach reduces boilerplate code in
favor of a declarative configuration. Down the road, this approach also
allows for automation through scripts and tools.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (N/A)

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
