### PR TITLE
Fixing the return type hint for the transaction method in the standalone client.

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -450,7 +450,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
 
     def transaction(
         self, func: Callable[["Pipeline"], None], *watches, **kwargs
-    ) -> Optional[Union[List[Any], Any]]:
+    ) -> Union[List[Any], Any, None]:
         """
         Convenience method for executing the callable `func` as a transaction
         while watching all keys specified in `watches`. The 'func' callable


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Fixing the return type hint for the transaction method in the standalone client.
The method returns either the returned response from execute method call which is List[Any] or None, or the response from the provided custom function, which can be anything.

Fixes issue #3631 
