### PR TITLE
Add REPLICA aliases for deprecated SLAVE terminology in Sentinel

### DIFF
--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -9,6 +9,7 @@ import redis.asyncio.sentinel
 from redis import exceptions
 from redis.asyncio.sentinel import (
     MasterNotFoundError,
+    ReplicaNotFoundError,
     Sentinel,
     SentinelConnectionPool,
     SlaveNotFoundError,
@@ -396,3 +397,65 @@ async def test_sentinel_commands_with_strict_redis_client(request):
     assert isinstance(await client.sentinel_ckquorum("redis-py-test"), bool)
 
     await client.close()
+
+
+# Tests for REPLICA aliases (Redis 5.0+ terminology)
+@pytest.mark.onlynoncluster
+async def test_replica_not_found_error_alias():
+    """Test that ReplicaNotFoundError is an alias for SlaveNotFoundError"""
+    assert ReplicaNotFoundError is SlaveNotFoundError
+
+
+@pytest.mark.onlynoncluster
+async def test_replica_for_alias(cluster, sentinel):
+    """Test that replica_for() is an alias for slave_for()"""
+    cluster.slaves = [
+        {"ip": "127.0.0.1", "port": 6379, "is_odown": False, "is_sdown": False}
+    ]
+    async with sentinel.replica_for("mymaster", db=9) as replica:
+        assert await replica.ping()
+
+
+@pytest.mark.onlynoncluster
+async def test_discover_replicas_alias(cluster, sentinel):
+    """Test that discover_replicas() is an alias for discover_slaves()"""
+    cluster.slaves = [
+        {"ip": "slave0", "port": 1234, "is_odown": False, "is_sdown": False},
+        {"ip": "slave1", "port": 1234, "is_odown": False, "is_sdown": False},
+    ]
+    # discover_replicas should return the same result as discover_slaves
+    replicas = await sentinel.discover_replicas("mymaster")
+    slaves = await sentinel.discover_slaves("mymaster")
+    assert replicas == slaves
+    assert replicas == [("slave0", 1234), ("slave1", 1234)]
+
+
+@pytest.mark.onlynoncluster
+async def test_filter_replicas_alias(cluster, sentinel):
+    """Test that filter_replicas() is an alias for filter_slaves()"""
+    replicas = [
+        {"ip": "replica0", "port": 1234, "is_odown": False, "is_sdown": False},
+        {"ip": "replica1", "port": 1234, "is_odown": True, "is_sdown": False},
+    ]
+    # filter_replicas should return the same result as filter_slaves
+    filtered_replicas = sentinel.filter_replicas(replicas)
+    filtered_slaves = sentinel.filter_slaves(replicas)
+    assert filtered_replicas == filtered_slaves
+    assert filtered_replicas == [("replica0", 1234)]
+
+
+@pytest.mark.onlynoncluster
+async def test_rotate_replicas_alias(cluster, sentinel, master_ip):
+    """Test that rotate_replicas() is an alias for rotate_slaves()"""
+    cluster.slaves = [
+        {"ip": "slave0", "port": 6379, "is_odown": False, "is_sdown": False},
+        {"ip": "slave1", "port": 6379, "is_odown": False, "is_sdown": False},
+    ]
+    pool = SentinelConnectionPool("mymaster", sentinel)
+    rotator = pool.rotate_replicas()
+    assert await rotator.__anext__() in (("slave0", 6379), ("slave1", 6379))
+    assert await rotator.__anext__() in (("slave0", 6379), ("slave1", 6379))
+    # Fallback to master
+    assert await rotator.__anext__() == (master_ip, 6379)
+    with pytest.raises(SlaveNotFoundError):
+        await rotator.__anext__()


### PR DESCRIPTION
## Summary
Fixes #3817

Redis 5.0 deprecated SLAVE in favor of REPLICA. This adds aliases for the Sentinel APIs to match the modern Redis terminology.

## Changes
Added the following aliases (both sync and async):

- `ReplicaNotFoundError` (alias for `SlaveNotFoundError`)
- `Sentinel.replica_for()` (alias for `slave_for()`)
- `Sentinel.discover_replicas()` (alias for `discover_slaves()`)
- `Sentinel.filter_replicas()` (alias for `filter_slaves()`)
- `SentinelConnectionPool.rotate_replicas()` (alias for `rotate_slaves()`)

## Notes
- The original `slave_*` methods are kept for backward compatibility
- New methods simply delegate to the existing implementations
- Both `redis.sentinel` and `redis.asyncio.sentinel` are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)