### PR TITLE
Adding a twine check prior to package release

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -27,6 +27,10 @@ jobs:
           python setup.py build
           python setup.py sdist bdist_wheel
 
+      - name: Basic package test prior to upload
+        run: |
+          twine check dist/*
+
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Twine supports a basic check for the package prior to upload. Prior to this the package was built and installed via a different CI.

It is theoretically possible for the associated tools (or a python version) to create broken packages, in between the initial pull request, and an actual release. This at least adds a basic safety check.
