### PR TITLE
Add missing check_health argument to Connection overrides

### DIFF
--- a/benchmarks/command_packer_benchmark.py
+++ b/benchmarks/command_packer_benchmark.py
@@ -7,7 +7,7 @@ from base import Benchmark
 
 
 class StringJoiningConnection(Connection):
-    def send_packed_command(self, command):
+    def send_packed_command(self, command, check_health=True):
         "Send an already packed command to the Redis server"
         if not self._sock:
             self.connect()
@@ -38,7 +38,7 @@ class StringJoiningConnection(Connection):
 
 
 class ListJoiningConnection(Connection):
-    def send_packed_command(self, command):
+    def send_packed_command(self, command, check_health=True):
         if not self._sock:
             self.connect()
         try:


### PR DESCRIPTION
Now matches the parent class signature. Running the benchmark previously
failed with the error:

    TypeError: send_packed_command() got an unexpected keyword argument 'check_health'

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?