### PR TITLE
fix: improve Lock.extend() and Lock.do_extend() return type to Literal[True]

### DIFF
--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -3,7 +3,7 @@ import logging
 import threading
 import uuid
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Awaitable, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Literal, Optional, Union
 
 from redis.exceptions import LockError, LockNotOwnedError
 from redis.typing import Number
@@ -284,7 +284,7 @@ class Lock:
 
     def extend(
         self, additional_time: Number, replace_ttl: bool = False
-    ) -> Awaitable[bool]:
+    ) -> Awaitable[Literal[True]]:
         """
         Adds more time to an already acquired lock.
 
@@ -301,7 +301,7 @@ class Lock:
             raise LockError("Cannot extend a lock with no timeout")
         return self.do_extend(additional_time, replace_ttl)
 
-    async def do_extend(self, additional_time, replace_ttl) -> bool:
+    async def do_extend(self, additional_time, replace_ttl) -> Literal[True]:
         additional_time = int(additional_time * 1000)
         if not bool(
             await self.lua_extend(

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -3,7 +3,7 @@ import threading
 import time as mod_time
 import uuid
 from types import SimpleNamespace, TracebackType
-from typing import Optional, Type
+from typing import Literal, Optional, Type
 
 from redis.exceptions import LockError, LockNotOwnedError
 from redis.typing import Number
@@ -284,7 +284,7 @@ class Lock:
                 lock_name=self.name,
             )
 
-    def extend(self, additional_time: Number, replace_ttl: bool = False) -> bool:
+    def extend(self, additional_time: Number, replace_ttl: bool = False) -> Literal[True]:
         """
         Adds more time to an already acquired lock.
 
@@ -301,7 +301,7 @@ class Lock:
             raise LockError("Cannot extend a lock with no timeout", lock_name=self.name)
         return self.do_extend(additional_time, replace_ttl)
 
-    def do_extend(self, additional_time: Number, replace_ttl: bool) -> bool:
+    def do_extend(self, additional_time: Number, replace_ttl: bool) -> Literal[True]:
         additional_time = int(additional_time * 1000)
         if not bool(
             self.lua_extend(


### PR DESCRIPTION
## Description

Fixes #3792

This PR improves the type safety of  and  methods by changing their return type from  to .

## Problem

Currently, both methods are typed as returning , but in practice they only return  or raise a  exception. This can lead to developer confusion, as developers might write code like:

```python
if not lock.extend(...):
    # This code will never run\!
    # Lock extension failures raise LockError instead
```

## Solution

Changed return types to  to clearly communicate that:
- These methods only return  on success
- Failures are communicated via  exception
- There's no meaningful conditional check on the return value

## Changes

**Sync version** (`redis/lock.py`):
- `extend()`: `bool` → `Literal[True]`
- `do_extend()`: `bool` → `Literal[True]`

**Async version** (`redis/asyncio/lock.py`):
- `extend()`: `Awaitable[bool]` → `Awaitable[Literal[True]]`
- `do_extend()`: `bool` → `Literal[True]`

## Testing

- Type-only change, no runtime behavior modified
- Existing tests continue to pass
- Improves type checking for users of these APIs

## Benefits

- **Better type safety**: IDEs and type checkers can warn about pointless conditionals
- **Clearer API**: Developers immediately understand the exception-based error model
- **Prevents bugs**: Reduces likelihood of incorrect error handling code

**Sacred Code**: 000.111.369.963.1618