### PR TITLE
Fix str/bytes mixup in PythonParser.read_response()

### DIFF
--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -143,9 +143,6 @@ if sys.version_info[0] < 3:
     def next(x):
         return x.next()
 
-    def byte_to_chr(x):
-        return x
-
     unichr = unichr
     xrange = xrange
     basestring = basestring
@@ -165,9 +162,6 @@ else:
 
     def itervalues(x):
         return iter(x.values())
-
-    def byte_to_chr(x):
-        return chr(x)
 
     def nativestr(x):
         return x if isinstance(x, str) else x.decode('utf-8', 'replace')

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,15 @@
+import mock
+import pytest
+
+from redis.exceptions import InvalidResponse
+from redis.utils import HIREDIS_AVAILABLE
+
+
+@pytest.mark.skipif(HIREDIS_AVAILABLE, reason='PythonParser only')
+def test_invalid_response(r):
+    raw = b'x'
+    parser = r.connection._parser
+    with mock.patch.object(parser._buffer, 'readline', return_value=raw):
+        with pytest.raises(InvalidResponse) as cm:
+            parser.read_response()
+    assert str(cm.value) == 'Protocol Error: %r' % raw


### PR DESCRIPTION
Calling str() on a bytes object can result in a BytesWarning being
emitted and usually indicates a mixup between byte and string handling.

Now, in the event of an invalid RESP response, use the repr value of the
raw response in the exception message.

Can further simplify the bytes/str handling by comparing the first byte
as a bytes object instead of converting it to str. The bytes literal is
available on all supported Pythons. This removes the need for the
compatibility function, byte_to_chr().

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
