### PR TITLE
do not recreate replica ClusterNode for every slot

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1549,25 +1549,25 @@ class NodesManager:
                 # add this node to the nodes cache
                 tmp_nodes_cache[target_node.name] = target_node
 
+                target_replica_nodes = []
+                for replica_node in slot[3:]:
+                    host = str_if_bytes(replica_node[0])
+                    port = int(replica_node[1])
+                    host, port = self.remap_host_port(host, port)
+
+                    target_replica_node = self._get_or_create_cluster_node(
+                        host, port, REPLICA, tmp_nodes_cache
+                    )
+                    target_replica_nodes.append(target_replica_node)
+                    # add this node to the nodes cache
+                    tmp_nodes_cache[target_replica_node.name] = target_replica_node
+
                 for i in range(int(slot[0]), int(slot[1]) + 1):
                     if i not in tmp_slots:
                         tmp_slots[i] = []
                         tmp_slots[i].append(target_node)
-                        replica_nodes = [slot[j] for j in range(3, len(slot))]
-
-                        for replica_node in replica_nodes:
-                            host = str_if_bytes(replica_node[0])
-                            port = replica_node[1]
-                            host, port = self.remap_host_port(host, port)
-
-                            target_replica_node = self._get_or_create_cluster_node(
-                                host, port, REPLICA, tmp_nodes_cache
-                            )
+                        for target_replica_node in target_replica_nodes:
                             tmp_slots[i].append(target_replica_node)
-                            # add this node to the nodes cache
-                            tmp_nodes_cache[
-                                target_replica_node.name
-                            ] = target_replica_node
                     else:
                         # Validate that 2 nodes want to use the same slot cache
                         # setup


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Do tests and lints pass with this change?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
previous implementation is creating replica nodes repeatedly for the number of slots and slicing `slot` array by creating a new array. This PR removes unnecessary overhead to optimize the performance of `initialize` method

i didn't add test code as `test_init_slots_cache` should be enough to cover the changes

timing test result on my local machine:
```
iteration count = 1000
number of rows in CLUSTER SLOTS response: 50

original implementation => 14.714476291002939 seconds
new implementation => 2.973068332998083 seconds
```
timing test code: https://github.com/zakaf/redis-py/blob/64cb53e0313ffc0f5f674153e981a57eb81dd8ee/tests/test_cluster.py#L2647-L2727
