### PR TITLE
Idle connection management

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -251,7 +251,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
         idle_connection_timeout: Optional[float] = None,
-        idle_check_interval: Optional[float] = None,
+        idle_check_interval: float = 60.0,
     ) -> None:
         """
         Initialize a new Redis client.

--- a/redis/client.py
+++ b/redis/client.py
@@ -250,6 +250,8 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         cache_config: Optional[CacheConfig] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
+        idle_connection_timeout: Optional[float] = None,
+        idle_check_interval: Optional[float] = None,
     ) -> None:
         """
         Initialize a new Redis client.
@@ -314,6 +316,8 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                 "redis_connect_func": redis_connect_func,
                 "credential_provider": credential_provider,
                 "protocol": protocol,
+                "idle_connection_timeout": idle_connection_timeout,
+                "idle_check_interval": idle_check_interval,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/client.py
+++ b/redis/client.py
@@ -125,6 +125,17 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     Connection object to talk to redis.
 
     It is not safe to pass PubSub or Pipeline objects between threads.
+
+    :param float idle_connection_timeout:
+        If set, connections that have been idle for longer than this timeout
+        (in seconds) will be automatically closed. If unset, idle connections
+        are never closed. This parameter is passed through to the connection pool
+        constructor, so it's only used when a connection_pool instance is not provided.
+    :param float idle_check_interval:
+        Minimum time between idle connection cleanup runs. Defaults to 60 seconds.
+        Only used when idle_connection_timeout is set. As with idle_connection_timeout,
+        this parameter is passed through to the connection pool constructor,
+        so it's only used when a connection_pool instance is not provided.
     """
 
     @classmethod

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -196,6 +196,8 @@ REDIS_ALLOWED_KEYS = (
     "username",
     "cache",
     "cache_config",
+    "idle_connection_timeout",
+    "idle_check_interval",
 )
 KWARGS_DISABLED_KEYS = ("host", "port", "retry")
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2385,14 +2385,13 @@ def _cleanup_idle_connections_worker(
         check_interval: How often to check for idle connections (seconds)
     """
     while True:
-        # Wait for the check interval or stop event
         if stop_event.wait(timeout=check_interval):
-            # Stop event was set, exit thread
+            # the pool is being explicitly closed
             break
 
-        # Check again if pool still exists before cleanup
         pool = pool_ref()
         if pool is None:
+            # our weak reference points to nothing now; the pool has been GC'd.
             break
 
         try:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2433,16 +2433,9 @@ class IdleConnectionCleanupManager:
         self._worker_thread.start()
 
     def register_pool(self, pool: "ConnectionPool", next_check_time: float) -> None:
-        """Register or re-register a pool for idle connection cleanup.
+        # Register a pool for idle connection cleanup.
+        # Called when a connection is released.
 
-        This is called both on pool initialization and when releasing a connection
-        to an empty pool that was previously removed from tracking.
-
-        Args:
-            pool: The ConnectionPool to register
-            next_check_time: When to check this pool next. If None, defaults to
-                            now + idle_connection_timeout
-        """
         if pool.idle_connection_timeout is None:
             # no need to register, because this pool doesn't close idle connections
             return
@@ -2469,11 +2462,7 @@ class IdleConnectionCleanupManager:
             self._condition.notify()
 
     def unregister_pool(self, pool: "ConnectionPool") -> None:
-        """Unregister a pool from cleanup (optional optimization).
-
-        Args:
-            pool: The ConnectionPool to unregister
-        """
+        # Unregister a pool from cleanup
         pool_id = id(pool)
         with self._condition:
             self._registered_pools.discard(pool_id)
@@ -2482,7 +2471,7 @@ class IdleConnectionCleanupManager:
             # processes the entry.
 
     def _worker_loop(self) -> None:
-        """Main worker loop. Processes pools in priority order."""
+        # processes pools in schedule order
         while not self._shutdown_event.is_set():
             try:
                 with self._condition:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -987,9 +987,7 @@ class MockDateTime:
         mock_time = self._time_patcher.__enter__()
 
         mock_datetime.datetime.now = lambda: self.current_time
-        mock_datetime.datetime.side_effect = lambda *args, **kwargs: datetime.datetime(
-            *args, **kwargs
-        )
+        mock_datetime.datetime.side_effect = datetime.datetime
         mock_time.time = lambda: self.current_time.timestamp()
 
         return self

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1397,3 +1397,130 @@ class TestIdleConnectionTimeout:
 
         for pool in pools:
             pool.close()
