### PR TITLE
xgroup_createconsumer

### DIFF
--- a/redis/commands.py
+++ b/redis/commands.py
@@ -1807,6 +1807,18 @@ class Commands:
         """
         return self.execute_command('XGROUP DESTROY', name, groupname)
 
+    def xgroup_createconsumer(self, name, groupname, consumername):
+        """
+        Consumers in a consumer group are auto-created every time a new
+        consumer name is mentioned by some command.
+        They can be explicitly created by using this command.
+        name: name of the stream.
+        groupname: name of the consumer group.
+        consumername: name of consumer to create.
+        """
+        return self.execute_command('XGROUP CREATECONSUMER', name, groupname,
+                                    consumername)
+
     def xgroup_setid(self, name, groupname, id):
         """
         Set the consumer group last delivered ID to something else.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2598,6 +2598,22 @@ class TestRedisCommands:
         # deleting the consumer should return 2 pending messages
         assert r.xgroup_delconsumer(stream, group, consumer) == 2
 
+    @skip_if_server_version_lt('6.2.0')
+    def test_xgroup_createconsumer(self, r):
+        stream = 'stream'
+        group = 'group'
+        consumer = 'consumer'
+        r.xadd(stream, {'foo': 'bar'})
+        r.xadd(stream, {'foo': 'bar'})
+        r.xgroup_create(stream, group, 0)
+        assert r.xgroup_createconsumer(stream, group, consumer) == 1
+
+        # read all messages from the group
+        r.xreadgroup(group, consumer, streams={stream: '>'})
+
+        # deleting the consumer should return 2 pending messages
+        assert r.xgroup_delconsumer(stream, group, consumer) == 2
+
     @skip_if_server_version_lt('5.0.0')
     def test_xgroup_destroy(self, r):
         stream = 'stream'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Support CREATECONSUMER on XGROUP