### PR TITLE
fix(connection): Ensure we have an initialized protocol in connection

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -248,7 +248,7 @@ class AbstractConnection:
         else:
             if p < 2 or p > 3:
                 raise ConnectionError("protocol must be either 2 or 3")
-            self.protocol = p
+        self.protocol = p
 
     def __del__(self, _warnings: Any = warnings):
         # For some reason, the individual streams don't get properly garbage

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -884,8 +884,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         else:
             if p < 2 or p > 3:
                 raise ConnectionError("protocol must be either 2 or 3")
-                # p = DEFAULT_RESP_VERSION
-            self.protocol = p
+        self.protocol = p
         if self.protocol == 3 and parser_class == _RESP2Parser:
             # If the protocol is 3 but the parser is RESP2, change it to RESP3
             # This is needed because the parser might be set before the protocol


### PR DESCRIPTION
### Description of change

Following https://github.com/redis/redis-py/pull/3965
Previously, the `finally` block ensured the `self.protocol` was assigned. However, since the `else` branch is triggered when a failure occurs, `self.protocol` could remain unassigned. 
This results in the following exception:
```
  if self.protocol == 3 and parser_class == _RESP2Parser:
     ^^^^^^^^^^^^^
AttributeError: 'Connection' object has no attribute 'protocol'
```

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that only adjusts control flow for RESP protocol validation/assignment; main risk is behavior change for invalid protocol inputs now consistently leaving `self.protocol` set only when validation succeeds.
> 
> **Overview**
> Fixes a bug where `self.protocol` could remain uninitialized in both sync (`redis/connection.py`) and asyncio (`redis/asyncio/connection.py`) connections due to mis-indented assignment during protocol parsing/validation.
> 
> This ensures `self.protocol` is always set after successful validation, preventing downstream `AttributeError` when later code checks the protocol to select the RESP2/RESP3 parser.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8df587dec40341a4d5bed5117f0925c47801e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->