+
+    def test_manager_automatically_cleans_idle_connections(self):
+        """Integration test: Manager automatically cleans up idle connections without manual trigger."""
+        import time
+
+        pool = redis.ConnectionPool(
+            connection_class=DummyConnection,
+            idle_connection_timeout=0.1,  # 100ms timeout
+            idle_check_interval=0.05,  # Check every 50ms
+        )
+
+        try:
+            # Get and release a connection
+            conn1 = pool.get_connection()
+            pool.release(conn1)
+
+            # Should have 1 available connection
+            assert len(pool._available_connections) == 1
+            assert pool._created_connections == 1
+
+            # Wait for manager to clean it up automatically (no manual call to _cleanup_idle_connections)
+            # Need to wait: idle_timeout (100ms) + check_interval (50ms) + small buffer
+            time.sleep(0.2)
+
+            # The manager should have cleaned it up automatically
+            assert len(pool._available_connections) == 0
+            assert pool._created_connections == 0
+        finally:
+            pool.close()
+
+    def test_manager_reschedules_pools_after_cleanup(self):
+        """Integration test: Manager reschedules pools that still have connections after cleanup."""
+        import time
+
+        pool = redis.ConnectionPool(
+            connection_class=DummyConnection,
+            idle_connection_timeout=0.15,  # 150ms timeout
+            idle_check_interval=0.05,  # Check every 50ms
+        )
+
+        try:
+            # Get and release two connections
+            conn1 = pool.get_connection()
+            conn2 = pool.get_connection()
+            pool.release(conn1)
+
+            # Wait 100ms, then release conn2
+            time.sleep(0.1)
+            pool.release(conn2)
+
+            # Now we have:
+            # - conn1: idle for ~100ms
+            # - conn2: idle for ~0ms
+
+            # Wait for first cleanup cycle (conn1 should be cleaned, conn2 should stay)
+            time.sleep(0.1)  # Total: conn1 at ~200ms, conn2 at ~100ms
+
+            # conn1 should be cleaned (>150ms), conn2 should remain (<150ms)
+            assert len(pool._available_connections) == 1
+            assert pool._created_connections == 1
+
+            # Verify pool was rescheduled by waiting for another cleanup cycle
+            time.sleep(0.1)  # Total: conn2 at ~200ms
+
+            # Now conn2 should also be cleaned
+            assert len(pool._available_connections) == 0
+            assert pool._created_connections == 0
+        finally:
+            pool.close()
+
+    def test_manager_removes_empty_pools_from_tracking(self):
+        """Integration test: Manager removes empty pools from its internal tracking."""
+        import time
+
+        pool = redis.ConnectionPool(
+            connection_class=DummyConnection,
+            idle_connection_timeout=0.1,  # 100ms timeout
+            idle_check_interval=0.05,  # Check every 50ms
+        )
+
+        try:
+            # Get and release a connection
+            conn = pool.get_connection()
+            pool.release(conn)
+
+            # Pool should be registered
+            manager = redis.connection.IdleConnectionCleanupManager.get_instance()
+            pool_id = id(pool)
+            assert pool_id in manager._registered_pools
+
+            # Wait for cleanup
+            time.sleep(0.2)
+
+            # Pool should be empty
+            assert len(pool._available_connections) == 0
+
+            # Pool should be removed from manager's tracking
+            assert pool_id not in manager._registered_pools
+        finally:
+            pool.close()
+
+    def test_manager_schedules_at_correct_time(self):
+        """Integration test: Manager schedules cleanups at the correct time based on idle_timeout."""
+        import time
+
+        pool = redis.ConnectionPool(
+            connection_class=DummyConnection,
+            idle_connection_timeout=0.2,  # 200ms timeout
+            idle_check_interval=0.05,  # Check every 50ms
+        )
+
+        try:
+            # Get and release a connection
+            conn = pool.get_connection()
+            pool.release(conn)
+
+            # Connection should NOT be cleaned up before timeout
+            time.sleep(0.1)  # 100ms - less than 200ms timeout
+            assert len(pool._available_connections) == 1
+            assert pool._created_connections == 1
+
+            # Connection SHOULD be cleaned up after timeout
+            time.sleep(0.15)  # Total 250ms - more than 200ms timeout
+            assert len(pool._available_connections) == 0
+            assert pool._created_connections == 0
+        finally:
+            pool.close()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1056,7 +1056,14 @@ class TestIdleConnectionTimeout:
             idle_connection_timeout=None,
         )
         manager = redis.connection.IdleConnectionCleanupManager.get_instance()
