### PR TITLE
Add retry mechanism with backoff

### DIFF
--- a/redis/backoff.py
+++ b/redis/backoff.py
@@ -1,0 +1,105 @@
+from abc import ABC, abstractmethod
+import random
+
+
+class AbstractBackoff(ABC):
+    """Backoff interface"""
+
+    def reset(self):
+        """
+        Reset internal state before an operation.
+        `reset` is called once at the beginning of
+        every call to `Retry.call_with_retry`
+        """
+        pass
+
+    @abstractmethod
+    def compute(self, failures):
+        """Compute backoff in seconds upon failure"""
+        pass
+
+
+class ConstantBackoff(AbstractBackoff):
+    """Constant backoff upon failure"""
+
+    def __init__(self, backoff):
+        """`backoff`: backoff time in seconds"""
+        self._backoff = backoff
+
+    def compute(self, failures):
+        return self._backoff
+
+
+class NoBackoff(ConstantBackoff):
+    """No backoff upon failure"""
+
+    def __init__(self):
+        super().__init__(0)
+
+
+class ExponentialBackoff(AbstractBackoff):
+    """Exponential backoff upon failure"""
+
+    def __init__(self, cap, base):
+        """
+        `cap`: maximum backoff time in seconds
+        `base`: base backoff time in seconds
+        """
+        self._cap = cap
+        self._base = base
+
+    def compute(self, failures):
+        return min(self._cap, self._base * 2 ** failures)
+
+
+class FullJitterBackoff(AbstractBackoff):
+    """Full jitter backoff upon failure"""
+
+    def __init__(self, cap, base):
+        """
+        `cap`: maximum backoff time in seconds
+        `base`: base backoff time in seconds
+        """
+        self._cap = cap
+        self._base = base
+
+    def compute(self, failures):
+        return random.uniform(0, min(self._cap, self._base * 2 ** failures))
+
+
+class EqualJitterBackoff(AbstractBackoff):
+    """Equal jitter backoff upon failure"""
+
+    def __init__(self, cap, base):
+        """
+        `cap`: maximum backoff time in seconds
+        `base`: base backoff time in seconds
+        """
+        self._cap = cap
+        self._base = base
+
+    def compute(self, failures):
+        temp = min(self._cap, self._base * 2 ** failures) / 2
+        return temp + random.uniform(0, temp)
+
+
+class DecorrelatedJitterBackoff(AbstractBackoff):
+    """Decorrelated jitter backoff upon failure"""
+
+    def __init__(self, cap, base):
+        """
+        `cap`: maximum backoff time in seconds
+        `base`: base backoff time in seconds
+        """
+        self._cap = cap
+        self._base = base
+        self._previous_backoff = 0
+
+    def reset(self):
+        self._previous_backoff = 0
+
+    def compute(self, failures):
+        max_backoff = max(self._base, self._previous_backoff * 3)
+        temp = random.uniform(self._base, max_backoff)
+        self._previous_backoff = min(self._cap, temp)
+        return self._previous_backoff

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3,6 +3,7 @@ from itertools import chain
 from time import time
 from queue import LifoQueue, Empty, Full
 from urllib.parse import parse_qs, unquote, urlparse
+import copy
 import errno
 import io
 import os
@@ -28,6 +29,8 @@ from redis.exceptions import (
     ModuleError,
 )
 from redis.utils import HIREDIS_AVAILABLE, str_if_bytes
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 
 try:
     import ssl
@@ -499,7 +502,13 @@ class Connection:
                  socket_type=0, retry_on_timeout=False, encoding='utf-8',
                  encoding_errors='strict', decode_responses=False,
                  parser_class=DefaultParser, socket_read_size=65536,
-                 health_check_interval=0, client_name=None, username=None):
+                 health_check_interval=0, client_name=None, username=None,
+                 retry=None):
+        """
+        Initialize a new Connection.
+        To specify a retry policy, first set `retry_on_timeout` to `True`
+        then set `retry` to a valid `Retry` object
+        """
         self.pid = os.getpid()
         self.host = host
         self.port = int(port)
@@ -513,6 +522,14 @@ class Connection:
         self.socket_keepalive_options = socket_keepalive_options or {}
         self.socket_type = socket_type
         self.retry_on_timeout = retry_on_timeout
+        if retry_on_timeout:
+            if retry is None:
+                self.retry = Retry(NoBackoff(), 1)
+            else:
+                # deep-copy the Retry object as it is mutable
+                self.retry = copy.deepcopy(retry)
+        else:
+            self.retry = Retry(NoBackoff(), 0)
         self.health_check_interval = health_check_interval
         self.next_health_check = 0
         self.encoder = Encoder(encoding, encoding_errors, decode_responses)
@@ -673,23 +690,23 @@ class Connection:
             pass
         self._sock = None
 
+    def _send_ping(self):
+        """Send PING, expect PONG in return"""
+        self.send_command('PING', check_health=False)
+        if str_if_bytes(self.read_response()) != 'PONG':
+            raise ConnectionError('Bad response from PING health check')
+
+    def _ping_failed(self, error):
+        """Function to call when PING fails"""
+        self.disconnect()
+
     def check_health(self):
-        "Check the health of the connection with a PING/PONG"
+        """Check the health of the connection with a PING/PONG"""
         if self.health_check_interval and time() > self.next_health_check:
-            try:
-                self.send_command('PING', check_health=False)
-                if str_if_bytes(self.read_response()) != 'PONG':
-                    raise ConnectionError(
-                        'Bad response from PING health check')
-            except (ConnectionError, TimeoutError):
-                self.disconnect()
-                self.send_command('PING', check_health=False)
-                if str_if_bytes(self.read_response()) != 'PONG':
-                    raise ConnectionError(
-                        'Bad response from PING health check')
+            self.retry.call_with_retry(self._send_ping, self._ping_failed)
 
     def send_packed_command(self, command, check_health=True):
