### PR TITLE
Simplify exception handlers

### DIFF
--- a/benchmarks/command_packer_benchmark.py
+++ b/benchmarks/command_packer_benchmark.py
@@ -13,8 +13,7 @@ class StringJoiningConnection(Connection):
             self.connect()
         try:
             self._sock.sendall(command)
-        except socket.error:
-            e = sys.exc_info()[1]
+        except socket.error as e:
             self.disconnect()
             if len(e.args) == 1:
                 _errno, errmsg = 'UNKNOWN', e.args[0]
@@ -22,9 +21,9 @@ class StringJoiningConnection(Connection):
                 _errno, errmsg = e.args
             raise ConnectionError("Error %s while writing to socket. %s." %
                                   (_errno, errmsg))
-        except Exception as e:
+        except Exception:
             self.disconnect()
-            raise e
+            raise
 
     def pack_command(self, *args):
         "Pack a series of arguments into a value Redis command"
@@ -46,8 +45,7 @@ class ListJoiningConnection(Connection):
                 command = [command]
             for item in command:
                 self._sock.sendall(item)
-        except socket.error:
-            e = sys.exc_info()[1]
+        except socket.error as e:
             self.disconnect()
             if len(e.args) == 1:
                 _errno, errmsg = 'UNKNOWN', e.args[0]
@@ -55,9 +53,9 @@ class ListJoiningConnection(Connection):
                 _errno, errmsg = e.args
             raise ConnectionError("Error %s while writing to socket. %s." %
                                   (_errno, errmsg))
-        except Exception as e:
+        except Exception:
             self.disconnect()
-            raise e
+            raise
 
     def pack_command(self, *args):
         output = []

--- a/redis/client.py
+++ b/redis/client.py
@@ -3887,8 +3887,8 @@ class Pipeline(Redis):
         # the socket
         try:
             self.parse_response(connection, '_')
-        except ResponseError:
-            errors.append((0, sys.exc_info()[1]))
+        except ResponseError as e:
+            errors.append((0, e))
 
         # and all the other commands
         for i, command in enumerate(commands):
@@ -3897,10 +3897,9 @@ class Pipeline(Redis):
             else:
                 try:
                     self.parse_response(connection, '_')
-                except ResponseError:
-                    ex = sys.exc_info()[1]
-                    self.annotate_exception(ex, i + 1, command[0])
-                    errors.append((i, ex))
+                except ResponseError as e:
+                    self.annotate_exception(e, i + 1, command[0])
+                    errors.append((i, e))
 
         # parse the EXEC.
         try:
@@ -3908,7 +3907,7 @@ class Pipeline(Redis):
         except ExecAbortError:
             if errors:
                 raise errors[0][1]
-            raise sys.exc_info()[1]
+            raise
 
         # EXEC clears any watched keys
         self.watching = False
@@ -3950,8 +3949,8 @@ class Pipeline(Redis):
             try:
                 response.append(
                     self.parse_response(connection, args[0], **options))
-            except ResponseError:
-                response.append(sys.exc_info()[1])
+            except ResponseError as e:
+                response.append(e)
 
         if raise_on_error:
             self.raise_first_error(commands, response)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -552,8 +552,7 @@ class Connection(object):
             sock = self._connect()
         except socket.timeout:
             raise TimeoutError("Timeout connecting to server")
-        except socket.error:
-            e = sys.exc_info()[1]
+        except socket.error as e:
             raise ConnectionError(self._error_message(e))
 
         self._sock = sock
@@ -701,8 +700,7 @@ class Connection(object):
         except socket.timeout:
             self.disconnect()
             raise TimeoutError("Timeout writing to socket")
-        except socket.error:
-            e = sys.exc_info()[1]
+        except socket.error as e:
             self.disconnect()
             if len(e.args) == 1:
                 errno, errmsg = 'UNKNOWN', e.args[0]
@@ -711,7 +709,7 @@ class Connection(object):
                 errmsg = e.args[1]
             raise ConnectionError("Error %s while writing to socket. %s." %
                                   (errno, errmsg))
-        except:  # noqa: E722
+        except BaseException:
             self.disconnect()
             raise
 
@@ -736,12 +734,11 @@ class Connection(object):
             self.disconnect()
             raise TimeoutError("Timeout reading from %s:%s" %
                                (self.host, self.port))
-        except socket.error:
+        except socket.error as e:
             self.disconnect()
-            e = sys.exc_info()[1]
             raise ConnectionError("Error while reading from %s:%s : %s" %
                                   (self.host, self.port, e.args))
-        except:  # noqa: E722
+        except BaseException:
             self.disconnect()
             raise
 
@@ -1197,7 +1194,7 @@ class ConnectionPool(object):
                     connection.connect()
                     if connection.can_read():
                         raise ConnectionError('Connection not ready')
-            except:  # noqa: E722
+            except BaseException:
                 # release the connection back to the pool so that we don't
                 # leak it
                 self.release(connection)
@@ -1359,7 +1356,7 @@ class BlockingConnectionPool(ConnectionPool):
                 connection.connect()
                 if connection.can_read():
                     raise ConnectionError('Connection not ready')
-        except:  # noqa: E722
+        except BaseException:
             # release the connection back to the pool so that we don't leak it
             self.release(connection)
             raise


### PR DESCRIPTION
Use the "as" keyword to capture the exception in a variable instead of
sys.exc_info().

Re-raise exception with the bare "raise" syntax.

Avoid "# noqa: E722" by catching BaseException, which includes all
exceptions including SystemExit.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._