### PR TITLE
implementing the LMOVE and BLMOVE commands

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1831,11 +1831,11 @@ class Redis:
         params = [first_list, second_list, src, dest]
         return self.execute_command("LMOVE", *params)
 
-    def blmove(self, first_list, second_list, src="LEFT", dest="RIGHT"):
+    def blmove(self, first_list, second_list, timeout, src="LEFT", dest="RIGHT"):
         """
         Blocking version of lmove.
         """
-        params = [first_list, second_list, src, dest]
+        params = [first_list, second_list, src, dest, timeout]
         return self.execute_command("BLMOVE", *params)
 
     def mget(self, keys, *args):

--- a/redis/client.py
+++ b/redis/client.py
@@ -561,7 +561,7 @@ class Redis:
     """
     RESPONSE_CALLBACKS = {
         **string_keys_to_dict(
-            'AUTH EXPIRE EXPIREAT HEXISTS HMSET LOVE MOVE MSETNX PERSIST '
+            'AUTH EXPIRE EXPIREAT HEXISTS HMSET LMOVE BLMOVE MOVE MSETNX PERSIST '
             'PSETEX RENAMENX SISMEMBER SMOVE SETEX SETNX',
             bool
         ),

--- a/redis/client.py
+++ b/redis/client.py
@@ -561,7 +561,7 @@ class Redis:
     """
     RESPONSE_CALLBACKS = {
         **string_keys_to_dict(
-            'AUTH EXPIRE EXPIREAT HEXISTS HMSET MOVE MSETNX PERSIST '
+            'AUTH EXPIRE EXPIREAT HEXISTS HMSET LOVE MOVE MSETNX PERSIST '
             'PSETEX RENAMENX SISMEMBER SMOVE SETEX SETNX',
             bool
         ),
@@ -1725,6 +1725,15 @@ class Redis:
     def keys(self, pattern='*'):
         "Returns a list of keys matching ``pattern``"
         return self.execute_command('KEYS', pattern)
+
+    def lmove(self, first_list, second_list, src="LEFT", dest="RIGHT"):
+        """
+        Atomically returns and removes the first/last element of a list,
+        pushing it as the first/last element on the destination list.
+        Returns the element being popped and pushed.
+        """
+        params = [first_list, second_list, src, dest]
+        return self.execute_command("LMOVE", *params)
 
     def mget(self, keys, *args):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -561,8 +561,8 @@ class Redis:
     """
     RESPONSE_CALLBACKS = {
         **string_keys_to_dict(
-            'AUTH COPY EXPIRE EXPIREAT HEXISTS HMSET LMOVE BLMOVE MOVE MSETNX  '
-            'PERSIST PSETEX RENAMENX SISMEMBER SMOVE SETEX SETNX',
+            'AUTH COPY EXPIRE EXPIREAT HEXISTS HMSET LMOVE BLMOVE MOVE '
+            'MSETNX PERSIST PSETEX RENAMENX SISMEMBER SMOVE SETEX SETNX',
             bool
         ),
         **string_keys_to_dict(

--- a/redis/client.py
+++ b/redis/client.py
@@ -1835,7 +1835,8 @@ class Redis:
         """
         Blocking version of lmove.
         """
-        return self.lmove(first_list, second_list, src, dest)
+        params = [first_list, second_list, src, dest]
+        return self.execute_command("BLMOVE", *params)
 
     def mget(self, keys, *args):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -1741,7 +1741,6 @@ class Redis:
         """
         return self.lmove(first_list, second_list, src, dest)
 
-
     def mget(self, keys, *args):
         """
         Returns a list of values ordered identically to ``keys``

--- a/redis/client.py
+++ b/redis/client.py
@@ -1735,6 +1735,13 @@ class Redis:
         params = [first_list, second_list, src, dest]
         return self.execute_command("LMOVE", *params)
 
+    def blmove(self, first_list, second_list, src="LEFT", dest="RIGHT"):
+        """
+        Blocking version of lmove.
+        """
+        return self.lmove(first_list, second_list, src, dest)
+
+
     def mget(self, keys, *args):
         """
         Returns a list of values ordered identically to ``keys``

--- a/redis/client.py
+++ b/redis/client.py
@@ -1843,7 +1843,8 @@ class Redis:
         params = [first_list, second_list, src, dest]
         return self.execute_command("LMOVE", *params)
 
-    def blmove(self, first_list, second_list, timeout, src="LEFT", dest="RIGHT"):
+    def blmove(self, first_list, second_list, timeout,
+               src="LEFT", dest="RIGHT"):
         """
         Blocking version of lmove.
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -781,6 +781,12 @@ class TestRedisCommands:
         r['c'] = '3'
         assert r.mget('a', 'other', 'b', 'c') == [b'1', None, b'2', b'3']
 
+    @skip_if_server_version_lt('6.2.0')
+    def test_lmove(self, r):
+        r.rpush('a', 'one', 'two', 'three', 'four')
+        assert r.lmove('a', 'b') == b'one'
+        assert r.lmove('a', 'b', 'right', 'left') == b'four'
+
     def test_mset(self, r):
         d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.mset(d)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -792,7 +792,6 @@ class TestRedisCommands:
         assert r.blmove('a', 'b') == b'one'
         assert r.blmove('a', 'b', 'right', 'left') == b'four'
 
-
     def test_mset(self, r):
         d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.mset(d)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -781,11 +781,17 @@ class TestRedisCommands:
         r['c'] = '3'
         assert r.mget('a', 'other', 'b', 'c') == [b'1', None, b'2', b'3']
 
-    @skip_if_server_version_lt('6.2.0')
     def test_lmove(self, r):
         r.rpush('a', 'one', 'two', 'three', 'four')
         assert r.lmove('a', 'b') == b'one'
         assert r.lmove('a', 'b', 'right', 'left') == b'four'
+
+    @skip_if_server_version_lt('6.2.0')
+    def test_blmove(self, r):
+        r.rpush('a', 'one', 'two', 'three', 'four')
+        assert r.blmove('a', 'b') == b'one'
+        assert r.blmove('a', 'b', 'right', 'left') == b'four'
+
 
     def test_mset(self, r):
         d = {'a': b'1', 'b': b'2', 'c': b'3'}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -865,7 +865,7 @@ class TestRedisCommands:
     def test_blmove(self, r):
         r.rpush('a', 'one', 'two', 'three', 'four')
         assert r.blmove('a', 'b')
-        assert r.blmove('a', 'b', 'right', 'left')
+        assert r.blmove('a', 'b', 'RIGHT', 'LEFT')
 
     def test_mset(self, r):
         d = {'a': b'1', 'b': b'2', 'c': b'3'}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -864,8 +864,8 @@ class TestRedisCommands:
     @skip_if_server_version_lt('6.2.0')
     def test_blmove(self, r):
         r.rpush('a', 'one', 'two', 'three', 'four')
-        assert r.blmove('a', 'b')
-        assert r.blmove('a', 'b', 'RIGHT', 'LEFT')
+        assert r.blmove('a', 'b', 5)
+        assert r.blmove('a', 'b', 1, 'RIGHT', 'LEFT')
 
     def test_mset(self, r):
         d = {'a': b'1', 'b': b'2', 'c': b'3'}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -781,6 +781,7 @@ class TestRedisCommands:
         r['c'] = '3'
         assert r.mget('a', 'other', 'b', 'c') == [b'1', None, b'2', b'3']
 
+    @skip_if_server_version_lt('6.2.0')
     def test_lmove(self, r):
         r.rpush('a', 'one', 'two', 'three', 'four')
         assert r.lmove('a', 'b') == b'one'

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -783,14 +783,14 @@ class TestRedisCommands:
     @skip_if_server_version_lt('6.2.0')
     def test_lmove(self, r):
         r.rpush('a', 'one', 'two', 'three', 'four')
-        assert r.lmove('a', 'b') == b'one'
-        assert r.lmove('a', 'b', 'right', 'left') == b'four'
+        assert r.lmove('a', 'b')
+        assert r.lmove('a', 'b', 'right', 'left')
 
     @skip_if_server_version_lt('6.2.0')
     def test_blmove(self, r):
         r.rpush('a', 'one', 'two', 'three', 'four')
-        assert r.blmove('a', 'b') == b'one'
-        assert r.blmove('a', 'b', 'right', 'left') == b'four'
+        assert r.blmove('a', 'b')
+        assert r.blmove('a', 'b', 'right', 'left')
 
     def test_mset(self, r):
         d = {'a': b'1', 'b': b'2', 'c': b'3'}


### PR DESCRIPTION
closes #1503
closes #1447 

Note - this passes in completion again - once [my pr to fix unit tests](https://github.com/andymccurdy/redis-py/pull/1499) is merged in. Checkboxes here are checked based on that assumption.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Added support for the redis [lmove](https://redis.io/commands/lmove) and [blmove](https://redis.io/commands/blmove) command, new in 6.2. See #1434 