-        assert id(pool) not in manager._registered_pools
+        assert id(pool) not in manager._registered_pool_ids
+        pool.close()
+
+        # Get and release a connection, which would trigger registration if we had set the idle timeout
+        conn = pool.get_connection()
+        pool.release(conn)
+
+        assert id(pool) not in manager._registered_pool_ids
         pool.close()
 
     def test_pool_registered_with_timeout(self):
@@ -1069,36 +1076,19 @@ class TestIdleConnectionTimeout:
         manager = redis.connection.IdleConnectionCleanupManager.get_instance()
 
         # Pool is not registered until a connection is released
-        assert id(pool) not in manager._registered_pools
+        assert id(pool) not in manager._registered_pool_ids
 
         # Get and release a connection to trigger registration
         conn = pool.get_connection()
         pool.release(conn)
 
-        assert id(pool) in manager._registered_pools
+        assert id(pool) in manager._registered_pool_ids
         assert manager._worker_thread is not None
         assert manager._worker_thread.is_alive()
         pool.close()
 
-    def test_pool_unregistered_on_close(self):
-        """Test that pool is unregistered from manager when closed."""
-        pool = redis.ConnectionPool(
-            connection_class=DummyConnection,
-            idle_connection_timeout=10.0,
-            idle_check_interval=1.0,
-        )
-        manager = redis.connection.IdleConnectionCleanupManager.get_instance()
-        pool_id = id(pool)
-
-        # Get and release a connection to trigger registration
-        conn = pool.get_connection()
-        pool.release(conn)
-
-        # Pool should now be registered
-        assert pool_id in manager._registered_pools
-        pool.close()
         # After close, pool should be unregistered
-        assert pool_id not in manager._registered_pools
+        assert id(pool) not in manager._registered_pool_ids
 
     def test_idle_connections_cleaned_up(self):
         """Test that idle connections are actually cleaned up."""
@@ -1255,24 +1245,12 @@ class TestIdleConnectionTimeout:
         conn = pool.get_connection()
         pool.release(conn)
 
-        pool_id = id(pool)
-        # Pool should be registered with manager
-        assert pool_id in manager._registered_pools
+        assert id(pool) in manager._registered_pool_ids
 
-        # Create a weak reference to the pool
         pool_weak_ref = weakref.ref(pool)
-
-        # Drop the pool reference
         del pool
-
-        # Force garbage collection
         gc.collect()
-
-        # Pool should be garbage collected
         assert pool_weak_ref() is None
-
-        # Manager should eventually clean up the dead pool reference
-        # (this happens in _cleanup_dead_pools which is called in the worker loop)
 
     def test_manager_singleton(self):
         """Test that IdleConnectionCleanupManager is a singleton."""
@@ -1299,19 +1277,15 @@ class TestIdleConnectionTimeout:
         manager = redis.connection.IdleConnectionCleanupManager.get_instance()
 
         # Both pools should be registered with the same manager
-        assert id(pool1) in manager._registered_pools
-        assert id(pool2) in manager._registered_pools
-
-        # Manager should have only one worker thread
-        assert manager._worker_thread is not None
-        assert manager._worker_thread.is_alive()
+        assert id(pool1) in manager._registered_pool_ids
+        assert id(pool2) in manager._registered_pool_ids
 
         pool1.close()
         pool2.close()
 
     def test_manager_connection_release_notification(self):
         """Test that manager is notified when connections are released."""
