### PR TITLE
add random load balancing strategy which allows for use of the primary

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1955,8 +1955,8 @@ class ClusterNode:
 class LoadBalancingStrategy(Enum):
     ROUND_ROBIN = "round_robin"
     ROUND_ROBIN_REPLICAS = "round_robin_replicas"
-    RANDOM_REPLICA = "random_replica"
     RANDOM = "random"
+    RANDOM_REPLICA = "random_replica"
 
 
 class LoadBalancer:
@@ -1975,15 +1975,15 @@ class LoadBalancer:
         list_size: int,
         load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
     ) -> int:
-        if (
-            load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA
-            or load_balancing_strategy == LoadBalancingStrategy.RANDOM
-        ):
-            return self._get_random_replica_index(
+        if load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
+            return self._get_random_server_index(
                 list_size,
-                replicas_only=(
-                    load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA
-                ),
+                replicas_only=True,
+            )
+        elif load_balancing_strategy == LoadBalancingStrategy.RANDOM:
+            return self._get_random_server_index(
+                list_size,
+                replicas_only=False,
             )
         else:
             return self._get_round_robin_index(
@@ -1996,7 +1996,7 @@ class LoadBalancer:
         with self._lock:
             self.primary_to_idx.clear()
 
-    def _get_random_replica_index(self, list_size: int, replicas_only: bool) -> int:
+    def _get_random_server_index(self, list_size: int, replicas_only: bool) -> int:
         return random.randint(1 if replicas_only else 0, list_size - 1)
 
     def _get_round_robin_index(

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1956,6 +1956,7 @@ class LoadBalancingStrategy(Enum):
     ROUND_ROBIN = "round_robin"
     ROUND_ROBIN_REPLICAS = "round_robin_replicas"
     RANDOM_REPLICA = "random_replica"
+    RANDOM = "random"
 
 
 class LoadBalancer:
@@ -1974,8 +1975,16 @@ class LoadBalancer:
         list_size: int,
         load_balancing_strategy: LoadBalancingStrategy = LoadBalancingStrategy.ROUND_ROBIN,
     ) -> int:
-        if load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA:
-            return self._get_random_replica_index(list_size)
+        if (
+            load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA
+            or load_balancing_strategy == LoadBalancingStrategy.RANDOM
+        ):
+            return self._get_random_replica_index(
+                list_size,
+                replicas_only=(
+                    load_balancing_strategy == LoadBalancingStrategy.RANDOM_REPLICA
+                ),
+            )
         else:
             return self._get_round_robin_index(
                 primary,
@@ -1987,8 +1996,8 @@ class LoadBalancer:
         with self._lock:
             self.primary_to_idx.clear()
 
-    def _get_random_replica_index(self, list_size: int) -> int:
-        return random.randint(1, list_size - 1)
+    def _get_random_replica_index(self, list_size: int, replicas_only: bool) -> int:
+        return random.randint(1 if replicas_only else 0, list_size - 1)
 
     def _get_round_robin_index(
         self, primary: str, list_size: int, replicas_only: bool

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -770,9 +770,11 @@ class TestRedisClusterObj:
             (True, None, [7001, 7002, 7001]),
             (True, LoadBalancingStrategy.ROUND_ROBIN, [7001, 7002, 7001]),
             (True, LoadBalancingStrategy.ROUND_ROBIN_REPLICAS, [7002, 7002, 7002]),
+            (True, LoadBalancingStrategy.RANDOM, [7002, 7001, 7002]),
             (True, LoadBalancingStrategy.RANDOM_REPLICA, [7002, 7002, 7002]),
             (False, LoadBalancingStrategy.ROUND_ROBIN, [7001, 7002, 7001]),
             (False, LoadBalancingStrategy.ROUND_ROBIN_REPLICAS, [7002, 7002, 7002]),
+            (False, LoadBalancingStrategy.RANDOM, [7002, 7001, 7002]),
             (False, LoadBalancingStrategy.RANDOM_REPLICA, [7002, 7002, 7002]),
         ],
     )
@@ -782,6 +784,25 @@ class TestRedisClusterObj:
         load_balancing_strategy: LoadBalancingStrategy,
         mocks_srv_ports: List[int],
     ) -> None:
+        def _make_mock_randint():
+            _state = 1 # Start with 1 so we have clearly different results from round robin
+
+            def _mock_randint(lower: int, upper: int) -> int:
+                """
+                Return a controlled sequence of numbers when called repeatedly
+                """
+                if lower == upper:
+                    return lower
+
+                nonlocal _state
+                res = _state + lower
+                _state ^= 1
+                return res
+            
+            return _mock_randint
+        
+        mock_randint = _make_mock_randint()
+
         with mock.patch.multiple(
             Connection,
             send_command=mock.DEFAULT,
@@ -792,7 +813,9 @@ class TestRedisClusterObj:
         ) as mocks:
             with mock.patch.object(
                 ClusterNode, "execute_command", autospec=True
-            ) as execute_command:
+            ) as execute_command, patch(
+                "random.randint", wraps=mock_randint
+            ):
 
                 async def execute_command_mock_first(self, *args, **options):
                     await self.connection_class(**self.connection_kwargs).connect()
