### PR TITLE
Remove blocking behaviour from context manager __enter__

### DIFF
--- a/redis/lock.py
+++ b/redis/lock.py
@@ -149,9 +149,7 @@ class Lock:
                 client.register_script(cls.LUA_REACQUIRE_SCRIPT)
 
     def __enter__(self):
-        # force blocking, as otherwise the user would have to check whether
-        # the lock was actually acquired or not.
-        if self.acquire(blocking=True):
+        if self.acquire():
             return self
         raise LockError("Unable to acquire lock within the time specified")
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Removing unneccessary fixed blocking behaviour in Lock's context manager. Using a lock in a context manager now pays respect to the _blocking_ setting passed to the constructor instead of being ignored. This looks like a leftover from the transition from 2.x to 3.x. 

The comment in the Lock's context manager enter method was also somewhat misleading: The user does know if the lock was or wasn't acquired by the raised exception, so there really is no need in overwriting the blocking behaviour and sacrificing flexibility. 
