### PR TITLE
Fix Sync ClusterPubSub.disconnect() — Potential AttributeError

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2835,7 +2835,8 @@ class ClusterPubSub(PubSub):
         if self.connection:
             self.connection.disconnect()
         for pubsub in self.node_pubsub_mapping.values():
-            pubsub.connection.disconnect()
+            if pubsub.connection:
+                pubsub.connection.disconnect()
 
 
 class ClusterPipeline(RedisCluster):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3289,6 +3289,48 @@ class TestClusterPubSubObject:
         p = r.pubsub(node=node)
         assert p.get_redis_connection() == node.redis_connection
 
+    def test_disconnect_with_none_connections(self, r):
+        """
+        Test that disconnect() does not raise when pubsub.connection is None,
+        both on the ClusterPubSub itself and on node pubsub instances in
+        node_pubsub_mapping.
+        """
+        node = r.get_default_node()
+        p = r.pubsub(node=node)
+        # Ensure self.connection is None
+        p.connection = None
+
+        # Add a mock pubsub with connection=None into node_pubsub_mapping
+        mock_pubsub = Mock()
+        mock_pubsub.connection = None
+        p.node_pubsub_mapping["fake_node"] = mock_pubsub
+
+        # Should not raise AttributeError
+        p.disconnect()
+
+    def test_disconnect_calls_disconnect_on_existing_connections(self, r):
+        """
+        Test that disconnect() properly disconnects non-None connections
+        on both self and node_pubsub_mapping entries.
+        """
+        node = r.get_default_node()
+        p = r.pubsub(node=node)
+
+        # Mock self.connection
+        mock_conn = Mock()
+        p.connection = mock_conn
+
+        # Add a mock pubsub with a real connection into node_pubsub_mapping
+        mock_node_conn = Mock()
+        mock_node_pubsub = Mock()
+        mock_node_pubsub.connection = mock_node_conn
+        p.node_pubsub_mapping["fake_node"] = mock_node_pubsub
+
+        p.disconnect()
+
+        mock_conn.disconnect.assert_called_once()
+        mock_node_conn.disconnect.assert_called_once()
+
 
 @pytest.mark.onlycluster
 class TestClusterPipeline:


### PR DESCRIPTION
## Fix Sync ClusterPubSub.disconnect() — Potential AttributeError

Fixes a potential `AttributeError` in `ClusterPubSub.disconnect()` when a node's pubsub instance in `node_pubsub_mapping` has a `None` connection. 
The fix adds a guard check (`if pubsub.connection`) before calling `disconnect()`, consistent with the existing check already present for `self.connection`. 
Unit tests are added to verify that `disconnect()` handles `None` connections gracefully and still properly disconnects non-None connections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change to connection cleanup logic plus targeted tests; unlikely to affect runtime behavior except avoiding a crash in an edge case.
> 
> **Overview**
> Prevents `ClusterPubSub.disconnect()` from raising `AttributeError` by skipping `disconnect()` calls for entries in `node_pubsub_mapping` whose `connection` is `None`.
> 
> Adds unit tests to cover both the *no-op* behavior with `None` connections and the expected `disconnect()` calls when connections exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8656d6f268117bfb6f1977b64c3ef3f121973ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->