-        "Send an already packed command to the Redis server"
+        """Send an already packed command to the Redis server"""
         if not self._sock:
             self.connect()
         # guard against health check recursion
@@ -717,12 +734,12 @@ class Connection:
             raise
 
     def send_command(self, *args, **kwargs):
-        "Pack and send a command to the Redis server"
+        """Pack and send a command to the Redis server"""
         self.send_packed_command(self.pack_command(*args),
                                  check_health=kwargs.get('check_health', True))
 
     def can_read(self, timeout=0):
-        "Poll the socket to see if there's data that can be read."
+        """Poll the socket to see if there's data that can be read."""
         sock = self._sock
         if not sock:
             self.connect()
@@ -730,7 +747,7 @@ class Connection:
         return self._parser.can_read(timeout)
 
     def read_response(self):
-        "Read the response from a previously sent command"
+        """Read the response from a previously sent command"""
         try:
             response = self._parser.read_response()
         except socket.timeout:
@@ -753,7 +770,7 @@ class Connection:
         return response
 
     def pack_command(self, *args):
-        "Pack a series of arguments into the Redis protocol"
+        """Pack a series of arguments into the Redis protocol"""
         output = []
         # the client might have included 1 or more literal arguments in
         # the command name, e.g., 'CONFIG GET'. The Redis server expects these
@@ -787,7 +804,7 @@ class Connection:
         return output
 
     def pack_commands(self, commands):
-        "Pack multiple commands into the Redis protocol"
+        """Pack multiple commands into the Redis protocol"""
         output = []
         pieces = []
         buffer_length = 0

--- a/redis/retry.py
+++ b/redis/retry.py
@@ -1,0 +1,40 @@
+from time import sleep
+
+from redis.exceptions import ConnectionError, TimeoutError
+
+
+class Retry:
+    """Retry a specific number of times after a failure"""
+
+    def __init__(self, backoff, retries,
+                 supported_errors=(ConnectionError, TimeoutError)):
+        """
+        Initialize a `Retry` object with a `Backoff` object
+        that retries a maximum of `retries` times.
+        You can specify the types of supported errors which trigger
+        a retry with the `supported_errors` parameter.
+        """
+        self._backoff = backoff
+        self._retries = retries
+        self._supported_errors = supported_errors
+
+    def call_with_retry(self, do, fail):
+        """
+        Execute an operation that might fail and returns its result, or
+        raise the exception that was thrown depending on the `Backoff` object.
+        `do`: the operation to call. Expects no argument.
+        `fail`: the failure handler, expects the last error that was thrown
+        """
+        self._backoff.reset()
+        failures = 0
+        while True:
+            try:
+                return do()
+            except self._supported_errors as error:
+                failures += 1
+                fail(error)
+                if failures > self._retries:
+                    raise error
+                backoff = self._backoff.compute(failures)
+                if backoff > 0:
+                    sleep(backoff)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 import pytest
 import random
 import redis
@@ -107,6 +109,7 @@ def r2(request):
 
 def _gen_cluster_mock_resp(r, response):
     connection = Mock()
+    connection.retry = Retry(NoBackoff(), 0)
     connection.read_response.return_value = response
     r.connection = connection
     return r

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,66 @@
+from redis.backoff import NoBackoff
+import pytest
+
+from redis.exceptions import ConnectionError
+from redis.connection import Connection
+from redis.retry import Retry
+
+
+class BackoffMock:
+    def __init__(self):
+        self.reset_calls = 0
+        self.calls = 0
+
+    def reset(self):
+        self.reset_calls += 1
+
+    def compute(self, failures):
+        self.calls += 1
+        return 0
+
+
+class TestConnectionConstructorWithRetry:
+    "Test that the Connection constructor properly handles Retry objects"
+
+    @pytest.mark.parametrize("retry_on_timeout", [False, True])
+    def test_retry_on_timeout_boolean(self, retry_on_timeout):
+        c = Connection(retry_on_timeout=retry_on_timeout)
+        assert c.retry_on_timeout == retry_on_timeout
+        assert isinstance(c.retry, Retry)
+        assert c.retry._retries == (1 if retry_on_timeout else 0)
+
+    @pytest.mark.parametrize("retries", range(10))
+    def test_retry_on_timeout_retry(self, retries):
+        retry_on_timeout = retries > 0
+        c = Connection(retry_on_timeout=retry_on_timeout,
+                       retry=Retry(NoBackoff(), retries))
+        assert c.retry_on_timeout == retry_on_timeout
+        assert isinstance(c.retry, Retry)
+        assert c.retry._retries == retries
+
+
+class TestRetry:
+    "Test that Retry calls backoff and retries the expected number of times"
+
+    def setup_method(self, test_method):
+        self.actual_attempts = 0
+        self.actual_failures = 0
+
+    def _do(self):
+        self.actual_attempts += 1
+        raise ConnectionError()
+
+    def _fail(self, error):
+        self.actual_failures += 1
+
+    @pytest.mark.parametrize("retries", range(10))
+    def test_retry(self, retries):
+        backoff = BackoffMock()
+        retry = Retry(backoff, retries)
+        with pytest.raises(ConnectionError):
+            retry.call_with_retry(self._do, self._fail)
+
+        assert self.actual_attempts == 1 + retries
+        assert self.actual_failures == 1 + retries
+        assert backoff.reset_calls == 1
+        assert backoff.calls == retries


### PR DESCRIPTION
* Add the Backoff abstract base class with four backoff strategies
  based on https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
* Add the Retry class which is constructed from
  a backoff strategy and a maximum number of retries, through the `retry` parameter