### PR TITLE
test_xpending_range_negative should only test on 6.2.0

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3148,6 +3148,7 @@ class TestRedisCommands:
                                     min='-', max='+', count=5, idle=1000)
         assert len(response) == 0
 
+    @skip_if_server_version_lt('6.2.0')
     def test_xpending_range_negative(self, r):
         stream = 'stream'
         group = 'group'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This test includes using the idle command which was only included in 6.2.0