### PR TITLE
Add FULL option to XINFO SUMMARY

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -308,14 +308,24 @@ def parse_xautoclaim(response, **options):
     return parse_stream_list(response[1])
 
 
-def parse_xinfo_stream(response):
+def parse_xinfo_stream(response, **options):
     data = pairs_to_dict(response, decode_keys=True)
-    first = data['first-entry']
-    if first is not None:
-        data['first-entry'] = (first[0], pairs_to_dict(first[1]))
-    last = data['last-entry']
-    if last is not None:
-        data['last-entry'] = (last[0], pairs_to_dict(last[1]))
+    if not options.get('full', False):
+        first = data['first-entry']
+        if first is not None:
+            data['first-entry'] = (first[0], pairs_to_dict(first[1]))
+        last = data['last-entry']
+        if last is not None:
+            data['last-entry'] = (last[0], pairs_to_dict(last[1]))
+    else:
+        data['entries'] = {
+            _id: pairs_to_dict(entry)
+            for _id, entry in data['entries']
+        }
+        data['groups'] = [
+            pairs_to_dict(group, decode_keys=True)
+            for group in data['groups']
+        ]
     return data
 
 

--- a/redis/commands.py
+++ b/redis/commands.py
@@ -2050,12 +2050,18 @@ class Commands:
         """
         return self.execute_command('XINFO GROUPS', name)
 
-    def xinfo_stream(self, name):
+    def xinfo_stream(self, name, full=False):
         """
         Returns general information about the stream.
         name: name of the stream.
+        full: optional boolean, false by default. Return full summary
         """
-        return self.execute_command('XINFO STREAM', name)
+        pieces = [name]
+        options = {}
+        if full:
+            pieces.append(b'FULL')
+            options = {'full': full}
+        return self.execute_command('XINFO STREAM', *pieces, **options)
 
     def xlen(self, name):
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3156,6 +3156,18 @@ class TestRedisCommands:
         assert info['first-entry'] == get_stream_message(r, stream, m1)
         assert info['last-entry'] == get_stream_message(r, stream, m2)
 
+    @skip_if_server_version_lt('6.0.0')
+    def test_xinfo_stream_full(self, r):
+        stream = 'stream'
+        group = 'group'
+        m1 = r.xadd(stream, {'foo': 'bar'})
+        r.xgroup_create(stream, group, 0)
+        info = r.xinfo_stream(stream, full=True)
+
+        assert info['length'] == 1
+        assert m1 in info['entries']
+        assert len(info['groups']) == 1
+
     @skip_if_server_version_lt('5.0.0')
     def test_xlen(self, r):
         stream = 'stream'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

Add flag `FULL` to `XINFO STREAM` supported from Redis 6.0.0

https://redis.io/commands/xinfo
