### PR TITLE
fix: Align from_url in utils.py to remove DB as a 2nd param

### DIFF
--- a/redis/utils.py
+++ b/redis/utils.py
@@ -8,7 +8,7 @@ except ImportError:
     HIREDIS_AVAILABLE = False
 
 
-def from_url(url, db=None, **kwargs):
+def from_url(url, **kwargs):
     """
     Returns an active Redis client generated from the given database URL.
 
@@ -16,7 +16,7 @@ def from_url(url, db=None, **kwargs):
     none is provided.
     """
     from redis.client import Redis
-    return Redis.from_url(url, db, **kwargs)
+    return Redis.from_url(url, **kwargs)
 
 
 @contextmanager


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

The recent change 6b37f4bedc349eb2c91e680d2ef811a3c2f7e879 removed the `db` parameter from the `from_url` function within `client.py` https://github.com/andymccurdy/redis-py/commit/6b37f4bedc349eb2c91e680d2ef811a3c2f7e879#diff-085cbe85ef9bc2ad832d79163eb39172L650.

Problem is the `from_url` function in `utils.py` continued to pass the `db` param causing it to crash. Discovered through another module using this endpoint.