### PR TITLE
Changing the default RESP protocol configurations for Redis clients and connections to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,20 @@ The above code connects to localhost on port 6379, sets a value in Redis, and re
 
 
 #### RESP3 Support
-To enable support for RESP3, ensure you have at least version 5.0 of the client, and change your connection object to include *protocol=3*
+RESP3 is the default protocol used by the client.
+To use support for RESP3, ensure you have at least version 5.0 of the client.
 
 ``` python
 >>> import redis
 >>> r = redis.Redis(host='localhost', port=6379, db=0, protocol=3)
+```
+
+#### RESP2 Support
+To use support for RESP2, ensure you provide *protocol=2* when creating the client.
+
+``` python
+>>> import redis
+>>> r = redis.Redis(host='localhost', port=6379, db=0, protocol=2)
 ```
 
 ### Connection Pools

--- a/docs/examples/asyncio_examples.ipynb
+++ b/docs/examples/asyncio_examples.ipynb
@@ -102,7 +102,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, this library uses version 2 of the RESP protocol. To enable RESP version 3, you will want to set `protocol` to 3"
+    "For versions < 8.0, by default, this library uses version 2 of the RESP protocol. To enable RESP version 3, you will want to set `protocol` to 3. \n",
+    "Starting from redis-py 8.0, RESP3 is the default protocol."
    ]
   },
   {
@@ -367,7 +368,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To enable the RESP 3 protocol, append `protocol=3` to the URL."
+    "For versions < 8.0, to enable the RESP 3 protocol, append `protocol=3` to the URL.\n",
+    "Starting from redis-py 8.0, RESP3 is the default protocol."
    ]
   },
   {

--- a/docs/examples/connection_examples.ipynb
+++ b/docs/examples/connection_examples.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### By default this library uses the RESP 2 protocol. To enable RESP3, set protocol=3."
+    "### For older versions of redis-py, by default this library uses the RESP 2 protocol. To enable RESP3, set protocol=3. Starting from redis-py 8.0, RESP3 is the default protocol."
    ]
   },
   {
@@ -84,7 +84,7 @@
       "text/plain": [
        "True"
       ]
-    },
+     },
      "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"

