### PR TITLE
Fix cache proxy connection unbalanced command send and read

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1513,9 +1513,7 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
                 self._current_command_cache_entry is not None
                 and self._current_command_cache_entry.status == CacheEntryStatus.VALID
             ):
-                res = copy.deepcopy(
-                    self._current_command_cache_entry.cache_value
-                )
+                res = copy.deepcopy(self._current_command_cache_entry.cache_value)
                 self._current_command_cache_entry = None
                 return res
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1539,7 +1539,7 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
 
             # Cache only responses that still valid
             # and wasn't invalidated by another connection in meantime.
-            if cache_entry is self._current_command_cache_entry:
+            if cache_entry is not None:
                 cache_entry.status = CacheEntryStatus.VALID
                 cache_entry.cache_value = response
                 self._cache.set(cache_entry)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -592,14 +592,11 @@ class TestUnitCacheProxyConnection:
         assert another_conn.can_read.call_count == 2
         another_conn.read_response.assert_called_once()
 
-
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
         reason="Pypy doesn't support side_effect",
     )
-    def test_cache_entry_in_progress(
-        self, mock_cache, mock_connection
-    ):
+    def test_cache_entry_in_progress(self, mock_cache, mock_connection):
         mock_connection.retry = "mock"
         mock_connection.host = "mock"
         mock_connection.port = "mock"
@@ -629,14 +626,11 @@ class TestUnitCacheProxyConnection:
         mock_connection.send_command.assert_called_once()
         mock_connection.read_response.assert_called_once()
 
-
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
         reason="Pypy doesn't support side_effect",
     )
-    def test_cache_entry_gone_between_send_and_read(
-        self, mock_cache, mock_connection
-    ):
+    def test_cache_entry_gone_between_send_and_read(self, mock_cache, mock_connection):
         mock_connection.retry = "mock"
         mock_connection.host = "mock"
         mock_connection.port = "mock"
@@ -669,14 +663,11 @@ class TestUnitCacheProxyConnection:
         mock_connection.send_command.assert_not_called()
         mock_connection.read_response.assert_not_called()
 
-
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
         reason="Pypy doesn't support side_effect",
     )
