### PR TITLE
SentinelConnectionPool should retrieve updated master address from Sentinel on connection retries

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -323,6 +323,8 @@ class AbstractConnection:
             raise TimeoutError("Timeout connecting to server")
         except OSError as e:
             raise ConnectionError(self._error_message(e))
+        except ConnectionError:
+            raise
         except Exception as exc:
             raise ConnectionError(exc) from exc
 

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -50,7 +50,8 @@ class SentinelManagedConnection(Connection):
         async for slave in self.connection_pool.rotate_slaves():
             try:
                 self.host, self.port = slave
-                return await super()._connect()
+                await super()._connect()
+                return None
             except ConnectionError:
                 continue
         raise SlaveNotFoundError  # Never be here

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -39,7 +39,7 @@ class SentinelManagedConnection(Connection):
 
     def _connect(self):
         if self._sock:
-            return super()._connect() # already connected
+            return super()._connect()  # already connected
         if self.connection_pool.is_master:
             self.host, self.port = self.connection_pool.get_master_address()
             return super()._connect()

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -39,12 +39,10 @@ class SentinelManagedConnection(Connection):
 
     def _connect(self):
         if self._sock:
-            super()._connect()
-            return None # already connected
+            return super()._connect() # already connected
         if self.connection_pool.is_master:
             self.host, self.port = self.connection_pool.get_master_address()
-            super()._connect()
-            return None
+            return super()._connect()
         for slave in self.connection_pool.rotate_slaves():
             try:
                 self.host, self.port = slave

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -36,3 +36,29 @@ async def test_connect_retry_on_timeout_error(connect_args):
         assert mock_super_connect.await_count == 3
         assert connection_pool.get_master_address.call_count == 3
         await conn.disconnect()
+
+async def test_connect_check_health_retry_on_timeout_error(connect_args):
+    """Test that the _connect function is retried in case of a timeout"""
+    connection_pool = mock.AsyncMock()
+    connection_pool.get_master_address = mock.AsyncMock(
+        return_value=(connect_args["host"], connect_args["port"])
+    )
+    conn = SentinelManagedConnection(
+        retry_on_timeout=True,
+        retry=Retry(NoBackoff(), 3),
+        connection_pool=connection_pool,
+    )
+    original_super_connect = Connection._connect.__get__(conn, Connection)
+
+    with mock.patch.object(Connection, "_connect", new_callable=mock.AsyncMock) as mock_super_connect:
+        async def side_effect(*args, **kwargs):
+            if mock_super_connect.await_count <= 2:
+                raise socket.timeout()
+            return await original_super_connect(*args, **kwargs)
+
+        mock_super_connect.side_effect = side_effect
+
+        await conn.connect_check_health()
+        assert mock_super_connect.await_count == 3
+        assert connection_pool.get_master_address.call_count == 3
+        await conn.disconnect()

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -24,7 +24,10 @@ async def test_connect_retry_on_timeout_error(connect_args):
     )
     original_super_connect = Connection._connect.__get__(conn, Connection)
 
-    with mock.patch.object(Connection, "_connect", new_callable=mock.AsyncMock) as mock_super_connect:
+    with mock.patch.object(
+        Connection, "_connect", new_callable=mock.AsyncMock
+    ) as mock_super_connect:
+
         async def side_effect(*args, **kwargs):
             if mock_super_connect.await_count <= 2:
                 raise socket.timeout()
@@ -36,6 +39,7 @@ async def test_connect_retry_on_timeout_error(connect_args):
         assert mock_super_connect.await_count == 3
         assert connection_pool.get_master_address.call_count == 3
         await conn.disconnect()
+
 
 async def test_connect_check_health_retry_on_timeout_error(connect_args):
     """Test that the _connect function is retried in case of a timeout"""
@@ -50,7 +54,10 @@ async def test_connect_check_health_retry_on_timeout_error(connect_args):
     )
     original_super_connect = Connection._connect.__get__(conn, Connection)
 
