### PR TITLE
Use `MaxConnectionsError` in the asyncio pool too

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -57,6 +57,7 @@ from redis.exceptions import (
     AuthenticationWrongNumberOfArgsError,
     ConnectionError,
     DataError,
+    MaxConnectionsError,
     RedisError,
     ResponseError,
     TimeoutError,
@@ -1208,7 +1209,7 @@ class ConnectionPool:
             connection = self._available_connections.pop()
         except IndexError:
             if len(self._in_use_connections) >= self.max_connections:
-                raise ConnectionError("Too many connections") from None
+                raise MaxConnectionsError("Too many connections") from None
             connection = self.make_connection()
         self._in_use_connections.add(connection)
         return connection


### PR DESCRIPTION
### Description of change

This aligns to the docs which indicate that this error type will be used when pool attempts to create more connections than are allowed.

Fixes https://github.com/redis/redis-py/issues/3237

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
       Unknown
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
       Docs already suggested this was the behaviour.
- [x] Is there an example added to the examples folder (if applicable)?