@@ -1092,6 +1115,7 @@ class TestClusterRedisCommands:
         [
             LoadBalancingStrategy.ROUND_ROBIN,
             LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
+            LoadBalancingStrategy.RANDOM,
             LoadBalancingStrategy.RANDOM_REPLICA,
         ],
     )

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -785,7 +785,9 @@ class TestRedisClusterObj:
         mocks_srv_ports: List[int],
     ) -> None:
         def _make_mock_randint():
-            _state = 1 # Start with 1 so we have clearly different results from round robin
+            _state = (
+                1  # Start with 1 so we have clearly different results from round robin
+            )
 
             def _mock_randint(lower: int, upper: int) -> int:
                 """
@@ -798,9 +800,9 @@ class TestRedisClusterObj:
                 res = _state + lower
                 _state ^= 1
                 return res
-            
+
             return _mock_randint
-        
+
         mock_randint = _make_mock_randint()
 
         with mock.patch.multiple(
@@ -811,10 +813,11 @@ class TestRedisClusterObj:
             can_read_destructive=mock.DEFAULT,
             on_connect=mock.DEFAULT,
         ) as mocks:
-            with mock.patch.object(
-                ClusterNode, "execute_command", autospec=True
-            ) as execute_command, patch(
-                "random.randint", wraps=mock_randint
+            with (
+                mock.patch.object(
+                    ClusterNode, "execute_command", autospec=True
+                ) as execute_command,
+                patch("random.randint", wraps=mock_randint),
             ):
 
                 async def execute_command_mock_first(self, *args, **options):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -660,9 +660,11 @@ class TestRedisClusterObj:
             (True, None, [7001, 7002, 7001]),
             (True, LoadBalancingStrategy.ROUND_ROBIN, [7001, 7002, 7001]),
             (True, LoadBalancingStrategy.ROUND_ROBIN_REPLICAS, [7002, 7002, 7002]),
+            (True, LoadBalancingStrategy.RANDOM, [7002, 7001, 7002]),
             (True, LoadBalancingStrategy.RANDOM_REPLICA, [7002, 7002, 7002]),
             (False, LoadBalancingStrategy.ROUND_ROBIN, [7001, 7002, 7001]),
             (False, LoadBalancingStrategy.ROUND_ROBIN_REPLICAS, [7002, 7002, 7002]),
+            (False, LoadBalancingStrategy.RANDOM, [7002, 7001, 7002]),
             (False, LoadBalancingStrategy.RANDOM_REPLICA, [7002, 7002, 7002]),
         ],
     )
@@ -672,6 +674,25 @@ class TestRedisClusterObj:
         load_balancing_strategy: LoadBalancingStrategy,
         mocks_srv_ports: List[int],
     ):
+        def _make_mock_randint():
+            _state = 1 # Start with 1 so we have clearly different results from round robin
+
+            def _mock_randint(lower: int, upper: int) -> int:
+                """
+                Return a controlled sequence of numbers when called repeatedly
+                """
+                if lower == upper:
+                    return lower
+
+                nonlocal _state
+                res = _state + lower
+                _state ^= 1
+                return res
+            
+            return _mock_randint
+        
+        mock_randint = _make_mock_randint()
+
         with patch.multiple(
             Connection,
             send_command=DEFAULT,
@@ -680,7 +701,9 @@ class TestRedisClusterObj:
             can_read=DEFAULT,
             on_connect=DEFAULT,
         ) as mocks:
-            with patch.object(Redis, "parse_response") as parse_response:
+            with patch.object(Redis, "parse_response") as parse_response, patch(
+                "random.randint", wraps=mock_randint
+            ):
 
                 def parse_response_mock_first(connection, *args, **options):
                     # Primary
@@ -732,8 +755,9 @@ class TestRedisClusterObj:
                 if (
                     load_balancing_strategy is None
                     or load_balancing_strategy == LoadBalancingStrategy.ROUND_ROBIN
+                    or load_balancing_strategy == LoadBalancingStrategy.RANDOM
                 ):
-                    # in the round robin strategy the primary node can also receive read
+                    # in the round robin and random strategies, the primary node can also receive read
                     # requests and this means that there will be second node connected
                     expected_calls_list.append(call("READONLY"))
 
@@ -1092,6 +1116,7 @@ class TestClusterRedisCommands:
         [
             LoadBalancingStrategy.ROUND_ROBIN,
             LoadBalancingStrategy.ROUND_ROBIN_REPLICAS,
+            LoadBalancingStrategy.RANDOM,
             LoadBalancingStrategy.RANDOM_REPLICA,
         ],
     )

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -675,7 +675,9 @@ class TestRedisClusterObj:
         mocks_srv_ports: List[int],
     ):
         def _make_mock_randint():
-            _state = 1 # Start with 1 so we have clearly different results from round robin
+            _state = (
+                1  # Start with 1 so we have clearly different results from round robin
+            )
 
             def _mock_randint(lower: int, upper: int) -> int:
                 """
