### PR TITLE
Auto-reconnect PubSub on `get_message`

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1259,7 +1259,10 @@ class PubSub:
 
         self.check_health()
 
-        if not block and not conn.can_read(timeout=timeout):
+        if(
+                not block
+                and not self._execute(conn, conn.can_read, timeout=timeout)
+        ):
             return None
         response = self._execute(conn, conn.read_response)
 


### PR DESCRIPTION
Wraps `conn.can_read()` in `_execute()`, so that a connection error is properly handled.

Fixes #1572.

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?  *I don't think a new test is necessary*
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?  *N/A*
