### PR TITLE
Allow BlockingIOError when not timeout for sock.recvfrom()

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -213,7 +213,7 @@ class SocketBuffer:
             # there's no data to be read. otherwise raise the
             # original exception.
             allowed = NONBLOCKING_EXCEPTION_ERROR_NUMBERS.get(ex.__class__, -1)
-            if not raise_on_timeout and ex.errno == allowed:
+            if ex.errno == allowed:
                 return False
             raise ConnectionError("Error while reading from socket: %s" %
                                   (ex.args,))
@@ -443,7 +443,7 @@ class HiredisParser(BaseParser):
             # there's no data to be read. otherwise raise the
             # original exception.
             allowed = NONBLOCKING_EXCEPTION_ERROR_NUMBERS.get(ex.__class__, -1)
-            if not raise_on_timeout and ex.errno == allowed:
+            if ex.errno == allowed:
                 return False
             raise ConnectionError("Error while reading from socket: %s" %
                                   (ex.args,))


### PR DESCRIPTION
The issue was captured from workload running on top of LibOS like graphene
in enclave environment. Please refer https://github.com/oscarlab/graphene/issues/1772.

In a simple redis.ping() testing, the sock will return EAGAIN errono without
timeout, so should not judge raise_on_timeout variable and just return False.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
