### PR TITLE
Adding support for new COUNT aggregator for some sorted set commands - ZINTER, ZINTERSTORE, ZUNION, ZUNIONSTORE

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -7469,12 +7469,26 @@ class SortedSetCommands(CommandsProtocol):
     ) -> ZSetRangeResponse | Awaitable[ZSetRangeResponse]:
         """
         Return the intersect of multiple sorted sets specified by ``keys``.
+
         With the ``aggregate`` option, it is possible to specify how the
-        results of the union are aggregated. This option defaults to SUM,
-        where the score of an element is summed across the inputs where it
-        exists. When this option is set to either MIN or MAX, the resulting
-        set will contain the minimum or maximum score of an element across
-        the inputs where it exists.
+        results of the intersection are aggregated. Available aggregation
+        modes:
+
+        - ``SUM`` (default): the score of an element is summed across the
+          inputs where it exists.
+          Score = SUM(score₁×weight₁, score₂×weight₂, ...)
+        - ``MIN``: the resulting set will contain the minimum score of an
+          element across the inputs where it exists.
+          Score = MIN(score₁×weight₁, score₂×weight₂, ...)
+        - ``MAX``: the resulting set will contain the maximum score of an
+          element across the inputs where it exists.
+          Score = MAX(score₁×weight₁, score₂×weight₂, ...)
+        - ``COUNT``: ignores the original scores and counts weighted set
+          membership. Each element's score is the sum of the weights of
+          the input sets that contain it.
+          Score = SUM(weight₁, weight₂, ...) for sets containing the element.
+          When all weights are 1 (default), the score equals the number
+          of input sets containing the element.
 
         For more information, see https://redis.io/commands/zinter
         """
@@ -7505,11 +7519,25 @@ class SortedSetCommands(CommandsProtocol):
         """
         Intersect multiple sorted sets specified by ``keys`` into a new
         sorted set, ``dest``. Scores in the destination will be aggregated
-        based on the ``aggregate``. This option defaults to SUM, where the
-        score of an element is summed across the inputs where it exists.
-        When this option is set to either MIN or MAX, the resulting set will
-        contain the minimum or maximum score of an element across the inputs
-        where it exists.
+        based on the ``aggregate``.
+
+        Available aggregation modes:
+
+        - ``SUM`` (default): the score of an element is summed across the
+          inputs where it exists.
+          Score = SUM(score₁×weight₁, score₂×weight₂, ...)
+        - ``MIN``: the resulting set will contain the minimum score of an
+          element across the inputs where it exists.
+          Score = MIN(score₁×weight₁, score₂×weight₂, ...)
+        - ``MAX``: the resulting set will contain the maximum score of an
+          element across the inputs where it exists.
+          Score = MAX(score₁×weight₁, score₂×weight₂, ...)
+        - ``COUNT``: ignores the original scores and counts weighted set
+          membership. Each element's score is the sum of the weights of
+          the input sets that contain it.
+          Score = SUM(weight₁, weight₂, ...) for sets containing the element.
+          When all weights are 1 (default), the score equals the number
+          of input sets containing the element.
 
         For more information, see https://redis.io/commands/zinterstore
         """
@@ -8490,6 +8518,24 @@ class SortedSetCommands(CommandsProtocol):
         Scores will be aggregated based on the ``aggregate``, or SUM if
         none is provided.
 
+        Available aggregation modes:
+
+        - ``SUM`` (default): the score of an element is summed across the
+          inputs where it exists.
+          Score = SUM(score₁×weight₁, score₂×weight₂, ...)
+        - ``MIN``: the resulting set will contain the minimum score of an
+          element across the inputs where it exists.
+          Score = MIN(score₁×weight₁, score₂×weight₂, ...)
+        - ``MAX``: the resulting set will contain the maximum score of an
+          element across the inputs where it exists.
+          Score = MAX(score₁×weight₁, score₂×weight₂, ...)
+        - ``COUNT``: ignores the original scores and counts weighted set
+          membership. Each element's score is the sum of the weights of
+          the input sets that contain it.
+          Score = SUM(weight₁, weight₂, ...) for sets containing the element.
+          When all weights are 1 (default), the score equals the number
+          of input sets containing the element.
+
         ``score_cast_func`` a callable used to cast the score return value
 
         For more information, see https://redis.io/commands/zunion
