### PR TITLE
Add python_requires setuptools check for python > 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url="https://github.com/redis/redis-py",
     author="Redis Inc.",
     author_email="oss@redis.com",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `$ tox` pass with this change (including linting)?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

I noticed that in your latest release candidate version 4.0.0b3 the Python 2.7 support has been removed but your forgot to add the `python_requires` check that will prevent users with Python 2.7 from downloading a sdist version that they cannot build on Python 2.7. 

Note: supporting python_requires requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

I open this MR in order to merge the python_requires before releasing the official version because if the official version will not have this check, the Python 2 users will not be able to build the sdist and in the end that new version should be yanked and release a new version with the python_requires check. 

