### PR TITLE
Enable BytesWarning during test and fix discovered case

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -172,6 +172,11 @@ else:
     def nativestr(x):
         return x if isinstance(x, str) else x.decode('utf-8', 'replace')
 
+    def safe_unicode(value):
+        if isinstance(value, bytes):
+            value = value.decode('utf-8', 'replace')
+        return str(value)
+
     next = next
     unichr = chr
     imap = map
@@ -179,7 +184,6 @@ else:
     xrange = range
     basestring = str
     unicode = str
-    safe_unicode = str
     long = int
     BlockingIOError = BlockingIOError
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest >= 2.7.0
 extras =
     hiredis: hiredis
-commands = {envpython} -m coverage run -m pytest -W always {posargs}
+commands = {envpython} -b -m coverage run -m pytest -W always {posargs}
 
 [testenv:pycodestyle]
 basepython = python3.6


### PR DESCRIPTION
The Python command line argument -b causes Python to emit a warning when
bytes and str usage is mixed. This is generally considered bad practice
as either one or the other is required. Enabling this feature during
tests helps catch them before reaching production.

The warning appeared as:

    tests/test_scripting.py::TestScripting::test_eval_msgpack_pipeline_error_in_lua
      .../redis-py/redis/client.py:3967: BytesWarning: str() on a bytes instance
        cmd = ' '.join(imap(safe_unicode, command))

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?