### PR TITLE
pass blocking argument to acquire func

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -151,7 +151,7 @@ class Lock:
     def __enter__(self):
         # force blocking, as otherwise the user would have to check whether
         # the lock was actually acquired or not.
-        if self.acquire(blocking=True):
+        if self.acquire(blocking=self.blocking):
             return self
         raise LockError("Unable to acquire lock within the time specified")
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -115,9 +115,12 @@ class TestLock:
         assert r.get('foo') is None
 
     def test_lock_context_manager(self, r):
-        with Lock(r, 'foo', blocking_timeout=0.2, blocking=False) as lock:
-            assert r.get('foo') == lock.local.token
-        assert r.get('foo') is None
+        for blocking in [True, False]:
+            with Lock(
+                r, 'foo', blocking_timeout=0.2, blocking=blocking
+            ) as lock:
+                assert r.get('foo') == lock.local.token
+            assert r.get('foo') is None
 
     def test_context_manager_raises_when_locked_not_acquired(self, r):
         r.set('foo', 'bar')

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -114,6 +114,11 @@ class TestLock:
             assert r.get('foo') == lock.local.token
         assert r.get('foo') is None
 
+    def test_lock_context_manager(self, r):
+        with Lock(r, 'foo', blocking_timeout=0.2, blocking=False) as lock:
+            assert r.get('foo') == lock.local.token
+        assert r.get('foo') is None
+
     def test_context_manager_raises_when_locked_not_acquired(self, r):
         r.set('foo', 'bar')
         with pytest.raises(LockError):


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Now if you want to use lock as context manager it uses `blocking=True` in acquire func instead of using passed `blocking` argument.
