### PR TITLE
Add port feature for unix socket for OTel instrumentation compatibility

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1016,6 +1016,17 @@ class UnixDomainSocketConnection(AbstractConnection):
         self.path = path
         super().__init__(**kwargs)
 
+    # host and port properties are required for OTel instrumentation compatibility.
+    # TCP Connection has these as attributes; Unix sockets use path instead.
+
+    @property
+    def host(self):
+        return self.path
+
+    @property
+    def port(self):
+        return None
+
     def repr_pieces(self) -> Iterable[Tuple[str, Union[str, int]]]:
         pieces = [("path", self.path), ("db", self.db)]
         if self.client_name:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2090,6 +2090,17 @@ class UnixDomainSocketConnection(AbstractConnection):
         self.path = path
         self.socket_timeout = socket_timeout
 
+    # host and port properties are required for OTel instrumentation compatibility.
+    # TCP Connection has these as attributes; Unix sockets use path instead.
+
+    @property
+    def host(self):
+        return self.path
+
+    @property
+    def port(self):
+        return None
+
     def repr_pieces(self):
         pieces = [("path", self.path), ("db", self.db)]
         if self.client_name:


### PR DESCRIPTION
### Description of change

Fix #3957 
Fix #3958 

Add `host` and `port` properties to `UnixDomainSocketConnection` to fix `AttributeError: 'UnixDomainSocketConnection' object has no attribute 'port'` when using Unix sockets with the new OTel metrics introduced in v7.2.0.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
