### PR TITLE
If index 3 is not a list, assume Redis Enterprise and return index 4 as slowlog command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -404,7 +404,12 @@ def parse_slowlog_get(response, **options):
         'id': item[0],
         'start_time': int(item[1]),
         'duration': int(item[2]),
-        'command': space.join(item[3])
+        'command':
+            # Redis Enterprise injects another entry at index [3], which has
+            # the complexity info (i.e. the value N in case the command has
+            # an O(N) complexity) instead of the command.
+            space.join(item[3]) if isinstance(item[3], list) else
+            space.join(item[4])
     } for item in response]
 
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Some redis instances, Redislabs for example, return slowlog entries with the commands at `item[4]` instead of `item[3]`. 

`command` is always a list; return item[4] if item[3] is not a list.

Example:

```
 1) 1) (integer) 4764
    2) (integer) 1592198570
    3) (integer) 3
    4)
    5) 1) "LPUSH"
       2) "testkey2"
       3) "0.7346415842722306"
 2) 1) (integer) 4763
    2) (integer) 1592198570
    3) (integer) 3
    4)
    5) 1) "LPUSH"
       2) "testkey2"
       3) "0.6277650251277609"
 3) 1) (integer) 4762
    2) (integer) 1592198570
    3) (integer) 4
    4)
    5) 1) "LPUSH"
       2) "testkey2"
       3) "0.7646428397907798"
 4) 1) (integer) 4761
    2) (integer) 1592198570
    3) (integer) 3
    4)
    5) 1) "LPUSH"
       2) "testkey2"
       3) "0.7501418278370815"
```
