### PR TITLE
Fix Dockerfile (cache clear of apt)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM fkrull/multi-python:latest
 
-RUN apt update && apt install -y pypy pypy-dev pypy3-dev
+RUN apt update \
+    && apt install -y pypy pypy-dev pypy3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /redis-py
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fixed to remove cache of package manager apt. The size has been reduced by about 10MB.

before -> after

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
redis01             before              a8ee6e0e403f        3 minutes ago       1.23GB
redis01             after               ea251fef3ac6        10 seconds ago      1.22GB
```