-        with MockDateTime() as mock_time:
+        with MockDateTime():
             pool = redis.ConnectionPool(
                 connection_class=DummyConnection,
                 idle_connection_timeout=10.0,
@@ -1323,23 +1297,22 @@ class TestIdleConnectionTimeout:
 
             # Get and release a connection
             conn = pool.get_connection()
-            release_time = time.time()
             pool.release(conn)
 
             # Manager should have metadata for this pool
-            assert pool_id in manager._registered_pools
+            assert pool_id in manager._registered_pool_ids
             metadata = manager._schedule[0]
 
             # Check that idle_timeout and check_interval are stored correctly
             assert metadata.pool_id == pool_id
             assert metadata.idle_timeout == 10.0
-            assert metadata.check_interval == 5.0
+            assert metadata.minimum_check_interval == 5.0
 
             pool.close()
 
     def test_manager_schedules_multiple_pools(self):
         """Test that manager correctly schedules cleanup for multiple pools."""
-        with MockDateTime() as mock_time:
+        with MockDateTime():
             # Create pools with different timeouts
             pool1 = redis.ConnectionPool(
                 connection_class=DummyConnection,
@@ -1376,9 +1349,13 @@ class TestIdleConnectionTimeout:
         pool_id = id(pool)
 
         # Now pool should not be tracked
-        assert pool_id not in manager._registered_pools
+        assert pool_id not in manager._registered_pool_ids
         # Filter for this pool_id AND check that weakref is not dead (in case memory address was reused)
-        schedule = [entry for entry in manager._schedule if entry.pool_id == pool_id and entry.pool_ref() is not None]
+        schedule = [
+            entry
+            for entry in manager._schedule
+            if entry.pool_id == pool_id and entry.pool_ref() is not None
+        ]
         assert len(schedule) == 0
 
         # Release a connection
@@ -1386,38 +1363,16 @@ class TestIdleConnectionTimeout:
         pool.release(conn)
 
         # Pool should now be re-registered and scheduled
-        assert pool_id in manager._registered_pools
+        assert pool_id in manager._registered_pool_ids
         # Filter for this pool_id AND check that weakref is not dead (in case memory address was reused)
-        schedule = [entry for entry in manager._schedule if entry.pool_id == pool_id and entry.pool_ref() is not None]
+        schedule = [
+            entry
+            for entry in manager._schedule
+            if entry.pool_id == pool_id and entry.pool_ref() is not None
+        ]
         assert len(schedule) == 1
 
         pool.close()
-
-    def test_no_per_pool_threads(self):
-        """Test that creating many pools doesn't create many threads."""
-        import threading
-
-        initial_thread_count = threading.active_count()
-
-        pools = []
-        for i in range(10):
-            pool = redis.ConnectionPool(
-                connection_class=DummyConnection,
-                idle_connection_timeout=10.0,
-                idle_check_interval=1.0,
-            )
-            pools.append(pool)
-
-        # Should only have one additional thread (the manager's worker)
-        # Not 10 threads (one per pool)
-        final_thread_count = threading.active_count()
-        new_threads = final_thread_count - initial_thread_count
-
-        # Allow some tolerance for test infrastructure threads, but should be much less than 10
-        assert new_threads <= 2, f"Expected at most 2 new threads, got {new_threads}"
-
-        for pool in pools:
-            pool.close()
 
     def test_manager_automatically_cleans_idle_connections(self):
         """Integration test: Manager automatically cleans up idle connections without manual trigger."""
@@ -1544,7 +1499,7 @@ class TestIdleConnectionTimeout:
                 # Pool should be registered
                 manager = redis.connection.IdleConnectionCleanupManager.get_instance()
                 pool_id = id(pool)
-                assert pool_id in manager._registered_pools
+                assert pool_id in manager._registered_pool_ids
 
                 # Advance time past timeout
                 mock_time.advance(1.5)
@@ -1556,7 +1511,7 @@ class TestIdleConnectionTimeout:
                 # Poll until cleanup happens
                 deadline = time.time() + 1.0
                 while time.time() < deadline:
-                    if pool_id not in manager._registered_pools:
+                    if pool_id not in manager._registered_pool_ids:
                         break
                     time.sleep(0.01)
 
@@ -1564,7 +1519,7 @@ class TestIdleConnectionTimeout:
                 assert len(pool._available_connections) == 0
 
                 # Pool should be removed from manager's tracking
-                assert pool_id not in manager._registered_pools
+                assert pool_id not in manager._registered_pool_ids
             finally:
                 pool.close()
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1377,7 +1377,8 @@ class TestIdleConnectionTimeout:
 
         # Now pool should not be tracked
         assert pool_id not in manager._registered_pools
-        schedule = [entry for entry in manager._schedule if entry.pool_id == pool_id]
+        # Filter for this pool_id AND check that weakref is not dead (in case memory address was reused)
+        schedule = [entry for entry in manager._schedule if entry.pool_id == pool_id and entry.pool_ref() is not None]
         assert len(schedule) == 0
 
         # Release a connection
@@ -1386,7 +1387,8 @@ class TestIdleConnectionTimeout:
 
         # Pool should now be re-registered and scheduled
         assert pool_id in manager._registered_pools
-        schedule = [entry for entry in manager._schedule if entry.pool_id == pool_id]
+        # Filter for this pool_id AND check that weakref is not dead (in case memory address was reused)
+        schedule = [entry for entry in manager._schedule if entry.pool_id == pool_id and entry.pool_ref() is not None]
         assert len(schedule) == 1
 
         pool.close()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -2,7 +2,6 @@ import datetime
 import gc
 import os
 import re
-import sys
 import time
 import weakref
 from contextlib import closing

--- a/tests/test_maint_notifications_handling.py
+++ b/tests/test_maint_notifications_handling.py
@@ -104,12 +104,7 @@ class Helpers:
     ):
         """Helper method to validate state of free/available connections."""
 
-        if isinstance(pool, BlockingConnectionPool):
-            free_connections = [conn for conn in pool.pool.queue if conn is not None]
-        elif isinstance(pool, ConnectionPool):
-            free_connections = pool._available_connections
-        else:
-            raise ValueError(f"Unsupported pool type: {type(pool)}")
+        free_connections = pool._get_free_connections()
 
         connected_count = 0
         for connection in free_connections:
@@ -2076,10 +2071,7 @@ class TestMaintenanceNotificationsHandlingMultipleProxies(
         )
         # validate free connections for ip1
         changed_free_connections = 0
-        if isinstance(pool, BlockingConnectionPool):
-            free_connections = [conn for conn in pool.pool.queue if conn is not None]
-        elif isinstance(pool, ConnectionPool):
-            free_connections = pool._available_connections
+        free_connections = pool._get_free_connections()
         for conn in free_connections:
             if conn.host == new_ip:
                 changed_free_connections += 1
@@ -2126,10 +2118,7 @@ class TestMaintenanceNotificationsHandlingMultipleProxies(
         )
         # validate free connections for ip2
         changed_free_connections = 0
-        if isinstance(pool, BlockingConnectionPool):
-            free_connections = [conn for conn in pool.pool.queue if conn is not None]
-        elif isinstance(pool, ConnectionPool):
-            free_connections = pool._available_connections
+        free_connections = pool._get_free_connections()
         for conn in free_connections:
             if conn.host == new_ip_2:
                 changed_free_connections += 1

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -125,7 +125,9 @@ class TestMultiprocessing:
                 pool.release(parent_conn)
                 assert pool._created_connections == 1
                 assert child_conn in [p.connection for p in pool._available_connections]
-                assert parent_conn not in [p.connection for p in pool._available_connections]
+                assert parent_conn not in [
+                    p.connection for p in pool._available_connections
+                ]
 
         proc = self._mp_context.Process(target=target, args=(pool, parent_conn))
         proc.start()

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -121,11 +121,11 @@ class TestMultiprocessing:
                 assert child_conn.pid != parent_conn.pid
                 pool.release(child_conn)
                 assert pool._created_connections == 1
-                assert child_conn in pool._available_connections
+                assert child_conn in [p.connection for p in pool._available_connections]
                 pool.release(parent_conn)
                 assert pool._created_connections == 1
-                assert child_conn in pool._available_connections
-                assert parent_conn not in pool._available_connections
+                assert child_conn in [p.connection for p in pool._available_connections]
+                assert parent_conn not in [p.connection for p in pool._available_connections]
 
         proc = self._mp_context.Process(target=target, args=(pool, parent_conn))
         proc.start()

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -184,8 +184,8 @@ class TestPushNotifications:
     def _get_all_connections_in_pool(self, client: Redis) -> List[ConnectionInterface]:
         connections = []
         if hasattr(client.connection_pool, "_available_connections"):
-            for conn in client.connection_pool._available_connections:
-                connections.append(conn)
+            for pooled_conn in client.connection_pool._available_connections:
+                connections.append(pooled_conn.connection)
         if hasattr(client.connection_pool, "_in_use_connections"):
             for conn in client.connection_pool._in_use_connections:
                 connections.append(conn)


### PR DESCRIPTION
### Description of change
Adds idle connection management to `ConnectionPool`. This is disabled by default, but clients can configure a `idle_connection_timeout`. If set, connections that aren't used for longer than the configured timeout are closed automatically by a background thread. (There's a singleton `IdleConnectionCleanupManager` which schedules these checks for all connection pools, to avoid needing to allocate a separate thread for each pool.)

Right now, because connections are never closed once opened, clients have a "high water mark" property - the client will hold open as many connections as it needed during the busiest period that client has experienced. This can cause far more connections to be used than are really needed, as well as making the number of connections used difficult to reason about. I've deployed this patch to production, and seen a roughly 2x reduction in connections used in practice, on a large deployment of clients.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