--- a/docs/examples/connection_examples.ipynb
+++ b/docs/examples/connection_examples.ipynb
@@ -71,7 +71,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### For older versions of redis-py, by default this library uses the RESP 2 protocol. To enable RESP3, set protocol=3. Starting from redis-py 8.0, RESP3 is the default protocol."
+    "### For older versions of redis-py, by default this library uses the RESP 2 protocol. To enable RESP3, set protocol=3. \n",
+    "### Starting from redis-py 8.0, RESP3 is the default protocol."
    ]
   },
   {

--- a/docs/resp3_features.rst
+++ b/docs/resp3_features.rst
@@ -5,8 +5,9 @@ As of version 5.0, redis-py supports the `RESP 3 standard <https://github.com/re
 
 Connecting
 -----------
+As of version 8.0, redis-py uses RESP3 by default.
 
-Enabling RESP3 is no different than other connections in redis-py. In all cases, the connection type must be extending by setting `protocol=3`. The following are some base examples illustrating how to enable a RESP 3 connection.
+For older versions enabling RESP3 is no different than other connections in redis-py. In all cases, the connection type must be extending by setting `protocol=3`. The following are some base examples illustrating how to enable a RESP 3 connection.
 
 Connect with a standard connection, but specifying resp 3:
 
@@ -63,7 +64,7 @@ This means that should you want to perform something, on a given push notificati
     >>    if message.find("This special thing happened"):
     >>        raise IOError("This was the message: \n" + message)
     >>
-    >> r = Redis(protocol=3)
+    >> r = Redis()
     >> p = r.pubsub(push_handler_func=our_func)
 
 In the example above, upon receipt of a push notification, rather than log the message, in the case where specific text occurs, an IOError is raised. This example, highlights how one could start implementing a customized message handler.
@@ -84,7 +85,7 @@ Enable caching with default configuration:
 
     >>> import redis
     >>> from redis.cache import CacheConfig
-    >>> r = redis.Redis(host='localhost', port=6379, protocol=3, cache_config=CacheConfig())
+    >>> r = redis.Redis(host='localhost', port=6379, cache_config=CacheConfig())
 
 The same interface applies to Redis Cluster and Sentinel.
 
@@ -94,7 +95,7 @@ Enable caching with custom cache implementation:
 
     >>> import redis
     >>> from foo.bar import CacheImpl
-    >>> r = redis.Redis(host='localhost', port=6379, protocol=3, cache=CacheImpl())
+    >>> r = redis.Redis(host='localhost', port=6379, cache=CacheImpl())
 
 CacheImpl should implement a `CacheInterface` specified in `redis.cache` package.
 

--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -154,12 +154,22 @@ def parse_sentinel_state_resp3(response, **options):
     result = {}
     for key in response:
         try:
-            value = SENTINEL_STATE_TYPES[key](str_if_bytes(response[key]))
+            value = SENTINEL_STATE_TYPES[str_if_bytes(key)](str_if_bytes(response[key]))
             result[str_if_bytes(key)] = value
         except Exception:
-            result[str_if_bytes(key)] = response[str_if_bytes(key)]
+            result[str_if_bytes(key)] = str_if_bytes(response[key])
     flags = set(result["flags"].split(","))
     result["flags"] = flags
+    for name, flag in (
+        ("is_master", "master"),
+        ("is_slave", "slave"),
+        ("is_sdown", "s_down"),
+        ("is_odown", "o_down"),
+        ("is_sentinel", "sentinel"),
+        ("is_disconnected", "disconnected"),
+        ("is_master_down", "master_down"),
+    ):
+        result[name] = flag in flags
     return result
 
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -79,8 +79,10 @@ from redis.exceptions import (
 from redis.observability.attributes import PubSubDirection
 from redis.typing import ChannelT, EncodableT, KeyT
 from redis.utils import (
+    DEFAULT_RESP_VERSION,
     SSL_AVAILABLE,
     _set_info_logger,
+    check_protocol_version,
     deprecated_args,
     deprecated_function,
     safe_str,
@@ -409,7 +411,12 @@ class Redis(
 
         self.response_callbacks = CaseInsensitiveDict(_RedisCallbacks)
 
-        if self.connection_pool.connection_kwargs.get("protocol") in ["3", 3]:
+        if check_protocol_version(
+            self.connection_pool.connection_kwargs.get(
+                "protocol", DEFAULT_RESP_VERSION
+            ),
+            3,
+        ):
             self.response_callbacks.update(_RedisCallbacksRESP3)
         else:
             self.response_callbacks.update(_RedisCallbacksRESP2)

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -276,7 +276,7 @@ class Redis(
         auto_close_connection_pool: Optional[bool] = None,
         redis_connect_func=None,
         credential_provider: Optional[CredentialProvider] = None,
-        protocol: Optional[int] = 2,
+        protocol: Optional[int] = 3,
         event_dispatcher: Optional[EventDispatcher] = None,
     ):
         """

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -97,7 +97,9 @@ from redis.exceptions import (
 )
 from redis.typing import AnyKeyT, EncodableT, KeyT
 from redis.utils import (
+    DEFAULT_RESP_VERSION,
     SSL_AVAILABLE,
+    check_protocol_version,
     deprecated_args,
     deprecated_function,
     safe_str,
@@ -417,7 +419,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             self.retry.update_supported_errors(retry_on_error)
 
         kwargs["response_callbacks"] = _RedisCallbacks.copy()
-        if kwargs.get("protocol") in ["3", 3]:
+        if check_protocol_version(kwargs.get("protocol", DEFAULT_RESP_VERSION), 3):
             kwargs["response_callbacks"].update(_RedisCallbacksRESP3)
         else:
             kwargs["response_callbacks"].update(_RedisCallbacksRESP2)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -336,7 +336,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         ssl_keyfile: Optional[str] = None,
         ssl_min_version: Optional[TLSVersion] = None,
         ssl_ciphers: Optional[str] = None,
-        protocol: Optional[int] = 2,
+        protocol: Optional[int] = 3,
         address_remap: Optional[Callable[[Tuple[str, int]], Tuple[str, int]]] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: AsyncPolicyResolver = AsyncStaticPolicyResolver(),

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -249,7 +249,6 @@ class AbstractConnection:
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._socket_read_size = socket_read_size
-        self.set_parser(parser_class)
         self._connect_callbacks: List[weakref.WeakMethod[ConnectCallbackT]] = []
         self._buffer_cutoff = 6000
         self._re_auth_token: Optional[TokenInterface] = None
@@ -265,6 +264,14 @@ class AbstractConnection:
             if p < 2 or p > 3:
                 raise ConnectionError("protocol must be either 2 or 3")
         self.protocol = p
+        # Reconcile parser ↔ protocol mismatches.
+        # Hiredis handles both RESP2 and RESP3 natively, so only
+        # pure-Python parsers need to be swapped.
+        if self.protocol == 3 and parser_class == _AsyncRESP2Parser:
+            parser_class = _AsyncRESP3Parser
+        elif self.protocol == 2 and parser_class == _AsyncRESP3Parser:
+            parser_class = _AsyncRESP2Parser
+        self.set_parser(parser_class)
 
     def __del__(self, _warnings: Any = warnings):
         # For some reason, the individual streams don't get properly garbage

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -66,7 +66,6 @@ from redis.asyncio.observability.recorder import (
 )
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
-from redis.connection import DEFAULT_RESP_VERSION
 from redis.credentials import CredentialProvider, UsernamePasswordCredentialProvider
 from redis.exceptions import (
     AuthenticationError,
@@ -80,7 +79,7 @@ from redis.exceptions import (
 )
 from redis.observability.metrics import CloseReason
 from redis.typing import EncodableT
-from redis.utils import HIREDIS_AVAILABLE, str_if_bytes
+from redis.utils import DEFAULT_RESP_VERSION, HIREDIS_AVAILABLE, str_if_bytes
 
 from .._parsers import (
     BaseParser,

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -108,7 +108,7 @@ DefaultParser: Type[Union[_AsyncRESP2Parser, _AsyncRESP3Parser, _AsyncHiredisPar
 if HIREDIS_AVAILABLE:
     DefaultParser = _AsyncHiredisParser
 else:
-    DefaultParser = _AsyncRESP2Parser
+    DefaultParser = _AsyncRESP3Parser
 
 
 class ConnectCallbackProtocol(Protocol):
@@ -183,7 +183,7 @@ class AbstractConnection:
         redis_connect_func: Optional[ConnectCallbackT] = None,
         encoder_class: Type[Encoder] = Encoder,
         credential_provider: Optional[CredentialProvider] = None,
-        protocol: Optional[int] = 2,
+        protocol: Optional[int] = 3,
         event_dispatcher: Optional[EventDispatcher] = None,
     ):
         """

--- a/redis/client.py
+++ b/redis/client.py
@@ -72,6 +72,7 @@ from redis.observability.recorder import (
 )
 from redis.retry import Retry
 from redis.utils import (
+    DEFAULT_RESP_VERSION,
     _set_info_logger,
     check_protocol_version,
     deprecated_args,
@@ -480,7 +481,12 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
 
         self.response_callbacks = CaseInsensitiveDict(_RedisCallbacks)
 
-        if self.connection_pool.connection_kwargs.get("protocol") in ["3", 3]:
+        if check_protocol_version(
+            self.connection_pool.connection_kwargs.get(
+                "protocol", DEFAULT_RESP_VERSION
+            ),
+            3,
+        ):
             self.response_callbacks.update(_RedisCallbacksRESP3)
         else:
             self.response_callbacks.update(_RedisCallbacksRESP2)

--- a/redis/client.py
+++ b/redis/client.py
@@ -281,7 +281,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         username: Optional[str] = None,
         redis_connect_func: Optional[Callable[[], None]] = None,
         credential_provider: Optional[CredentialProvider] = None,
-        protocol: Optional[int] = 2,
+        protocol: Optional[int] = 3,
         cache: Optional[CacheInterface] = None,
         cache_config: Optional[CacheConfig] = None,
         event_dispatcher: Optional[EventDispatcher] = None,

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -77,6 +77,7 @@ from redis.observability.recorder import (
 )
 from redis.retry import Retry
 from redis.utils import (
+    DEFAULT_RESP_VERSION,
     check_protocol_version,
     deprecated_args,
     deprecated_function,
@@ -281,7 +282,9 @@ class MaintNotificationsAbstractRedisCluster:
         **kwargs,
     ):
         # Initialize maintenance notifications
-        is_protocol_supported = check_protocol_version(kwargs.get("protocol"), 3)
+        is_protocol_supported = check_protocol_version(
+            kwargs.get("protocol", DEFAULT_RESP_VERSION), 3
+        )
 
         if (
             maint_notifications_config
@@ -814,7 +817,7 @@ class RedisCluster(
             kwargs.get("encoding_errors", "strict"),
             kwargs.get("decode_responses", False),
         )
-        protocol = kwargs.get("protocol", None)
+        protocol = kwargs.get("protocol", DEFAULT_RESP_VERSION)
         if (cache_config or cache) and not check_protocol_version(protocol, 3):
             raise RedisError("Client caching is only supported with RESP version 3")
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -82,6 +82,7 @@ from .observability.recorder import (
 from .retry import Retry
 from .utils import (
     CRYPTOGRAPHY_AVAILABLE,
+    DEFAULT_RESP_VERSION,
     HIREDIS_AVAILABLE,
     SSL_AVAILABLE,
     check_protocol_version,
@@ -107,7 +108,6 @@ SYM_DOLLAR = b"$"
 SYM_CRLF = b"\r\n"
 SYM_EMPTY = b""
 
-DEFAULT_RESP_VERSION = 3
 
 DefaultParser: Type[Union[_RESP2Parser, _RESP3Parser, _HiredisParser]]
 if HIREDIS_AVAILABLE:
@@ -2343,7 +2343,9 @@ class MaintNotificationsAbstractConnectionPool:
         **kwargs,
     ):
         # Initialize maintenance notifications
-        is_protocol_supported = check_protocol_version(kwargs.get("protocol"), 3)
+        is_protocol_supported = check_protocol_version(
+            kwargs.get("protocol", DEFAULT_RESP_VERSION), 3
+        )
 
         if maint_notifications_config is None and is_protocol_supported:
             maint_notifications_config = MaintNotificationsConfig()
@@ -2844,7 +2846,9 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
             self._event_dispatcher = EventDispatcher()
 
         if connection_kwargs.get("cache_config") or connection_kwargs.get("cache"):
-            if not check_protocol_version(self._connection_kwargs.get("protocol"), 3):
+            if not check_protocol_version(
+                self._connection_kwargs.get("protocol", DEFAULT_RESP_VERSION), 3
+            ):
                 raise RedisError("Client caching is only supported with RESP version 3")
 
             cache = self._connection_kwargs.get("cache")

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -899,13 +899,13 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             if p < 2 or p > 3:
                 raise ConnectionError("protocol must be either 2 or 3")
         self.protocol = p
+        # Reconcile parser ↔ protocol mismatches.
+        # Hiredis handles both RESP2 and RESP3 natively, so only
+        # pure-Python parsers need to be swapped.
         if self.protocol == 3 and parser_class == _RESP2Parser:
-            # If the protocol is 3 but the parser is RESP2, change it to RESP3
-            # This is needed because the parser might be set before the protocol
-            # or might be provided as a kwarg to the constructor
-            # We need to react on discrepancy only for RESP2 and RESP3
-            # as hiredis supports both
             parser_class = _RESP3Parser
+        elif self.protocol == 2 and parser_class == _RESP3Parser:
+            parser_class = _RESP2Parser
         self.set_parser(parser_class)
 
         self._command_packer = self._construct_command_packer(command_packer)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -107,13 +107,13 @@ SYM_DOLLAR = b"$"
 SYM_CRLF = b"\r\n"
 SYM_EMPTY = b""
 
-DEFAULT_RESP_VERSION = 2
+DEFAULT_RESP_VERSION = 3
 
 DefaultParser: Type[Union[_RESP2Parser, _RESP3Parser, _HiredisParser]]
 if HIREDIS_AVAILABLE:
     DefaultParser = _HiredisParser
 else:
-    DefaultParser = _RESP2Parser
+    DefaultParser = _RESP3Parser
 
 
 class HiredisRespSerializer:
@@ -799,7 +799,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         retry: Union[Any, None] = None,
         redis_connect_func: Optional[Callable[[], None]] = None,
         credential_provider: Optional[CredentialProvider] = None,
-        protocol: Optional[int] = 2,
+        protocol: Optional[int] = 3,
         command_packer: Optional[Callable[[], None]] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -6,10 +6,13 @@ import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
+from importlib import metadata
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, TypeVar, Union
 
 from redis.exceptions import DataError
 from redis.typing import AbsExpiryT, EncodableT, ExpiryT
+
+DEFAULT_RESP_VERSION = 3
 
 if TYPE_CHECKING:
     from redis.client import Redis
@@ -40,8 +43,6 @@ try:
     CRYPTOGRAPHY_AVAILABLE = True
 except ImportError:
     CRYPTOGRAPHY_AVAILABLE = False
-
-from importlib import metadata
 
 
 def from_url(url: str, **kwargs: Any) -> "Redis":

--- a/tasks.py
+++ b/tasks.py
@@ -45,7 +45,7 @@ def all_tests(c):
 
 
 @task
-def tests(c, uvloop=False, protocol=2, profile=False):
+def tests(c, uvloop=False, protocol=3, profile=False):
     """Run the redis-py test suite against the current python."""
     print("Starting Redis tests")
     standalone_tests(c, uvloop=uvloop, protocol=protocol, profile=profile)
@@ -54,7 +54,7 @@ def tests(c, uvloop=False, protocol=2, profile=False):
 
 @task
 def standalone_tests(
-    c, uvloop=False, protocol=2, profile=False, redis_mod_url=None, extra_markers=""
+    c, uvloop=False, protocol=3, profile=False, redis_mod_url=None, extra_markers=""
 ):
     """Run tests against a standalone redis instance"""
     profile_arg = "--profile" if profile else ""
@@ -72,7 +72,7 @@ def standalone_tests(
 
 
 @task
-def cluster_tests(c, uvloop=False, protocol=2, profile=False):
+def cluster_tests(c, uvloop=False, protocol=3, profile=False):
     """Run tests against a redis cluster"""
     profile_arg = "--profile" if profile else ""
     cluster_url = "redis://localhost:16379/0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from tests.ssl_utils import get_tls_certificates
 
 REDIS_INFO = {}
 default_redis_url = "redis://localhost:6379/0"
-default_protocol = "2"
+default_protocol = "3"
 default_redismod_url = "redis://localhost:6479"
 
 # default ssl client ignores verification for the purpose of testing

--- a/tests/test_asyncio/test_client.py
+++ b/tests/test_asyncio/test_client.py
@@ -57,7 +57,7 @@ class TestAsyncRedisClientOperationDurationMetricsRecording:
         pool.get_connection = AsyncMock(return_value=mock_async_connection)
         pool.release = AsyncMock()
         pool.get_encoder.return_value = MagicMock()
-        pool.get_protocol.return_value = 2
+        pool.get_protocol.return_value = 3
         return pool
 
     @pytest.fixture
@@ -252,7 +252,7 @@ class TestAsyncRedisClientErrorMetricsRecording:
         pool.get_connection = AsyncMock(return_value=mock_async_connection)
         pool.release = AsyncMock()
         pool.get_encoder.return_value = MagicMock()
-        pool.get_protocol.return_value = 2
+        pool.get_protocol.return_value = 3
         return pool
 
     @pytest.fixture

--- a/tests/test_asyncio/test_connect.py
+++ b/tests/test_asyncio/test_connect.py
@@ -17,7 +17,13 @@ _CLIENT_NAME = "test-suite-client"
 _CMD_SEP = b"\r\n"
 _SUCCESS_RESP = b"+OK" + _CMD_SEP
 _ERROR_RESP = b"-ERR" + _CMD_SEP
-_SUPPORTED_CMDS = {f"CLIENT SETNAME {_CLIENT_NAME}": _SUCCESS_RESP}
+_HELLO_RESP = (
+    b"%1" + _CMD_SEP + b"$5" + _CMD_SEP + b"proto" + _CMD_SEP + b":3" + _CMD_SEP
+)
+_SUPPORTED_CMDS = {
+    f"CLIENT SETNAME {_CLIENT_NAME}": _SUCCESS_RESP,
+    "HELLO 3": _HELLO_RESP,
+}
 
 
 @pytest.fixture

--- a/tests/test_asyncio/test_pipeline.py
+++ b/tests/test_asyncio/test_pipeline.py
@@ -524,7 +524,7 @@ class TestAsyncPipelineOperationDurationMetricsRecording:
         pool.get_connection = AsyncMock(return_value=mock_async_connection)
         pool.release = AsyncMock()
         pool.get_encoder.return_value = MagicMock()
-        pool.get_protocol.return_value = 2
+        pool.get_protocol.return_value = 3
         return pool
 
     @pytest.fixture

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -99,7 +99,7 @@ async def deployed_sentinel(request):
     sentinel_kwargs = {"decode_responses": decode_responses}
     force_master_ip = "localhost"
 
-    protocol = request.config.getoption("--protocol", 2)
+    protocol = request.config.getoption("--protocol", 3)
 
     sentinel = Sentinel(
         sentinel_endpoints,
@@ -371,7 +371,7 @@ async def test_redis_master_usage(deployed_sentinel):
 async def test_sentinel_commands_with_strict_redis_client(request):
     sentinel_ips = request.config.getoption("--sentinels")
     sentinel_host, sentinel_port = sentinel_ips.split(",")[0].split(":")
-    protocol = request.config.getoption("--protocol", 2)
+    protocol = request.config.getoption("--protocol", 3)
 
     client = StrictRedis(
         host=sentinel_host, port=sentinel_port, decode_responses=True, protocol=protocol

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -14,7 +14,13 @@ _CLIENT_NAME = "test-suite-client"
 _CMD_SEP = b"\r\n"
 _SUCCESS_RESP = b"+OK" + _CMD_SEP
 _ERROR_RESP = b"-ERR" + _CMD_SEP
-_SUPPORTED_CMDS = {f"CLIENT SETNAME {_CLIENT_NAME}": _SUCCESS_RESP}
+_HELLO_RESP = (
+    b"%1" + _CMD_SEP + b"$5" + _CMD_SEP + b"proto" + _CMD_SEP + b":3" + _CMD_SEP
+)
+_SUPPORTED_CMDS = {
+    f"CLIENT SETNAME {_CLIENT_NAME}": _SUCCESS_RESP,
+    "HELLO 3": _HELLO_RESP,
+}
 
 
 @pytest.fixture

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -15,6 +15,7 @@ from redis.event import (
     EventDispatcher,
     EventListenerInterface,
 )
+from redis.maint_notifications import MaintNotificationsConfig
 from redis.utils import SSL_AVAILABLE
 
 from .conftest import (
@@ -27,6 +28,35 @@ from .test_pubsub import wait_for_message
 
 if SSL_AVAILABLE:
     import ssl
+
+
+# Default maint notification keys injected into connection_kwargs when protocol
+# defaults to RESP3.  Tests must expect these keys to be present.
+MAINT_NOTIFICATION_KEYS = {
+    "maint_notifications_config",
+    "maint_notifications_pool_handler",
+    "orig_host_address",
+    "orig_socket_connect_timeout",
+    "orig_socket_timeout",
+}
+
+
+def assert_kwargs_match(actual, expected):
+    """Assert *expected* items are a subset of *actual* and that the default
+    maintenance-notification keys are present (RESP3 default)."""
+    assert expected.items() <= actual.items(), (
+        f"Expected keys missing or mismatched.\n"
+        f"  Expected: {expected}\n"
+        f"  Actual:   {actual}"
+    )
+    assert MAINT_NOTIFICATION_KEYS <= set(actual.keys()), (
+        f"Default maint notification keys missing.\n"
+        f"  Missing: {MAINT_NOTIFICATION_KEYS - set(actual.keys())}"
+    )
+    # Verify the auto-created config is the right type
+    assert isinstance(
+        actual.get("maint_notifications_config"), MaintNotificationsConfig
+    )
 
 
 class DummyConnection:
@@ -79,7 +109,7 @@ class TestConnectionPool:
 
         connection = pool.get_connection()
         assert isinstance(connection, DummyConnection)
-        assert connection.kwargs == connection_kwargs
+        assert_kwargs_match(connection.kwargs, connection_kwargs)
 
     def test_closing(self):
         connection_kwargs = {"foo": "bar", "biz": "baz"}
@@ -191,7 +221,7 @@ class TestBlockingConnectionPool:
         pool = self.get_pool(connection_kwargs=connection_kwargs)
         connection = pool.get_connection()
         assert isinstance(connection, DummyConnection)
-        assert connection.kwargs == connection_kwargs
+        assert_kwargs_match(connection.kwargs, connection_kwargs)
 
     def test_multiple_connections(self, master_host):
         connection_kwargs = {"host": master_host[0], "port": master_host[1]}
@@ -319,23 +349,25 @@ class TestConnectionPoolURLParsing:
     def test_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my.host")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "my.host"}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "my.host"})
 
     def test_quoted_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my %2F host %2B%3D+")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "my / host +=+"}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "my / host +=+"})
 
     def test_port(self):
         pool = redis.ConnectionPool.from_url("redis://localhost:6380")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "port": 6380}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "localhost", "port": 6380})
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self):
         pool = redis.ConnectionPool.from_url("redis://myuser:@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "username": "myuser"}
+        assert_kwargs_match(
+            pool.connection_kwargs, {"host": "localhost", "username": "myuser"}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_quoted_username(self):
@@ -343,50 +375,61 @@ class TestConnectionPoolURLParsing:
             "redis://%2Fmyuser%2F%2B name%3D%24+:@localhost"
         )
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "username": "/myuser/+ name=$+",
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "username": "/myuser/+ name=$+",
+            },
+        )
 
     def test_password(self):
         pool = redis.ConnectionPool.from_url("redis://:mypassword@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "password": "mypassword"}
+        assert_kwargs_match(
+            pool.connection_kwargs, {"host": "localhost", "password": "mypassword"}
+        )
 
     def test_quoted_password(self):
         pool = redis.ConnectionPool.from_url(
             "redis://:%2Fmypass%2F%2B word%3D%24+@localhost"
         )
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "password": "/mypass/+ word=$+",
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "password": "/mypass/+ word=$+",
+            },
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_username_and_password(self):
         pool = redis.ConnectionPool.from_url("redis://myuser:mypass@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "username": "myuser",
-            "password": "mypass",
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "username": "myuser",
+                "password": "mypass",
+            },
+        )
 
     def test_db_as_argument(self):
         pool = redis.ConnectionPool.from_url("redis://localhost", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 1}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "localhost", "db": 1})
 
     def test_db_in_path(self):
         pool = redis.ConnectionPool.from_url("redis://localhost/2", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 2}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "localhost", "db": 2})
 
     def test_db_in_querystring(self):
         pool = redis.ConnectionPool.from_url("redis://localhost/2?db=3", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 3}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "localhost", "db": 3})
 
     def test_extra_typed_querystring_options(self):
         pool = redis.ConnectionPool.from_url(
@@ -395,13 +438,16 @@ class TestConnectionPoolURLParsing:
         )
 
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "db": 2,
-            "socket_timeout": 20.0,
-            "socket_connect_timeout": 10.0,
-            "retry_on_timeout": True,
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "db": 2,
+                "socket_timeout": 20.0,
+                "socket_connect_timeout": 10.0,
+                "retry_on_timeout": True,
+            },
+        )
         assert pool.max_connections == 10
 
     def test_boolean_parsing(self):
@@ -437,7 +483,9 @@ class TestConnectionPoolURLParsing:
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("redis://localhost?a=1&b=2")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "a": "1", "b": "2"}
+        assert_kwargs_match(
+            pool.connection_kwargs, {"host": "localhost", "a": "1", "b": "2"}
+        )
 
     def test_calling_from_subclass_returns_correct_instance(self):
         pool = redis.BlockingConnectionPool.from_url("redis://localhost")
@@ -446,7 +494,7 @@ class TestConnectionPoolURLParsing:
     def test_client_creates_connection_pool(self):
         r = redis.Redis.from_url("redis://myhost")
         assert r.connection_pool.connection_class == redis.Connection
-        assert r.connection_pool.connection_kwargs == {"host": "myhost"}
+        assert_kwargs_match(r.connection_pool.connection_kwargs, {"host": "myhost"})
 
     def test_invalid_scheme_raises_error(self):
         with pytest.raises(ValueError) as cm:
@@ -473,13 +521,16 @@ class TestBlockingConnectionPoolURLParsing:
         )
 
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "db": 2,
-            "socket_timeout": 20.0,
-            "socket_connect_timeout": 10.0,
-            "retry_on_timeout": True,
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "db": 2,
+                "socket_timeout": 20.0,
+                "socket_connect_timeout": 10.0,
+                "retry_on_timeout": True,
+            },
+        )
         assert pool.max_connections == 10
         assert pool.timeout == 42.0
 
@@ -494,13 +545,15 @@ class TestConnectionPoolUnixSocketURLParsing:
     def test_defaults(self):
         pool = redis.ConnectionPool.from_url("unix:///socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket"}
+        assert_kwargs_match(pool.connection_kwargs, {"path": "/socket"})
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self):
         pool = redis.ConnectionPool.from_url("unix://myuser:@/socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "username": "myuser"}
+        assert_kwargs_match(
+            pool.connection_kwargs, {"path": "/socket", "username": "myuser"}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_quoted_username(self):
@@ -508,45 +561,56 @@ class TestConnectionPoolUnixSocketURLParsing:
             "unix://%2Fmyuser%2F%2B name%3D%24+:@/socket"
         )
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {
-            "path": "/socket",
-            "username": "/myuser/+ name=$+",
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "path": "/socket",
+                "username": "/myuser/+ name=$+",
+            },
+        )
 
     def test_password(self):
         pool = redis.ConnectionPool.from_url("unix://:mypassword@/socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "password": "mypassword"}
+        assert_kwargs_match(
+            pool.connection_kwargs, {"path": "/socket", "password": "mypassword"}
+        )
 
     def test_quoted_password(self):
         pool = redis.ConnectionPool.from_url(
             "unix://:%2Fmypass%2F%2B word%3D%24+@/socket"
         )
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {
-            "path": "/socket",
-            "password": "/mypass/+ word=$+",
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "path": "/socket",
+                "password": "/mypass/+ word=$+",
+            },
+        )
 
     def test_quoted_path(self):
         pool = redis.ConnectionPool.from_url(
             "unix://:mypassword@/my%2Fpath%2Fto%2F..%2F+_%2B%3D%24ocket"
         )
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {
-            "path": "/my/path/to/../+_+=$ocket",
-            "password": "mypassword",
-        }
+        assert_kwargs_match(
+            pool.connection_kwargs,
+            {
+                "path": "/my/path/to/../+_+=$ocket",
+                "password": "mypassword",
+            },
+        )
 
     def test_db_as_argument(self):
         pool = redis.ConnectionPool.from_url("unix:///socket", db=1)
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "db": 1}
+        assert_kwargs_match(pool.connection_kwargs, {"path": "/socket", "db": 1})
 
     def test_db_in_querystring(self):
         pool = redis.ConnectionPool.from_url("unix:///socket?db=2", db=1)
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "db": 2}
+        assert_kwargs_match(pool.connection_kwargs, {"path": "/socket", "db": 2})
 
     def test_client_name_in_querystring(self):
         pool = redis.ConnectionPool.from_url("redis://location?client_name=test-client")
@@ -555,7 +619,9 @@ class TestConnectionPoolUnixSocketURLParsing:
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("unix:///socket?a=1&b=2")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "a": "1", "b": "2"}
+        assert_kwargs_match(
+            pool.connection_kwargs, {"path": "/socket", "a": "1", "b": "2"}
+        )
 
     def test_connection_class_override(self):
         class MyConnection(redis.UnixDomainSocketConnection):
@@ -572,7 +638,7 @@ class TestSSLConnectionURLParsing:
     def test_host(self):
         pool = redis.ConnectionPool.from_url("rediss://my.host")
         assert pool.connection_class == redis.SSLConnection
-        assert pool.connection_kwargs == {"host": "my.host"}
+        assert_kwargs_match(pool.connection_kwargs, {"host": "my.host"})
 
     def test_connection_class_override(self):
         class MyConnection(redis.SSLConnection):
@@ -742,25 +808,32 @@ class TestConnection:
         connection = redis.Redis.from_url("redis://localhost:6379?db=0")
         pool = connection.connection_pool
 
-        assert re.match(
-            r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >", repr(pool), re.VERBOSE
-        ).groups() == (
-            "ConnectionPool",
-            "Connection",
-            "db=0,host=localhost,port=6379",
+        match = re.match(
+            r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >",
+            repr(pool),
+            re.VERBOSE,
         )
+        groups = match.groups()
+        assert groups[0] == "ConnectionPool"
+        assert groups[1] == "Connection"
+        # The kwargs string now includes maint notification keys by default;
+        # verify the essential connection parameters are present.
+        for expected in ("db=0", "host=localhost", "port=6379"):
+            assert expected in groups[2]
 
     def test_connect_from_url_unix(self):
         connection = redis.Redis.from_url("unix:///path/to/socket")
         pool = connection.connection_pool
 
-        assert re.match(
-            r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >", repr(pool), re.VERBOSE
-        ).groups() == (
-            "ConnectionPool",
-            "UnixDomainSocketConnection",
-            "path=/path/to/socket",
+        match = re.match(
+            r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >",
+            repr(pool),
+            re.VERBOSE,
         )
+        groups = match.groups()
+        assert groups[0] == "ConnectionPool"
+        assert groups[1] == "UnixDomainSocketConnection"
+        assert "path=/path/to/socket" in groups[2]
 
     @skip_if_redis_enterprise()
     def test_connect_no_auth_configured(self, r):

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -101,7 +101,7 @@ def deployed_sentinel(request):
     sentinel_kwargs = {"decode_responses": decode_responses}
     force_master_ip = "localhost"
 
-    protocol = request.config.getoption("--protocol", 2)
+    protocol = request.config.getoption("--protocol", 3)
 
     sentinel = Sentinel(
         sentinel_endpoints,
@@ -350,7 +350,7 @@ def test_redis_master_usage(deployed_sentinel):
 def test_sentinel_commands_with_strict_redis_client(request):
     sentinel_ips = request.config.getoption("--sentinels")
     sentinel_host, sentinel_port = sentinel_ips.split(",")[0].split(":")
-    protocol = request.config.getoption("--protocol", 2)
+    protocol = request.config.getoption("--protocol", 3)
 
     client = StrictRedis(
         host=sentinel_host, port=sentinel_port, decode_responses=True, protocol=protocol


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the default wire protocol to RESP3 for sync/async/cluster clients and parsers, which can affect response types and compatibility with older servers or apps expecting RESP2 semantics. Also adjusts maintenance-notification defaults and sentinel parsing, increasing risk of subtle behavior/regression in connection setup and response handling.
> 
> **Overview**
> **RESP3 is now the default protocol** across sync/async standalone and cluster clients by setting the default `protocol` to `3`, moving `DEFAULT_RESP_VERSION` to `redis.utils`, and selecting RESP3 parsers/callbacks unless explicitly overridden.
> 
> Connection code now **reconciles parser↔protocol mismatches** (including switching between pure-Python RESP2/RESP3 parsers) and hardens RESP3 checks via `check_protocol_version` with a default. Sentinel RESP3 state parsing is fixed to handle byte keys correctly and now adds boolean `is_*` flag fields.
> 
> Docs/examples and the test suite are updated to reflect the new default (including URL parsing expectations and `HELLO 3` handshake mocks), and test helpers were added to account for extra maint-notification kwargs that appear when RESP3 defaults are in effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bf78715ba1924e38e5ab8b42d6877298b95938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->