### PR TITLE
MINID and LIMIT support for xtrim

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -2744,6 +2744,10 @@ class Redis:
         limit: specifies the maximum number of entries to retrieve
         """
         pieces = []
+        if maxlen is not None and minid is not None:
+            raise DataError("Only one of ```maxlen``` or ```minid```",
+                            "may be specified")
+
         if maxlen is not None:
             pieces.append(b'MAXLEN')
         if minid is not None:

--- a/redis/client.py
+++ b/redis/client.py
@@ -2733,17 +2733,31 @@ class Redis:
 
         return self.execute_command('XREVRANGE', name, *pieces)
 
-    def xtrim(self, name, maxlen, approximate=True):
+    def xtrim(self, name, maxlen=None, approximate=True, minid=None,
+              limit=None):
         """
         Trims old messages from a stream.
         name: name of the stream.
         maxlen: truncate old stream messages beyond this size
         approximate: actual stream length may be slightly more than maxlen
+        minin: the minimum id in the stream to query
+        limit: specifies the maximum number of entries to retrieve
         """
-        pieces = [b'MAXLEN']
+        pieces = []
+        if maxlen is not None:
+            pieces.append(b'MAXLEN')
+        if minid is not None:
+            pieces.append(b'MINID')
         if approximate:
             pieces.append(b'~')
-        pieces.append(maxlen)
+        if maxlen is not None:
+            pieces.append(maxlen)
+        if minid is not None:
+            pieces.append(minid)
+        if limit is not None:
+            pieces.append(b"LIMIT")
+            pieces.append(limit)
+
         return self.execute_command('XTRIM', name, *pieces)
 
     # SORTED SET COMMANDS

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2648,6 +2648,9 @@ class TestRedisCommands:
         assert r.xtrim(stream, 3, approximate=True, limit=2) == 0
         r.delete(stream)
 
+        with pytest.raises(redis.DataError):
+            assert r.xtrim(stream, maxlen=3, minid="sometestvalue")
+
         # minid with a limit
         m1 = r.xadd(stream, {'foo': 'bar'})
         r.xadd(stream, {'foo': 'bar'})

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2632,6 +2632,44 @@ class TestRedisCommands:
         # 1 message is trimmed
         assert r.xtrim(stream, 3, approximate=False) == 1
 
+    @skip_if_server_version_lt('6.2.4')
+    def test_xtrim_minlen_and_length_args(self, r):
+        stream = 'stream'
+
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+
+        # Future self: No limits without approximate, according to the api
+        with pytest.raises(redis.ResponseError):
+            assert r.xtrim(stream, 3, approximate=False, limit=2)
+
+        # maxlen with a limit
+        assert r.xtrim(stream, 3, approximate=True, limit=2) == 0
+        r.delete(stream)
+
+        # minid with a limit
+        m1 = r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        assert r.xtrim(stream, None, approximate=True, minid=m1, limit=3) == 0
+
+        # pure minid
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        m4 = r.xadd(stream, {'foo': 'bar'})
+        assert r.xtrim(stream, None, approximate=False, minid=m4) == 7
+
+        # minid approximate
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        m3 = r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        assert r.xtrim(stream, None, approximate=True, minid=m3) == 0
+
     def test_bitfield_operations(self, r):
         # comments show affected bits
         bf = r.bitfield('a')


### PR DESCRIPTION
Part of the new commands in #1434

Fixed #1454 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `$ tox` pass with this change (including linting)?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Adds support for the new minid, and limit args to xtrim.  To ensure no API changes broke anything both minid and limit arguments were added to the end of the function.