### PR TITLE
Add the getdel command available from redis 6.2.0

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,1 +1,1 @@
-FROM redis:6.0.9-buster
+FROM redis:6.2-buster

--- a/redis/client.py
+++ b/redis/client.py
@@ -1666,6 +1666,13 @@ class Redis:
         """
         return self.execute_command('GET', name)
 
+    def getdel(self, name):
+        """
+        Return the value at key ``name``, or None if the key doesn't exist.
+        Delete the key once read.
+        """
+        return self.execute_command('GETDEL', name)
+
     def __getitem__(self, name):
         """
         Return the value at key ``name``, raises a KeyError if the key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 # redis 6 release candidates report a version number of 5.9.x. Use this
 # constant for skip_if decorators as a placeholder until 6.0.0 is officially
 # released
-REDIS_6_VERSION = '5.9.0'
+REDIS_6_VERSION = '6.2.0'
 
 
 REDIS_INFO = {}

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -8,7 +8,7 @@ import redis
 from redis.exceptions import ConnectionError
 
 from .conftest import _get_client
-from .conftest import skip_if_server_version_lt, skip_if_server_version_gte
+from .conftest import skip_if_server_version_lt
 
 
 def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
@@ -474,7 +474,7 @@ class TestPubSubSubcommands:
     def test_pubsub_channels(self, r):
         p = r.pubsub()
         p.subscribe('foo', 'bar', 'baz', 'quux')
-        for i in range(4):
+        for _ in range(4):
             assert wait_for_message(p)['type'] == 'subscribe'
         expected = [b'bar', b'baz', b'foo', b'quux']
         assert all([channel in r.pubsub_channels() for channel in expected])
@@ -483,11 +483,11 @@ class TestPubSubSubcommands:
     def test_pubsub_numsub(self, r):
         p1 = r.pubsub()
         p1.subscribe('foo', 'bar', 'baz')
-        for i in range(3):
+        for _ in range(3):
             assert wait_for_message(p1)['type'] == 'subscribe'
         p2 = r.pubsub()
         p2.subscribe('bar', 'baz')
-        for i in range(2):
+        for _ in range(2):
             assert wait_for_message(p2)['type'] == 'subscribe'
         p3 = r.pubsub()
         p3.subscribe('baz')
@@ -500,7 +500,7 @@ class TestPubSubSubcommands:
     def test_pubsub_numpat(self, r):
         p = r.pubsub()
         p.psubscribe('*oo', '*ar', 'b*z')
-        for i in range(3):
+        for _ in range(3):
             assert wait_for_message(p)['type'] == 'psubscribe'
         assert r.pubsub_numpat() == 3
 
@@ -549,7 +549,6 @@ class TestPubSubTimeouts:
 
 
 class TestPubSubWorkerThread:
-    @skip_if_server_version_gte('6.0.0')
     def test_pubsub_worker_thread_exception_handler(self, r):
         event = threading.Event()
 
@@ -565,6 +564,6 @@ class TestPubSubWorkerThread:
                 exception_handler=exception_handler
             )
 
-        assert event.wait(timeout=1.0)
+        assert event.wait(timeout=2.0)
         pubsub_thread.join(timeout=1.0)
         assert not pubsub_thread.is_alive()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -564,6 +564,6 @@ class TestPubSubWorkerThread:
                 exception_handler=exception_handler
             )
 
-        assert event.wait(timeout=2.0)
+        assert event.wait(timeout=10.0)
         pubsub_thread.join(timeout=1.0)
         assert not pubsub_thread.is_alive()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -8,7 +8,7 @@ import redis
 from redis.exceptions import ConnectionError
 
 from .conftest import _get_client
-from .conftest import skip_if_server_version_lt
+from .conftest import skip_if_server_version_lt, skip_if_server_version_gte
 
 
 def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
@@ -549,6 +549,7 @@ class TestPubSubTimeouts:
 
 
 class TestPubSubWorkerThread:
+    @skip_if_server_version_gte('6.0.0')
     def test_pubsub_worker_thread_exception_handler(self, r):
         event = threading.Event()
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Coming with **Redis 6.2** is the new command [GETDEL](https://redis.io/commands/getdel). This pull request allows to also have it in this Python interface. 
