### PR TITLE
Fix async ClusterPipeline missing nodes_manager and set_response_callback required by JSON module

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1989,6 +1989,15 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
             else TransactionStrategy(self)
         )
 
+    @property
+    def nodes_manager(self) -> "NodesManager":
+        """Get the nodes manager from the cluster client."""
+        return self.cluster_client.nodes_manager
+
+    def set_response_callback(self, command: str, callback: ResponseCallbackT) -> None:
+        """Set a custom response callback on the cluster client."""
+        self.cluster_client.set_response_callback(command, callback)
+
     async def initialize(self) -> "ClusterPipeline":
         await self._execution_strategy.initialize()
         return self

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3162,6 +3162,44 @@ class TestClusterConnectionErrorHandling:
 class TestClusterPipeline:
     """Tests for the ClusterPipeline class."""
 
+    async def test_pipeline_nodes_manager_property(self) -> None:
+        """
+        Test that ClusterPipeline exposes nodes_manager property
+        that delegates to the cluster client's nodes_manager.
+        """
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            pipeline = r.pipeline()
+            # Verify that nodes_manager property exists and returns the same object
+            # as the cluster client's nodes_manager
+            assert pipeline.nodes_manager is r.nodes_manager
+            # Verify that we can access nodes_manager attributes
+            assert pipeline.nodes_manager.default_node is not None
+        finally:
+            await r.aclose()
+
+    async def test_pipeline_set_response_callback(self) -> None:
+        """
+        Test that ClusterPipeline exposes set_response_callback method
+        that delegates to the cluster client's set_response_callback.
+        """
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        try:
+            pipeline = r.pipeline()
+
+            # Define a custom callback
+            def custom_callback(response):
+                return f"custom_{response}"
+
+            # Set the callback via the pipeline
+            pipeline.set_response_callback("CUSTOM_CMD", custom_callback)
+
+            # Verify that the callback was set on the cluster client
+            assert "CUSTOM_CMD" in r.response_callbacks
+            assert r.response_callbacks["CUSTOM_CMD"] is custom_callback
+        finally:
+            await r.aclose()
+
     async def test_blocked_arguments(self, r: RedisCluster) -> None:
         """Test handling for blocked pipeline arguments."""
 

--- a/tests/test_asyncio/test_pipeline.py
+++ b/tests/test_asyncio/test_pipeline.py
@@ -466,6 +466,26 @@ class TestPipeline:
                 {"key1_transaction": "value1", "key2_transaction": "value2"}, ex=10
             )
 
+    async def test_pipeline_json_module_access(self, r):
+        """
+        Test that pipeline can access the json() module.
+        The JSON module requires nodes_manager (for cluster) and set_response_callback
+        on the client during initialization.
+
+        """
+        pipeline = r.pipeline()
+
+        # This should not raise an AttributeError
+        json_pipeline = pipeline.json()
+
+        # Verify the JSON module was created successfully
+        assert json_pipeline is not None
+        assert json_pipeline.client is pipeline
+
+        # Verify that JSON callbacks were registered
+        assert "JSON.SET" in r.response_callbacks
+        assert "JSON.GET" in r.response_callbacks
+
 
 @pytest.mark.asyncio
 class TestAsyncPipelineOperationDurationMetricsRecording:


### PR DESCRIPTION
## Summary
Fixes #3936 where calling `.json()` on an async `ClusterPipeline` raised `AttributeError: 'ClusterPipeline' object has no attribute 'nodes_manager'`.

## Problem
The Redis JSON module requires access to `nodes_manager` (for protocol version checking) and `set_response_callback` (for registering command decoders) during initialization. The async `ClusterPipeline` uses a composition pattern—holding a reference to `cluster_client` rather than inheriting from `RedisCluster` like the sync implementation—so these members weren't automatically available.

## Solution
- Added `nodes_manager` property that delegates to `self.cluster_client.nodes_manager`
- Added `set_response_callback()` method that delegates to `self.cluster_client.set_response_callback()`

## Testing
- Unit tests verify the property and method correctly delegate to the cluster client
- Test confirms `pipeline.json()` can now be called without errors on both standalone and cluster pipelines

## Notes
The sync `ClusterPipeline` is not affected since it inherits directly from `RedisCluster`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple delegation accessors on `ClusterPipeline` and corresponding tests, mainly to unblock `pipeline.json()` without changing command execution behavior.
> 
> **Overview**
> Fixes an `AttributeError` when calling `pipeline.json()` on async cluster pipelines by exposing `ClusterPipeline.nodes_manager` and `ClusterPipeline.set_response_callback()` as delegations to the underlying `RedisCluster` client.
> 
> Adds async tests verifying these delegations and that `pipeline.json()` initializes successfully and registers `JSON.*` response callbacks on the cluster client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e689342e098020bf03c77f8d1a76efe06fdc4f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->