-    with mock.patch.object(Connection, "_connect", new_callable=mock.AsyncMock) as mock_super_connect:
+    with mock.patch.object(
+        Connection, "_connect", new_callable=mock.AsyncMock
+    ) as mock_super_connect:
+
         async def side_effect(*args, **kwargs):
             if mock_super_connect.await_count <= 2:
                 raise socket.timeout()

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -20,7 +20,10 @@ def test_connect_retry_on_timeout_error(master_host):
     )
     original_super_connect = Connection._connect.__get__(conn, Connection)
 
-    with mock.patch.object(Connection, "_connect", new_callable=mock.Mock) as mock_super_connect:
+    with mock.patch.object(
+        Connection, "_connect", new_callable=mock.Mock
+    ) as mock_super_connect:
+
         def side_effect(*args, **kwargs):
             if mock_super_connect.call_count <= 2:
                 raise socket.timeout()
@@ -32,6 +35,7 @@ def test_connect_retry_on_timeout_error(master_host):
         assert mock_super_connect.call_count == 3
         assert connection_pool.get_master_address.call_count == 3
         conn.disconnect()
+
 
 def test_connect_check_health_retry_on_timeout_error(master_host):
     """Test that the _connect function is retried in case of a timeout"""
@@ -46,7 +50,10 @@ def test_connect_check_health_retry_on_timeout_error(master_host):
     )
     original_super_connect = Connection._connect.__get__(conn, Connection)
 
-    with mock.patch.object(Connection, "_connect", new_callable=mock.Mock) as mock_super_connect:
+    with mock.patch.object(
+        Connection, "_connect", new_callable=mock.Mock
+    ) as mock_super_connect:
+
         def side_effect(*args, **kwargs):
             if mock_super_connect.call_count <= 2:
                 raise socket.timeout()

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -1,9 +1,10 @@
 import socket
+from unittest import mock
 
+from redis import Connection
 from redis.retry import Retry
 from redis.sentinel import SentinelManagedConnection
 from redis.backoff import NoBackoff
-from unittest import mock
 
 
 def test_connect_retry_on_timeout_error(master_host):
@@ -17,18 +18,43 @@ def test_connect_retry_on_timeout_error(master_host):
         retry=Retry(NoBackoff(), 3),
         connection_pool=connection_pool,
     )
-    origin_connect = conn._connect
-    conn._connect = mock.Mock()
+    original_super_connect = Connection._connect.__get__(conn, Connection)
 
-    def mock_connect():
-        # connect only on the last retry
-        if conn._connect.call_count <= 2:
-            raise socket.timeout
-        else:
-            return origin_connect()
+    with mock.patch.object(Connection, "_connect", new_callable=mock.Mock) as mock_super_connect:
+        def side_effect(*args, **kwargs):
+            if mock_super_connect.call_count <= 2:
+                raise socket.timeout()
+            return original_super_connect(*args, **kwargs)
 
-    conn._connect.side_effect = mock_connect
-    conn.connect()
-    assert conn._connect.call_count == 3
-    assert connection_pool.get_master_address.call_count == 3
-    conn.disconnect()
+        mock_super_connect.side_effect = side_effect
+
+        conn.connect()
+        assert mock_super_connect.call_count == 3
+        assert connection_pool.get_master_address.call_count == 3
+        conn.disconnect()
+
+def test_connect_check_health_retry_on_timeout_error(master_host):
+    """Test that the _connect function is retried in case of a timeout"""
+    connection_pool = mock.Mock()
+    connection_pool.get_master_address = mock.Mock(
+        return_value=(master_host[0], master_host[1])
+    )
+    conn = SentinelManagedConnection(
+        retry_on_timeout=True,
+        retry=Retry(NoBackoff(), 3),
+        connection_pool=connection_pool,
+    )
+    original_super_connect = Connection._connect.__get__(conn, Connection)
+
+    with mock.patch.object(Connection, "_connect", new_callable=mock.Mock) as mock_super_connect:
+        def side_effect(*args, **kwargs):
+            if mock_super_connect.call_count <= 2:
+                raise socket.timeout()
+            return original_super_connect(*args, **kwargs)
+
+        mock_super_connect.side_effect = side_effect
+
+        conn.connect_check_health()
+        assert mock_super_connect.call_count == 3
+        assert connection_pool.get_master_address.call_count == 3
+        conn.disconnect()


### PR DESCRIPTION
### Description of change

https://github.com/redis/redis-py/issues/3874

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
