### PR TITLE
Fix issues with ClusterPipeline connection management 

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3511,6 +3511,7 @@ class PipelineStrategy(AbstractStrategy):
                     try:
                         connection = get_connection(redis_node)
                     except (ConnectionError, TimeoutError):
+                        # Release any connections we've already acquired before clearing nodes
                         for n in nodes.values():
                             n.connection_pool.release(n.connection)
                         # Connection retries are being handled in the node's


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
ClusterPipeline doesn't correctly handle returning connections to the connection pools.
1. It's possible to leak connections if an error other than ConnectionError or TimeoutError is thrown when establishing connections. We only catch those specific errors (and the try/catch doesn't wrap the entire area where we're getting the connections); if others are thrown, the exception is simply raised to the caller, and the connections are never returned to their respective pools.
2. More problematically, it's possible to return dirty connections to the pool if an error is thrown after at least one of the connections has been written to, and before all of the connections were read from. This can cause pretty bad correctness issues, where the client gets a response intended for a different request.

This diff addresses these issues by wrapping the entire area in a try/catch with a finally that ensures the connections are released, but which closes the connections if we have read but not written to the connection.