### PR TITLE
Fix acl_setuser docstring

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -993,7 +993,7 @@ class Redis(object):
         ``passwords`` if specified is a list of plain text passwords
         to add to or remove from the user. Each password must be prefixed with
         a '+' to add or a '-' to remove. For convenience, the value of
-        ``add_passwords`` can be a simple prefixed string when adding or
+        ``passwords`` can be a simple prefixed string when adding or
         removing a single password.
 
         ``hashed_passwords`` if specified is a list of SHA-256 hashed passwords


### PR DESCRIPTION
Fix the docstring for acl_setuser() so that it refers to the correct parameter name,`passwords`.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fix the docstring for acl_setuser() so that it refers to the correct parameter name,`passwords`.
