### PR TITLE
Added GET argument to SET command

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -557,6 +557,7 @@ def parse_set_result(response, **options):
         return response
     return response and str_if_bytes(response) == 'OK'
 
+
 class Redis:
     """
     Implementation of the Redis protocol.

--- a/redis/client.py
+++ b/redis/client.py
@@ -1691,6 +1691,9 @@ class Redis:
         """
         Sets the value at key ``name`` to ``value``
         and returns the old value at key ``name`` atomically.
+
+        As per Redis 6.2, GETSET is considered deprecated.
+        Please use SET with GET parameter in new code.
         """
         return self.execute_command('GETSET', name, value)
 
@@ -1822,7 +1825,7 @@ class Redis:
         return self.execute_command('RESTORE', *params)
 
     def set(self, name, value,
-            ex=None, px=None, nx=False, xx=False, keepttl=False):
+            ex=None, px=None, nx=False, xx=False, keepttl=False, get=False):
         """
         Set the value at key ``name`` to ``value``
 
@@ -1838,6 +1841,10 @@ class Redis:
 
         ``keepttl`` if True, retain the time to live associated with the key.
             (Available since Redis 6.0)
+
+        ``get`` if True, set the value at key ``name`` to ``value`` and return
+            the old value stored at key, or None when key did not exist.
+            (Available since Redis 6.2)
         """
         pieces = [name, value]
         if ex is not None:
@@ -1858,6 +1865,9 @@ class Redis:
 
         if keepttl:
             pieces.append('KEEPTTL')
+
+        if get:
+            pieces.append('GET')
 
         return self.execute_command('SET', *pieces)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -912,6 +912,12 @@ class TestRedisCommands:
         assert r.get('a') == b'2'
         assert 0 < r.ttl('a') <= 10
 
+    @skip_if_server_version_lt('6.2.0')
+    def test_set_get(self, r):
+        assert r.set('a', 'foo', get=True) is None
+        assert r.set('a', 'bar', get=True) == b'foo'
+        assert r.get('a') == b'bar'
+
     def test_setex(self, r):
         assert r.setex('a', 60, '1')
         assert r['a'] == b'1'

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -914,7 +914,9 @@ class TestRedisCommands:
 
     @skip_if_server_version_lt('6.2.0')
     def test_set_get(self, r):
-        assert r.set('a', 'foo', get=True) is None
+        assert r.set('a', 'True', get=True) is None
+        assert r.set('a', 'True', get=True) == b'True'
+        assert r.set('a', 'foo') is True
         assert r.set('a', 'bar', get=True) == b'foo'
         assert r.get('a') == b'bar'
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Issue: https://github.com/andymccurdy/redis-py/issues/1411

Added GET argument to SET command, new in Redis 6.2: https://redis.io/commands/set