@@ -688,9 +690,9 @@ class TestRedisClusterObj:
                 res = _state + lower
                 _state ^= 1
                 return res
-            
+
             return _mock_randint
-        
+
         mock_randint = _make_mock_randint()
 
         with patch.multiple(
@@ -701,8 +703,9 @@ class TestRedisClusterObj:
             can_read=DEFAULT,
             on_connect=DEFAULT,
         ) as mocks:
-            with patch.object(Redis, "parse_response") as parse_response, patch(
-                "random.randint", wraps=mock_randint
+            with (
+                patch.object(Redis, "parse_response") as parse_response,
+                patch("random.randint", wraps=mock_randint),
             ):
 
                 def parse_response_mock_first(connection, *args, **options):


### PR DESCRIPTION
### Description of change

This MR adds a new `LoadBalancingStrategy` value: `RANDOM`. It is identical to the existing `RANDOM_REPLICA` except it allows for the use of the primary as well.

Our team would like to make use of the random load balancer but don't want to waste the primary, which is the motivation for this PR

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster node selection for read commands by introducing a new random strategy that can route reads to primaries as well as replicas; incorrect selection boundaries could shift traffic patterns or expose edge cases in slot node lists.
> 
> **Overview**
> Adds a new `LoadBalancingStrategy.RANDOM` option that randomly selects from *all* nodes serving a slot (including the primary), alongside the existing replica-only random behavior.
> 
> Refactors the load balancer’s random selection into `_get_random_server_index(list_size, replicas_only)` and updates sync/async cluster tests to cover the new strategy with deterministic `random.randint` mocking and adjusted expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e96dddd6cf5f12d9fada5ed723eef87d93342b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->