### PR TITLE
Add Pub/Sub examples notebook

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,3 +15,4 @@ Examples
    examples/timeseries_examples
    examples/redis-stream-example
    examples/opentelemetry_api_examples
+   examples/pubsub_examples

--- a/docs/examples/pubsub_examples.ipynb
+++ b/docs/examples/pubsub_examples.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Redis Pub/Sub Examples\n",
+    "\n",
+    "Redis Pub/Sub implements a messaging paradigm where senders (publishers) send messages to channels without knowledge of receivers (subscribers). This is useful for real-time notifications, event-driven architectures, and decoupled communication between services."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## Start off by connecting to the Redis server\n",
+    "\n",
+    "Pub/Sub requires two connections: one for the subscriber (which blocks waiting for messages) and one for the publisher."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis\n",
+    "\n",
+    "# Subscriber connection\n",
+    "sub_client = redis.Redis(decode_responses=True)\n",
+    "sub_client.ping()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Publisher connection (must be separate from subscriber)\n",
+    "pub_client = redis.Redis(decode_responses=True)\n",
+    "pub_client.ping()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Basic Pub/Sub\n",
+    "\n",
+    "Subscribe to a channel, then publish a message to it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a PubSub object and subscribe to a channel\n",
+    "pubsub = sub_client.pubsub()\n",
+    "pubsub.subscribe(\"notifications\")\n",
+    "\n",
+    "# The subscribe call returns a confirmation message\n",
+    "message = pubsub.get_message()\n",
+    "print(\"Subscribe confirmation:\", message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Publish a message to the channel\n",
+    "pub_client.publish(\"notifications\", \"Hello from Redis Pub/Sub!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Receive the published message\n",
+    "message = pubsub.get_message()\n",
+    "print(\"Received message:\", message)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "## Pattern-Based Subscriptions\n",
+    "\n",
+    "You can subscribe to multiple channels matching a pattern using `psubscribe`. The `*` wildcard matches any characters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pubsub_pattern = sub_client.pubsub()\n",
+    "pubsub_pattern.psubscribe(\"user:*:events\")\n",
+    "\n",
+    "# Confirm subscription\n",
+    "pubsub_pattern.get_message()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Publish to channels matching the pattern\n",
+    "pub_client.publish(\"user:123:events\", \"login\")\n",
+    "pub_client.publish(\"user:456:events\", \"purchase\")\n",
+    "\n",
+    "# Receive messages\n",
+    "msg1 = pubsub_pattern.get_message()\n",
+    "msg2 = pubsub_pattern.get_message()\n",
+    "print(\"Message 1:\", msg1)\n",
+    "print(\"Message 2:\", msg2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "## Listening in a Loop\n",
+    "\n",
+    "In practice, you typically listen for messages in a loop using `listen()` or `get_message()` with a timeout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pubsub_loop = sub_client.pubsub()\n",
+    "pubsub_loop.subscribe(\"alerts\")\n",
+    "\n",
+    "# Consume the subscription confirmation\n",
+    "pubsub_loop.get_message()\n",
+    "\n",
+    "# Publish a few messages\n",
+    "pub_client.publish(\"alerts\", \"System starting up\")\n",
+    "pub_client.publish(\"alerts\", \"All services healthy\")\n",
+    "pub_client.publish(\"alerts\", \"Scheduled maintenance in 30 minutes\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read all pending messages with a timeout\n",
+    "while True:\n",
+    "    message = pubsub_loop.get_message(timeout=1.0)\n",
+    "    if message is None:\n",
+    "        break\n",
+    "    if message[\"type\"] == \"message\":\n",
+    "        print(f\"Alert: {message['data']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "## Unsubscribing\n",
+    "\n",
+    "Always unsubscribe when done to clean up resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unsubscribe from specific channels\n",
+    "pubsub.unsubscribe(\"notifications\")\n",
+    "pubsub_loop.unsubscribe(\"alerts\")\n",
+    "pubsub_pattern.punsubscribe(\"user:*:events\")\n",
+    "\n",
+    "# Close the PubSub objects\n",
+    "pubsub.close()\n",
+    "pubsub_loop.close()\n",
+    "pubsub_pattern.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "source": [
+    "## Pub/Sub with JSON Messages\n",
+    "\n",
+    "Pub/Sub messages are strings, so you can easily send JSON-encoded data for structured communication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "pubsub_json = sub_client.pubsub()\n",
+    "pubsub_json.subscribe(\"task_updates\")\n",
+    "pubsub_json.get_message()  # consume confirmation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Publish a JSON-encoded message\n",
+    "task = {\n",
+    "    \"task_id\": \"abc-123\",\n",
+    "    \"status\": \"completed\",\n",
+    "    \"result\": {\"rows_affected\": 42}\n",
+    "}\n",
+    "pub_client.publish(\"task_updates\", json.dumps(task))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0c1d2e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Receive and decode the JSON message\n",
+    "message = pubsub_json.get_message()\n",
+    "if message and message[\"type\"] == \"message\":\n",
+    "    data = json.loads(message[\"data\"])\n",
+    "    print(f\"Task {data['task_id']} is {data['status']}\")\n",
+    "    print(f\"Result: {data['result']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cleanup\n",
+    "pubsub_json.unsubscribe(\"task_updates\")\n",
+    "pubsub_json.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds a Jupyter notebook covering Redis Pub/Sub patterns, addressing #1744.

### What's included
- **Basic Pub/Sub**: subscribe, publish, receive messages
- **Pattern-based subscriptions**: using `psubscribe` with wildcards
- **Listening in a loop**: practical `get_message()` with timeout
- **Unsubscribing and cleanup**: resource management best practices
- **JSON messages**: structured communication pattern

### Why Pub/Sub?
Pub/Sub is a core Redis feature widely used for real-time notifications, event-driven architectures, and decoupled microservices. It was missing from the examples directory.

Relates to #1744

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new example notebook and links it from the examples index; no runtime/library code paths are modified.
> 
> **Overview**
> Adds a new `docs/examples/pubsub_examples.ipynb` Jupyter notebook demonstrating Redis Pub/Sub usage patterns (basic subscribe/publish, pattern subscriptions, looped consumption with timeout, cleanup/unsubscribe, and JSON-encoded payloads).
> 
> Updates `docs/examples.rst` to include the new `examples/pubsub_examples` entry in the documentation toctree.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e92a97cb7f1ad5ff5ed79f92af8293737d473dd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->