### PR TITLE
Use Version instead of StrictVersion since distutils is deprecated.

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,4 @@
-from distutils.version import StrictVersion
+from packaging.version import Version
 from itertools import chain
 from time import time
 from queue import LifoQueue, Empty, Full
@@ -54,13 +54,13 @@ NONBLOCKING_EXCEPTIONS = tuple(NONBLOCKING_EXCEPTION_ERROR_NUMBERS.keys())
 if HIREDIS_AVAILABLE:
     import hiredis
 
-    hiredis_version = StrictVersion(hiredis.__version__)
+    hiredis_version = Version(hiredis.__version__)
     HIREDIS_SUPPORTS_CALLABLE_ERRORS = \
-        hiredis_version >= StrictVersion('0.1.3')
+        hiredis_version >= Version('0.1.3')
     HIREDIS_SUPPORTS_BYTE_BUFFER = \
-        hiredis_version >= StrictVersion('0.1.4')
+        hiredis_version >= Version('0.1.4')
     HIREDIS_SUPPORTS_ENCODING_ERRORS = \
-        hiredis_version >= StrictVersion('1.0.0')
+        hiredis_version >= Version('1.0.0')
 
     if not HIREDIS_SUPPORTS_BYTE_BUFFER:
         msg = ("redis-py works best with hiredis >= 0.1.4. You're running "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from redis.retry import Retry
 import pytest
 import random
 import redis
-from distutils.version import StrictVersion
+from packaging.version import Version
 from redis.connection import parse_url
 from unittest.mock import Mock
 from urllib.parse import urlparse
@@ -44,7 +44,7 @@ def pytest_sessionstart(session):
 
 def skip_if_server_version_lt(min_version):
     redis_version = REDIS_INFO["version"]
-    check = StrictVersion(redis_version) < StrictVersion(min_version)
+    check = Version(redis_version) < Version(min_version)
     return pytest.mark.skipif(
         check,
         reason="Redis version required >= {}".format(min_version))
@@ -52,7 +52,7 @@ def skip_if_server_version_lt(min_version):
 
 def skip_if_server_version_gte(min_version):
     redis_version = REDIS_INFO["version"]
-    check = StrictVersion(redis_version) >= StrictVersion(min_version)
+    check = Version(redis_version) >= Version(min_version)
     return pytest.mark.skipif(
         check,
         reason="Redis version required < {}".format(min_version))
@@ -183,7 +183,7 @@ def wait_for_command(client, monitor, command):
     # if we find a command with our key before the command we're waiting
     # for, something went wrong
     redis_version = REDIS_INFO["version"]
-    if StrictVersion(redis_version) >= StrictVersion('5.0.0'):
+    if Version(redis_version) >= Version('5.0.0'):
         id_str = str(client.client_id())
     else:
         id_str = '%08x' % random.randrange(2**32)


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Use Version instead of StrictVersion since distutils is deprecated. Ref : https://github.com/jamesls/fakeredis/commit/ff1861c249620245305ba1b9e079ce1b1f5ab4e7 . I had run the tests with hiredis installed in tox and couldn't see any issues in tests. Migration : https://www.python.org/dev/peps/pep-0632/#migration-advice

Fixes #1551 