### PR TITLE
Use Oxford comma properly in getex

### DIFF
--- a/redis/commands.py
+++ b/redis/commands.py
@@ -843,7 +843,7 @@ class Commands:
 
         opset = set([ex, px, exat, pxat])
         if len(opset) > 2 or len(opset) > 1 and persist:
-            raise DataError("``ex``, ``px``, ``exat``, ``pxat``",
+            raise DataError("``ex``, ``px``, ``exat``, ``pxat``, "
                             "and ``persist`` are mutually exclusive.")
 
         pieces = []


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

I believe the original implementation was trying to use an Oxford comma in the exception.