### PR TITLE
Remove unnecessary coerce to list

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2656,7 +2656,7 @@ class TestBinarySave(object):
             r.rpush(key, *value)
 
         # check that KEYS returns all the keys as they are
-        assert sorted(r.keys('*')) == sorted(list(iterkeys(mapping)))
+        assert sorted(r.keys('*')) == sorted(iterkeys(mapping))
 
         # check that it is possible to get list content by key name
         for key, value in iteritems(mapping):


### PR DESCRIPTION
`sorted()` takes any iterable and always returns a new list. No need to
eagerly coerce to a list.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
