### PR TITLE
Fixing #1390 modules key in info command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -115,7 +115,6 @@ def parse_info(response):
     "Parse the result of Redis's INFO command into a Python dict"
     info = {}
     response = str_if_bytes(response)
-    modules_list = []  # Prepare a list for modules field if exist in resp
 
     def get_value(value):
         if ',' not in value or '=' not in value:
@@ -143,17 +142,12 @@ def parse_info(response):
                 if key == 'cmdstat_host':
                     key, value = line.rsplit(':', 1)
 
-                line_value = get_value(value)
-                # Hardcode a list for key 'modules' since there could be
-                # multiple lines that started with 'module'
                 if key == 'module':
-                    modules_list.append(line_value)
+                    # Hardcode a list for key 'modules' since there could be
+                    # multiple lines that started with 'module'
+                    info.setdefault('modules', []).append(get_value(value))
                 else:
-                    info[key] = line_value
-
-                if modules_list:
-                    # Note that the key is 'modules', not 'module'
-                    info['modules'] = modules_list
+                    info[key] = get_value(value)
             else:
                 # if the line isn't splittable, append it to the "__raw__" key
                 info.setdefault('__raw__', []).append(line)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
In `r.info()` function we generate a dict as reply, using `:` to seperate **key** and value from redis response line.
When redis is loaded with mulitiple modules, there would be more than 1 line started with "module":
```
# Modules
module:name=bf,ver=20204,api=1,filters=0,usedby=[],using=[],options=[]
module:name=redis-cell,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
```

So the content in last line will cover the previous one if we set `info[key] = value`.

Altinatively, we can prepare a list for `module` content, and set `info['modules'] = module_list` when we catch one or more `module` line.

