### PR TITLE
remove remaining imports of typing_extensions

### DIFF
--- a/redis/multidb/config.py
+++ b/redis/multidb/config.py
@@ -1,13 +1,8 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Type, Union
+from typing import List, Optional, Type, Union
 
 import pybreaker
-
-try:
-    from typing import Optional  # Py 3.11+
-except ImportError:
-    from typing_extensions import Optional
 
 from redis import ConnectionPool, Redis, RedisCluster
 from redis.backoff import ExponentialWithJitterBackoff, NoBackoff

--- a/redis/multidb/failure_detector.py
+++ b/redis/multidb/failure_detector.py
@@ -2,12 +2,7 @@ import math
 import threading
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import List, Type
-
-try:
-    from typing import Optional  # Py 3.11+
-except ImportError:
-    from typing_extensions import Optional
+from typing import List, Optional, Type
 
 from redis.multidb.circuit import State as CBState
 


### PR DESCRIPTION
### Description of change
It's not a dependency anymore:
https://github.com/redis/redis-py/blob/fb3095480c794846a906ad2876424e8404ff4b34/pyproject.toml#L31

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