-    def test_cache_entry_fill_between_send_and_read(
-        self, mock_cache, mock_connection
-    ):
+    def test_cache_entry_fill_between_send_and_read(self, mock_cache, mock_connection):
         mock_connection.retry = "mock"
         mock_connection.host = "mock"
         mock_connection.port = "mock"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -483,7 +483,6 @@ class TestUnitCacheProxyConnection:
         mock_cache.is_cachable.return_value = True
         mock_cache.get.side_effect = [
             None,
-            None,
             CacheEntry(
                 cache_key=CacheKey(
                     command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
@@ -560,11 +559,6 @@ class TestUnitCacheProxyConnection:
 
         mock_cache.get.assert_has_calls(
             [
-                call(
-                    CacheKey(
-                        command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
-                    )
-                ),
                 call(
                     CacheKey(
                         command="GET", redis_keys=("foo",), redis_args=("GET", "foo")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -487,14 +487,6 @@ class TestUnitCacheProxyConnection:
                 cache_key=CacheKey(
                     command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
                 ),
-                cache_value=CacheProxyConnection.DUMMY_CACHE_VALUE,
-                status=CacheEntryStatus.IN_PROGRESS,
-                connection_ref=mock_connection,
-            ),
-            CacheEntry(
-                cache_key=CacheKey(
-                    command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
-                ),
                 cache_value=b"bar",
                 status=CacheEntryStatus.VALID,
                 connection_ref=mock_connection,
@@ -526,22 +518,14 @@ class TestUnitCacheProxyConnection:
         proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
         assert proxy_connection.read_response() == b"bar"
         assert proxy_connection._current_command_cache_entry is None
+
+        # cached reply
+        proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
         assert proxy_connection.read_response() == b"bar"
+        assert proxy_connection._current_command_cache_entry is None
 
         mock_cache.set.assert_has_calls(
             [
-                call(
-                    CacheEntry(
-                        cache_key=CacheKey(
-                            command="GET",
-                            redis_keys=("foo",),
-                            redis_args=("GET", "foo"),
-                        ),
-                        cache_value=CacheProxyConnection.DUMMY_CACHE_VALUE,
-                        status=CacheEntryStatus.IN_PROGRESS,
-                        connection_ref=mock_connection,
-                    )
-                ),
                 call(
                     CacheEntry(
                         cache_key=CacheKey(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -613,3 +613,121 @@ class TestUnitCacheProxyConnection:
         assert proxy_connection.read_response() == b"bar"
         assert another_conn.can_read.call_count == 2
         another_conn.read_response.assert_called_once()
+
+
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy",
+        reason="Pypy doesn't support side_effect",
+    )
+    def test_cache_entry_in_progress(
+        self, mock_cache, mock_connection
+    ):
+        mock_connection.retry = "mock"
+        mock_connection.host = "mock"
+        mock_connection.port = "mock"
+        mock_connection.credential_provider = UsernamePasswordCredentialProvider()
+
+        another_conn = copy.deepcopy(mock_connection)
+        another_conn.can_read.return_value = False
+        cache_entry = CacheEntry(
+            cache_key=CacheKey(
+                command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
+            ),
+            cache_value=b"bar",
+            status=CacheEntryStatus.IN_PROGRESS,
+            connection_ref=another_conn,
+        )
+        mock_cache.is_cachable.return_value = True
+        mock_cache.get.return_value = cache_entry
+        mock_connection.can_read.return_value = False
+        mock_connection.read_response.return_value = b"bar2"
+
+        proxy_connection = CacheProxyConnection(
+            mock_connection, mock_cache, threading.RLock()
+        )
+        proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
+
+        assert proxy_connection.read_response() == b"bar2"
+        mock_connection.send_command.assert_called_once()
+        mock_connection.read_response.assert_called_once()
+
+
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy",
+        reason="Pypy doesn't support side_effect",
+    )
+    def test_cache_entry_gone_between_send_and_read(
+        self, mock_cache, mock_connection
+    ):
+        mock_connection.retry = "mock"
+        mock_connection.host = "mock"
+        mock_connection.port = "mock"
+        mock_connection.credential_provider = UsernamePasswordCredentialProvider()
+
+        another_conn = copy.deepcopy(mock_connection)
+        another_conn.can_read.return_value = False
+        cache_entry = CacheEntry(
+            cache_key=CacheKey(
+                command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
+            ),
+            cache_value=b"bar",
+            status=CacheEntryStatus.VALID,
+            connection_ref=another_conn,
+        )
+        mock_cache.is_cachable.return_value = True
+        mock_cache.get.return_value = cache_entry
+        mock_connection.can_read.return_value = False
+        mock_connection.read_response.return_value = None
+
+        proxy_connection = CacheProxyConnection(
+            mock_connection, mock_cache, threading.RLock()
+        )
+        proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
+
+        # cache entry gone
+        mock_cache.get.return_value = None
+
+        assert proxy_connection.read_response() == b"bar"
+        mock_connection.send_command.assert_not_called()
+        mock_connection.read_response.assert_not_called()
+
+
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy",
+        reason="Pypy doesn't support side_effect",
+    )
+    def test_cache_entry_fill_between_send_and_read(
+        self, mock_cache, mock_connection
+    ):
+        mock_connection.retry = "mock"
+        mock_connection.host = "mock"
+        mock_connection.port = "mock"
+        mock_connection.credential_provider = UsernamePasswordCredentialProvider()
+
+        another_conn = copy.deepcopy(mock_connection)
+        another_conn.can_read.return_value = False
+
+        mock_cache.is_cachable.return_value = True
+        mock_cache.get.return_value = None
+        mock_connection.can_read.return_value = False
+        mock_connection.read_response.return_value = b"bar2"
+
+        proxy_connection = CacheProxyConnection(
+            mock_connection, mock_cache, threading.RLock()
+        )
+        proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
+
+        cache_entry = CacheEntry(
+            cache_key=CacheKey(
+                command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
+            ),
+            cache_value=b"bar",
+            status=CacheEntryStatus.VALID,
+            connection_ref=another_conn,
+        )
+        # cache entry fill
+        mock_cache.get.return_value = cache_entry
+
+        assert proxy_connection.read_response() == b"bar2"
+        mock_connection.send_command.assert_called_once()
+        mock_connection.read_response.assert_called_once()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -526,7 +526,7 @@ class TestUnitCacheProxyConnection:
         )
         proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
         assert proxy_connection.read_response() == b"bar"
-        assert proxy_connection._current_command_cache_key is None
+        assert proxy_connection._current_command_cache_entry is None
         assert proxy_connection.read_response() == b"bar"
 
         mock_cache.set.assert_has_calls(


### PR DESCRIPTION
### Description of change

Fix `CacheProxyConnection` race conditions between `send_command` and `read_response`, as [test cases](https://github.com/redis/redis-py/commit/a006e22e61a6e7c9f72a0f7e687d66d6a6c21f06) described, covers issue #3600.

### Test cases
1. cache entry be in progress at all time.
2. cache entry exitsts at first but gone later.
3. cache entry not exists at first but filled later.

 These cause unbalanced command send and read and the connection will hang forever or read a mismatched response.
