### PR TITLE
Fix check_health not work after the first tick

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -704,6 +704,8 @@ class Connection(object):
                 if nativestr(self.read_response()) != 'PONG':
                     raise ConnectionError(
                         'Bad response from PING health check')
+            else:
+                self.next_health_check = time() + self.health_check_interval
 
     def send_packed_command(self, command, check_health=True):
         "Send an already packed command to the Redis server"
@@ -761,9 +763,6 @@ class Connection(object):
         except BaseException:
             self.disconnect()
             raise
-
-        if self.health_check_interval:
-            self.next_health_check = time() + self.health_check_interval
 
         if isinstance(response, ResponseError):
             raise response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import random
+import sys
 
 import pytest
 import redis
@@ -39,6 +40,10 @@ def pytest_sessionstart(session):
     arch_bits = info["arch_bits"]
     REDIS_INFO["version"] = version
     REDIS_INFO["arch_bits"] = arch_bits
+
+
+def skip_if_python_2():
+    return pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
 
 
 def skip_if_server_version_lt(min_version):


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?


### Description of change

We found that `health_check_interval` not fully work.
It turns out `next_health_check` always updated in `read_response`, so `time() > self.next_health_check` never comes to true after the first time.

The new added test case `test_health_check_invoked_after_interval` covers this. However, I'm not very clear with the health check under `pipeline`, and please tell me if I break anything? Thanks!