@@ -8529,6 +8575,24 @@ class SortedSetCommands(CommandsProtocol):
         Union multiple sorted sets specified by ``keys`` into
         a new sorted set, ``dest``. Scores in the destination will be
         aggregated based on the ``aggregate``, or SUM if none is provided.
+
+        Available aggregation modes:
+
+        - ``SUM`` (default): the score of an element is summed across the
+          inputs where it exists.
+          Score = SUM(score₁×weight₁, score₂×weight₂, ...)
+        - ``MIN``: the resulting set will contain the minimum score of an
+          element across the inputs where it exists.
+          Score = MIN(score₁×weight₁, score₂×weight₂, ...)
+        - ``MAX``: the resulting set will contain the maximum score of an
+          element across the inputs where it exists.
+          Score = MAX(score₁×weight₁, score₂×weight₂, ...)
+        - ``COUNT``: ignores the original scores and counts weighted set
+          membership. Each element's score is the sum of the weights of
+          the input sets that contain it.
+          Score = SUM(weight₁, weight₂, ...) for sets containing the element.
+          When all weights are 1 (default), the score equals the number
+          of input sets containing the element.
 
         For more information, see https://redis.io/commands/zunionstore
         """
@@ -8583,11 +8647,11 @@ class SortedSetCommands(CommandsProtocol):
             pieces.append(b"WEIGHTS")
             pieces.extend(weights)
         if aggregate:
-            if aggregate.upper() in ["SUM", "MIN", "MAX"]:
+            if aggregate.upper() in ["SUM", "MIN", "MAX", "COUNT"]:
                 pieces.append(b"AGGREGATE")
                 pieces.append(aggregate)
             else:
-                raise DataError("aggregate can be sum, min or max.")
+                raise DataError("aggregate can be sum, min, max or count.")
         if options.get("withscores", False):
             pieces.append(b"WITHSCORES")
         options["keys"] = keys

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2010,6 +2010,40 @@ class TestClusterRedisCommands:
             [b"a1", 23.0],
         ]
 
+    @skip_if_server_version_lt("8.7.0")
+    async def test_cluster_zinterstore_count(self, r: RedisCluster) -> None:
+        await r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            await r.zinterstore(
+                "{foo}d", ["{foo}a", "{foo}b", "{foo}c"], aggregate="COUNT"
+            )
+            == 2
+        )
+        assert await r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a1", 3.0],
+            [b"a3", 3.0],
+        ]
+
+    @skip_if_server_version_lt("8.7.0")
+    async def test_cluster_zinterstore_count_with_weight(self, r: RedisCluster) -> None:
+        await r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            await r.zinterstore(
+                "{foo}d",
+                {"{foo}a": 1, "{foo}b": 2, "{foo}c": 3},
+                aggregate="COUNT",
+            )
+            == 2
+        )
+        assert await r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a1", 6.0],
+            [b"a3", 6.0],
+        ]
+
     @skip_if_server_version_lt("4.9.0")
     async def test_cluster_bzpopmax(self, r: RedisCluster) -> None:
         await r.zadd("{foo}a", {"a1": 1, "a2": 2})
@@ -2180,6 +2214,44 @@ class TestClusterRedisCommands:
             [b"a4", 12.0],
             [b"a3", 20.0],
             [b"a1", 23.0],
+        ]
+
+    @skip_if_server_version_lt("8.7.0")
+    async def test_cluster_zunionstore_count(self, r: RedisCluster) -> None:
+        await r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            await r.zunionstore(
+                "{foo}d", ["{foo}a", "{foo}b", "{foo}c"], aggregate="COUNT"
+            )
+            == 4
+        )
+        assert await r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a4", 1.0],
+            [b"a2", 2.0],
+            [b"a1", 3.0],
+            [b"a3", 3.0],
+        ]
+
+    @skip_if_server_version_lt("8.7.0")
+    async def test_cluster_zunionstore_count_with_weight(self, r: RedisCluster) -> None:
+        await r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            await r.zunionstore(
+                "{foo}d",
+                {"{foo}a": 1, "{foo}b": 2, "{foo}c": 3},
+                aggregate="COUNT",
+            )
+            == 4
+        )
+        assert await r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a2", 3.0],
+            [b"a4", 3.0],
+            [b"a1", 6.0],
+            [b"a3", 6.0],
         ]
 
     @skip_if_server_version_lt("2.8.9")

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2870,6 +2870,28 @@ class TestRedisCommands:
         response = await r.zrange("d", 0, -1, withscores=True)
         assert response == [[b"a3", 20.0], [b"a1", 23.0]]
 
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    async def test_zinterstore_count(self, r: redis.Redis):
+        await r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert await r.zinterstore("d", ["a", "b", "c"], aggregate="COUNT") == 2
+        response = await r.zrange("d", 0, -1, withscores=True)
+        assert response == [[b"a1", 3.0], [b"a3", 3.0]]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    async def test_zinterstore_count_with_weight(self, r: redis.Redis):
+        await r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            await r.zinterstore("d", {"a": 1, "b": 2, "c": 3}, aggregate="COUNT") == 2
+        )
+        response = await r.zrange("d", 0, -1, withscores=True)
+        assert response == [[b"a1", 6.0], [b"a3", 6.0]]
+
     @skip_if_server_version_lt("4.9.0")
     async def test_zpopmax(self, r: redis.Redis):
         await r.zadd("a", {"a1": 1, "a2": 2, "a3": 3})
@@ -3125,6 +3147,38 @@ class TestRedisCommands:
         assert await r.zunionstore("d", {"a": 1, "b": 2, "c": 3}) == 4
         response = await r.zrange("d", 0, -1, withscores=True)
         assert response == [[b"a2", 5.0], [b"a4", 12.0], [b"a3", 20.0], [b"a1", 23.0]]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    async def test_zunionstore_count(self, r: redis.Redis):
+        await r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert await r.zunionstore("d", ["a", "b", "c"], aggregate="COUNT") == 4
+        response = await r.zrange("d", 0, -1, withscores=True)
+        assert response == [
+            [b"a4", 1.0],
+            [b"a2", 2.0],
+            [b"a1", 3.0],
+            [b"a3", 3.0],
+        ]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    async def test_zunionstore_count_with_weight(self, r: redis.Redis):
+        await r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        await r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        await r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            await r.zunionstore("d", {"a": 1, "b": 2, "c": 3}, aggregate="COUNT") == 4
+        )
+        response = await r.zrange("d", 0, -1, withscores=True)
+        assert response == [
+            [b"a2", 3.0],
+            [b"a4", 3.0],
+            [b"a1", 6.0],
+            [b"a3", 6.0],
+        ]
 
     # HYPERLOGLOG TESTS
     @skip_if_server_version_lt("2.8.9")

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2130,6 +2130,38 @@ class TestClusterRedisCommands:
             [b"a1", 23.0],
         ]
 
+    @skip_if_server_version_lt("8.7.0")
+    def test_cluster_zinterstore_count(self, r):
+        r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            r.zinterstore("{foo}d", ["{foo}a", "{foo}b", "{foo}c"], aggregate="COUNT")
+            == 2
+        )
+        assert r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a1", 3.0],
+            [b"a3", 3.0],
+        ]
+
+    @skip_if_server_version_lt("8.7.0")
+    def test_cluster_zinterstore_count_with_weight(self, r):
+        r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            r.zinterstore(
+                "{foo}d",
+                {"{foo}a": 1, "{foo}b": 2, "{foo}c": 3},
+                aggregate="COUNT",
+            )
+            == 2
+        )
+        assert r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a1", 6.0],
+            [b"a3", 6.0],
+        ]
+
     @skip_if_server_version_lt("4.9.0")
     def test_cluster_bzpopmax(self, r):
         r.zadd("{foo}a", {"a1": 1, "a2": 2})
@@ -2260,6 +2292,42 @@ class TestClusterRedisCommands:
             [b"a4", 12.0],
             [b"a3", 20.0],
             [b"a1", 23.0],
+        ]
+
+    @skip_if_server_version_lt("8.7.0")
+    def test_cluster_zunionstore_count(self, r):
+        r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            r.zunionstore("{foo}d", ["{foo}a", "{foo}b", "{foo}c"], aggregate="COUNT")
+            == 4
+        )
+        assert r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a4", 1.0],
+            [b"a2", 2.0],
+            [b"a1", 3.0],
+            [b"a3", 3.0],
+        ]
+
+    @skip_if_server_version_lt("8.7.0")
+    def test_cluster_zunionstore_count_with_weight(self, r):
+        r.zadd("{foo}a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("{foo}b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("{foo}c", {"a1": 6, "a3": 5, "a4": 4})
+        assert (
+            r.zunionstore(
+                "{foo}d",
+                {"{foo}a": 1, "{foo}b": 2, "{foo}c": 3},
+                aggregate="COUNT",
+            )
+            == 4
+        )
+        assert r.zrange("{foo}d", 0, -1, withscores=True) == [
+            [b"a2", 3.0],
+            [b"a4", 3.0],
+            [b"a1", 6.0],
+            [b"a3", 6.0],
         ]
 
     @skip_if_server_version_lt("2.8.9")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3804,6 +3804,25 @@ class TestRedisCommands:
         ]
 
     @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    def test_zinter_count(self, r):
+        r.zadd("a", {"a1": 1, "a2": 2, "a3": 1})
+        r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        # aggregate with COUNT (scores ignored, counts membership)
+        assert r.zinter(["a", "b", "c"], aggregate="COUNT", withscores=True) == [
+            [b"a1", 3],
+            [b"a3", 3],
+        ]
+        # COUNT with weights
+        assert r.zinter(
+            {"a": 1, "b": 2, "c": 3}, aggregate="COUNT", withscores=True
+        ) == [
+            [b"a1", 6],
+            [b"a3", 6],
+        ]
+
+    @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("7.0.0")
     def test_zintercard(self, r):
         r.zadd("a", {"a1": 1, "a2": 2, "a3": 1})
@@ -3856,6 +3875,30 @@ class TestRedisCommands:
             [b"a1", 23],
         ]
 
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    def test_zinterstore_count(self, r):
+        r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert r.zinterstore("d", ["a", "b", "c"], aggregate="COUNT") == 2
+        assert r.zrange("d", 0, -1, withscores=True) == [
+            [b"a1", 3],
+            [b"a3", 3],
+        ]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    def test_zinterstore_count_with_weight(self, r):
+        r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert r.zinterstore("d", {"a": 1, "b": 2, "c": 3}, aggregate="COUNT") == 2
+        assert r.zrange("d", 0, -1, withscores=True) == [
+            [b"a1", 6],
+            [b"a3", 6],
+        ]
+
     @skip_if_server_version_lt("4.9.0")
     def test_zpopmax(self, r):
         r.zadd("a", {"a1": 1, "a2": 2, "a3": 3})
@@ -3875,6 +3918,7 @@ class TestRedisCommands:
         r.zadd("a", {"a1": 1, "a2": 2, "a3": 3, "a4": 4, "a5": 5})
         assert r.zrandmember("a") is not None
         assert len(r.zrandmember("a", 2)) == 2
+
         # with scores
         assert len(r.zrandmember("a", 2, withscores=True)) == 2
         # without duplications
@@ -4267,6 +4311,29 @@ class TestRedisCommands:
         ]
 
     @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    def test_zunion_count(self, r):
+        r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        # aggregate with COUNT (scores ignored, counts membership)
+        assert r.zunion(["a", "b", "c"], aggregate="COUNT", withscores=True) == [
+            [b"a4", 1],
+            [b"a2", 2],
+            [b"a1", 3],
+            [b"a3", 3],
+        ]
+        # COUNT with weights
+        assert r.zunion(
+            {"a": 1, "b": 2, "c": 3}, aggregate="COUNT", withscores=True
+        ) == [
+            [b"a2", 3],
+            [b"a4", 3],
+            [b"a1", 6],
+            [b"a3", 6],
+        ]
+
+    @pytest.mark.onlynoncluster
     def test_zunionstore_sum(self, r):
         r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
         r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
@@ -4316,6 +4383,34 @@ class TestRedisCommands:
             [b"a4", 12],
             [b"a3", 20],
             [b"a1", 23],
+        ]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    def test_zunionstore_count(self, r):
+        r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert r.zunionstore("d", ["a", "b", "c"], aggregate="COUNT") == 4
+        assert r.zrange("d", 0, -1, withscores=True) == [
+            [b"a4", 1],
+            [b"a2", 2],
+            [b"a1", 3],
+            [b"a3", 3],
+        ]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.7.0")
+    def test_zunionstore_count_with_weight(self, r):
+        r.zadd("a", {"a1": 1, "a2": 1, "a3": 1})
+        r.zadd("b", {"a1": 2, "a2": 2, "a3": 2})
+        r.zadd("c", {"a1": 6, "a3": 5, "a4": 4})
+        assert r.zunionstore("d", {"a": 1, "b": 2, "c": 3}, aggregate="COUNT") == 4
+        assert r.zrange("d", 0, -1, withscores=True) == [
+            [b"a2", 3],
+            [b"a4", 3],
+            [b"a1", 6],
+            [b"a3", 6],
         ]
 
     @skip_if_server_version_lt("6.1.240")


### PR DESCRIPTION
## Add COUNT aggregator support for sorted set commands (ZINTER, ZINTERSTORE, ZUNION, ZUNIONSTORE)

This PR adds support for the new `COUNT` aggregation mode introduced in Redis 8.8.0 for sorted set aggregate commands: `ZINTER`, `ZINTERSTORE`, `ZUNION`, and `ZUNIONSTORE`. The `COUNT` aggregator ignores original element scores and instead counts weighted set membership — each element's resulting score is the sum of the weights of the input sets that contain it. When all weights are 1 (the default), the score simply equals the number of input sets containing the element.

The implementation updates the `_zaggregate` helper in `redis/commands/core.py` to accept `"COUNT"` as a valid aggregate option alongside the existing `SUM`, `MIN`, and `MAX` modes. 
The error message for invalid aggregate values has been updated accordingly. 
Docstrings for `zinter`, `zinterstore`, `zunion`, and `zunionstore` have been expanded to document all four aggregation modes with clear descriptions and score formulas.

Comprehensive tests have been added across all test suites — sync, async, sync cluster, and async cluster — covering both basic `COUNT` aggregation and `COUNT` with custom weights.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to argument validation for sorted-set aggregate commands plus new tests; low risk aside from potential compatibility differences on older Redis versions (tests are version-gated).
> 
> **Overview**
> Adds support for the new `COUNT` `AGGREGATE` mode for sorted-set aggregate commands by allowing `COUNT` in the internal `_zaggregate` command builder (and updating the invalid-aggregate `DataError` message).
> 
> Updates docstrings for `zinter`, `zinterstore`, `zunion`, and `zunionstore` to document `COUNT` semantics and formulas, and adds version-gated tests (sync/async, cluster/non-cluster) covering `COUNT` behavior with and without weights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7031bad4fc395f083385362092bd9ff90b5f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->