### PR TITLE
Implement/test LOLWUT command

### DIFF
--- a/redis/commands.py
+++ b/redis/commands.py
@@ -505,7 +505,9 @@ class Commands:
         return self.execute_command('LASTSAVE')
 
     def lolwut(self, *version_numbers):
-        "Get the Redis version and a piece of generative computer art"
+        """Get the Redis version and a piece of generative computer art
+        See: https://redis.io/commands/lolwut
+        """
         if version_numbers:
             return self.execute_command('LOLWUT VERSION', *version_numbers)
         else:

--- a/redis/commands.py
+++ b/redis/commands.py
@@ -504,6 +504,13 @@ class Commands:
         """
         return self.execute_command('LASTSAVE')
 
+    def lolwut(self, *version_numbers):
+        "Get the Redis version and a piece of generative computer art"
+        if version_numbers:
+            return self.execute_command('LOLWUT VERSION', *version_numbers)
+        else:
+            return self.execute_command('LOLWUT')
+
     def migrate(self, host, port, keys, destination_db, timeout,
                 copy=False, replace=False, auth=None):
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -518,6 +518,7 @@ class TestRedisCommands:
     def test_lastsave(self, r):
         assert isinstance(r.lastsave(), datetime.datetime)
 
+    @skip_if_server_version_lt('5.0.0')
     def test_lolwut(self, r):
         lolwut = r.lolwut().decode('utf-8')
         assert 'Redis ver.' in lolwut

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -518,6 +518,13 @@ class TestRedisCommands:
     def test_lastsave(self, r):
         assert isinstance(r.lastsave(), datetime.datetime)
 
+    def test_lolwut(self, r):
+        lolwut = r.lolwut().decode('utf-8')
+        assert 'Redis ver.' in lolwut
+
+        lolwut = r.lolwut(5, 6, 7, 8).decode('utf-8')
+        assert 'Redis ver.' in lolwut
+
     def test_object(self, r):
         r['a'] = 'foo'
         assert isinstance(r.object('refcount', 'a'), int)


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Does travis tests pass with this change (enable it first in your forked repo and wait for the travis build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Implement/test [`LOLWUT`](https://redis.io/commands/lolwut) command

This is a lot of fun to play with:

```python
>>> from redis import Redis
>>> redis = Redis()
>>> print(redis.lolwut(5, 6, 7, 8).decode('utf-8'))
⣴⣶⣶⣶⣶⡆
⣿⣿⣿⣿⣿⡇
⠹⡿⠟⣿⡿⠃
⠀⠀⠀⠀⠀⠀
Georg Nees - schotter, plotter on paper, 1968. Redis ver. 6.0.10

>>> print(redis.lolwut(5, 6, 7, 8).decode('utf-8'))
⢰⣶⣶⣶⣶⡆
⢿⣿⣿⣿⣿⠁
⠸⡿⢿⠿⡿⠃
⠀⠀⠀⠀⠀⠀
Georg Nees - schotter, plotter on paper, 1968. Redis ver. 6.0.10

>>> print(redis.lolwut(5, 6, 7, 8).decode('utf-8'))
⢰⣶⣶⣶⣶⡆
⣸⣿⣿⣻⣿⡅
⠿⡿⠻⠿⠿⠁
⠀⠀⠀⠀⠀⠀
Georg Nees - schotter, plotter on paper, 1968. Redis ver. 6.0.10

>>>
```