### PR TITLE
Add support for the ABSTTL option of the RESTORE command.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
       @aparcar #1353/#1354
     * Added support for the ACL LOG command available in Redis 6. Thanks
       @2014BDuck. #1307
+    * Added support for ABSTTL option of the RESTORE command available in
+      Redis 5.0. Thanks @charettes. #1423
 * 3.5.3 (June 1, 2020)
     * Restore try/except clauses to __del__ methods. These will be removed
       in 4.0 when more explicit resource management if enforced. #1339

--- a/redis/client.py
+++ b/redis/client.py
@@ -1815,6 +1815,9 @@ class Redis:
         """
         Create a key using the provided serialized value, previously obtained
         using DUMP.
+
+        ``replace`` allows an existing key on ``name`` to be overridden. If
+        it's not specified an error is raised on collision.
         """
         params = [name, ttl, value]
         if replace:

--- a/redis/client.py
+++ b/redis/client.py
@@ -1811,17 +1811,23 @@ class Redis:
         "Rename key ``src`` to ``dst`` if ``dst`` doesn't already exist"
         return self.execute_command('RENAMENX', src, dst)
 
-    def restore(self, name, ttl, value, replace=False):
+    def restore(self, name, ttl, value, replace=False, absttl=False):
         """
         Create a key using the provided serialized value, previously obtained
         using DUMP.
 
         ``replace`` allows an existing key on ``name`` to be overridden. If
         it's not specified an error is raised on collision.
+
+        ``absttl`` if True, specified ``ttl`` should represent an absolute Unix
+        timestamp in milliseconds in which the key will expire. (Redis 5.0 or
+        greater).
         """
         params = [name, ttl, value]
         if replace:
             params.append('REPLACE')
+        if absttl:
+            params.append('ABSTTL')
         return self.execute_command('RESTORE', *params)
 
     def set(self, name, value,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -642,6 +642,19 @@ class TestRedisCommands:
         r.restore('a', 0, dumped, replace=True)
         assert r['a'] == b'bar'
 
+    @skip_if_server_version_lt('5.0.0')
+    def test_dump_and_restore_absttl(self, r):
+        r['a'] = 'foo'
+        dumped = r.dump('a')
+        del r['a']
+        ttl = int(
+            (redis_server_time(r) + datetime.timedelta(minutes=1)).timestamp()
+            * 1000
+        )
+        r.restore('a', ttl, dumped, absttl=True)
+        assert r['a'] == b'foo'
+        assert 0 < r.ttl('a') <= 61
+
     def test_exists(self, r):
         assert r.exists('a') == 0
         r['a'] = 'foo'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

The `ABSTTL` option of the `RESTORE` command has been available since Redis 5.0. This PR adds an `absttl=False` kwarg to the `restore` command to allow enabling this option.