```
(redis-py) ➜  redis-py git:(2014bduck/fix_modules_in_info_command) ✗ python
Python 3.7.7 (default, Mar 10 2020, 15:43:33)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import redis
>>> r = redis.Redis()
>>> r.info()
{'redis_version': '6.0.1', 'redis_git_sha1': 0, 'redis_git_dirty': 0, 'redis_build_id': 'c1d517e76e3925b0', 'redis_mode': 'standalone', 'os': 'Darwin 19.3.0 x86_64', 'arch_bits': 64, 'multiplexing_api': 'kqueue', 'atomicvar_api': 'atomic-builtin', 'gcc_version': '4.2.1', 'process_id': 4156, 'run_id': '8a906e64aca442e7e62cb1cc7b701672d056ad0d', 'tcp_port': 6379, 'uptime_in_seconds': 41, 'uptime_in_days': 0, 'hz': 10, 'configured_hz': 10, 'lru_clock': 5283926, 'executable': '/Users/jiekunzhu/vhost/redis-py/redis-server', 'config_file': '', 'connected_clients': 1, 'client_recent_max_input_buffer': 2, 'client_recent_max_output_buffer': 0, 'blocked_clients': 0, 'tracking_clients': 0, 'clients_in_timeout_table': 0, 'used_memory': 1077392, 'used_memory_human': '1.03M', 'used_memory_rss': 4517888, 'used_memory_rss_human': '4.31M', 'used_memory_peak': 1077392, 'used_memory_peak_human': '1.03M', 'used_memory_peak_perc': '100.00%', 'used_memory_overhead': 1012864, 'used_memory_startup': 1012864, 'used_memory_dataset': 64528, 'used_memory_dataset_perc': '100.00%', 'allocator_allocated': 1012880, 'allocator_active': 4480000, 'allocator_resident': 4480000, 'total_system_memory': 17179869184, 'total_system_memory_human': '16.00G', 'used_memory_lua': 37888, 'used_memory_lua_human': '37.00K', 'used_memory_scripts': 0, 'used_memory_scripts_human': '0B', 'number_of_cached_scripts': 0, 'maxmemory': 0, 'maxmemory_human': '0B', 'maxmemory_policy': 'noeviction', 'allocator_frag_ratio': 4.42, 'allocator_frag_bytes': 3467120, 'allocator_rss_ratio': 1.0, 'allocator_rss_bytes': 0, 'rss_overhead_ratio': 1.01, 'rss_overhead_bytes': 37888, 'mem_fragmentation_ratio': 4.46, 'mem_fragmentation_bytes': 3505008, 'mem_not_counted_for_evict': 0, 'mem_replication_backlog': 0, 'mem_clients_slaves': 0, 'mem_clients_normal': 0, 'mem_aof_buffer': 0, 'mem_allocator': 'libc', 'active_defrag_running': 0, 'lazyfree_pending_objects': 0, 'loading': 0, 'rdb_changes_since_last_save': 0, 'rdb_bgsave_in_progress': 0, 'rdb_last_save_time': 1599119405, 'rdb_last_bgsave_status': 'ok', 'rdb_last_bgsave_time_sec': -1, 'rdb_current_bgsave_time_sec': -1, 'rdb_last_cow_size': 0, 'aof_enabled': 0, 'aof_rewrite_in_progress': 0, 'aof_rewrite_scheduled': 0, 'aof_last_rewrite_time_sec': -1, 'aof_current_rewrite_time_sec': -1, 'aof_last_bgrewrite_status': 'ok', 'aof_last_write_status': 'ok', 'aof_last_cow_size': 0, 'module_fork_in_progress': 0, 'module_fork_last_cow_size': 0, 'total_connections_received': 2, 'total_commands_processed': 2, 'instantaneous_ops_per_sec': 0, 'total_net_input_bytes': 45, 'total_net_output_bytes': 24475, 'instantaneous_input_kbps': 0.0, 'instantaneous_output_kbps': 0.0, 'rejected_connections': 0, 'sync_full': 0, 'sync_partial_ok': 0, 'sync_partial_err': 0, 'expired_keys': 0, 'expired_stale_perc': 0.0, 'expired_time_cap_reached_count': 0, 'expire_cycle_cpu_milliseconds': 0, 'evicted_keys': 0, 'keyspace_hits': 0, 'keyspace_misses': 0, 'pubsub_channels': 0, 'pubsub_patterns': 0, 'latest_fork_usec': 0, 'migrate_cached_sockets': 0, 'slave_expires_tracked_keys': 0, 'active_defrag_hits': 0, 'active_defrag_misses': 0, 'active_defrag_key_hits': 0, 'active_defrag_key_misses': 0, 'tracking_total_keys': 0, 'tracking_total_items': 0, 'unexpected_error_replies': 0, 'role': 'master', 'connected_slaves': 0, 'master_replid': '74410b81f53be3a0958091d5a8e84e0bfccb1a32', 'master_replid2': 0, 'master_repl_offset': 0, 'master_repl_meaningful_offset': 0, 'second_repl_offset': -1, 'repl_backlog_active': 0, 'repl_backlog_size': 1048576, 'repl_backlog_first_byte_offset': 0, 'repl_backlog_histlen': 0, 'used_cpu_sys': 0.026034, 'used_cpu_user': 0.01872, 'used_cpu_sys_children': 0.0, 'used_cpu_user_children': 0.0, 'modules': [{'name': 'bf', 'ver': 20204, 'api': 1, 'filters': 0, 'usedby': '[]', 'using': '[]', 'options': '[]'}, {'name': 'redis-cell', 'ver': 1, 'api': 1, 'filters': 0, 'usedby': '[]', 'using': '[]', 'options': '[]'}], 'cluster_enabled': 0}
>>> r.info(section="modules")
{'modules': [{'name': 'bf', 'ver': 20204, 'api': 1, 'filters': 0, 'usedby': '[]', 'using': '[]', 'options': '[]'}, {'name': 'redis-cell', 'ver': 1, 'api': 1, 'filters': 0, 'usedby': '[]', 'using': '[]', 'options': '[]'}]}
```

The test cases is not covering the code changed in this PR. 

And please notice that this test case will fail as well when running with a module loaded redis server (in the future):
```
    @skip_if_server_version_lt('4.0.0')
    def test_module_list(self, r):
        assert isinstance(r.module_list(), list)
        assert not r.module_list()  # HERE, will not pass when modules are loaded
```