### PR TITLE
Changing log level to be debug for failed maintenance notification enablement per connection when enabled='auto'

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -539,7 +539,7 @@ class MaintNotificationsAbstractConnection:
                 import logging
 
                 logger = logging.getLogger(__name__)
-                logger.warning(f"Failed to enable maintenance notifications: {e}")
+                logger.debug(f"Failed to enable maintenance notifications: {e}")
             else:
                 raise
 


### PR DESCRIPTION
Changing/Decreasing the log level from WARN to DEBUG for the log message related to the case when the maintenance notifications feature is enabled in "auto" mode and the server command that allows the notifications fails.
