### PR TITLE
Reorganize unit tests grouping - extracting the tests that define their hardcoded client configuration separately

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -161,21 +161,24 @@ runs:
           echo "::group::RESP${protocol} standalone tests"
           echo "REDIS_MOD_URL=${REDIS_MOD_URL}"
 
-          if (( $REDIS_MAJOR_VERSION < 7 )) && [ "$protocol" == "3" ]; then
-            echo "Skipping module tests: Modules doesn't support RESP3 for Redis versions < 7"
-            invoke standalone-tests --redis-mod-url=${REDIS_MOD_URL} $eventloop --protocol="${protocol}" --extra-markers="not redismod and not cp_integration"
+          if [ "$protocol" == "None" ]; then
+            echo "::group::RESP${protocol} fixed client tests"
+            echo "Running fixed client tests - in those tests client instance and configuration is fixed and not changed by pytest configuration"
+            invoke fixed-client-tests $eventloop
+            echo "::endgroup::"
           else
+            echo "::group::RESP${protocol} standalone tests"
             invoke standalone-tests --redis-mod-url=${REDIS_MOD_URL} $eventloop --protocol="${protocol}"
+            echo "::endgroup::"
+
+            echo "::group::RESP${protocol} cluster tests"
+            invoke cluster-tests $eventloop --protocol=${protocol}
+            echo "::endgroup::"
           fi
-
-          echo "::endgroup::"
-
-          echo "::group::RESP${protocol} cluster tests"
-          invoke cluster-tests $eventloop --protocol=${protocol}
-          echo "::endgroup::"
         }
 
         if [ "${{inputs.protocol}}" == "all" ]; then
