### PR TITLE
Switch to flake8 for static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 matrix:
   include:
-    - env: TOXENV=pycodestyle
+    - env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=py27-plain
     - python: 2.7
@@ -39,4 +39,4 @@ install:
 script:
   - tox
 after_success:
-  - "if [[ $TOXENV != 'pycodestyle' ]]; then codecov; fi"
+  - "if [[ $TOXENV != 'flake8' ]]; then codecov; fi"

--- a/benchmarks/command_packer_benchmark.py
+++ b/benchmarks/command_packer_benchmark.py
@@ -1,5 +1,4 @@
 import socket
-import sys
 from redis.connection import (Connection, SYM_STAR, SYM_DOLLAR, SYM_EMPTY,
                               SYM_CRLF)
 from redis._compat import imap

--- a/redis/_compat.py
+++ b/redis/_compat.py
@@ -1,4 +1,5 @@
 """Internal module for Python 2 backwards compatibility."""
+# flake8: noqa
 import errno
 import socket
 import sys

--- a/redis/client.py
+++ b/redis/client.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from itertools import chain
 import datetime
-import sys
 import warnings
 import time
 import threading

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -6,7 +6,6 @@ import errno
 import io
 import os
 import socket
-import sys
 import threading
 import warnings
 

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 
 try:
-    import hiredis
+    import hiredis  # noqa
     HIREDIS_AVAILABLE = True
 except ImportError:
     HIREDIS_AVAILABLE = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,7 @@ python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 [options.extras_require]
 hiredis = hiredis>=0.1.3
 
-[pycodestyle]
-show-source = 1
+[flake8]
 exclude = .venv,.tox,dist,docs,build,*.egg,redis_install
 
 [bdist_wheel]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = {py27,py35,py36,py37,py38,py,py3}-{plain,hiredis}, pycodestyle
+envlist = {py27,py35,py36,py37,py38,py,py3}-{plain,hiredis}, flake8
 
 [testenv]
 deps =
@@ -11,9 +11,9 @@ extras =
     hiredis: hiredis
 commands = {envpython} -b -m coverage run -m pytest -W always {posargs}
 
-[testenv:pycodestyle]
+[testenv:flake8]
 basepython = python3.6
-deps = pycodestyle
-commands = pycodestyle
+deps = flake8
+commands = flake8
 skipsdist = true
 skip_install = true


### PR DESCRIPTION
flake8 catches a wider net of mistakes than pycodestyle and is more
commonly used by the larger community. For example, it catches unused
imports, a few of which existed. These have since been removed.

Two "noqa" comments were added. One ignores the _compat.py file as it
has a large amount of Python version specific code. The second is in
utils.py which intentionally does not use an import.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
