### PR TITLE
NOMKSTREAM support for XADD

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2434,7 +2434,8 @@ class Redis:
         """
         return self.execute_command('XACK', name, groupname, *ids)
 
-    def xadd(self, name, fields, id='*', maxlen=None, approximate=True):
+    def xadd(self, name, fields, id='*', maxlen=None, approximate=True,
+             nomkstream=False):
         """
         Add to a stream.
         name: name of the stream
@@ -2442,7 +2443,7 @@ class Redis:
         id: Location to insert this record. By default it is appended.
         maxlen: truncate old stream members beyond this size
         approximate: actual stream length may be slightly more than maxlen
-
+        nomkstream: When set to true, do not make a stream
         """
         pieces = []
         if maxlen is not None:
@@ -2452,6 +2453,8 @@ class Redis:
             if approximate:
                 pieces.append(b'~')
             pieces.append(str(maxlen))
+        if nomkstream:
+            pieces.append(b'NOMKSTREAM')
         pieces.append(id)
         if not isinstance(fields, dict) or len(fields) == 0:
             raise DataError('XADD fields must be a non-empty dict')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2191,6 +2191,16 @@ class TestRedisCommands:
         r.xadd(stream, {'foo': 'bar'}, maxlen=2, approximate=False)
         assert r.xlen(stream) == 2
 
+    @skip_if_server_version_lt('6.2.0')
+    def test_xadd_nomkstream(self, r):
+        # nomkstream option
+        stream = 'stream'
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'some': 'other'}, nomkstream=False)
+        assert r.xlen(stream) == 2
+        r.xadd(stream, {'some': 'other'}, nomkstream=True)
+        assert r.xlen(stream) == 3
+
     @skip_if_server_version_lt('5.0.0')
     def test_xclaim(self, r):
         stream = 'stream'


### PR DESCRIPTION
Part of #1434 

Pending [unit test fix pr](https://github.com/andymccurdy/redis-py/pull/1499)

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Adds NOMKSTREAM support to xadd.
