### PR TITLE
Add sorted set examples notebook

### DIFF
--- a/docs/examples/sorted_set_examples.ipynb
+++ b/docs/examples/sorted_set_examples.ipynb
@@ -1,0 +1,393 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b9e1d8a6",
+   "metadata": {},
+   "source": [
+    "# Sorted Set examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4f2e7d3",
+   "metadata": {},
+   "source": [
+    "## Connect to Redis\n",
+    "\n",
+    "To understand what ```decode_responses=True``` does, refer back to [this document](connection_examples.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis\n",
+    "\n",
+    "r = redis.Redis(decode_responses=True)\n",
+    "r.ping()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5e6f7a8",
+   "metadata": {},
+   "source": [
+    "## Basic ```ZADD``` and ```ZRANGE```\n",
+    "\n",
+    "```ZADD``` adds members with scores to a sorted set. Members are automatically ordered by score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9f0a1b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.delete(\"game:scores\")\n",
+    "\n",
+    "r.zadd(\"game:scores\", {\"alice\": 100, \"bob\": 200, \"charlie\": 150})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3a4b5c6",
+   "metadata": {},
+   "source": [
+    "```ZRANGE``` returns members ordered by score (ascending by default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrange(\"game:scores\", 0, -1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "source": [
+    "Pass ```withscores=True``` to include scores in the result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrange(\"game:scores\", 0, -1, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "source": [
+    "## ```ZRANGEBYSCORE```\n",
+    "\n",
+    "Query members whose scores fall within a given range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3f4a5b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrangebyscore(\"game:scores\", 100, 150, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7d8e9f0",
+   "metadata": {},
+   "source": [
+    "Use ```\"-inf\"``` and ```\"+inf\"``` for unbounded ranges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrangebyscore(\"game:scores\", \"-inf\", 150, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "source": [
+    "## ```ZINCRBY```\n",
+    "\n",
+    "Increment the score of a member. This is useful for updating scores in real time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zincrby(\"game:scores\", 75, \"alice\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrange(\"game:scores\", 0, -1, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "source": [
+    "## ```ZRANK``` and ```ZREVRANK```\n",
+    "\n",
+    "```ZRANK``` returns the rank of a member (0-based, lowest score first). ```ZREVRANK``` returns the rank with the highest score first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0c1d2e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrank(\"game:scores\", \"bob\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4a5b6c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrevrank(\"game:scores\", \"bob\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8e9f0a1",
+   "metadata": {},
+   "source": [
+    "## ```ZREM```\n",
+    "\n",
+    "Remove one or more members from a sorted set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrem(\"game:scores\", \"charlie\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zrange(\"game:scores\", 0, -1, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "## ```ZUNIONSTORE``` and ```ZINTERSTORE```\n",
+    "\n",
+    "Combine multiple sorted sets. ```ZUNIONSTORE``` stores the union and ```ZINTERSTORE``` stores the intersection of the input sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.delete(\"game:round1\", \"game:round2\", \"game:total\", \"game:common\")\n",
+    "\n",
+    "r.zadd(\"game:round1\", {\"alice\": 100, \"bob\": 200})\n",
+    "r.zadd(\"game:round2\", {\"bob\": 150, \"charlie\": 300})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "source": [
+    "Union sums scores by default for members that appear in both sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2e3f4a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zunionstore(\"game:total\", [\"game:round1\", \"game:round2\"])\n",
+    "r.zrange(\"game:total\", 0, -1, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6c7d8e9",
+   "metadata": {},
+   "source": [
+    "Intersection keeps only members present in all input sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0a1b2c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.zinterstore(\"game:common\", [\"game:round1\", \"game:round2\"])\n",
+    "r.zrange(\"game:common\", 0, -1, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a8",
+   "metadata": {},
+   "source": [
+    "## Practical example: Leaderboard\n",
+    "\n",
+    "Sorted sets are a natural fit for leaderboards. Scores are kept in order automatically, making rank lookups very efficient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.delete(\"leaderboard\")\n",
+    "\n",
+    "# Add players with their scores\n",
+    "r.zadd(\n",
+    "    \"leaderboard\",\n",
+    "    {\n",
+    "        \"player:anna\": 2500,\n",
+    "        \"player:ben\": 4000,\n",
+    "        \"player:cara\": 3500,\n",
+    "        \"player:dan\": 1800,\n",
+    "        \"player:eve\": 4200,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a3b4c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Top 3 players (highest scores first)\n",
+    "r.zrevrange(\"leaderboard\", 0, 2, withscores=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A player completes a level and earns bonus points\n",
+    "r.zincrby(\"leaderboard\", 600, \"player:anna\")\n",
+    "\n",
+    "# Check anna's new rank (0-based, highest score first)\n",
+    "r.zrevrank(\"leaderboard\", \"player:anna\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0c1d2e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a specific player's score\n",
+    "r.zscore(\"leaderboard\", \"player:anna\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4a5b6c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Total number of players on the leaderboard\n",
+    "r.zcard(\"leaderboard\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8e9f0a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Final leaderboard (highest to lowest)\n",
+    "r.zrevrange(\"leaderboard\", 0, -1, withscores=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Description of change

Added a Jupyter notebook demonstrating Redis sorted set operations. Covers:

- Basic `ZADD` and `ZRANGE`
- `ZRANGEBYSCORE` — range queries by score
- `ZINCRBY` — score increments
- `ZRANK` / `ZREVRANK` — rank lookups
- `ZREM` — removing members
- `ZUNIONSTORE` / `ZINTERSTORE` — combining sorted sets
- A practical leaderboard example

Follows the same structure and style as the existing example notebooks.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included? — This PR **is** documentation
- [x] Is there an example added to the examples folder?

Contributes to #1744

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new example notebook; no production code paths are modified.
> 
> **Overview**
> Adds a new Jupyter notebook `docs/examples/sorted_set_examples.ipynb` demonstrating Redis sorted set usage via `redis-py`, including `ZADD`/`ZRANGE`, score range queries, score increments, rank lookups, member removal, set union/intersection, and a small leaderboard walkthrough.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99d34bde69c90dfa0280140ec5e366b75548725b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->