### PR TITLE
LPOS: add new command

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,1 +1,1 @@
-FROM redis:6.0.5-buster
+FROM redis:6.0.6-buster

--- a/redis/client.py
+++ b/redis/client.py
@@ -2030,30 +2030,33 @@ class Redis(object):
         "Push ``value`` onto the tail of the list ``name`` if ``name`` exists"
         return self.execute_command('RPUSHX', name, value)
 
-    def lpos(self, name, value, first=None, count=None, maxlen=None):
+    def lpos(self, name, value, rank=None, count=None, maxlen=None):
         """
-        Get position of ``value`` withn the list ``name``
+        Get position of ``value`` within the list ``name``
 
-         ``first`` "rank" is the position of the match, so if it is 1, the
-         first match is returned, if it is 2 the second match is returned and
-         so forth.  It is 1 by default. If negative has the same meaning but
-         the search is performed starting from the end of the list.
+         If specified, ``rank`` indicates the "rank" of the first element to
+         return in case there are multiple copies of ``value`` in the list.
+         By default, LPOS returns the position of the first occurrence of
+         ``value`` in the list. When ``rank`` 2, LPOS returns the position of
+         the second ``value`` in the list. If ``rank`` is negative, LPOS
+         searches the list in reverse. For example, -1 would return the
+         position of the last occurrence of ``value`` and -2 would return the
+         position of the next to last occurrence of ``value``.
 
-         If ``count`` is given, instead of returning the single element, a list
-         of all the matching elements up to "num-matches" are returned.
-         ``count`` can be combiled with ``count`` in order to returning only
-         the element starting from the Nth. If ``count`` is zero, all the
-         matching elements are returned.
+         If specified, ``count`` indicates that LPOS should return a list of
+         up to ``count`` positions. A ``count`` of 2 would return a list of
+         up to 2 positions. A ``count`` of 0 returns a list of all positions
+         matching ``value``. When ``count`` is specified and but ``value``
+         does not exist in the list, an empty list is returned.
 
-         ``maxlen`` tells the command to scan a max of len elements. If zero
-         (the default), all the elements in the list are scanned if needed.
-
-         The returned elements indexes are always referring to what ``lindex``
-         would return. So first element from head is 0, and so forth.
+         If specified, ``maxlen`` indicates the maximum number of list
+         elements to scan. A ``maxlen`` of 1000 will only return the
+         position(s) of items within the first 1000 entries in the list.
+         A ``maxlen`` of 0 (the default) will scan the entire list.
         """
         pieces = [name, value]
-        if first is not None:
-            pieces.extend(['FIRST', first])
+        if rank is not None:
+            pieces.extend(['RANK', rank])
 
         if count is not None:
             pieces.extend(['COUNT', count])

--- a/redis/client.py
+++ b/redis/client.py
@@ -2030,6 +2030,39 @@ class Redis(object):
         "Push ``value`` onto the tail of the list ``name`` if ``name`` exists"
         return self.execute_command('RPUSHX', name, value)
 
+    def lpos(self, name, value, first=None, count=None, maxlen=None):
+        """
+        Get position of ``value`` withn the list ``name``
+
+         ``first`` "rank" is the position of the match, so if it is 1, the
+         first match is returned, if it is 2 the second match is returned and
+         so forth.  It is 1 by default. If negative has the same meaning but
+         the search is performed starting from the end of the list.
+
+         If ``count`` is given, instead of returning the single element, a list
+         of all the matching elements up to "num-matches" are returned.
+         ``count`` can be combiled with ``count`` in order to returning only
+         the element starting from the Nth. If ``count`` is zero, all the
+         matching elements are returned.
+
+         ``maxlen`` tells the command to scan a max of len elements. If zero
+         (the default), all the elements in the list are scanned if needed.
+
+         The returned elements indexes are always referring to what ``lindex``
+         would return. So first element from head is 0, and so forth.
+        """
+        pieces = [name, value]
+        if first is not None:
+            pieces.extend(['FIRST', first])
+
+        if count is not None:
+            pieces.extend(['COUNT', count])
+
+        if maxlen is not None:
+            pieces.extend(['MAXLEN', maxlen])
+
+        return self.execute_command('LPOS', *pieces)
+
     def sort(self, name, start=None, num=None, by=None, get=None,
              desc=False, alpha=False, store=None, groups=False):
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1052,6 +1052,36 @@ class TestRedisCommands(object):
         assert r.rpush('a', '3', '4') == 4
         assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4']
 