+          run_tests None "${{inputs.event-loop}}"
           run_tests 2 "${{inputs.event-loop}}"
           run_tests 3 "${{inputs.event-loop}}"
         else

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -151,7 +151,7 @@ runs:
         set -e
 
         run_tests() {
-          test_config=$1
+          local test_config=$1
           local eventloop=""
 
           if [ "${{inputs.event-loop}}" == "uvloop" ]; then

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -158,7 +158,6 @@ runs:
             eventloop="--uvloop"
           fi
 
-          echo "::group::RESP${protocol} standalone tests"
           echo "REDIS_MOD_URL=${REDIS_MOD_URL}"
 
           if [ "$protocol" == "None" ]; then

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -22,8 +22,8 @@ inputs:
     description: 'Event loop to use'
     required: false
     default: 'asyncio'
-  protocol:
-    description: 'RESP protocol version to use'
+  test-config:
+    description: 'Test configuration to run. Can be "all", "fixed-clients", "2-standalone", "2-cluster", "3-standalone" or "3-cluster"'
     required: false
     default: 'all'
   repository:
@@ -151,7 +151,7 @@ runs:
         set -e
 
         run_tests() {
-          local protocol=$1
+          test_config=$1
           local eventloop=""
 
           if [ "${{inputs.event-loop}}" == "uvloop" ]; then
@@ -160,28 +160,34 @@ runs:
 
           echo "REDIS_MOD_URL=${REDIS_MOD_URL}"
 
-          if [ "$protocol" == "None" ]; then
-            echo "::group::RESP${protocol} fixed client tests"
+          if [ "$test_config" == "fixed-clients" ]; then
+            echo "::group::Fixed client tests"
             echo "Running fixed client tests - in those tests client instance and configuration is fixed and not changed by pytest configuration"
             invoke fixed-client-tests $eventloop
             echo "::endgroup::"
           else
-            echo "::group::RESP${protocol} standalone tests"
-            invoke standalone-tests --redis-mod-url=${REDIS_MOD_URL} $eventloop --protocol="${protocol}"
-            echo "::endgroup::"
-
-            echo "::group::RESP${protocol} cluster tests"
-            invoke cluster-tests $eventloop --protocol=${protocol}
-            echo "::endgroup::"
+            protocol="${test_config%%-*}"
+            test_type="${test_config#*-}"
+            if [ "$test_type" == "standalone" ]; then
+              echo "::group::RESP${protocol} standalone tests"
+              invoke standalone-tests --redis-mod-url=${REDIS_MOD_URL} $eventloop --protocol="${protocol}"
+              echo "::endgroup::"
+            elif [ "$test_type" == "cluster" ]; then
+              echo "::group::RESP${protocol} cluster tests"
+              invoke cluster-tests $eventloop --protocol=${protocol}
+              echo "::endgroup::"
+            fi
           fi
         }
 
-        if [ "${{inputs.protocol}}" == "all" ]; then
-          run_tests None "${{inputs.event-loop}}"
-          run_tests 2 "${{inputs.event-loop}}"
-          run_tests 3 "${{inputs.event-loop}}"
+        if [ "${{inputs.test-config}}" == "all" ]; then
+          run_tests fixed-clients "${{inputs.event-loop}}"
+          run_tests 2-standalone "${{inputs.event-loop}}"
+          run_tests 2-cluster "${{inputs.event-loop}}"
+          run_tests 3-standalone "${{inputs.event-loop}}"
+          run_tests 3-cluster "${{inputs.event-loop}}"
         else
-          run_tests "${{inputs.protocol}}" "${{inputs.event-loop}}"
+          run_tests "${{inputs.test-config}}" "${{inputs.event-loop}}"
         fi
       shell: bash
 
@@ -198,7 +204,7 @@ runs:
     - name: Upload test results and profiling data
       uses: actions/upload-artifact@v4
       with:
-        name: pytest-results-redis_${{inputs.redis-version}}-python_${{inputs.python-version}}-parser_${{env.PARSER_BACKEND}}-el_${{inputs.event-loop}}-protocol_${{inputs.protocol}}
+        name: pytest-results-redis_${{inputs.redis-version}}-python_${{inputs.python-version}}-parser_${{env.PARSER_BACKEND}}-el_${{inputs.event-loop}}-config_${{inputs.test-config}}
         path: |
           *-results.xml
           prof/**

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -23,7 +23,11 @@ inputs:
     required: false
     default: 'asyncio'
   test-config:
-    description: 'Test configuration to run. Can be "all", "fixed-clients", "2-standalone", "2-cluster", "3-standalone" or "3-cluster"'
+    description: |
+      Test configuration to run. Can be "all", "fixed-clients",
+      "2-standalone", "2-cluster", "3-standalone" or "3-cluster",
+      where the number is the RESP protocol version to test with,
+      the word describes the topology to test.
     required: false
     default: 'all'
   repository:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -84,10 +84,10 @@ jobs:
         python-version: ['3.10', '3.14']
         parser-backend: ['plain']
         event-loop: ['asyncio']
-        protocol: ['None', '2', '3']
+        test-config: ['fixed-clients', '2-standalone', '2-cluster', '3-standalone', '3-cluster']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
+    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Config:${{matrix.test-config}}
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
@@ -96,7 +96,7 @@ jobs:
             python-version: ${{ matrix.python-version }}
             parser-backend: ${{ matrix.parser-backend }}
             redis-version: ${{ matrix.redis-version }}
-            protocol: ${{ matrix.protocol }}
+            test-config: ${{ matrix.test-config }}
 
   python-compatibility-tests:
     runs-on: ubuntu-latest
@@ -110,10 +110,10 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
         parser-backend: [ 'plain' ]
         event-loop: [ 'asyncio' ]
-        protocol: ['None', '2', '3']
+        test-config: ['fixed-clients', '2-standalone', '2-cluster', '3-standalone', '3-cluster']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
+    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Config:${{matrix.test-config}}
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
@@ -122,7 +122,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           parser-backend: ${{ matrix.parser-backend }}
           redis-version: ${{ matrix.redis-version }}
-          protocol: ${{ matrix.protocol }}
+          test-config: ${{ matrix.test-config }}
 
   pypy-compatibility-tests:
     runs-on: ubuntu-latest
@@ -139,10 +139,10 @@ jobs:
         python-version: ['pypy-3.10', 'pypy-3.11']
         parser-backend: [ 'plain' ]
         event-loop: [ 'asyncio' ]
-        protocol: ['None', '2', '3']
+        test-config: ['fixed-clients', '2-standalone', '2-cluster', '3-standalone', '3-cluster']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-    name: PyPy Redis ${{ matrix.redis-version }}; ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
+    name: PyPy Redis ${{ matrix.redis-version }}; ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Config:${{matrix.test-config}}
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
@@ -151,7 +151,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           parser-backend: ${{ matrix.parser-backend }}
           redis-version: ${{ matrix.redis-version }}
-          protocol: ${{ matrix.protocol }}
+          test-config: ${{ matrix.test-config }}
 
   hiredis-tests:
     runs-on: ubuntu-latest
@@ -166,10 +166,10 @@ jobs:
         parser-backend: [ 'hiredis' ]
         hiredis-version: [ '>=3.2.0', '<3.0.0' ]
         event-loop: [ 'asyncio' ]
-        protocol: ['None', '2', '3']
+        test-config: ['fixed-clients', '2-standalone', '2-cluster', '3-standalone', '3-cluster']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}} (${{ matrix.hiredis-version }}); EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
+    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}} (${{ matrix.hiredis-version }}); EL:${{matrix.event-loop}}; Config:${{matrix.test-config}}
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
@@ -179,7 +179,7 @@ jobs:
           parser-backend: ${{ matrix.parser-backend }}
           redis-version: ${{ matrix.redis-version }}
           hiredis-version: ${{ matrix.hiredis-version }}
-          protocol: ${{ matrix.protocol }}
+          test-config: ${{ matrix.test-config }}
 
   uvloop-tests:
     runs-on: ubuntu-latest
@@ -193,10 +193,10 @@ jobs:
         python-version: [ '3.10', '3.14' ]
         parser-backend: [ 'plain' ]
         event-loop: [ 'uvloop' ]
-        protocol: ['None', '2', '3']
+        test-config: ['fixed-clients', '2-standalone', '2-cluster', '3-standalone', '3-cluster']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
+    name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Config:${{matrix.test-config}}
     steps:
       - uses: actions/checkout@v6
       - name: Run tests
@@ -206,7 +206,7 @@ jobs:
           parser-backend: ${{ matrix.parser-backend }}
           redis-version: ${{ matrix.redis-version }}
           event-loop: ${{ matrix.event-loop }}
-          protocol: ${{ matrix.protocol }}
+          test-config: ${{ matrix.test-config }}
 
   build-and-test-package:
     name: Validate building and installing the package

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -139,7 +139,7 @@ jobs:
         python-version: ['pypy-3.10', 'pypy-3.11']
         parser-backend: [ 'plain' ]
         event-loop: [ 'asyncio' ]
-        protocol: ['2', '3']
+        protocol: ['None', '2', '3']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: PyPy Redis ${{ matrix.redis-version }}; ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -84,7 +84,7 @@ jobs:
         python-version: ['3.10', '3.14']
         parser-backend: ['plain']
         event-loop: ['asyncio']
-        protocol: ['2', '3']
+        protocol: ['None', '2', '3']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
@@ -110,7 +110,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
         parser-backend: [ 'plain' ]
         event-loop: [ 'asyncio' ]
-        protocol: ['2', '3']
+        protocol: ['None', '2', '3']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
@@ -166,7 +166,7 @@ jobs:
         parser-backend: [ 'hiredis' ]
         hiredis-version: [ '>=3.2.0', '<3.0.0' ]
         event-loop: [ 'asyncio' ]
-        protocol: ['2', '3']
+        protocol: ['None', '2', '3']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}} (${{ matrix.hiredis-version }}); EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}
@@ -193,7 +193,7 @@ jobs:
         python-version: [ '3.10', '3.14' ]
         parser-backend: [ 'plain' ]
         event-loop: [ 'uvloop' ]
-        protocol: ['2', '3']
+        protocol: ['None', '2', '3']
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: Redis ${{ matrix.redis-version }}; Python ${{ matrix.python-version }}; RESP Parser:${{matrix.parser-backend}}; EL:${{matrix.event-loop}}; Protocol:${{matrix.protocol}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ include = ["/redis"]
 [tool.pytest.ini_options]
 addopts = "-s"
 markers = [
+    "fixed_client: tests, in which client instance and configuration is fixed",
     "redismod: run only the redis module tests",
     "pipeline: pipeline tests",
     "onlycluster: marks tests to be run only with cluster mode redis",

--- a/tasks.py
+++ b/tasks.py
@@ -58,10 +58,12 @@ def fixed_client_tests(c, uvloop=False, profile=False):
     profile_arg = "--profile" if profile else ""
     if uvloop:
         run(
-            f"pytest {profile_arg} --uvloop --junit-xml=fixed_client-uvloop-results.xml -m fixed_client"
+            f"pytest {profile_arg} --uvloop --cov=./ --cov-report=xml:coverage_fixed_client_uvloop.xml --junit-xml=fixed_client-uvloop-results.xml -m fixed_client"
         )
     else:
-        run(f"pytest {profile_arg} --junit-xml=fixed_client-results.xml -m fixed_client")
+        run(
+            f"pytest {profile_arg} --cov=./ --cov-report=xml:coverage_fixed_client.xml --junit-xml=fixed_client-results.xml -m fixed_client"
+        )
 
 @task
 def standalone_tests(

--- a/tasks.py
+++ b/tasks.py
@@ -48,9 +48,20 @@ def all_tests(c):
 def tests(c, uvloop=False, protocol=3, profile=False):
     """Run the redis-py test suite against the current python."""
     print("Starting Redis tests")
+    fixed_client_tests(c, uvloop=uvloop, profile=profile)
     standalone_tests(c, uvloop=uvloop, protocol=protocol, profile=profile)
     cluster_tests(c, uvloop=uvloop, protocol=protocol, profile=profile)
 
+@task
+def fixed_client_tests(c, uvloop=False, profile=False):
+    """Run tests that use the fixed client fixture."""
+    profile_arg = "--profile" if profile else ""
+    if uvloop:
+        run(
+            f"pytest {profile_arg} --uvloop --junit-xml=fixed_client-uvloop-results.xml -m fixed_client"
+        )
+    else:
+        run(f"pytest {profile_arg} --junit-xml=fixed_client-results.xml -m fixed_client")
 
 @task
 def standalone_tests(
@@ -63,11 +74,11 @@ def standalone_tests(
 
     if uvloop:
         run(
-            f"pytest {profile_arg} --protocol={protocol} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_resp{protocol}_uvloop.xml -m 'not onlycluster{extra_markers}' --uvloop --junit-xml=standalone-resp{protocol}-uvloop-results.xml"
+            f"pytest {profile_arg} --protocol={protocol} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_resp{protocol}_uvloop.xml -m 'not onlycluster and not fixed_client{extra_markers}' --uvloop --junit-xml=standalone-resp{protocol}-uvloop-results.xml"
         )
     else:
         run(
-            f"pytest {profile_arg} --protocol={protocol} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_resp{protocol}.xml -m 'not onlycluster{extra_markers}' --junit-xml=standalone-resp{protocol}-results.xml"
+            f"pytest {profile_arg} --protocol={protocol} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_resp{protocol}.xml -m 'not onlycluster and not fixed_client{extra_markers}' --junit-xml=standalone-resp{protocol}-results.xml"
         )
 
 
@@ -79,11 +90,11 @@ def cluster_tests(c, uvloop=False, protocol=3, profile=False):
     cluster_tls_url = "rediss://localhost:27379/0"
     if uvloop:
         run(
-            f"pytest {profile_arg} --protocol={protocol}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_resp{protocol}_uvloop.xml -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-resp{protocol}-uvloop-results.xml --uvloop"
+            f"pytest {profile_arg} --protocol={protocol}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_resp{protocol}_uvloop.xml -m 'not onlynoncluster and not redismod and not fixed_client' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-resp{protocol}-uvloop-results.xml --uvloop"
         )
     else:
         run(
-            f"pytest  {profile_arg} --protocol={protocol}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_resp{protocol}.xml -m 'not onlynoncluster and not redismod' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-resp{protocol}-results.xml"
+            f"pytest  {profile_arg} --protocol={protocol}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_resp{protocol}.xml -m 'not onlynoncluster and not redismod and not fixed_client' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-resp{protocol}-results.xml"
         )
 
 

--- a/tests/maint_notifications/test_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_cluster_maint_notifications_handling.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 import logging
+
+import pytest
 from typing import List, Optional, cast
 
 from redis import ConnectionPool, RedisCluster
@@ -36,6 +38,7 @@ PROXY_CLUSTER_NODES = [
 CLUSTER_SLOTS_INTERCEPTOR_NAME = "test_topology"
 
 
+@pytest.mark.fixed_client
 class TestRespTranslatorHelper:
     def test_oss_maint_notification_to_resp(self):
         resp = RespTranslator.oss_maint_notification_to_resp(
@@ -91,6 +94,7 @@ class TestClusterMaintNotificationsBase:
         return test_redis_client
 
 
+@pytest.mark.fixed_client
 class TestClusterMaintNotificationsConfig(TestClusterMaintNotificationsBase):
     """Test the maint_notifications_config parameter of RedisCluster."""
 
@@ -345,6 +349,7 @@ class TestClusterMaintNotificationsConfig(TestClusterMaintNotificationsBase):
             cluster.close()
 
 
+@pytest.mark.fixed_client
 class TestClusterMaintNotificationsHandler(TestClusterMaintNotificationsBase):
     """Test OSSMaintNotificationsHandler propagation with RedisCluster."""
 
@@ -460,6 +465,7 @@ class ConnectionStateExpectation:
     relaxed_timeout: Optional[int] = None
 
 
+@pytest.mark.fixed_client
 class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlingBase):
     """Test maintenance notifications handling with RedisCluster."""
 

--- a/tests/maint_notifications/test_maint_notifications.py
+++ b/tests/maint_notifications/test_maint_notifications.py
@@ -21,6 +21,7 @@ from redis.maint_notifications import (
 )
 
 
+@pytest.mark.fixed_client
 class TestMaintenanceNotification:
     """Test the base MaintenanceNotification class functionality through concrete subclasses."""
 
@@ -72,6 +73,7 @@ class TestMaintenanceNotification:
             assert notification.is_expired()
 
 
+@pytest.mark.fixed_client
 class TestNodeMovingNotification:
     """Test the NodeMovingNotification class."""
 
@@ -223,6 +225,7 @@ class TestNodeMovingNotification:
         )  # notification1 and notification2 should be considered the same
 
 
+@pytest.mark.fixed_client
 class TestNodeMigratingNotification:
     """Test the NodeMigratingNotification class."""
 
@@ -261,6 +264,7 @@ class TestNodeMigratingNotification:
         assert hash(notification1) != hash(notification3)
 
 
+@pytest.mark.fixed_client
 class TestNodeMigratedNotification:
     """Test the NodeMigratedNotification class."""
 
@@ -303,6 +307,7 @@ class TestNodeMigratedNotification:
         assert hash(notification1) != hash(notification3)
 
 
+@pytest.mark.fixed_client
 class TestNodeFailingOverNotification:
     """Test the NodeFailingOverNotification class."""
 
@@ -341,6 +346,7 @@ class TestNodeFailingOverNotification:
         assert hash(notification1) != hash(notification3)
 
 
+@pytest.mark.fixed_client
 class TestNodeFailedOverNotification:
     """Test the NodeFailedOverNotification class."""
 
@@ -383,6 +389,7 @@ class TestNodeFailedOverNotification:
         assert hash(notification1) != hash(notification3)
 
 
+@pytest.mark.fixed_client
 class TestOSSNodeMigratingNotification:
     """Test the OSSNodeMigratingNotification class."""
 
@@ -487,6 +494,7 @@ class TestOSSNodeMigratingNotification:
         )  # notification1 and notification2 should be the same
 
 
+@pytest.mark.fixed_client
 class TestOSSNodeMigratedNotification:
     """Test the OSSNodeMigratedNotification class."""
 
@@ -630,6 +638,7 @@ class TestOSSNodeMigratedNotification:
         )  # notification1 and notification2 should be the same
 
 
+@pytest.mark.fixed_client
 class TestMaintNotificationsConfig:
     """Test the MaintNotificationsConfig class."""
 
@@ -686,6 +695,7 @@ class TestMaintNotificationsConfig:
         assert config.relaxed_timeout is None
 
 
+@pytest.mark.fixed_client
 class TestMaintNotificationsPoolHandler:
     """Test the MaintNotificationsPoolHandler class."""
 
@@ -852,6 +862,7 @@ class TestMaintNotificationsPoolHandler:
         self.mock_pool.update_connections_settings.assert_called_once()
 
 
+@pytest.mark.fixed_client
 class TestMaintNotificationsConnectionHandler:
     """Test the MaintNotificationsConnectionHandler class."""
 
@@ -990,6 +1001,7 @@ class TestMaintNotificationsConnectionHandler:
         )
 
 
+@pytest.mark.fixed_client
 class TestEndpointType:
     """Test the EndpointType class functionality."""
 
@@ -1002,6 +1014,7 @@ class TestEndpointType:
         assert EndpointType.NONE.value == "none"
 
 
+@pytest.mark.fixed_client
 class TestMaintNotificationsConfigEndpointType:
     """Test MaintNotificationsConfig endpoint type functionality."""
 
@@ -1157,6 +1170,7 @@ class TestMaintNotificationsConfigEndpointType:
         assert config.get_endpoint_type("localhost", conn) == EndpointType.EXTERNAL_IP
 
 
+@pytest.mark.fixed_client
 class TestMaintNotificationsMetricsRecording:
     """
     Tests for metrics recording from maintenance notification handlers.

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -466,6 +466,7 @@ class TestMaintenanceNotificationsBase:
         return test_redis_client
 
 
+@pytest.mark.fixed_client
 class TestMaintenanceNotificationsHandshake(TestMaintenanceNotificationsBase):
     """Integration tests for maintenance notifications handling with real connection pool."""
 
@@ -530,6 +531,7 @@ class TestMaintenanceNotificationsHandshake(TestMaintenanceNotificationsBase):
             test_redis_client.close()
 
 
+@pytest.mark.fixed_client
 class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificationsBase):
     """Integration tests for maintenance notifications handling with real connection pool."""
 
@@ -1980,6 +1982,7 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
             pool.disconnect()
 
 
+@pytest.mark.fixed_client
 class TestMaintenanceNotificationsHandlingMultipleProxies(
     TestMaintenanceNotificationsBase
 ):

--- a/tests/test_asyncio/test_client.py
+++ b/tests/test_asyncio/test_client.py
@@ -19,6 +19,7 @@ from redis.observability.config import OTelConfig, MetricGroup
 from redis.observability.metrics import RedisMetricsCollector
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestAsyncRedisClientOperationDurationMetricsRecording:
     """
@@ -214,6 +215,7 @@ class TestAsyncRedisClientOperationDurationMetricsRecording:
         async_recorder.reset_collector()
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestAsyncRedisClientErrorMetricsRecording:
     """

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -50,7 +50,7 @@ async def test_invalid_response(create_redis):
     await r.connection.disconnect()
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 async def test_single_connection():
     """Test that concurrent requests on a single client are synchronised."""
     r = Redis(single_connection_client=True)
@@ -157,6 +157,7 @@ async def test_connect_retry_on_timeout_error(connect_args):
     await conn.disconnect()
 
 
+@pytest.mark.fixed_client
 async def test_connect_without_retry_on_non_retryable_error():
     """
     Test that the _connect function is not being retried in case of a CancelledError -
@@ -169,6 +170,7 @@ async def test_connect_without_retry_on_non_retryable_error():
         assert _connect.call_count == 1
 
 
+@pytest.mark.fixed_client
 async def test_connect_with_retries():
     """
     Test that retries occur for the entire connect+handshake flow when OSError happens during the handshake phase.
@@ -184,6 +186,7 @@ async def test_connect_with_retries():
         assert writelines.call_count == 3
 
 
+@pytest.mark.fixed_client
 async def test_connect_timeout_error_without_retry():
     """Test that the _connect function is not being retried if retry_on_timeout is
     set to False"""
@@ -311,7 +314,7 @@ async def test_connection_disconect_race(parser_class, connect_args):
     assert vals == [b"Hello, World!", None]
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 def test_create_single_connection_client_from_url():
     client = Redis.from_url("redis://localhost:6379/0?", single_connection_client=True)
     assert client.single_connection_client is True
@@ -550,6 +553,7 @@ async def test_format_error_message(conn, error, expected_message):
     assert error_message == expected_message
 
 
+@pytest.mark.fixed_client
 async def test_network_connection_failure():
     exp_err = rf"^Error {ECONNREFUSED} connecting to 127.0.0.1:9999.(.+)$"
     with pytest.raises(ConnectionError, match=exp_err):
@@ -557,6 +561,7 @@ async def test_network_connection_failure():
         await redis.set("a", "b")
 
 
+@pytest.mark.fixed_client
 async def test_unix_socket_connection_failure():
     exp_err = "Error 2 connecting to unix:///tmp/a.sock. No such file or directory."
     with pytest.raises(ConnectionError, match=exp_err):

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -151,6 +151,7 @@ class TestConnectionPool:
         finally:
             await pool.disconnect(inuse_connections=True)
 
+    @pytest.mark.fixed_client
     async def test_connection_creation(self):
         connection_kwargs = {"foo": "bar", "biz": "baz"}
         async with self.get_pool(
@@ -160,6 +161,7 @@ class TestConnectionPool:
             assert isinstance(connection, DummyConnection)
             assert connection.kwargs == connection_kwargs
 
+    @pytest.mark.fixed_client
     async def test_aclosing(self):
         connection_kwargs = {"foo": "bar", "biz": "baz"}
         pool = redis.ConnectionPool(
@@ -195,6 +197,7 @@ class TestConnectionPool:
             c2 = await pool.get_connection()
             assert c1 == c2
 
+    @pytest.mark.fixed_client
     async def test_repr_contains_db_info_tcp(self):
         connection_kwargs = {
             "host": "localhost",
@@ -208,6 +211,7 @@ class TestConnectionPool:
             expected = "host=localhost,port=6379,db=1,client_name=test-client"
             assert expected in repr(pool)
 
+    @pytest.mark.fixed_client
     async def test_repr_contains_db_info_unix(self):
         connection_kwargs = {"path": "/abc", "db": 1, "client_name": "test-client"}
         async with self.get_pool(
@@ -231,6 +235,7 @@ class TestConnectionPool:
             await pool.disconnect(inuse_connections=False)
             assert conn.is_connected
 
+    @pytest.mark.fixed_client
     async def test_lock_not_held_during_connection_establishment(self):
         """
         Test that the connection pool lock is not held during the
@@ -262,6 +267,7 @@ class TestConnectionPool:
 
             await pool.release(connection)
 
+    @pytest.mark.fixed_client
     async def test_concurrent_connection_acquisition_performance(self):
         """
         Test that multiple concurrent connection acquisitions don't block
@@ -401,6 +407,7 @@ class TestBlockingConnectionPool:
             c2 = await pool.get_connection()
             assert c1 == c2
 
+    @pytest.mark.fixed_client
     def test_repr_contains_db_info_tcp(self):
         pool = redis.ConnectionPool(
             host="localhost", port=6379, client_name="test-client"
@@ -408,6 +415,7 @@ class TestBlockingConnectionPool:
         expected = "host=localhost,port=6379,client_name=test-client"
         assert expected in repr(pool)
 
+    @pytest.mark.fixed_client
     def test_repr_contains_db_info_unix(self):
         pool = redis.ConnectionPool(
             connection_class=redis.UnixDomainSocketConnection,
@@ -418,6 +426,7 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
+    @pytest.mark.fixed_client
     def test_repr_redacts_sensitive_information(self):
         """Test that __repr__ redacts sensitive values like password and username."""
         pool = ConnectionPool(
@@ -444,6 +453,7 @@ class TestBlockingConnectionPool:
         assert "db=0" in repr_output
 
 
+@pytest.mark.fixed_client
 class TestConnectionPoolURLParsing:
     def test_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my.host")
@@ -586,6 +596,7 @@ class TestConnectionPoolURLParsing:
         )
 
 
+@pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:
     def test_extra_typed_querystring_options(self):
         pool = redis.BlockingConnectionPool.from_url(
@@ -611,6 +622,7 @@ class TestBlockingConnectionPoolURLParsing:
             )
 
 
+@pytest.mark.fixed_client
 class TestConnectionPoolUnixSocketURLParsing:
     def test_defaults(self):
         pool = redis.ConnectionPool.from_url("unix:///socket")
@@ -679,6 +691,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {"path": "/socket", "a": "1", "b": "2"}
 
 
+@pytest.mark.fixed_client
 class TestSSLConnectionURLParsing:
     def test_host(self):
         pool = redis.ConnectionPool.from_url("rediss://my.host")
@@ -709,6 +722,7 @@ class TestSSLConnectionURLParsing:
 
 
 class TestConnection:
+    @pytest.mark.fixed_client
     async def test_on_connect_error(self):
         """
         An error in Connection.on_connect should disconnect from the server
@@ -787,6 +801,7 @@ class TestConnection:
             # as the db being full
             await r.execute_command("DEBUG", "ERROR", "OOM blah blah")
 
+    @pytest.mark.fixed_client
     def test_connect_from_url_tcp(self):
         connection = redis.Redis.from_url("redis://localhost:6379?db=0")
         pool = connection.connection_pool
@@ -799,6 +814,7 @@ class TestConnection:
             "db=0,host=localhost,port=6379",
         )
 
+    @pytest.mark.fixed_client
     def test_connect_from_url_unix(self):
         connection = redis.Redis.from_url("unix:///path/to/socket")
         pool = connection.connection_pool
@@ -1028,6 +1044,7 @@ class TestHealthCheck:
             self.assert_interval_advanced(p.connection)
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestAsyncConnectionPoolMetricsRecording:
     """Tests for async ConnectionPool metrics recording (create time and wait time)."""

--- a/tests/test_asyncio/test_multidb/test_client.py
+++ b/tests/test_asyncio/test_multidb/test_client.py
@@ -22,7 +22,7 @@ from tests.test_asyncio.helpers import wait_for_condition
 from tests.test_asyncio.test_multidb.conftest import create_weighted_list
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestMultiDbClient:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -763,7 +763,7 @@ class TestMultiDbClient:
                     await client.set_active_database(mock_db1)
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestGeoFailoverMetricRecording:
     """Tests for geo failover metric recording in async MultiDBClient."""
 
@@ -911,7 +911,7 @@ class TestGeoFailoverMetricRecording:
                     mock_record_geo_failover.assert_not_called()
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestInitialHealthCheckPolicy:
     """Tests for initial health check policy evaluation."""
 

--- a/tests/test_asyncio/test_multidb/test_command_executor.py
+++ b/tests/test_asyncio/test_multidb/test_command_executor.py
@@ -15,7 +15,7 @@ from redis.observability.attributes import GeoFailoverReason
 from tests.test_asyncio.test_multidb.conftest import create_weighted_list
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestDefaultCommandExecutor:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_multidb/test_config.py
+++ b/tests/test_asyncio/test_multidb/test_config.py
@@ -24,7 +24,7 @@ from redis.asyncio.retry import Retry
 from redis.multidb.circuit import CircuitBreaker
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestMultiDbConfig:
     def test_default_config(self):
         db_configs = [
@@ -140,7 +140,7 @@ class TestMultiDbConfig:
         assert config.auto_fallback_interval == auto_fallback_interval
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestDatabaseConfig:
     def test_default_config(self):
         config = DatabaseConfig(

--- a/tests/test_asyncio/test_multidb/test_failover.py
+++ b/tests/test_asyncio/test_multidb/test_failover.py
@@ -14,7 +14,7 @@ from redis.asyncio.multidb.failover import (
 )
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestAsyncWeightBasedFailoverStrategy:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -69,6 +69,7 @@ class TestAsyncWeightBasedFailoverStrategy:
             assert await failover_strategy.database()
 
 
+@pytest.mark.fixed_client
 class TestDefaultStrategyExecutor:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_multidb/test_failure_detector.py
+++ b/tests/test_asyncio/test_multidb/test_failure_detector.py
@@ -10,7 +10,7 @@ from redis.multidb.circuit import State as CBState
 from redis.multidb.failure_detector import CommandFailureDetector
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestFailureDetectorAsyncWrapper:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_observability/test_cluster_metrics_error_handling.py
+++ b/tests/test_asyncio/test_observability/test_cluster_metrics_error_handling.py
@@ -19,6 +19,7 @@ from redis.exceptions import (
 )
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestAsyncClusterMetricsRecordingDuringErrorHandling:
     """

--- a/tests/test_asyncio/test_observability/test_recorder.py
+++ b/tests/test_asyncio/test_observability/test_recorder.py
@@ -166,6 +166,7 @@ def setup_async_recorder(metrics_collector, mock_instruments):
     get_observables_registry_instance().clear()
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordOperationDuration:
     """Tests for record_operation_duration - verifies Histogram.record() calls."""
@@ -219,6 +220,7 @@ class TestRecordOperationDuration:
         assert attrs[ERROR_TYPE] == "ConnectionError"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionCreateTime:
     """Tests for record_connection_create_time - verifies Histogram.record() calls."""
@@ -248,6 +250,7 @@ class TestRecordConnectionCreateTime:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "localhost:6379_a1b2c3d4"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionTimeout:
     """Tests for record_connection_timeout - verifies Counter.add() calls."""
@@ -266,6 +269,7 @@ class TestRecordConnectionTimeout:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "test_pool"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionWaitTime:
     """Tests for record_connection_wait_time - verifies Histogram.record() calls."""
@@ -287,6 +291,7 @@ class TestRecordConnectionWaitTime:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "test_pool"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionClosed:
     """Tests for record_connection_closed - verifies Counter.add() calls."""
@@ -303,6 +308,7 @@ class TestRecordConnectionClosed:
         instruments.connection_closed.add.assert_called_once()
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionRelaxedTimeout:
     """Tests for record_connection_relaxed_timeout - verifies UpDownCounter calls."""
@@ -340,6 +346,7 @@ class TestRecordConnectionRelaxedTimeout:
         assert call_args[0][0] == -1  # -1 for unrelaxed
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionHandoff:
     """Tests for record_connection_handoff - verifies Counter.add() calls."""
@@ -355,6 +362,7 @@ class TestRecordConnectionHandoff:
         assert call_args[0][0] == 1
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordErrorCount:
     """Tests for record_error_count - verifies Counter.add() calls."""
@@ -412,6 +420,7 @@ class TestRecordErrorCount:
         assert attrs[REDIS_CLIENT_OPERATION_RETRY_ATTEMPTS] == 2
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordPubsubMessage:
     """Tests for record_pubsub_message - verifies Counter.add() calls."""
@@ -441,6 +450,7 @@ class TestRecordPubsubMessage:
         instruments.pubsub_messages.add.assert_called_once()
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordGeoFailover:
     """Tests for record_geo_failover - verifies Counter.add() calls."""
@@ -513,6 +523,7 @@ class TestRecordGeoFailover:
         assert attrs[DB_CLIENT_GEOFAILOVER_REASON] == "manual"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestHidePubSubChannelNames:
     """Tests for hide_pubsub_channel_names configuration option."""
@@ -599,6 +610,7 @@ class TestHidePubSubChannelNames:
         assert attrs[REDIS_CLIENT_PUBSUB_CHANNEL] == "bytes-channel"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordStreamingLag:
     """Tests for record_streaming_lag - verifies Histogram.record() calls."""
@@ -618,6 +630,7 @@ class TestRecordStreamingLag:
         assert call_args[0][0] == 0.150
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordStreamingLagFromResponse:
     """Tests for record_streaming_lag_from_response - RESP2/RESP3 parsing and timestamp extraction."""
@@ -874,6 +887,7 @@ class TestRecordStreamingLagFromResponse:
         # Should not raise - bytes message ID should be handled
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecorderDisabled:
     """Tests for recorder behavior when observability is disabled."""
@@ -944,6 +958,7 @@ class TestRecorderDisabled:
         recorder.reset_collector()
 
 
+@pytest.mark.fixed_client
 @pytest.mark.asyncio
 class TestRecordConnectionCount:
     """Tests for record_connection_count (UpDownCounter)."""

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -980,7 +980,7 @@ class TestPubSubRun:
 @pytest.mark.parametrize("method", ["get_message", "listen"])
 @pytest.mark.onlynoncluster
 class TestPubSubAutoReconnect:
-    timeout = 2
+    timeout = 4
 
     async def mysetup(self, r, method):
         self.messages = asyncio.Queue()
@@ -1106,7 +1106,7 @@ class TestPubSubAutoReconnect:
     async def loop_step_listen(self):
         # get a single message via listen()
         try:
-            async with async_timeout(0.1):
+            async with async_timeout(0.5):
                 async for message in self.pubsub.listen():
                     await self.messages.put(message)
                     return True

--- a/tests/test_asyncio/test_retry.py
+++ b/tests/test_asyncio/test_retry.py
@@ -19,6 +19,7 @@ class BackoffMock(AbstractBackoff):
         return 0
 
 
+@pytest.mark.fixed_client
 class TestConnectionConstructorWithRetry:
     "Test that the Connection constructors properly handles Retry objects"
 
@@ -72,6 +73,7 @@ class TestConnectionConstructorWithRetry:
         assert set(c.retry._supported_errors) == set(retry_on_error)
 
 
+@pytest.mark.fixed_client
 class TestRetry:
     "Test that Retry calls backoff and retries the expected number of times"
 

--- a/tests/test_asyncio/test_sentinel_managed_connection.py
+++ b/tests/test_asyncio/test_sentinel_managed_connection.py
@@ -9,6 +9,7 @@ from redis.backoff import NoBackoff
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.mark.fixed_client
 async def test_connect_retry_on_timeout_error(connect_args):
     """Test that the _connect function is retried in case of a timeout"""
     connection_pool = mock.AsyncMock()

--- a/tests/test_asyncio/test_utils.py
+++ b/tests/test_asyncio/test_utils.py
@@ -17,6 +17,7 @@ async def redis_server_time(client: redis.Redis):
 
 
 # Async tests for deprecated_function decorator
+@pytest.mark.fixed_client
 class TestDeprecatedFunctionAsync:
     @pytest.mark.asyncio
     async def test_async_function_warns(self):
@@ -44,6 +45,7 @@ class TestDeprecatedFunctionAsync:
 
 
 # Async tests for deprecated_args decorator
+@pytest.mark.fixed_client
 class TestDeprecatedArgsAsync:
     @pytest.mark.asyncio
     async def test_async_function_warns_on_deprecated_arg(self):
@@ -86,6 +88,7 @@ class TestDeprecatedArgsAsync:
 
 
 # Async tests for experimental_method decorator
+@pytest.mark.fixed_client
 class TestExperimentalMethodAsync:
     @pytest.mark.asyncio
     async def test_async_function_warns(self):
@@ -113,6 +116,7 @@ class TestExperimentalMethodAsync:
 
 
 # Async tests for experimental_args decorator
+@pytest.mark.fixed_client
 class TestExperimentalArgsAsync:
     @pytest.mark.asyncio
     async def test_async_function_warns_on_experimental_arg(self):

--- a/tests/test_auth/test_token.py
+++ b/tests/test_auth/test_token.py
@@ -5,6 +5,7 @@ from redis.auth.err import InvalidTokenSchemaErr
 from redis.auth.token import JWToken, SimpleToken
 
 
+@pytest.mark.fixed_client
 class TestToken:
     def test_simple_token(self):
         token = SimpleToken(

--- a/tests/test_auth/test_token_manager.py
+++ b/tests/test_auth/test_token_manager.py
@@ -15,6 +15,7 @@ from redis.auth.token_manager import (
 )
 
 
+@pytest.mark.fixed_client
 class TestTokenManager:
     @pytest.mark.parametrize(
         "exp_refresh_ratio",

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -5,6 +5,7 @@ import pytest
 from redis.backoff import ExponentialWithJitterBackoff
 
 
+@pytest.mark.fixed_client
 def test_exponential_with_jitter_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_random = Mock(side_effect=[0.25, 0.5, 0.75, 1.0, 0.9])
     monkeypatch.setattr("random.random", mock_random)

--- a/tests/test_command_policies.py
+++ b/tests/test_command_policies.py
@@ -13,7 +13,7 @@ from redis.commands.search.field import TextField, NumericField
 from tests.conftest import skip_if_server_version_lt
 
 
-@pytest.mark.onlycluster
+@pytest.mark.fixed_client
 class TestBasePolicyResolver:
     def test_resolve(self):
         mock_command_parser = Mock(spec=CommandsParser)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -82,6 +82,7 @@ def test_loading_external_modules(r):
     # assert mod.get('fookey') == d
 
 
+@pytest.mark.fixed_client
 class TestConnection:
     def test_disconnect(self):
         conn = Connection()
@@ -214,7 +215,7 @@ def test_connection_parse_response_resume(r: redis.Redis, parser_class):
     assert i > 0
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "Class",
     [
@@ -250,7 +251,7 @@ def test_pack_command(Class):
     assert actual == expected, f"actual = {actual}, expected = {expected}"
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 def test_create_single_connection_client_from_url():
     client = redis.Redis.from_url(
         "redis://localhost:6379/0?", single_connection_client=True
@@ -373,6 +374,7 @@ def test_format_error_message(conn, error, expected_message):
     assert error_message == expected_message
 
 
+@pytest.mark.fixed_client
 def test_network_connection_failure():
     # Match only the stable part of the error message across OS
     exp_err = rf"Error {ECONNREFUSED} connecting to localhost:9999\."
@@ -381,6 +383,7 @@ def test_network_connection_failure():
         redis.set("a", "b")
 
 
+@pytest.mark.fixed_client
 @pytest.mark.skipif(
     not hasattr(socket, "AF_UNIX"),
     reason="Unix domain sockets not supported on this platform",
@@ -392,6 +395,7 @@ def test_unix_socket_connection_failure():
         redis.set("a", "b")
 
 
+@pytest.mark.fixed_client
 class TestUnitConnectionPool:
     @pytest.mark.parametrize(
         "max_conn", (-1, "str"), ids=("non-positive", "wrong type")
@@ -453,6 +457,7 @@ class TestUnitConnectionPool:
         connection_pool.disconnect()
 
 
+@pytest.mark.fixed_client
 class TestUnitCacheProxyConnection:
     def test_clears_cache_on_disconnect(self, mock_connection, cache_conf):
         cache = DefaultCache(CacheConfig(max_size=10))

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -98,6 +98,7 @@ class TestConnectionPool:
         )
         return pool
 
+    @pytest.mark.fixed_client
     def test_connection_creation(self):
         connection_kwargs = {
             "foo": "bar",
@@ -111,6 +112,7 @@ class TestConnectionPool:
         assert isinstance(connection, DummyConnection)
         assert_kwargs_match(connection.kwargs, connection_kwargs)
 
+    @pytest.mark.fixed_client
     def test_closing(self):
         connection_kwargs = {"foo": "bar", "biz": "baz"}
         pool = redis.ConnectionPool(
@@ -161,6 +163,7 @@ class TestConnectionPool:
         pool2.release(c1)
         assert len(pool2._available_connections) == 1
 
+    @pytest.mark.fixed_client
     def test_repr_contains_db_info_tcp(self):
         connection_kwargs = {
             "host": "localhost",
@@ -174,6 +177,7 @@ class TestConnectionPool:
         expected = "host=localhost,port=6379,db=1,client_name=test-client"
         assert expected in repr(pool)
 
+    @pytest.mark.fixed_client
     def test_repr_contains_db_info_unix(self):
         connection_kwargs = {"path": "/abc", "db": 1, "client_name": "test-client"}
         pool = self.get_pool(
@@ -272,6 +276,7 @@ class TestBlockingConnectionPool:
         c2 = pool.get_connection()
         assert c1 == c2
 
+    @pytest.mark.fixed_client
     def test_repr_contains_db_info_tcp(self):
         pool = redis.ConnectionPool(
             host="localhost", port=6379, client_name="test-client"
@@ -279,6 +284,7 @@ class TestBlockingConnectionPool:
         expected = "host=localhost,port=6379,client_name=test-client"
         assert expected in repr(pool)
 
+    @pytest.mark.fixed_client
     def test_repr_contains_db_info_unix(self):
         pool = redis.ConnectionPool(
             connection_class=redis.UnixDomainSocketConnection,
@@ -289,6 +295,7 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
+    @pytest.mark.fixed_client
     def test_repr_redacts_sensitive_information(self):
         """Test that __repr__ redacts sensitive values like password and username."""
         pool = redis.ConnectionPool(
@@ -345,6 +352,7 @@ class TestBlockingConnectionPool:
         assert conn._sock
 
 
+@pytest.mark.fixed_client
 class TestConnectionPoolURLParsing:
     def test_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my.host")
@@ -513,6 +521,7 @@ class TestConnectionPoolURLParsing:
         )
 
 
+@pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:
     def test_extra_typed_querystring_options(self):
         pool = redis.BlockingConnectionPool.from_url(
@@ -541,6 +550,7 @@ class TestBlockingConnectionPoolURLParsing:
             )
 
 
+@pytest.mark.fixed_client
 class TestConnectionPoolUnixSocketURLParsing:
     def test_defaults(self):
         pool = redis.ConnectionPool.from_url("unix:///socket")
@@ -633,6 +643,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_class == MyConnection
 
 
+@pytest.mark.fixed_client
 @pytest.mark.skipif(not SSL_AVAILABLE, reason="SSL not installed")
 class TestSSLConnectionURLParsing:
     def test_host(self):
@@ -730,6 +741,7 @@ class TestSSLConnectionURLParsing:
 
 
 class TestConnection:
+    @pytest.mark.fixed_client
     def test_on_connect_error(self):
         """
         An error in Connection.on_connect should disconnect from the server
@@ -804,6 +816,7 @@ class TestConnection:
             # as the db being full
             r.execute_command("DEBUG", "ERROR", "OOM blah blah")
 
+    @pytest.mark.fixed_client
     def test_connect_from_url_tcp(self):
         connection = redis.Redis.from_url("redis://localhost:6379?db=0")
         pool = connection.connection_pool
@@ -821,6 +834,7 @@ class TestConnection:
         for expected in ("db=0", "host=localhost", "port=6379"):
             assert expected in groups[2]
 
+    @pytest.mark.fixed_client
     def test_connect_from_url_unix(self):
         connection = redis.Redis.from_url("unix:///path/to/socket")
         pool = connection.connection_pool
@@ -1064,6 +1078,7 @@ class TestHealthCheck:
             self.assert_interval_advanced(p.connection)
 
 
+@pytest.mark.fixed_client
 class TestConnectionPoolReleasedEventEmission:
     """Tests for AfterConnectionReleasedEvent emission from ConnectionPool."""
 

--- a/tests/test_data_structure.py
+++ b/tests/test_data_structure.py
@@ -3,9 +3,12 @@ import random
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 
+import pytest
+
 from redis.data_structure import WeightedList
 
 
+@pytest.mark.fixed_client
 class TestWeightedList:
     def test_add_items(self):
         wlist = WeightedList()

--- a/tests/test_driver_info.py
+++ b/tests/test_driver_info.py
@@ -4,6 +4,7 @@ from redis.driver_info import DriverInfo
 from redis.utils import get_lib_version
 
 
+@pytest.mark.fixed_client
 def test_driver_info_default_name_no_upstream():
     info = DriverInfo()
     assert info.formatted_name == "redis-py"
@@ -11,17 +12,20 @@ def test_driver_info_default_name_no_upstream():
     assert info.lib_version == get_lib_version()
 
 
+@pytest.mark.fixed_client
 def test_driver_info_custom_lib_version():
     info = DriverInfo(lib_version="5.0.0")
     assert info.lib_version == "5.0.0"
     assert info.formatted_name == "redis-py"
 
 
+@pytest.mark.fixed_client
 def test_driver_info_single_upstream():
     info = DriverInfo().add_upstream_driver("django-redis", "5.4.0")
     assert info.formatted_name == "redis-py(django-redis_v5.4.0)"
 
 
+@pytest.mark.fixed_client
 def test_driver_info_multiple_upstreams_latest_first():
     info = DriverInfo()
     info.add_upstream_driver("django-redis", "5.4.0")
@@ -29,6 +33,7 @@ def test_driver_info_multiple_upstreams_latest_first():
     assert info.formatted_name == "redis-py(celery_v5.4.1;django-redis_v5.4.0)"
 
 
+@pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "name",
     [
@@ -44,6 +49,7 @@ def test_driver_info_invalid_name(name):
         info.add_upstream_driver(name, "3.2.0")
 
 
+@pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "version",
     [

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, AsyncMock
 
+import pytest
+
 from redis.event import (
     EventListenerInterface,
     EventDispatcher,
@@ -7,6 +9,7 @@ from redis.event import (
 )
 
 
+@pytest.mark.fixed_client
 class TestEventDispatcher:
     def test_register_listeners(self):
         mock_event = Mock(spec=object)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,7 @@
 import string
 
+import pytest
+
 from redis.commands.helpers import (
     delist,
     list_or_args,
@@ -9,6 +11,7 @@ from redis.commands.helpers import (
 )
 
 
+@pytest.mark.fixed_client
 def test_list_or_args():
     k = ["hello, world"]
     a = ["some", "argument", "list"]
@@ -18,23 +21,27 @@ def test_list_or_args():
         assert list_or_args(i, a) == [i] + a
 
 
+@pytest.mark.fixed_client
 def test_parse_to_list():
     assert parse_to_list(None) == []
     r = ["hello", b"my name", "45", "555.55", "is simon!", None]
     assert parse_to_list(r) == ["hello", "my name", 45, 555.55, "is simon!", None]
 
 
+@pytest.mark.fixed_client
 def test_nativestr():
     assert nativestr("teststr") == "teststr"
     assert nativestr(b"teststr") == "teststr"
     assert nativestr("null") is None
 
 
+@pytest.mark.fixed_client
 def test_delist():
     assert delist(None) is None
     assert delist([b"hello", "world", b"banana"]) == ["hello", "world", "banana"]
 
 
+@pytest.mark.fixed_client
 def test_random_string():
     assert len(random_string()) == 10
     assert len(random_string(15)) == 15

--- a/tests/test_multidb/test_circuit.py
+++ b/tests/test_multidb/test_circuit.py
@@ -8,7 +8,7 @@ from redis.multidb.circuit import (
 )
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestPBCircuitBreaker:
     @pytest.mark.parametrize(
         "mock_db",

--- a/tests/test_multidb/test_client.py
+++ b/tests/test_multidb/test_client.py
@@ -24,7 +24,7 @@ from tests.helpers import wait_for_condition
 from tests.test_multidb.conftest import create_weighted_list
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestMultiDbClient:
     @pytest.mark.parametrize(
         "mock_multi_db_config,mock_db, mock_db1, mock_db2",
@@ -943,7 +943,7 @@ class TestMultiDbClient:
                 client.close()
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestGeoFailoverMetricRecording:
     """Tests for geo failover metric recording in MultiDBClient."""
 
@@ -1095,7 +1095,7 @@ class TestGeoFailoverMetricRecording:
                 client.close()
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestInitialHealthCheckPolicy:
     """Tests for initial health check policy evaluation."""
 

--- a/tests/test_multidb/test_command_executor.py
+++ b/tests/test_multidb/test_command_executor.py
@@ -13,7 +13,7 @@ from redis.retry import Retry
 from tests.test_multidb.conftest import create_weighted_list
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestDefaultCommandExecutor:
     @pytest.mark.parametrize(
         "mock_db,mock_db1,mock_db2",

--- a/tests/test_multidb/test_config.py
+++ b/tests/test_multidb/test_config.py
@@ -22,7 +22,7 @@ from redis.multidb.failover import WeightBasedFailoverStrategy, FailoverStrategy
 from redis.retry import Retry
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestMultiDbConfig:
     def test_default_config(self):
         db_configs = [
@@ -196,7 +196,7 @@ class TestMultiDbConfig:
         assert pool._maint_notifications_pool_handler.config.enabled is True
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestDatabaseConfig:
     def test_default_config(self):
         config = DatabaseConfig(

--- a/tests/test_multidb/test_failover.py
+++ b/tests/test_multidb/test_failover.py
@@ -14,7 +14,7 @@ from redis.multidb.failover import (
 )
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestWeightBasedFailoverStrategy:
     @pytest.mark.parametrize(
         "mock_db,mock_db1,mock_db2",
@@ -65,7 +65,7 @@ class TestWeightBasedFailoverStrategy:
             assert failover_strategy.database()
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestDefaultStrategyExecutor:
     @pytest.mark.parametrize(
         "mock_db",

--- a/tests/test_multidb/test_failure_detector.py
+++ b/tests/test_multidb/test_failure_detector.py
@@ -10,7 +10,7 @@ from redis.multidb.circuit import State as CBState
 from redis.exceptions import ConnectionError
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestCommandFailureDetector:
     @pytest.mark.parametrize(
         "min_num_failures,failure_rate_threshold,circuit_state",

--- a/tests/test_multidb/test_pipeline.py
+++ b/tests/test_multidb/test_pipeline.py
@@ -22,7 +22,7 @@ def mock_pipe() -> Pipeline:
     return mock_pipe
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestPipeline:
     @pytest.mark.parametrize(
         "mock_multi_db_config,mock_db, mock_db1, mock_db2",
@@ -286,7 +286,7 @@ class TestPipeline:
                 client.close()
 
 
-@pytest.mark.onlynoncluster
+@pytest.mark.fixed_client
 class TestTransaction:
     @pytest.mark.parametrize(
         "mock_multi_db_config,mock_db, mock_db1, mock_db2",

--- a/tests/test_observability/test_cluster_metrics_error_handling.py
+++ b/tests/test_observability/test_cluster_metrics_error_handling.py
@@ -20,7 +20,7 @@ from redis.exceptions import (
 )
 
 
-@pytest.mark.onlycluster
+@pytest.mark.fixed_client
 class TestClusterMetricsRecordingDuringErrorHandling:
     """
     Tests for cluster metrics recording during error handling.

--- a/tests/test_observability/test_config.py
+++ b/tests/test_observability/test_config.py
@@ -9,9 +9,12 @@ These tests verify the OTelConfig class behavior including:
 - Runtime configuration changes
 """
 
+import pytest
+
 from redis.observability.config import OTelConfig, MetricGroup, TelemetryOption
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigDefaults:
     """Tests for OTelConfig default values."""
 
@@ -42,6 +45,7 @@ class TestOTelConfigDefaults:
         assert config.is_enabled() is True
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigEnabledTelemetry:
     """Tests for enabled_telemetry configuration."""
 
@@ -57,6 +61,7 @@ class TestOTelConfigEnabledTelemetry:
         assert config.is_enabled() is False
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigMetricGroups:
     """Tests for metric_groups configuration."""
 
@@ -98,6 +103,7 @@ class TestOTelConfigMetricGroups:
         assert config.metric_groups == MetricGroup(0)
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigIncludeCommands:
     """Tests for include_commands configuration."""
 
@@ -117,6 +123,7 @@ class TestOTelConfigIncludeCommands:
         assert config.include_commands is None
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigExcludeCommands:
     """Tests for exclude_commands configuration."""
 
@@ -136,6 +143,7 @@ class TestOTelConfigExcludeCommands:
         assert config.exclude_commands == set()
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigShouldTrackCommand:
     """Tests for should_track_command method."""
 
@@ -187,6 +195,7 @@ class TestOTelConfigShouldTrackCommand:
         assert config.should_track_command("SET") is True
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigRepr:
     """Tests for __repr__ method."""
 
@@ -197,6 +206,7 @@ class TestOTelConfigRepr:
         assert "enabled_telemetry" in repr_str
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigPrivacyControls:
     """Tests for privacy control configuration options."""
 
@@ -230,6 +240,7 @@ class TestOTelConfigPrivacyControls:
         assert config.hide_stream_names is True
 
 
+@pytest.mark.fixed_client
 class TestOTelConfigHistogramBuckets:
     """Tests for custom histogram bucket boundary configuration."""
 
@@ -315,6 +326,7 @@ class TestOTelConfigHistogramBuckets:
         assert config.buckets_operation_duration == [1.0]
 
 
+@pytest.mark.fixed_client
 class TestDefaultBucketFunctions:
     """Tests for default bucket boundary functions."""
 
@@ -363,6 +375,7 @@ class TestDefaultBucketFunctions:
         assert all(b > 0 for b in buckets)
 
 
+@pytest.mark.fixed_client
 class TestMetricGroupEnum:
     """Tests for MetricGroup IntFlag enum."""
 

--- a/tests/test_observability/test_metrics_connection_attributes.py
+++ b/tests/test_observability/test_metrics_connection_attributes.py
@@ -105,6 +105,7 @@ class MockConnectionWithoutHostPort(ConnectionInterface):
         return self._sock is not None
 
 
+@pytest.mark.fixed_client
 class TestConnectionAttributesWithoutHostPort:
     """Tests for metrics recording with connections lacking host/port attributes."""
 

--- a/tests/test_observability/test_provider.py
+++ b/tests/test_observability/test_provider.py
@@ -20,6 +20,7 @@ from redis.observability.providers import (
 )
 
 
+@pytest.mark.fixed_client
 class TestOTelProviderManagerInit:
     """Tests for OTelProviderManager initialization."""
 
@@ -42,6 +43,7 @@ class TestOTelProviderManagerInit:
         assert "DEBUG" in manager.config.exclude_commands
 
 
+@pytest.mark.fixed_client
 class TestOTelProviderManagerGetMeterProvider:
     """Tests for get_meter_provider method."""
 
@@ -103,6 +105,7 @@ class TestOTelProviderManagerGetMeterProvider:
         assert result1 is result2
 
 
+@pytest.mark.fixed_client
 class TestOTelProviderManagerShutdown:
     """Tests for shutdown method."""
 
@@ -128,6 +131,7 @@ class TestOTelProviderManagerShutdown:
         mock_flush.assert_called_once_with(timeout_millis=30000)
 
 
+@pytest.mark.fixed_client
 class TestOTelProviderManagerForceFlush:
     """Tests for force_flush method."""
 
@@ -167,6 +171,7 @@ class TestOTelProviderManagerForceFlush:
         assert result is False
 
 
+@pytest.mark.fixed_client
 class TestOTelProviderManagerContextManager:
     """Tests for context manager support."""
 
@@ -200,6 +205,7 @@ class TestOTelProviderManagerContextManager:
             mock_shutdown.assert_called_once()
 
 
+@pytest.mark.fixed_client
 class TestOTelProviderManagerRepr:
     """Tests for __repr__ method."""
 
@@ -214,6 +220,7 @@ class TestOTelProviderManagerRepr:
         assert "config=" in repr_str
 
 
+@pytest.mark.fixed_client
 class TestObservabilityInstanceInit:
     """Tests for ObservabilityInstance initialization."""
 
@@ -250,6 +257,7 @@ class TestObservabilityInstanceInit:
         assert "SLOWLOG" in instance._provider_manager.config.exclude_commands
 
 
+@pytest.mark.fixed_client
 class TestObservabilityInstanceIsEnabled:
     """Tests for is_enabled method."""
 
@@ -278,6 +286,7 @@ class TestObservabilityInstanceIsEnabled:
         assert instance.is_enabled() is False
 
 
+@pytest.mark.fixed_client
 class TestObservabilityInstanceGetProviderManager:
     """Tests for get_provider_manager method."""
 
@@ -299,6 +308,7 @@ class TestObservabilityInstanceGetProviderManager:
         assert manager.config is config
 
 
+@pytest.mark.fixed_client
 class TestObservabilityInstanceShutdown:
     """Tests for shutdown method."""
 
@@ -337,6 +347,7 @@ class TestObservabilityInstanceShutdown:
         assert instance._provider_manager is None
 
 
+@pytest.mark.fixed_client
 class TestObservabilityInstanceForceFlush:
     """Tests for force_flush method."""
 
@@ -363,6 +374,7 @@ class TestObservabilityInstanceForceFlush:
         assert result is True
 
 
+@pytest.mark.fixed_client
 class TestGetObservabilityInstance:
     """Tests for get_observability_instance function."""
 
@@ -417,6 +429,7 @@ class TestGetObservabilityInstance:
             providers._observability_instance = original_instance
 
 
+@pytest.mark.fixed_client
 class TestObservabilityInstanceIntegration:
     """Integration tests for ObservabilityInstance."""
 

--- a/tests/test_observability/test_public_api.py
+++ b/tests/test_observability/test_public_api.py
@@ -5,7 +5,10 @@ These tests verify that all symbols exported from redis.observability
 are correctly re-exported and match the original implementations.
 """
 
+import pytest
 
+
+@pytest.mark.fixed_client
 class TestPublicAPIExports:
     """Tests for public API exports from redis.observability."""
 

--- a/tests/test_observability/test_recorder.py
+++ b/tests/test_observability/test_recorder.py
@@ -194,6 +194,7 @@ def setup_recorder(metrics_collector, mock_instruments):
     recorder.reset_collector()
 
 
+@pytest.mark.fixed_client
 class TestRecordOperationDuration:
     """Tests for record_operation_duration - verifies Histogram.record() calls."""
 
@@ -271,6 +272,7 @@ class TestRecordOperationDuration:
         assert isinstance(attrs[DB_OPERATION_NAME], str)
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionCreateTime:
     """Tests for record_connection_create_time - verifies Histogram.record() calls."""
 
@@ -302,6 +304,7 @@ class TestRecordConnectionCreateTime:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "localhost:6379_a1b2c3d4"
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionTimeout:
     """Tests for record_connection_timeout - verifies Counter.add() calls."""
 
@@ -324,6 +327,7 @@ class TestRecordConnectionTimeout:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "ConnectionPool<localhost:6379>"
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionWaitTime:
     """Tests for record_connection_wait_time - verifies Histogram.record() calls."""
 
@@ -345,6 +349,7 @@ class TestRecordConnectionWaitTime:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "ConnectionPool<localhost:6379>"
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionClosed:
     """Tests for record_connection_closed - verifies Counter.add() calls."""
 
@@ -384,6 +389,7 @@ class TestRecordConnectionClosed:
         assert attrs[ERROR_TYPE] == "ConnectionResetError"
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionRelaxedTimeout:
     """Tests for record_connection_relaxed_timeout - verifies UpDownCounter.add() calls."""
 
@@ -427,6 +433,7 @@ class TestRecordConnectionRelaxedTimeout:
         assert attrs[REDIS_CLIENT_CONNECTION_NOTIFICATION] == "MIGRATING"
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionHandoff:
     """Tests for record_connection_handoff - verifies Counter.add() calls."""
 
@@ -447,6 +454,7 @@ class TestRecordConnectionHandoff:
         assert attrs[DB_CLIENT_CONNECTION_POOL_NAME] == "ConnectionPool<localhost:6379>"
 
 
+@pytest.mark.fixed_client
 class TestRecordErrorCount:
     """Tests for record_error_count - verifies Counter.add() calls."""
 
@@ -503,6 +511,7 @@ class TestRecordErrorCount:
         assert attrs[REDIS_CLIENT_OPERATION_RETRY_ATTEMPTS] == 2
 
 
+@pytest.mark.fixed_client
 class TestRecordMaintNotificationCount:
     """Tests for record_maint_notification_count - verifies Counter.add() calls."""
 
@@ -553,6 +562,7 @@ class TestRecordMaintNotificationCount:
         assert attrs[REDIS_CLIENT_CONNECTION_NOTIFICATION] == "MIGRATING"
 
 
+@pytest.mark.fixed_client
 class TestRecordGeoFailover:
     """Tests for record_geo_failover - verifies Counter.add() calls."""
 
@@ -624,6 +634,7 @@ class TestRecordGeoFailover:
         assert attrs[DB_CLIENT_GEOFAILOVER_REASON] == "manual"
 
 
+@pytest.mark.fixed_client
 class TestRecordPubsubMessage:
     """Tests for record_pubsub_message - verifies Counter.add() calls."""
 
@@ -671,6 +682,7 @@ class TestRecordPubsubMessage:
         assert attrs[REDIS_CLIENT_PUBSUB_SHARDED] is True
 
 
+@pytest.mark.fixed_client
 class TestRecordStreamingLag:
     """Tests for record_streaming_lag - verifies Histogram.record() calls."""
 
@@ -726,6 +738,7 @@ class TestRecordStreamingLag:
         assert attrs[REDIS_CLIENT_STREAM_NAME] == "events-stream"
 
 
+@pytest.mark.fixed_client
 class TestHidePubSubChannelNames:
     """Tests for hide_pubsub_channel_names configuration option."""
 
@@ -785,6 +798,7 @@ class TestHidePubSubChannelNames:
         assert attrs[REDIS_CLIENT_PUBSUB_CHANNEL] == "visible-channel"
 
 
+@pytest.mark.fixed_client
 class TestHideStreamNames:
     """Tests for hide_stream_names configuration option."""
 
@@ -898,6 +912,7 @@ class TestHideStreamNames:
         assert REDIS_CLIENT_STREAM_NAME not in attrs
 
 
+@pytest.mark.fixed_client
 class TestRecorderDisabled:
     """Tests for recorder behavior when observability is disabled."""
 
@@ -949,6 +964,7 @@ class TestRecorderDisabled:
         recorder.reset_collector()
 
 
+@pytest.mark.fixed_client
 class TestResetCollector:
     """Tests for reset_collector function."""
 
@@ -959,6 +975,7 @@ class TestResetCollector:
         assert recorder._metrics_collector is None
 
 
+@pytest.mark.fixed_client
 class TestMetricGroupsDisabled:
     """Tests for verifying metrics are not sent to Meter when their MetricGroup is disabled.
 
@@ -1279,6 +1296,7 @@ class TestMetricGroupsDisabled:
         instruments.stream_lag.record.assert_not_called()
 
 
+@pytest.mark.fixed_client
 class TestObservablesRegistry:
     """Tests for ObservablesRegistry singleton and callback registration."""
 
@@ -1323,6 +1341,7 @@ class TestObservablesRegistry:
         assert len(registry) == 0
 
 
+@pytest.mark.fixed_client
 class TestRecordConnectionCount:
     """Tests for record_connection_count (UpDownCounter)."""
 
@@ -1494,6 +1513,7 @@ class TestRecordConnectionCount:
         assert calls[5][1]["attributes"][DB_CLIENT_CONNECTION_STATE] == "idle"
 
 
+@pytest.mark.fixed_client
 class TestInitCSCItems:
     """Tests for init_csc_items and register_csc_items_callback."""
 
@@ -1624,6 +1644,7 @@ class TestInitCSCItems:
         assert obs2[0].value == 20
 
 
+@pytest.mark.fixed_client
 class TestHistogramBucketBoundaries:
     """Tests for custom histogram bucket boundaries configuration."""
 

--- a/tests/test_parsers/test_errors.py
+++ b/tests/test_parsers/test_errors.py
@@ -118,6 +118,7 @@ class MockSocket:
         pass
 
 
+@pytest.mark.fixed_client
 class TestErrorParsing:
     def setup_method(self):
         """Set up test fixtures with mocked sockets."""

--- a/tests/test_parsers/test_helpers.py
+++ b/tests/test_parsers/test_helpers.py
@@ -1,6 +1,9 @@
+import pytest
+
 from redis._parsers.helpers import parse_info, parse_client_list
 
 
+@pytest.mark.fixed_client
 def test_parse_info():
     info_output = """
 # Modules
@@ -35,6 +38,7 @@ search_query_timeout_ms:500
     assert info["search_query_timeout_ms"] == 500
 
 
+@pytest.mark.fixed_client
 def test_parse_info_list():
     info_output = """
 list_one:a,
@@ -49,6 +53,7 @@ list_two:a b,,c,10,1.1
     assert info["list_two"] == ["a b", "c", 10, 1.1]
 
 
+@pytest.mark.fixed_client
 def test_parse_info_list_dict_mixed():
     info_output = """
 list_one:a,b=1
@@ -63,6 +68,7 @@ list_two:a b=foo,,c,d=bar,e,
     assert info["list_two"] == {"a b": "foo", "c": True, "d": "bar", "e": True}
 
 
+@pytest.mark.fixed_client
 def test_parse_client_list():
     response = "id=7 addr=/tmp/redis sock/redis.sock:0 fd=9 name=test=_complex_[name] age=-1 idle=0 cmd=client|list user=default lib-name=go-redis(,go1.24.4) lib-ver="
     expected = [

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -38,6 +38,7 @@ class BackoffMock(AbstractBackoff):
         return 0
 
 
+@pytest.mark.fixed_client
 class TestConnectionConstructorWithRetry:
     "Test that the Connection constructors properly handles Retry objects"
 
@@ -90,6 +91,7 @@ class TestConnectionConstructorWithRetry:
         assert c.retry._retries == retries
 
 
+@pytest.mark.fixed_client
 @pytest.mark.parametrize("retry_class", [Retry, AsyncRetry])
 @pytest.mark.parametrize(
     "args",
@@ -135,6 +137,7 @@ def test_retry_eq_and_hashable(retry_class, args):
     )
 
 
+@pytest.mark.fixed_client
 class TestRetry:
     "Test that Retry calls backoff and retries the expected number of times"
 

--- a/tests/test_sentinel_managed_connection.py
+++ b/tests/test_sentinel_managed_connection.py
@@ -1,5 +1,7 @@
 import socket
 
+import pytest
+
 from redis._parsers.socket import SENTINEL
 from redis.retry import Retry
 from redis.sentinel import SentinelManagedConnection
@@ -7,6 +9,7 @@ from redis.backoff import NoBackoff
 from unittest import mock
 
 
+@pytest.mark.fixed_client
 def test_connect_retry_on_timeout_error(master_host):
     """Test that the _connect function is retried in case of a timeout"""
     connection_pool = mock.Mock()
@@ -35,6 +38,7 @@ def test_connect_retry_on_timeout_error(master_host):
     conn.disconnect()
 
 
+@pytest.mark.fixed_client
 class TestSentinelManagedConnectionReadResponseTimeout:
     """
     Tests for timeout parameter propagation in SentinelManagedConnection.read_response().

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from redis.utils import (
 )
 
 
+@pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "version1,version2,expected_res",
     [
@@ -42,6 +43,7 @@ def redis_server_time(client):
 
 
 # Tests for deprecated_function decorator
+@pytest.mark.fixed_client
 class TestDeprecatedFunction:
     def test_sync_function_warns(self):
         @deprecated_function(reason="use new_func", version="1.0.0")
@@ -69,6 +71,7 @@ class TestDeprecatedFunction:
 
 
 # Tests for deprecated_args decorator
+@pytest.mark.fixed_client
 class TestDeprecatedArgs:
     def test_sync_function_warns_on_deprecated_arg(self):
         @deprecated_args(args_to_warn=["old_param"], reason="use new_param")
@@ -108,6 +111,7 @@ class TestDeprecatedArgs:
 
 
 # Tests for experimental_method decorator
+@pytest.mark.fixed_client
 class TestExperimentalMethod:
     def test_sync_function_warns(self):
         @experimental_method()
@@ -124,6 +128,7 @@ class TestExperimentalMethod:
 
 
 # Tests for experimental_args decorator
+@pytest.mark.fixed_client
 class TestExperimentalArgs:
     def test_sync_function_warns_on_experimental_arg(self):
         @experimental_args(args_to_warn=["beta_param"])


### PR DESCRIPTION
Reorganize unit tests grouping - extracting the tests that define their hardcoded client configuration separately so that they won't be executed twice - once with the standalone tests and once with cluster tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/test execution and pytest markers, with no runtime library behavior changes. Main risk is CI misconfiguration causing tests to be skipped or run in the wrong matrix combinations.
> 
> **Overview**
> **Reorganizes CI test execution to avoid running certain unit tests twice.** A new pytest marker, `fixed_client`, is introduced and applied broadly to tests that hardcode their client configuration.
> 
> CI is updated to run these `fixed_client` tests as a separate job/config (`fixed-clients`), while the existing standalone/cluster suites now explicitly exclude them. The GitHub Action input is changed from `protocol` to `test-config`, and artifacts are renamed accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c37e2b98b1d74635b7b26bc49f19219a15c080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->