### PR TITLE
Hold references to ClusterNode disconnect task

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1493,7 +1493,9 @@ class NodesManager:
                     # not to wait for the disconnects
                     removed_node = old.pop(name)
                     removed_node.update_active_connections_for_reconnect()
-                    task = asyncio.create_task(removed_node.disconnect_free_connections())
+                    task = asyncio.create_task(
+                        removed_node.disconnect_free_connections()
+                    )
                     self._background_tasks.add(task)
                     task.add_done_callback(self._background_tasks.discard)
 


### PR DESCRIPTION
Thank you for this awesome library!  I've been a long-time user of this project ✨ 

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

I found a potential bug and have fixed it.
This fix aligns with the recommendations in the official documentation linked below, as I have personally encountered unintended task loss due to this issue in the past.

> Important: Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done. For reliable “fire-and-forget” background tasks, gather them in a collection...

https://docs.python.org/3.13/library/asyncio-task.html#asyncio.create_task