+    def test_lpos(self, r):
+        assert r.rpush('a', 'a', 'b', 'c', '1', '2', '3', 'c', 'c') == 8
+        assert r.lpos('a', 'a') == 0
+        assert r.lpos('a', 'c') == 2
+
+        assert r.lpos('a', 'c', first=1) == 2
+        assert r.lpos('a', 'c', first=2) == 6
+        assert r.lpos('a', 'c', first=4) is None
+        assert r.lpos('a', 'c', first=-1) == 7
+        assert r.lpos('a', 'c', first=-2) == 6
+
+        assert r.lpos('a', 'c', count=0) == [2, 6, 7]
+        assert r.lpos('a', 'c', count=1) == [2]
+        assert r.lpos('a', 'c', count=2) == [2, 6]
+        assert r.lpos('a', 'c', count=100) == [2, 6, 7]
+
+        assert r.lpos('a', 'c', count=0, first=2) == [6, 7]
+        assert r.lpos('a', 'c', count=2, first=-1) == [7, 6]
+
+        assert r.lpos('axxx', 'c', count=0, first=2) == []
+
+        assert r.lpos('a', 'x', count=2, first=-1) == []
+        assert r.lpos('a', 'x', first=-1) is None
+
+        assert r.lpos('a', 'a', count=0, maxlen=1) == [0]
+        assert r.lpos('a', 'c', count=0, maxlen=1) == []
+        assert r.lpos('a', 'c', count=0, maxlen=3) == [2]
+        assert r.lpos('a', 'c', count=0, maxlen=3, first=-1) == [7, 6]
+        assert r.lpos('a', 'c', count=0, maxlen=7, first=2) == [6]
+
     def test_rpushx(self, r):
         assert r.rpushx('a', 'b') == 0
         assert r.lrange('a', 0, -1) == []

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1057,30 +1057,31 @@ class TestRedisCommands(object):
         assert r.lpos('a', 'a') == 0
         assert r.lpos('a', 'c') == 2
 
-        assert r.lpos('a', 'c', first=1) == 2
-        assert r.lpos('a', 'c', first=2) == 6
-        assert r.lpos('a', 'c', first=4) is None
-        assert r.lpos('a', 'c', first=-1) == 7
-        assert r.lpos('a', 'c', first=-2) == 6
+        assert r.lpos('a', 'c', rank=1) == 2
+        assert r.lpos('a', 'c', rank=2) == 6
+        assert r.lpos('a', 'c', rank=4) is None
+        assert r.lpos('a', 'c', rank=-1) == 7
+        assert r.lpos('a', 'c', rank=-2) == 6
 
         assert r.lpos('a', 'c', count=0) == [2, 6, 7]
         assert r.lpos('a', 'c', count=1) == [2]
         assert r.lpos('a', 'c', count=2) == [2, 6]
         assert r.lpos('a', 'c', count=100) == [2, 6, 7]
 
-        assert r.lpos('a', 'c', count=0, first=2) == [6, 7]
-        assert r.lpos('a', 'c', count=2, first=-1) == [7, 6]
+        assert r.lpos('a', 'c', count=0, rank=2) == [6, 7]
+        assert r.lpos('a', 'c', count=2, rank=-1) == [7, 6]
 
-        assert r.lpos('axxx', 'c', count=0, first=2) == []
+        assert r.lpos('axxx', 'c', count=0, rank=2) == []
+        assert r.lpos('axxx', 'c') is None
 
-        assert r.lpos('a', 'x', count=2, first=-1) == []
-        assert r.lpos('a', 'x', first=-1) is None
+        assert r.lpos('a', 'x', count=2) == []
+        assert r.lpos('a', 'x') is None
 
         assert r.lpos('a', 'a', count=0, maxlen=1) == [0]
         assert r.lpos('a', 'c', count=0, maxlen=1) == []
         assert r.lpos('a', 'c', count=0, maxlen=3) == [2]
-        assert r.lpos('a', 'c', count=0, maxlen=3, first=-1) == [7, 6]
-        assert r.lpos('a', 'c', count=0, maxlen=7, first=2) == [6]
+        assert r.lpos('a', 'c', count=0, maxlen=3, rank=-1) == [7, 6]
+        assert r.lpos('a', 'c', count=0, maxlen=7, rank=2) == [6]
 
     def test_rpushx(self, r):
         assert r.rpushx('a', 'b') == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1052,6 +1052,7 @@ class TestRedisCommands(object):
         assert r.rpush('a', '3', '4') == 4
         assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4']
 
+    @skip_if_server_version_lt('6.0.6')
     def test_lpos(self, r):
         assert r.rpush('a', 'a', 'b', 'c', '1', '2', '3', 'c', 'c') == 8
         assert r.lpos('a', 'a') == 0


### PR DESCRIPTION
fix #1353

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Redis 6.0.6 will support a new command called LPOS

> The command returns the index of matching elements inside a Redis list. By default, when no options are given, it will scan the list from head to tail, looking for the first match of "element". If the element is found, its index (the zero-based position in the list) is returned. Otherwise, if no match is found, NULL is returned.

This PR adds the command and tests
