### PR TITLE
Add `EXPIREMEMBER` for KeyDB

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -3306,6 +3306,28 @@ class Redis(object):
 
         return self.execute_command(command, *pieces, **kwargs)
 
+    def expiremember(self, key, subkey, delay, unit=None):
+        """
+        Set timeout on a subkey. This feature only available on KeyDB
+        https://docs.keydb.dev/docs/commands/#expiremember
+        :param key: key added by `SADD key [subkeys]`
+        :param subkey: subkey on the set
+        :param delay: timeout
+        :param unit: `s` or `ms`
+        :return: 0 if the timeout was set, otherwise 0
+        """
+        args = [key, subkey, delay]
+        if not isinstance(delay, (int, long)):
+            raise ValueError("`delay` must be an integer")
+
+        if unit is not None and unit not in ['s', 'ms']:
+            raise ValueError("`unit` must be s or ms")
+
+        if unit:
+            args.append(unit)
+
+        return self.execute_command('EXPIREMEMBER', *args)
+
 
 StrictRedis = Redis
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ x] Does `$ tox` pass with this change (including linting)?
- [x ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x ] Is the new or changed code fully tested?
- [ x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

We added `EXPIREMEMBER` to set the expire time of a member of the set. This feature is only work on [KeyDB](https://keydb.dev/)

```python
import redis 

r = redis.Redis()

r.sadd('a', 'A', 'B', 'C')
r.expiremember('a', 'B', 10)  # 10 seconds

```
