### PR TITLE
Added support for subkey notifications

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.6.1'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.8:8.8-m02
+    8.8:unstable-24805570909-debian
 
 jobs:
   dependency-audit:

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -21,6 +21,10 @@ from redis.keyspace_notifications import (
     KeyspaceNotifications,
     KeyspaceNotificationsInterface,
     KeyspaceWorkerThread,
+    SubkeyeventChannel,
+    SubkeyspaceChannel,
+    SubkeyspaceeventChannel,
+    SubkeyspaceitemChannel,
     get_channel_type,
 )
 from redis.exceptions import (
@@ -92,6 +96,10 @@ __all__ = [
     "KeyspaceNotifications",
     "KeyspaceNotificationsInterface",
     "KeyspaceWorkerThread",
+    "SubkeyeventChannel",
+    "SubkeyspaceChannel",
+    "SubkeyspaceeventChannel",
+    "SubkeyspaceitemChannel",
     "get_channel_type",
     "MaxConnectionsError",
     "OutOfMemoryError",

--- a/redis/asyncio/keyspace_notifications.py
+++ b/redis/asyncio/keyspace_notifications.py
@@ -58,6 +58,10 @@ from redis.keyspace_notifications import (
     KeyeventChannel,
     KeyNotification,
     KeyspaceChannel,
+    SubkeyeventChannel,
+    SubkeyspaceChannel,
+    SubkeyspaceeventChannel,
+    SubkeyspaceitemChannel,
     _is_pattern,
 )
 from redis.utils import safe_str
@@ -152,6 +156,48 @@ class AsyncKeyspaceNotificationsInterface(ABC):
         handler: AsyncHandlerT | None = None,
     ):
         """Subscribe to keyevent notifications for specific event types."""
+        pass
+
+    @abstractmethod
+    async def subscribe_subkeyspace(
+        self,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspace notifications for specific keys."""
+        pass
+
+    @abstractmethod
+    async def subscribe_subkeyevent(
+        self,
+        event: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyevent notifications for specific event types."""
+        pass
+
+    @abstractmethod
+    async def subscribe_subkeyspaceitem(
+        self,
+        key_or_pattern: str,
+        subkey_or_pattern: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspaceitem notifications for a specific subkey."""
+        pass
+
+    @abstractmethod
+    async def subscribe_subkeyspaceevent(
+        self,
+        event: str,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspaceevent notifications for an event on a key."""
         pass
 
     @abstractmethod
@@ -385,6 +431,48 @@ class AbstractAsyncKeyspaceNotifications(AsyncKeyspaceNotificationsInterface):
     ):
         """Subscribe to keyevent notifications for specific event types."""
         channel = KeyeventChannel(event, db=db)
+        await self.subscribe(channel, handler=handler)
+
+    async def subscribe_subkeyspace(
+        self,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspace notifications for specific keys."""
+        channel = SubkeyspaceChannel(key_or_pattern, db=db)
+        await self.subscribe(channel, handler=handler)
+
+    async def subscribe_subkeyevent(
+        self,
+        event: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyevent notifications for specific event types."""
+        channel = SubkeyeventChannel(event, db=db)
+        await self.subscribe(channel, handler=handler)
+
+    async def subscribe_subkeyspaceitem(
+        self,
+        key_or_pattern: str,
+        subkey_or_pattern: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspaceitem notifications for a specific subkey."""
+        channel = SubkeyspaceitemChannel(key_or_pattern, subkey_or_pattern, db=db)
+        await self.subscribe(channel, handler=handler)
+
+    async def subscribe_subkeyspaceevent(
+        self,
+        event: str,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: AsyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspaceevent notifications for an event on a key."""
+        channel = SubkeyspaceeventChannel(event, key_or_pattern, db=db)
         await self.subscribe(channel, handler=handler)
 
     async def __aenter__(self):

--- a/redis/keyspace_notifications.py
+++ b/redis/keyspace_notifications.py
@@ -84,7 +84,16 @@ if TYPE_CHECKING:
 
 # Type alias for channel arguments - can be a string, bytes, or Channel object
 # This is defined here and the actual types are added after class definitions
-ChannelT: TypeAlias = Union[str, bytes, "KeyspaceChannel", "KeyeventChannel"]
+ChannelT: TypeAlias = Union[
+    str,
+    bytes,
+    "KeyspaceChannel",
+    "KeyeventChannel",
+    "SubkeyspaceChannel",
+    "SubkeyeventChannel",
+    "SubkeyspaceitemChannel",
+    "SubkeyspaceeventChannel",
+]
 
 
 # Type alias for sync handlers
@@ -211,13 +220,34 @@ class EventType:
     SETIFNE = "setifne"
 
 
+def _parse_length_prefixed_subkeys(s: str) -> list[str]:
+    """Parse a length-prefixed subkey list.
+
+    The wire format is ``<len>:<subkey>[,<len>:<subkey>...]``.
+
+    Returns:
+        A list of subkey strings.
+    """
+    subkeys: list[str] = []
+    pos = 0
+    while pos < len(s):
+        colon = s.index(":", pos)
+        length = int(s[pos:colon])
+        start = colon + 1
+        subkeys.append(s[start : start + length])
+        pos = start + length
+        if pos < len(s) and s[pos] == ",":
+            pos += 1  # skip comma separator
+    return subkeys
+
+
 @dataclass
 class KeyNotification:
     """
-    Represents a parsed Redis keyspace or keyevent notification.
+    Represents a parsed Redis keyspace, keyevent, or subkey notification.
 
     This class provides convenient access to the notification details
-    like key, event type, and database number.
+    like key, event type, database number, and affected subkeys.
 
     Attributes:
         key: The Redis key that was affected (for keyspace notifications)
@@ -228,6 +258,9 @@ class KeyNotification:
         database: The database number where the event occurred
         channel: The original channel name
         is_keyspace: True if this is a keyspace notification, False for keyevent
+        data: The raw data payload from the notification message.
+        subkeys: List of affected subkeys (fields) for subkey notifications.
+                Empty list for regular keyspace/keyevent notifications.
     """
 
     # Regex patterns for parsing keyspace/keyevent channels
@@ -238,12 +271,30 @@ class KeyNotification:
     _KEYEVENT_PATTERN: ClassVar[re.Pattern] = re.compile(
         r"^__keyevent@(\d+|\*)__:(.+)$"
     )
+    _SUBKEYSPACE_PATTERN: ClassVar[re.Pattern] = re.compile(
+        r"^__subkeyspace@(\d+|\*)__:(.+)$"
+    )
+    _SUBKEYEVENT_PATTERN: ClassVar[re.Pattern] = re.compile(
+        r"^__subkeyevent@(\d+|\*)__:(.+)$"
+    )
+    _SUBKEYSPACEITEM_PATTERN: ClassVar[re.Pattern] = re.compile(
+        r"^__subkeyspaceitem@(\d+|\*)__:(.+)$", re.DOTALL
+    )
+    _SUBKEYSPACEEVENT_PATTERN: ClassVar[re.Pattern] = re.compile(
+        r"^__subkeyspaceevent@(\d+|\*)__:(.+)$"
+    )
 
     key: str
     event_type: str
     database: int
     channel: str
     is_keyspace: bool
+    data: str
+    subkeys: list[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.subkeys is None:
+            self.subkeys = []
 
     @classmethod
     def from_message(
@@ -349,6 +400,7 @@ class KeyNotification:
                 database=database,
                 channel=channel,
                 is_keyspace=True,
+                data=data,
             )
 
         # Try keyevent pattern: __keyevent@<db>__:<event>
@@ -370,6 +422,114 @@ class KeyNotification:
                 database=database,
                 channel=channel,
                 is_keyspace=False,
+                data=data,
+            )
+
+        # Try subkeyspace: channel=__subkeyspace@<db>__:<key>
+        # data=<event>|<subkey_len>:<subkey>[,<subkey_len>:<subkey>...]
+        match = cls._SUBKEYSPACE_PATTERN.match(channel)
+        if match:
+            db_str, key = match.groups()
+            database = int(db_str) if db_str != "*" else -1
+            pipe_idx = data.index("|")
+            event_type = data[:pipe_idx]
+            subkeys = _parse_length_prefixed_subkeys(data[pipe_idx + 1 :])
+
+            if key_prefix:
+                if not key.startswith(key_prefix):
+                    return None
+                key = key[len(key_prefix) :]
+
+            return cls(
+                key=key,
+                event_type=event_type,
+                database=database,
+                channel=channel,
+                is_keyspace=True,
+                data=data,
+                subkeys=subkeys,
+            )
+
+        # Try subkeyevent: channel=__subkeyevent@<db>__:<event>
+        # data=<key_len>:<key>|<subkey_len>:<subkey>[,...]
+        match = cls._SUBKEYEVENT_PATTERN.match(channel)
+        if match:
+            db_str, event_type = match.groups()
+            database = int(db_str) if db_str != "*" else -1
+            # Parse key by length prefix
+            colon_idx = data.index(":")
+            key_len = int(data[:colon_idx])
+            key_start = colon_idx + 1
+            key = data[key_start : key_start + key_len]
+            # After key, expect '|' then subkeys
+            subkeys_start = key_start + key_len + 1  # +1 for '|'
+            subkeys = _parse_length_prefixed_subkeys(data[subkeys_start:])
+
+            if key_prefix:
+                if not key.startswith(key_prefix):
+                    return None
+                key = key[len(key_prefix) :]
+
+            return cls(
+                key=key,
+                event_type=event_type,
+                database=database,
+                channel=channel,
+                is_keyspace=False,
+                data=data,
+                subkeys=subkeys,
+            )
+
+        # Try subkeyspaceitem: channel=__subkeyspaceitem@<db>__:<key>\n<subkey>
+        # data=<event>
+        match = cls._SUBKEYSPACEITEM_PATTERN.match(channel)
+        if match:
+            db_str, key_and_subkey = match.groups()
+            database = int(db_str) if db_str != "*" else -1
+            newline_idx = key_and_subkey.index("\n")
+            key = key_and_subkey[:newline_idx]
+            subkey = key_and_subkey[newline_idx + 1 :]
+            event_type = data
+
+            if key_prefix:
+                if not key.startswith(key_prefix):
+                    return None
+                key = key[len(key_prefix) :]
+
+            return cls(
+                key=key,
+                event_type=event_type,
+                database=database,
+                channel=channel,
+                is_keyspace=True,
+                data=data,
+                subkeys=[subkey],
+            )
+
+        # Try subkeyspaceevent: channel=__subkeyspaceevent@<db>__:<event>|<key>
+        # data=<subkey_len>:<subkey>[,...]
+        match = cls._SUBKEYSPACEEVENT_PATTERN.match(channel)
+        if match:
+            db_str, event_and_key = match.groups()
+            database = int(db_str) if db_str != "*" else -1
+            pipe_idx = event_and_key.index("|")
+            event_type = event_and_key[:pipe_idx]
+            key = event_and_key[pipe_idx + 1 :]
+            subkeys = _parse_length_prefixed_subkeys(data)
+
+            if key_prefix:
+                if not key.startswith(key_prefix):
+                    return None
+                key = key[len(key_prefix) :]
+
+            return cls(
+                key=key,
+                event_type=event_type,
+                database=database,
+                channel=channel,
+                is_keyspace=False,
+                data=data,
+                subkeys=subkeys,
             )
 
         return None
@@ -542,27 +702,234 @@ class KeyeventChannel:
         return hash(self._channel_str)
 
 
+class SubkeyspaceChannel:
+    """
+    Represents a subkeyspace notification channel for subscribing to
+    subkey-level events on keys (e.g., hash field changes).
+
+    The channel format is ``__subkeyspace@<db>__:<key>``.
+    The message payload is ``<event>|<subkey_len>:<subkey>[,...]``.
+
+    Examples:
+        >>> channel = SubkeyspaceChannel("myhash", db=0)
+        >>> str(channel)
+        '__subkeyspace@0__:myhash'
+    """
+
+    PREFIX: ClassVar[str] = "__subkeyspace@"
+
+    def __init__(self, key_or_pattern: str, db: int = 0):
+        self.key_or_pattern = key_or_pattern
+        self.db = db
+        self._channel_str = self._build_channel_string()
+
+    def _build_channel_string(self) -> str:
+        return f"{self.PREFIX}{self.db}__:{self.key_or_pattern}"
+
+    @property
+    def is_pattern(self) -> bool:
+        return _is_pattern(self.key_or_pattern)
+
+    def __str__(self) -> str:
+        return self._channel_str
+
+    def __repr__(self) -> str:
+        return f"SubkeyspaceChannel({self.key_or_pattern!r}, db={self.db})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SubkeyspaceChannel):
+            return self._channel_str == other._channel_str
+        if isinstance(other, str):
+            return self._channel_str == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._channel_str)
+
+
+class SubkeyeventChannel:
+    """
+    Represents a subkeyevent notification channel for subscribing to
+    specific event types with subkey-level detail.
+
+    The channel format is ``__subkeyevent@<db>__:<event>``.
+    The message payload is ``<key_len>:<key>|<subkey_len>:<subkey>[,...]``.
+
+    Examples:
+        >>> channel = SubkeyeventChannel("hdel", db=0)
+        >>> str(channel)
+        '__subkeyevent@0__:hdel'
+    """
+
+    PREFIX: ClassVar[str] = "__subkeyevent@"
+
+    def __init__(self, event: str, db: int = 0):
+        self.event = event
+        self.db = db
+        self._channel_str = self._build_channel_string()
+
+    def _build_channel_string(self) -> str:
+        return f"{self.PREFIX}{self.db}__:{self.event}"
+
+    @property
+    def is_pattern(self) -> bool:
+        return _is_pattern(self.event)
+
+    @classmethod
+    def all_events(cls, db: int = 0) -> SubkeyeventChannel:
+        """Create a channel for all subkeyevent types."""
+        return cls("*", db=db)
+
+    def __str__(self) -> str:
+        return self._channel_str
+
+    def __repr__(self) -> str:
+        return f"SubkeyeventChannel({self.event!r}, db={self.db})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SubkeyeventChannel):
+            return self._channel_str == other._channel_str
+        if isinstance(other, str):
+            return self._channel_str == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._channel_str)
+
+
+class SubkeyspaceitemChannel:
+    """
+    Represents a subkeyspaceitem notification channel for subscribing to
+    events on a specific subkey (field) of a specific key.
+
+    The channel format is ``__subkeyspaceitem@<db>__:<key>\\n<subkey>``.
+    The message payload is the event type (e.g., ``"hset"``).
+
+    Note:
+        The server only emits this notification when the key does not
+        contain a newline character.
+
+    Examples:
+        >>> channel = SubkeyspaceitemChannel("myhash", "myfield", db=0)
+        >>> str(channel)
+        '__subkeyspaceitem@0__:myhash\\nmyfield'
+    """
+
+    PREFIX: ClassVar[str] = "__subkeyspaceitem@"
+
+    def __init__(self, key_or_pattern: str, subkey_or_pattern: str, db: int = 0):
+        self.key_or_pattern = key_or_pattern
+        self.subkey_or_pattern = subkey_or_pattern
+        self.db = db
+        self._channel_str = self._build_channel_string()
+
+    def _build_channel_string(self) -> str:
+        return (
+            f"{self.PREFIX}{self.db}__:{self.key_or_pattern}\n{self.subkey_or_pattern}"
+        )
+
+    @property
+    def is_pattern(self) -> bool:
+        return _is_pattern(self.key_or_pattern) or _is_pattern(self.subkey_or_pattern)
+
+    def __str__(self) -> str:
+        return self._channel_str
+
+    def __repr__(self) -> str:
+        return (
+            f"SubkeyspaceitemChannel({self.key_or_pattern!r}, "
+            f"{self.subkey_or_pattern!r}, db={self.db})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SubkeyspaceitemChannel):
+            return self._channel_str == other._channel_str
+        if isinstance(other, str):
+            return self._channel_str == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._channel_str)
+
+
+class SubkeyspaceeventChannel:
+    """
+    Represents a subkeyspaceevent notification channel for subscribing to
+    a specific event on a specific key, receiving affected subkeys.
+
+    The channel format is ``__subkeyspaceevent@<db>__:<event>|<key>``.
+    The message payload is a length-prefixed subkey list.
+
+    Examples:
+        >>> channel = SubkeyspaceeventChannel("hset", "myhash", db=0)
+        >>> str(channel)
+        '__subkeyspaceevent@0__:hset|myhash'
+    """
+
+    PREFIX: ClassVar[str] = "__subkeyspaceevent@"
+
+    def __init__(self, event: str, key_or_pattern: str, db: int = 0):
+        self.event = event
+        self.key_or_pattern = key_or_pattern
+        self.db = db
+        self._channel_str = self._build_channel_string()
+
+    def _build_channel_string(self) -> str:
+        return f"{self.PREFIX}{self.db}__:{self.event}|{self.key_or_pattern}"
+
+    @property
+    def is_pattern(self) -> bool:
+        return _is_pattern(self.event) or _is_pattern(self.key_or_pattern)
+
+    def __str__(self) -> str:
+        return self._channel_str
+
+    def __repr__(self) -> str:
+        return (
+            f"SubkeyspaceeventChannel({self.event!r}, "
+            f"{self.key_or_pattern!r}, db={self.db})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SubkeyspaceeventChannel):
+            return self._channel_str == other._channel_str
+        if isinstance(other, str):
+            return self._channel_str == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._channel_str)
+
+
 class ChannelType(Enum):
     """
     Enum representing the type of a Redis keyspace notification channel.
 
-    Redis provides two types of keyspace notifications:
-    - KEYSPACE: Notifies about events on specific keys. The channel format is
-      `__keyspace@{db}__:{key}` and the message data contains the event type.
-    - KEYEVENT: Notifies about specific event types. The channel format is
-      `__keyevent@{db}__:{event}` and the message data contains the key name.
+    Redis provides two types of keyspace notifications and four subkey
+    notification types:
+
+    - KEYSPACE: ``__keyspace@{db}__:{key}`` — data is the event type.
+    - KEYEVENT: ``__keyevent@{db}__:{event}`` — data is the key name.
+    - SUBKEYSPACE: ``__subkeyspace@{db}__:{key}`` — data is event + subkeys.
+    - SUBKEYEVENT: ``__subkeyevent@{db}__:{event}`` — data is key + subkeys.
+    - SUBKEYSPACEITEM: ``__subkeyspaceitem@{db}__:{key}\\n{subkey}`` — data
+      is the event type.
+    - SUBKEYSPACEEVENT: ``__subkeyspaceevent@{db}__:{event}|{key}`` — data
+      is a subkey list.
 
     Examples:
         >>> get_channel_type("__keyspace@0__:mykey")
         ChannelType.KEYSPACE
-        >>> get_channel_type("__keyevent@0__:set")
-        ChannelType.KEYEVENT
-        >>> get_channel_type("regular_channel") is None
-        True
+        >>> get_channel_type("__subkeyspace@0__:myhash")
+        ChannelType.SUBKEYSPACE
     """
 
     KEYSPACE = "keyspace"
     KEYEVENT = "keyevent"
+    SUBKEYSPACE = "subkeyspace"
+    SUBKEYEVENT = "subkeyevent"
+    SUBKEYSPACEITEM = "subkeyspaceitem"
+    SUBKEYSPACEEVENT = "subkeyspaceevent"
 
 
 def get_channel_type(channel: str | bytes) -> ChannelType | None:
@@ -588,6 +955,15 @@ def get_channel_type(channel: str | bytes) -> ChannelType | None:
         ChannelType.KEYSPACE
     """
     channel_str = safe_str(channel)
+    # Check subkey prefixes first (they are longer and more specific)
+    if channel_str.startswith(SubkeyspaceitemChannel.PREFIX):
+        return ChannelType.SUBKEYSPACEITEM
+    if channel_str.startswith(SubkeyspaceeventChannel.PREFIX):
+        return ChannelType.SUBKEYSPACEEVENT
+    if channel_str.startswith(SubkeyspaceChannel.PREFIX):
+        return ChannelType.SUBKEYSPACE
+    if channel_str.startswith(SubkeyeventChannel.PREFIX):
+        return ChannelType.SUBKEYEVENT
     if channel_str.startswith(KeyspaceChannel.PREFIX):
         return ChannelType.KEYSPACE
     if channel_str.startswith(KeyeventChannel.PREFIX):
@@ -693,6 +1069,48 @@ class KeyspaceNotificationsInterface(ABC):
         handler: SyncHandlerT | None = None,
     ):
         """Subscribe to keyevent notifications for specific event types."""
+        pass
+
+    @abstractmethod
+    def subscribe_subkeyspace(
+        self,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspace notifications for specific keys."""
+        pass
+
+    @abstractmethod
+    def subscribe_subkeyevent(
+        self,
+        event: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyevent notifications for specific event types."""
+        pass
+
+    @abstractmethod
+    def subscribe_subkeyspaceitem(
+        self,
+        key_or_pattern: str,
+        subkey_or_pattern: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspaceitem notifications for a specific subkey."""
+        pass
+
+    @abstractmethod
+    def subscribe_subkeyspaceevent(
+        self,
+        event: str,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """Subscribe to subkeyspaceevent notifications for an event on a key."""
         pass
 
     @abstractmethod
@@ -949,6 +1367,88 @@ class AbstractKeyspaceNotifications(KeyspaceNotificationsInterface):
             >>> ksn.subscribe_keyevent(EventType.EXPIRED, handler=my_handler)
         """
         channel = KeyeventChannel(event, db=db)
+        self.subscribe(channel, handler=handler)
+
+    def subscribe_subkeyspace(
+        self,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """
+        Subscribe to subkeyspace notifications for specific keys.
+
+        Receives events with affected subkeys (fields) for the given key.
+
+        Args:
+            key_or_pattern: The key or pattern to monitor.
+            db: The database number (default 0).
+            handler: Optional callback for notifications.
+        """
+        channel = SubkeyspaceChannel(key_or_pattern, db=db)
+        self.subscribe(channel, handler=handler)
+
+    def subscribe_subkeyevent(
+        self,
+        event: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """
+        Subscribe to subkeyevent notifications for specific event types.
+
+        Receives the affected key and subkeys when the given event occurs.
+
+        Args:
+            event: The event type to monitor (e.g., "hset", "hdel").
+            db: The database number (default 0).
+            handler: Optional callback for notifications.
+        """
+        channel = SubkeyeventChannel(event, db=db)
+        self.subscribe(channel, handler=handler)
+
+    def subscribe_subkeyspaceitem(
+        self,
+        key_or_pattern: str,
+        subkey_or_pattern: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """
+        Subscribe to subkeyspaceitem notifications for a specific subkey.
+
+        Receives the event type when the given subkey of the given key is
+        modified.
+
+        Args:
+            key_or_pattern: The key or pattern to monitor.
+            subkey_or_pattern: The subkey (field) or pattern to monitor.
+            db: The database number (default 0).
+            handler: Optional callback for notifications.
+        """
+        channel = SubkeyspaceitemChannel(key_or_pattern, subkey_or_pattern, db=db)
+        self.subscribe(channel, handler=handler)
+
+    def subscribe_subkeyspaceevent(
+        self,
+        event: str,
+        key_or_pattern: str,
+        db: int = 0,
+        handler: SyncHandlerT | None = None,
+    ):
+        """
+        Subscribe to subkeyspaceevent notifications for an event on a key.
+
+        Receives the affected subkeys when the given event occurs on the
+        given key.
+
+        Args:
+            event: The event type to monitor.
+            key_or_pattern: The key or pattern to monitor.
+            db: The database number (default 0).
+            handler: Optional callback for notifications.
+        """
+        channel = SubkeyspaceeventChannel(event, key_or_pattern, db=db)
         self.subscribe(channel, handler=handler)
 
     def __enter__(self):

--- a/specs/keyspace-notifications/SPEC.md
+++ b/specs/keyspace-notifications/SPEC.md
@@ -20,6 +20,19 @@ Redis allows to notify clients whenever a key is modified. The mechanism that is
 - **Keyspace**: Have the prefix `__keyspace@0__:` and allow you to listen for operations performed on a specific key (e.g., `__keyspace@0__:mykey`). The notification then returns you the operation performed on the key.
 - **Keyevent**: Have the prefix `__keyevent@0__:` and allow you to listen for specific operation events (`__keyevent@0__:del`). The notification then returns you the impacted key.
 
+Many applications need more precise notifications, especially for hashes. Typical use cases include:
+
+- determining which field inside a hash was modified 
+- determining which specific fields expired 
+- performing fine-grained cache invalidation 
+- reacting to partial object changes without reprocessing the entire key
+
+The proposed Redis core feature extends keyspace notifications with subkey-aware notifications while preserving the existing Pub/Sub message envelope.
+
+**Subkeyspace**: Have the prefix `__subkeyspace@<db>__:` and allow you to listen for operations performed on a specific key (e.g., `__subkeyspace@0__:myhash`), but the payload returns the set of subkeys (fields) that were affected along with event `<event>|<subkeys> `.
+**Subkeyevent**: Have the prefix `__subkeyevent@<db>__:` and allow you to listen for specific operation events (`__subkeyevent@0__:del`), but the payload returns the set of subkeys (fields) that were affected along with impacted key `<key>|<subkeys>`.
+**Subkeyspaceitem**: Have the prefix `__subkeyspaceitem@<db>__:` and allow you to listen for operations performed on a specific subkey (e.g `__subkeyspaceitem@0__:myhash\nmyfield`). The notification then returns you the event performed on the subkeys.
+**Subkeyspaceevent**: Have the prefix `__subkeyspaceevent@<db>__:` and allow you to listen for specific events performed on a specific key (e.g `__subkeyspaceevent@<db>__:<event>|<key>`). The notification then returns you the impacted subkeys. 
 
 ## Cluster specifics
 
@@ -33,6 +46,11 @@ Redis allows to notify clients whenever a key is modified. The mechanism that is
 By using a cluster client, it should be possible to:
 
 - Consume keyspace and key event notifications across the cluster via a new API for subscribing to `keyspace` and `keyevent` channels
+- Consume Subkeyspace, Subkeyevent, Subkeyspaceitem and Subkeyspaceevent notifications across the cluster via a new API for subscribing to `subkeyspace`, `subkeyevent`, `subkeyspaceitem` and `subkeyspaceevent` channels
+- For subkeyspace, the canonical wire format is the multi-subkey length-prefixed form: `<event>|<subkey_len>:<subkey>[,<subkey_len>:<subkey>...]`. The compact single-subkey form is not part of the supported v1 contract. 
+- For subkeyevent, clients must parse the payload as `<key_len>:<key>|<subkey_len>:<subkey>[,<subkey_len>:<subkey>...]`, reading the key by length rather than delimiter.
+- For subkeyspaceitem, clients must parse the channel as `<key>\n<subkey>` and the payload as `<event>`. The server emits this family only when the key does not contain `\n`.
+- For subkeyspaceevent, clients must parse the channel as `<event>|<key>` and the payload as a length-prefixed subkey list.
 - Support multiple logical databases for standalone clients (via `SELECT <db_index>`), while Redis OSS Cluster continues to use database 0 only
 - Take the differences in behavior between normally published messages and keyspace notifications into account - Keyspace notifications aren't propagated between nodes via the cluster bus
 - Automatically react to topology changes (e.g. node added/removed, slot migration, ...) by resubscribing to the relevant channels
@@ -46,9 +64,14 @@ Please take a look at https://github.com/StackExchange/StackExchange.Redis/pull/
 ## Test cases
 
 - Create a key on node 1 and verify that the notification about the creation of the key is received
+- Create a hash field within a key on node 1 and verify that the Subkeyspace notification received contains the field that was created
 - Update a key on node 1 and verify that the keyspace notification is received
+- Update a hash field on node 1 and verify that the Subkeyspace and Subkeyspaceitem notification are received
 - Update a key on node 2 and verify that the key event notification is received
+- Update a hash field within a key on node 2 and verify that the Subkeyspace and Subkeyspaceitem notification are received
 - Delete a key on node 3 and verify that the deletion notification is received
+- Delete a hash field on node 3 and verify that the deletion notification is received in Subkeyevent and Subkeyspaceevent channels
 - Modify a bunch of keys across nodes 1, 2 and 3 that all match the same pattern and check that all notifications are received
+- Modify a bunch of hash fields across nodes 1, 2 and 3 that all match the same pattern and check that all notifications are received
 - Move a bunch of slots from node 1 to node 2 that impact some pre-defined keys and ensure that keyspace notifications and key event notifications are received correctly before and after the migration
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -447,7 +447,7 @@ def _enable_keyspace_notifications(client):
             original = node_client.config_get("notify-keyspace-events")
             original_configs[node.name] = original.get("notify-keyspace-events", "")
             node_connections[node.name] = node_client
-            node_client.config_set("notify-keyspace-events", "KEA")
+            node_client.config_set("notify-keyspace-events", "KEASTIV")
 
         def restore():
             # Restore configuration on all nodes that were originally configured
@@ -481,7 +481,7 @@ def _enable_keyspace_notifications(client):
         # For standalone, configure the single server
         original_config = client.config_get("notify-keyspace-events")
         original_value = original_config.get("notify-keyspace-events", "")
-        client.config_set("notify-keyspace-events", "KEA")
+        client.config_set("notify-keyspace-events", "KEASTIV")
 
         def restore():
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,7 +429,7 @@ def r(request):
         yield client
 
 
-def _enable_keyspace_notifications(client):
+def _enable_keyspace_notifications(client, flags="KEA"):
     """
     Enable keyspace notifications on a Redis server (standalone or cluster).
 
@@ -447,7 +447,7 @@ def _enable_keyspace_notifications(client):
             original = node_client.config_get("notify-keyspace-events")
             original_configs[node.name] = original.get("notify-keyspace-events", "")
             node_connections[node.name] = node_client
-            node_client.config_set("notify-keyspace-events", "KEASTIV")
+            node_client.config_set("notify-keyspace-events", flags)
 
         def restore():
             # Restore configuration on all nodes that were originally configured
@@ -481,7 +481,7 @@ def _enable_keyspace_notifications(client):
         # For standalone, configure the single server
         original_config = client.config_get("notify-keyspace-events")
         original_value = original_config.get("notify-keyspace-events", "")
-        client.config_set("notify-keyspace-events", "KEASTIV")
+        client.config_set("notify-keyspace-events", flags)
 
         def restore():
             try:
@@ -507,6 +507,25 @@ def r_with_keyspace_notifications(request):
     """
     with _get_client(redis.Redis, request) as client:
         restore = _enable_keyspace_notifications(client)
+        try:
+            yield client
+        finally:
+            restore()
+
+
+@pytest.fixture()
+def r_with_subkey_notifications(request):
+    """
+    A Redis client with keyspace and subkey notifications enabled.
+
+    Uses notify-keyspace-events=KEASTIV, which enables subkey notification
+    flags (S, T, I, V). These flags are only available in Redis >= 8.7.2;
+    tests using this fixture must be guarded accordingly.
+
+    Works for both standalone Redis and RedisCluster.
+    """
+    with _get_client(redis.Redis, request) as client:
+        restore = _enable_keyspace_notifications(client, flags="KEASTIV")
         try:
             yield client
         finally:

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -285,3 +285,43 @@ def redis_url(request):
 def connect_args(request):
     url = request.config.getoption("--redis-url")
     return parse_url(url)
+
+
+@pytest_asyncio.fixture()
+async def async_r_with_keyspace_notifications(create_redis):
+    """An async Redis client with keyspace notifications enabled.
+
+    Works for both standalone Redis and RedisCluster.
+    In cluster mode, keyspace notifications are enabled on all primary nodes.
+    """
+    client = await create_redis()
+    cluster_mode = REDIS_INFO.get("cluster_enabled", False)
+
+    original_configs = {}
+    if cluster_mode:
+        for node in client.get_primaries():
+            node_conn = redis.Redis(host=node.host, port=node.port)
+            original = await node_conn.config_get("notify-keyspace-events")
+            original_configs[node.name] = (
+                node_conn,
+                original.get("notify-keyspace-events", ""),
+            )
+            await node_conn.config_set("notify-keyspace-events", "KEASTIV")
+    else:
+        original = await client.config_get("notify-keyspace-events")
+        original_configs["standalone"] = (
+            client,
+            original.get("notify-keyspace-events", ""),
+        )
+        await client.config_set("notify-keyspace-events", "KEASTIV")
+
+    try:
+        yield client
+    finally:
+        for _name, (conn, original_value) in original_configs.items():
+            try:
+                await conn.config_set("notify-keyspace-events", original_value)
+            except Exception:
+                pass
+            if cluster_mode:
+                await conn.aclose()

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -287,14 +287,12 @@ def connect_args(request):
     return parse_url(url)
 
 
-@pytest_asyncio.fixture()
-async def async_r_with_keyspace_notifications(create_redis):
-    """An async Redis client with keyspace notifications enabled.
-
-    Works for both standalone Redis and RedisCluster.
-    In cluster mode, keyspace notifications are enabled on all primary nodes.
+async def _async_enable_keyspace_notifications(client, flags="KEA"):
     """
-    client = await create_redis()
+    Enable keyspace notifications on an async Redis server (standalone or cluster).
+
+    Returns a dict mapping a label to (connection, original_value, owns_conn).
+    """
     cluster_mode = REDIS_INFO.get("cluster_enabled", False)
 
     original_configs = {}
@@ -306,22 +304,62 @@ async def async_r_with_keyspace_notifications(create_redis):
                 node_conn,
                 original.get("notify-keyspace-events", ""),
             )
-            await node_conn.config_set("notify-keyspace-events", "KEASTIV")
+            await node_conn.config_set("notify-keyspace-events", flags)
     else:
         original = await client.config_get("notify-keyspace-events")
         original_configs["standalone"] = (
             client,
             original.get("notify-keyspace-events", ""),
         )
-        await client.config_set("notify-keyspace-events", "KEASTIV")
+        await client.config_set("notify-keyspace-events", flags)
 
+    return original_configs, cluster_mode
+
+
+async def _async_restore_keyspace_notifications(original_configs, cluster_mode):
+    for _name, (conn, original_value) in original_configs.items():
+        try:
+            await conn.config_set("notify-keyspace-events", original_value)
+        except Exception:
+            pass
+        if cluster_mode:
+            await conn.aclose()
+
+
+@pytest_asyncio.fixture()
+async def async_r_with_keyspace_notifications(create_redis):
+    """An async Redis client with keyspace notifications enabled.
+
+    Uses notify-keyspace-events=KEA, supported on all Redis versions.
+
+    Works for both standalone Redis and RedisCluster.
+    In cluster mode, keyspace notifications are enabled on all primary nodes.
+    """
+    client = await create_redis()
+    original_configs, cluster_mode = await _async_enable_keyspace_notifications(
+        client, flags="KEA"
+    )
     try:
         yield client
     finally:
-        for _name, (conn, original_value) in original_configs.items():
-            try:
-                await conn.config_set("notify-keyspace-events", original_value)
-            except Exception:
-                pass
-            if cluster_mode:
-                await conn.aclose()
+        await _async_restore_keyspace_notifications(original_configs, cluster_mode)
+
+
+@pytest_asyncio.fixture()
+async def async_r_with_subkey_notifications(create_redis):
+    """An async Redis client with keyspace and subkey notifications enabled.
+
+    Uses notify-keyspace-events=KEASTIV, which enables subkey notification
+    flags (S, T, I, V). These flags are only available in Redis >= 8.7.2;
+    tests using this fixture must be guarded accordingly.
+
+    Works for both standalone Redis and RedisCluster.
+    """
+    client = await create_redis()
+    original_configs, cluster_mode = await _async_enable_keyspace_notifications(
+        client, flags="KEASTIV"
+    )
+    try:
+        yield client
+    finally:
+        await _async_restore_keyspace_notifications(original_configs, cluster_mode)

--- a/tests/test_asyncio/test_keyspace_notifications.py
+++ b/tests/test_asyncio/test_keyspace_notifications.py
@@ -724,16 +724,6 @@ class TestAsyncSubkeyNotifications:
     Works for both standalone Redis and RedisCluster.
     """
 
-    @staticmethod
-    async def _drain_subscribe_messages(notifications):
-        """Drain subscribe/psubscribe confirmation messages."""
-        while True:
-            msg = await notifications._pubsub.get_message(timeout=0.01)
-            if msg is None:
-                break
-            if msg["type"] not in ("subscribe", "psubscribe"):
-                break
-
     @pytest.mark.asyncio
     async def test_create_hash_field_subkeyspace_notification(
         self, async_r_with_subkey_notifications
@@ -741,9 +731,8 @@ class TestAsyncSubkeyNotifications:
         """Create a hash field and verify that the Subkeyspace notification
         contains the field that was created."""
         r = async_r_with_subkey_notifications
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:hash1")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash1", "field1", "value1")
 
@@ -764,9 +753,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.hset("test:hash2", "field1", "initial")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:hash2")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash2", "field1", "updated")
 
@@ -788,9 +776,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.hset("test:hash3", "myfield", "initial")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceitem("test:hash3", "myfield")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash3", "myfield", "updated")
 
@@ -812,9 +799,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.hset("test:hash4", "field1", "value1")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyevent("hdel")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hdel("test:hash4", "field1")
 
@@ -836,9 +822,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.hset("test:hash5", "field1", "value1")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceevent("hdel", "test:hash5")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hdel("test:hash5", "field1")
 
@@ -858,9 +843,8 @@ class TestAsyncSubkeyNotifications:
         """Create a key and verify that a regular keyspace notification
         is received (backward compatibility)."""
         r = async_r_with_subkey_notifications
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:simple1")
-        await self._drain_subscribe_messages(notifications)
 
         await r.set("test:simple1", "value1")
 
@@ -881,9 +865,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.set("test:simple2", "initial")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:simple2")
-        await self._drain_subscribe_messages(notifications)
 
         await r.set("test:simple2", "updated")
 
@@ -903,9 +886,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.set("test:simple3", "value")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:simple3")
-        await self._drain_subscribe_messages(notifications)
 
         await r.delete("test:simple3")
 
@@ -923,9 +905,8 @@ class TestAsyncSubkeyNotifications:
         """Create multiple hash fields at once and verify subkeyspace
         notification contains all affected fields."""
         r = async_r_with_subkey_notifications
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:hash6")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash6", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
 
@@ -946,9 +927,8 @@ class TestAsyncSubkeyNotifications:
         """Subscribe to a subkeyspace pattern and verify notifications are
         received for matching keys."""
         r = async_r_with_subkey_notifications
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:pattern:*")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:pattern:hash1", "field1", "value1")
         await r.hset("test:pattern:hash2", "field2", "value2")
@@ -973,9 +953,8 @@ class TestAsyncSubkeyNotifications:
         """Subscribe to a subkeyevent pattern for all hash events and
         verify notifications are received."""
         r = async_r_with_subkey_notifications
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyevent("h*")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash7", "field1", "value1")
         await r.hdel("test:hash7", "field1")
@@ -1002,9 +981,8 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         await r.hset("test:hash8", "watched_field", "initial")
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceitem("test:hash8", "watched_field")
-        await self._drain_subscribe_messages(notifications)
 
         # Modify a different field — should NOT trigger a notification
         await r.hset("test:hash8", "other_field", "value")
@@ -1028,10 +1006,9 @@ class TestAsyncSubkeyNotifications:
         verify that both types of notifications are received."""
         r = async_r_with_subkey_notifications
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:hash9")
         await notifications.subscribe_subkeyspace("test:hash9")
-        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash9", "field1", "value1")
 

--- a/tests/test_asyncio/test_keyspace_notifications.py
+++ b/tests/test_asyncio/test_keyspace_notifications.py
@@ -712,14 +712,14 @@ class TestAsyncClusterKeyspaceNotificationsMocked:
         await notifications.aclose()
 
 
-@skip_if_server_version_lt("8.7.3")
+@skip_if_server_version_lt("8.7.2")
 class TestAsyncSubkeyNotifications:
     """
     Integration tests for subkey keyspace notifications with an async
     Redis client.
 
     These tests require a Redis server with subkey notification support
-    (Redis >= 8.7.3) and keyspace notifications enabled.
+    (Redis >= 8.7.2) and keyspace notifications enabled.
 
     Works for both standalone Redis and RedisCluster.
     """
@@ -736,11 +736,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_create_hash_field_subkeyspace_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Create a hash field and verify that the Subkeyspace notification
         contains the field that was created."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_subkeyspace("test:hash1")
         await self._drain_subscribe_messages(notifications)
@@ -758,10 +758,10 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_update_hash_field_subkeyspace_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Update an existing hash field and verify the Subkeyspace notification."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.hset("test:hash2", "field1", "initial")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -781,11 +781,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_update_hash_field_subkeyspaceitem_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Update a hash field and verify the Subkeyspaceitem notification
         is received for the specific field."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.hset("test:hash3", "myfield", "initial")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -805,11 +805,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_delete_hash_field_subkeyevent_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Delete a hash field and verify the Subkeyevent notification
         is received for the hdel event."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.hset("test:hash4", "field1", "value1")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -829,11 +829,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_delete_hash_field_subkeyspaceevent_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Delete a hash field and verify the Subkeyspaceevent notification
         is received for the specific key and event."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.hset("test:hash5", "field1", "value1")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -853,11 +853,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_create_key_keyspace_notification_still_works(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Create a key and verify that a regular keyspace notification
         is received (backward compatibility)."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_keyspace("test:simple1")
         await self._drain_subscribe_messages(notifications)
@@ -875,10 +875,10 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_update_key_keyspace_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Update a key and verify the keyspace notification is received."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.set("test:simple2", "initial")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -897,10 +897,10 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_delete_key_keyspace_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Delete a key and verify that the deletion notification is received."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.set("test:simple3", "value")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -918,11 +918,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_multiple_hash_fields_subkeyspace_notification(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Create multiple hash fields at once and verify subkeyspace
         notification contains all affected fields."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_subkeyspace("test:hash6")
         await self._drain_subscribe_messages(notifications)
@@ -941,11 +941,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_subkeyspace_pattern_subscription(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Subscribe to a subkeyspace pattern and verify notifications are
         received for matching keys."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_subkeyspace("test:pattern:*")
         await self._drain_subscribe_messages(notifications)
@@ -968,11 +968,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_subkeyevent_pattern_subscription(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Subscribe to a subkeyevent pattern for all hash events and
         verify notifications are received."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_subkeyevent("h*")
         await self._drain_subscribe_messages(notifications)
@@ -995,11 +995,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_subkeyspaceitem_does_not_receive_other_fields(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Subscribe to a specific subkeyspaceitem and verify that
         modifications to other fields do not trigger notifications."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
         await r.hset("test:hash8", "watched_field", "initial")
 
         notifications = AsyncKeyspaceNotifications(r)
@@ -1022,11 +1022,11 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_combined_keyspace_and_subkeyspace(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Subscribe to both keyspace and subkeyspace on the same key and
         verify that both types of notifications are received."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
 
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_keyspace("test:hash9")
@@ -1054,12 +1054,12 @@ class TestAsyncSubkeyNotifications:
 
     @pytest.mark.asyncio
     async def test_subkeyspaceitem_pattern_receives_matching_fields(
-        self, async_r_with_keyspace_notifications
+        self, async_r_with_subkey_notifications
     ):
         """Subscribe to subkeyspaceitem with a pattern subkey (field*) and
         verify that notifications are received for field1, field2, and field3
         but not for unrelated fields."""
-        r = async_r_with_keyspace_notifications
+        r = async_r_with_subkey_notifications
 
         notifications = AsyncKeyspaceNotifications(r)
         await notifications.subscribe_subkeyspaceitem("test:hash10", "field*")

--- a/tests/test_asyncio/test_keyspace_notifications.py
+++ b/tests/test_asyncio/test_keyspace_notifications.py
@@ -13,6 +13,7 @@ from redis.asyncio.keyspace_notifications import (
     _ClusterNodePoolAdapter,
 )
 from redis.exceptions import ConnectionError
+from tests.conftest import skip_if_server_version_lt
 from redis.keyspace_notifications import (
     EventType,
     KeyspaceChannel,
@@ -709,3 +710,385 @@ class TestAsyncClusterKeyspaceNotificationsMocked:
         assert "__keyspace@0__:mykey" in notifications._subscribed_channels
 
         await notifications.aclose()
+
+
+@skip_if_server_version_lt("8.7.3")
+class TestAsyncSubkeyNotifications:
+    """
+    Integration tests for subkey keyspace notifications with an async
+    Redis client.
+
+    These tests require a Redis server with subkey notification support
+    (Redis >= 8.7.3) and keyspace notifications enabled.
+
+    Works for both standalone Redis and RedisCluster.
+    """
+
+    @staticmethod
+    async def _drain_subscribe_messages(notifications):
+        """Drain subscribe/psubscribe confirmation messages."""
+        while True:
+            msg = await notifications._pubsub.get_message(timeout=0.01)
+            if msg is None:
+                break
+            if msg["type"] not in ("subscribe", "psubscribe"):
+                break
+
+    @pytest.mark.asyncio
+    async def test_create_hash_field_subkeyspace_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Create a hash field and verify that the Subkeyspace notification
+        contains the field that was created."""
+        r = async_r_with_keyspace_notifications
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspace("test:hash1")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:hash1", "field1", "value1")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash1"
+        assert msg.event_type == "hset"
+        assert "field1" in msg.subkeys
+
+        await notifications.aclose()
+        await r.delete("test:hash1")
+
+    @pytest.mark.asyncio
+    async def test_update_hash_field_subkeyspace_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Update an existing hash field and verify the Subkeyspace notification."""
+        r = async_r_with_keyspace_notifications
+        await r.hset("test:hash2", "field1", "initial")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspace("test:hash2")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:hash2", "field1", "updated")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash2"
+        assert msg.event_type == "hset"
+        assert "field1" in msg.subkeys
+
+        await notifications.aclose()
+        await r.delete("test:hash2")
+
+    @pytest.mark.asyncio
+    async def test_update_hash_field_subkeyspaceitem_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Update a hash field and verify the Subkeyspaceitem notification
+        is received for the specific field."""
+        r = async_r_with_keyspace_notifications
+        await r.hset("test:hash3", "myfield", "initial")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspaceitem("test:hash3", "myfield")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:hash3", "myfield", "updated")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash3"
+        assert msg.event_type == "hset"
+        assert msg.subkeys == ["myfield"]
+
+        await notifications.aclose()
+        await r.delete("test:hash3")
+
+    @pytest.mark.asyncio
+    async def test_delete_hash_field_subkeyevent_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Delete a hash field and verify the Subkeyevent notification
+        is received for the hdel event."""
+        r = async_r_with_keyspace_notifications
+        await r.hset("test:hash4", "field1", "value1")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyevent("hdel")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hdel("test:hash4", "field1")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash4"
+        assert msg.event_type == "hdel"
+        assert "field1" in msg.subkeys
+
+        await notifications.aclose()
+        await r.delete("test:hash4")
+
+    @pytest.mark.asyncio
+    async def test_delete_hash_field_subkeyspaceevent_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Delete a hash field and verify the Subkeyspaceevent notification
+        is received for the specific key and event."""
+        r = async_r_with_keyspace_notifications
+        await r.hset("test:hash5", "field1", "value1")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspaceevent("hdel", "test:hash5")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hdel("test:hash5", "field1")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash5"
+        assert msg.event_type == "hdel"
+        assert "field1" in msg.subkeys
+
+        await notifications.aclose()
+        await r.delete("test:hash5")
+
+    @pytest.mark.asyncio
+    async def test_create_key_keyspace_notification_still_works(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Create a key and verify that a regular keyspace notification
+        is received (backward compatibility)."""
+        r = async_r_with_keyspace_notifications
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_keyspace("test:simple1")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.set("test:simple1", "value1")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:simple1"
+        assert msg.event_type == "set"
+        assert msg.subkeys == []
+
+        await notifications.aclose()
+        await r.delete("test:simple1")
+
+    @pytest.mark.asyncio
+    async def test_update_key_keyspace_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Update a key and verify the keyspace notification is received."""
+        r = async_r_with_keyspace_notifications
+        await r.set("test:simple2", "initial")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_keyspace("test:simple2")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.set("test:simple2", "updated")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:simple2"
+        assert msg.event_type == "set"
+
+        await notifications.aclose()
+        await r.delete("test:simple2")
+
+    @pytest.mark.asyncio
+    async def test_delete_key_keyspace_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Delete a key and verify that the deletion notification is received."""
+        r = async_r_with_keyspace_notifications
+        await r.set("test:simple3", "value")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_keyspace("test:simple3")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.delete("test:simple3")
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:simple3"
+        assert msg.event_type == "del"
+
+        await notifications.aclose()
+
+    @pytest.mark.asyncio
+    async def test_multiple_hash_fields_subkeyspace_notification(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Create multiple hash fields at once and verify subkeyspace
+        notification contains all affected fields."""
+        r = async_r_with_keyspace_notifications
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspace("test:hash6")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:hash6", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
+
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash6"
+        assert msg.event_type == "hset"
+        assert len(msg.subkeys) == 3
+        assert set(msg.subkeys) == {"f1", "f2", "f3"}
+
+        await notifications.aclose()
+        await r.delete("test:hash6")
+
+    @pytest.mark.asyncio
+    async def test_subkeyspace_pattern_subscription(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Subscribe to a subkeyspace pattern and verify notifications are
+        received for matching keys."""
+        r = async_r_with_keyspace_notifications
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspace("test:pattern:*")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:pattern:hash1", "field1", "value1")
+        await r.hset("test:pattern:hash2", "field2", "value2")
+
+        messages = []
+        for _ in range(2):
+            msg = await notifications.get_message(timeout=2.0)
+            assert msg is not None
+            messages.append(msg)
+
+        keys = {m.key for m in messages}
+        assert "test:pattern:hash1" in keys
+        assert "test:pattern:hash2" in keys
+
+        await notifications.aclose()
+        await r.delete("test:pattern:hash1", "test:pattern:hash2")
+
+    @pytest.mark.asyncio
+    async def test_subkeyevent_pattern_subscription(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Subscribe to a subkeyevent pattern for all hash events and
+        verify notifications are received."""
+        r = async_r_with_keyspace_notifications
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyevent("h*")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:hash7", "field1", "value1")
+        await r.hdel("test:hash7", "field1")
+
+        messages = []
+        for _ in range(2):
+            msg = await notifications.get_message(timeout=2.0)
+            assert msg is not None
+            messages.append(msg)
+
+        event_types = {m.event_type for m in messages}
+        assert "hset" in event_types
+        assert "hdel" in event_types
+
+        await notifications.aclose()
+        await r.delete("test:hash7")
+
+    @pytest.mark.asyncio
+    async def test_subkeyspaceitem_does_not_receive_other_fields(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Subscribe to a specific subkeyspaceitem and verify that
+        modifications to other fields do not trigger notifications."""
+        r = async_r_with_keyspace_notifications
+        await r.hset("test:hash8", "watched_field", "initial")
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspaceitem("test:hash8", "watched_field")
+        await self._drain_subscribe_messages(notifications)
+
+        # Modify a different field — should NOT trigger a notification
+        await r.hset("test:hash8", "other_field", "value")
+        msg = await notifications.get_message(timeout=1.0)
+        assert msg is None
+
+        # Modify the watched field — should trigger a notification
+        await r.hset("test:hash8", "watched_field", "updated")
+        msg = await notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.subkeys == ["watched_field"]
+
+        await notifications.aclose()
+        await r.delete("test:hash8")
+
+    @pytest.mark.asyncio
+    async def test_combined_keyspace_and_subkeyspace(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Subscribe to both keyspace and subkeyspace on the same key and
+        verify that both types of notifications are received."""
+        r = async_r_with_keyspace_notifications
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_keyspace("test:hash9")
+        await notifications.subscribe_subkeyspace("test:hash9")
+        await self._drain_subscribe_messages(notifications)
+
+        await r.hset("test:hash9", "field1", "value1")
+
+        messages = []
+        for _ in range(2):
+            msg = await notifications.get_message(timeout=2.0)
+            if msg is not None:
+                messages.append(msg)
+
+        # Should receive both keyspace (hset event, no subkeys) and
+        # subkeyspace (hset event, with subkeys) notifications
+        assert len(messages) == 2
+        has_subkeys = any(len(m.subkeys) > 0 for m in messages)
+        has_no_subkeys = any(len(m.subkeys) == 0 for m in messages)
+        assert has_subkeys
+        assert has_no_subkeys
+
+        await notifications.aclose()
+        await r.delete("test:hash9")
+
+    @pytest.mark.asyncio
+    async def test_subkeyspaceitem_pattern_receives_matching_fields(
+        self, async_r_with_keyspace_notifications
+    ):
+        """Subscribe to subkeyspaceitem with a pattern subkey (field*) and
+        verify that notifications are received for field1, field2, and field3
+        but not for unrelated fields."""
+        r = async_r_with_keyspace_notifications
+
+        notifications = AsyncKeyspaceNotifications(r)
+        await notifications.subscribe_subkeyspaceitem("test:hash10", "field*")
+        await self._drain_subscribe_messages(notifications)
+
+        # These should all match the pattern
+        await r.hset("test:hash10", "field1", "value1")
+        await r.hset("test:hash10", "field2", "value2")
+        await r.hset("test:hash10", "field3", "value3")
+
+        messages = []
+        for _ in range(3):
+            msg = await notifications.get_message(timeout=2.0)
+            assert msg is not None
+            messages.append(msg)
+
+        received_subkeys = [m.subkeys[0] for m in messages]
+        assert "field1" in received_subkeys
+        assert "field2" in received_subkeys
+        assert "field3" in received_subkeys
+
+        for msg in messages:
+            assert msg.key == "test:hash10"
+            assert msg.event_type == "hset"
+
+        # A non-matching field should NOT produce a notification
+        await r.hset("test:hash10", "other", "value")
+        msg = await notifications.get_message(timeout=1.0)
+        assert msg is None
+
+        await notifications.aclose()
+        await r.delete("test:hash10")

--- a/tests/test_asyncio/test_keyspace_notifications.py
+++ b/tests/test_asyncio/test_keyspace_notifications.py
@@ -1038,9 +1038,8 @@ class TestAsyncSubkeyNotifications:
         but not for unrelated fields."""
         r = async_r_with_subkey_notifications
 
-        notifications = AsyncKeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceitem("test:hash10", "field*")
-        await self._drain_subscribe_messages(notifications)
 
         # These should all match the pattern
         await r.hset("test:hash10", "field1", "value1")

--- a/tests/test_asyncio/test_keyspace_notifications.py
+++ b/tests/test_asyncio/test_keyspace_notifications.py
@@ -724,6 +724,27 @@ class TestAsyncSubkeyNotifications:
     Works for both standalone Redis and RedisCluster.
     """
 
+    @staticmethod
+    async def _drain_subscribe_messages(notifications):
+        """Drain subscribe/psubscribe confirmation messages so the next
+        ``get_message`` call returns a real notification.
+
+        Works for both standalone (``_pubsub``) and cluster
+        (``_node_pubsubs``) notification managers.
+        """
+        pubsubs = (
+            list(notifications._node_pubsubs.values())
+            if hasattr(notifications, "_node_pubsubs")
+            else [notifications._pubsub]
+        )
+        for pubsub in pubsubs:
+            while True:
+                msg = await pubsub.get_message(timeout=0.05)
+                if msg is None:
+                    break
+                if msg["type"] not in ("subscribe", "psubscribe"):
+                    break
+
     @pytest.mark.asyncio
     async def test_create_hash_field_subkeyspace_notification(
         self, async_r_with_subkey_notifications
@@ -733,6 +754,7 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:hash1")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash1", "field1", "value1")
 
@@ -755,6 +777,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:hash2")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash2", "field1", "updated")
 
@@ -778,6 +801,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceitem("test:hash3", "myfield")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash3", "myfield", "updated")
 
@@ -801,6 +825,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyevent("hdel")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hdel("test:hash4", "field1")
 
@@ -824,6 +849,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceevent("hdel", "test:hash5")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hdel("test:hash5", "field1")
 
@@ -845,6 +871,7 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:simple1")
+        await self._drain_subscribe_messages(notifications)
 
         await r.set("test:simple1", "value1")
 
@@ -867,6 +894,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:simple2")
+        await self._drain_subscribe_messages(notifications)
 
         await r.set("test:simple2", "updated")
 
@@ -888,6 +916,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:simple3")
+        await self._drain_subscribe_messages(notifications)
 
         await r.delete("test:simple3")
 
@@ -907,6 +936,7 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:hash6")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash6", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
 
@@ -929,6 +959,7 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspace("test:pattern:*")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:pattern:hash1", "field1", "value1")
         await r.hset("test:pattern:hash2", "field2", "value2")
@@ -955,6 +986,7 @@ class TestAsyncSubkeyNotifications:
         r = async_r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyevent("h*")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash7", "field1", "value1")
         await r.hdel("test:hash7", "field1")
@@ -983,6 +1015,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceitem("test:hash8", "watched_field")
+        await self._drain_subscribe_messages(notifications)
 
         # Modify a different field — should NOT trigger a notification
         await r.hset("test:hash8", "other_field", "value")
@@ -1009,6 +1042,7 @@ class TestAsyncSubkeyNotifications:
         notifications = r.keyspace_notifications()
         await notifications.subscribe_keyspace("test:hash9")
         await notifications.subscribe_subkeyspace("test:hash9")
+        await self._drain_subscribe_messages(notifications)
 
         await r.hset("test:hash9", "field1", "value1")
 
@@ -1040,6 +1074,7 @@ class TestAsyncSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         await notifications.subscribe_subkeyspaceitem("test:hash10", "field*")
+        await self._drain_subscribe_messages(notifications)
 
         # These should all match the pattern
         await r.hset("test:hash10", "field1", "value1")

--- a/tests/test_keyspace_notifications.py
+++ b/tests/test_keyspace_notifications.py
@@ -7,6 +7,14 @@ import time
 from unittest.mock import MagicMock, Mock, PropertyMock
 
 from redis.exceptions import ConnectionError
+from tests.conftest import skip_if_server_version_lt
+from redis.keyspace_notifications import (
+    SubkeyeventChannel,
+    SubkeyspaceChannel,
+    SubkeyspaceeventChannel,
+    SubkeyspaceitemChannel,
+    _parse_length_prefixed_subkeys,
+)
 from redis.keyspace_notifications import (
     ChannelType,
     ClusterKeyspaceNotifications,
@@ -1107,3 +1115,726 @@ class TestStandaloneClientKeyspaceNotificationsMocked:
         assert notification is None
 
         notifications.close()
+
+
+class TestParseLengthPrefixedSubkeys:
+    """Tests for _parse_length_prefixed_subkeys helper."""
+
+    def test_single_subkey(self):
+        assert _parse_length_prefixed_subkeys("5:field") == ["field"]
+
+    def test_multiple_subkeys(self):
+        assert _parse_length_prefixed_subkeys("5:field,6:field2") == [
+            "field",
+            "field2",
+        ]
+
+    def test_subkey_with_special_chars(self):
+        assert _parse_length_prefixed_subkeys("7:foo:bar") == ["foo:bar"]
+
+    def test_subkey_with_comma_in_value(self):
+        assert _parse_length_prefixed_subkeys("5:a,b,c,1:x") == ["a,b,c", "x"]
+
+    def test_empty_subkey(self):
+        assert _parse_length_prefixed_subkeys("0:") == [""]
+
+    def test_multiple_with_varying_lengths(self):
+        assert _parse_length_prefixed_subkeys("1:a,2:bb,3:ccc") == [
+            "a",
+            "bb",
+            "ccc",
+        ]
+
+
+class TestSubkeyspaceChannelClass:
+    """Tests for SubkeyspaceChannel class."""
+
+    def test_basic_channel(self):
+        channel = SubkeyspaceChannel("myhash", db=0)
+        assert str(channel) == "__subkeyspace@0__:myhash"
+        assert channel.key_or_pattern == "myhash"
+        assert channel.db == 0
+
+    def test_channel_default_db(self):
+        channel = SubkeyspaceChannel("myhash")
+        assert str(channel) == "__subkeyspace@0__:myhash"
+        assert channel.db == 0
+
+    def test_pattern_channel(self):
+        channel = SubkeyspaceChannel("hash:*", db=0)
+        assert str(channel) == "__subkeyspace@0__:hash:*"
+        assert channel.is_pattern is True
+
+    def test_exact_channel(self):
+        channel = SubkeyspaceChannel("myhash")
+        assert channel.is_pattern is False
+
+    def test_equality_with_string(self):
+        channel = SubkeyspaceChannel("myhash", db=0)
+        assert channel == "__subkeyspace@0__:myhash"
+        assert channel != "__subkeyspace@1__:myhash"
+
+    def test_equality_with_channel(self):
+        ch1 = SubkeyspaceChannel("myhash", db=0)
+        ch2 = SubkeyspaceChannel("myhash", db=0)
+        ch3 = SubkeyspaceChannel("other", db=0)
+        assert ch1 == ch2
+        assert ch1 != ch3
+
+    def test_hash(self):
+        ch1 = SubkeyspaceChannel("myhash", db=0)
+        ch2 = SubkeyspaceChannel("myhash", db=0)
+        assert hash(ch1) == hash(ch2)
+
+    def test_repr(self):
+        channel = SubkeyspaceChannel("myhash", db=2)
+        assert repr(channel) == "SubkeyspaceChannel('myhash', db=2)"
+
+    def test_different_db(self):
+        channel = SubkeyspaceChannel("myhash", db=5)
+        assert str(channel) == "__subkeyspace@5__:myhash"
+
+
+class TestSubkeyeventChannelClass:
+    """Tests for SubkeyeventChannel class."""
+
+    def test_basic_channel(self):
+        channel = SubkeyeventChannel("hset", db=0)
+        assert str(channel) == "__subkeyevent@0__:hset"
+        assert channel.event == "hset"
+        assert channel.db == 0
+
+    def test_channel_default_db(self):
+        channel = SubkeyeventChannel("hdel")
+        assert str(channel) == "__subkeyevent@0__:hdel"
+
+    def test_pattern_channel(self):
+        channel = SubkeyeventChannel("h*")
+        assert str(channel) == "__subkeyevent@0__:h*"
+        assert channel.is_pattern is True
+
+    def test_exact_channel(self):
+        channel = SubkeyeventChannel("hset")
+        assert channel.is_pattern is False
+
+    def test_all_events_factory(self):
+        channel = SubkeyeventChannel.all_events()
+        assert str(channel) == "__subkeyevent@0__:*"
+        assert channel.is_pattern is True
+
+    def test_all_events_with_db(self):
+        channel = SubkeyeventChannel.all_events(db=3)
+        assert str(channel) == "__subkeyevent@3__:*"
+
+    def test_equality_with_string(self):
+        channel = SubkeyeventChannel("hset", db=0)
+        assert channel == "__subkeyevent@0__:hset"
+
+    def test_equality_with_channel(self):
+        ch1 = SubkeyeventChannel("hset", db=0)
+        ch2 = SubkeyeventChannel("hset", db=0)
+        ch3 = SubkeyeventChannel("hdel", db=0)
+        assert ch1 == ch2
+        assert ch1 != ch3
+
+    def test_repr(self):
+        channel = SubkeyeventChannel("hset", db=1)
+        assert repr(channel) == "SubkeyeventChannel('hset', db=1)"
+
+
+class TestSubkeyspaceitemChannelClass:
+    """Tests for SubkeyspaceitemChannel class."""
+
+    def test_basic_channel(self):
+        channel = SubkeyspaceitemChannel("myhash", "myfield", db=0)
+        assert str(channel) == "__subkeyspaceitem@0__:myhash\nmyfield"
+        assert channel.key_or_pattern == "myhash"
+        assert channel.subkey_or_pattern == "myfield"
+        assert channel.db == 0
+
+    def test_channel_default_db(self):
+        channel = SubkeyspaceitemChannel("myhash", "myfield")
+        assert str(channel) == "__subkeyspaceitem@0__:myhash\nmyfield"
+
+    def test_pattern_in_key(self):
+        channel = SubkeyspaceitemChannel("hash:*", "myfield")
+        assert channel.is_pattern is True
+
+    def test_pattern_in_subkey(self):
+        channel = SubkeyspaceitemChannel("myhash", "field:*")
+        assert channel.is_pattern is True
+
+    def test_exact_channel(self):
+        channel = SubkeyspaceitemChannel("myhash", "myfield")
+        assert channel.is_pattern is False
+
+    def test_equality_with_string(self):
+        channel = SubkeyspaceitemChannel("myhash", "myfield", db=0)
+        assert channel == "__subkeyspaceitem@0__:myhash\nmyfield"
+
+    def test_equality_with_channel(self):
+        ch1 = SubkeyspaceitemChannel("myhash", "myfield", db=0)
+        ch2 = SubkeyspaceitemChannel("myhash", "myfield", db=0)
+        ch3 = SubkeyspaceitemChannel("myhash", "other", db=0)
+        assert ch1 == ch2
+        assert ch1 != ch3
+
+    def test_repr(self):
+        channel = SubkeyspaceitemChannel("myhash", "myfield", db=2)
+        assert repr(channel) == "SubkeyspaceitemChannel('myhash', 'myfield', db=2)"
+
+
+class TestSubkeyspaceeventChannelClass:
+    """Tests for SubkeyspaceeventChannel class."""
+
+    def test_basic_channel(self):
+        channel = SubkeyspaceeventChannel("hset", "myhash", db=0)
+        assert str(channel) == "__subkeyspaceevent@0__:hset|myhash"
+        assert channel.event == "hset"
+        assert channel.key_or_pattern == "myhash"
+        assert channel.db == 0
+
+    def test_channel_default_db(self):
+        channel = SubkeyspaceeventChannel("hset", "myhash")
+        assert str(channel) == "__subkeyspaceevent@0__:hset|myhash"
+
+    def test_pattern_in_event(self):
+        channel = SubkeyspaceeventChannel("h*", "myhash")
+        assert channel.is_pattern is True
+
+    def test_pattern_in_key(self):
+        channel = SubkeyspaceeventChannel("hset", "hash:*")
+        assert channel.is_pattern is True
+
+    def test_exact_channel(self):
+        channel = SubkeyspaceeventChannel("hset", "myhash")
+        assert channel.is_pattern is False
+
+    def test_equality_with_string(self):
+        channel = SubkeyspaceeventChannel("hset", "myhash", db=0)
+        assert channel == "__subkeyspaceevent@0__:hset|myhash"
+
+    def test_equality_with_channel(self):
+        ch1 = SubkeyspaceeventChannel("hset", "myhash", db=0)
+        ch2 = SubkeyspaceeventChannel("hset", "myhash", db=0)
+        ch3 = SubkeyspaceeventChannel("hdel", "myhash", db=0)
+        assert ch1 == ch2
+        assert ch1 != ch3
+
+    def test_repr(self):
+        channel = SubkeyspaceeventChannel("hset", "myhash", db=1)
+        assert repr(channel) == "SubkeyspaceeventChannel('hset', 'myhash', db=1)"
+
+
+class TestSubkeyChannelDetection:
+    """Tests for get_channel_type() with subkey channel types."""
+
+    def test_subkeyspace_detection(self):
+        assert get_channel_type("__subkeyspace@0__:myhash") == ChannelType.SUBKEYSPACE
+
+    def test_subkeyevent_detection(self):
+        assert get_channel_type("__subkeyevent@0__:hset") == ChannelType.SUBKEYEVENT
+
+    def test_subkeyspaceitem_detection(self):
+        channel = "__subkeyspaceitem@0__:myhash\nmyfield"
+        assert get_channel_type(channel) == ChannelType.SUBKEYSPACEITEM
+
+    def test_subkeyspaceevent_detection(self):
+        channel = "__subkeyspaceevent@0__:hset|myhash"
+        assert get_channel_type(channel) == ChannelType.SUBKEYSPACEEVENT
+
+    def test_subkeyspace_does_not_match_subkeyspaceitem(self):
+        """Ensure __subkeyspaceitem@ is not mistakenly detected as SUBKEYSPACE."""
+        channel = "__subkeyspaceitem@0__:myhash\nfield"
+        assert get_channel_type(channel) != ChannelType.SUBKEYSPACE
+
+    def test_subkeyspace_does_not_match_subkeyspaceevent(self):
+        """Ensure __subkeyspaceevent@ is not mistakenly detected as SUBKEYSPACE."""
+        channel = "__subkeyspaceevent@0__:hset|myhash"
+        assert get_channel_type(channel) != ChannelType.SUBKEYSPACE
+
+    def test_bytes_input(self):
+        assert get_channel_type(b"__subkeyspace@0__:myhash") == ChannelType.SUBKEYSPACE
+        assert get_channel_type(b"__subkeyevent@0__:hset") == ChannelType.SUBKEYEVENT
+
+    def test_regular_keyspace_still_works(self):
+        assert get_channel_type("__keyspace@0__:mykey") == ChannelType.KEYSPACE
+        assert get_channel_type("__keyevent@0__:set") == ChannelType.KEYEVENT
+
+
+class TestSubkeyNotificationParsing:
+    """Tests for KeyNotification parsing of subkey channels."""
+
+    # --- subkeyspace ---
+
+    def test_subkeyspace_parse(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspace@0__:myhash", "hset|5:field,6:field2"
+        )
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.event_type == "hset"
+        assert n.database == 0
+        assert n.is_keyspace is True
+        assert n.subkeys == ["field", "field2"]
+
+    def test_subkeyspace_single_subkey(self):
+        n = KeyNotification.try_parse("__subkeyspace@0__:myhash", "hdel|3:foo")
+        assert n.subkeys == ["foo"]
+        assert n.event_type == "hdel"
+
+    def test_subkeyspace_with_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspace@0__:prefix:myhash",
+            "hset|5:field",
+            key_prefix="prefix:",
+        )
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.subkeys == ["field"]
+
+    def test_subkeyspace_filtered_by_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspace@0__:other:myhash",
+            "hset|5:field",
+            key_prefix="prefix:",
+        )
+        assert n is None
+
+    def test_subkeyspace_wildcard_db(self):
+        n = KeyNotification.try_parse("__subkeyspace@*__:myhash", "hset|5:field")
+        assert n is not None
+        assert n.database == -1
+
+    # --- subkeyevent ---
+
+    def test_subkeyevent_parse(self):
+        n = KeyNotification.try_parse(
+            "__subkeyevent@0__:hset", "6:myhash|5:field,6:field2"
+        )
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.event_type == "hset"
+        assert n.database == 0
+        assert n.is_keyspace is False
+        assert n.subkeys == ["field", "field2"]
+
+    def test_subkeyevent_single_subkey(self):
+        n = KeyNotification.try_parse("__subkeyevent@0__:hdel", "6:myhash|3:foo")
+        assert n.key == "myhash"
+        assert n.subkeys == ["foo"]
+
+    def test_subkeyevent_with_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyevent@0__:hset",
+            "13:prefix:myhash|5:field",
+            key_prefix="prefix:",
+        )
+        assert n is not None
+        assert n.key == "myhash"
+
+    def test_subkeyevent_filtered_by_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyevent@0__:hset",
+            "6:myhash|5:field",
+            key_prefix="prefix:",
+        )
+        assert n is None
+
+    # --- subkeyspaceitem ---
+
+    def test_subkeyspaceitem_parse(self):
+        n = KeyNotification.try_parse("__subkeyspaceitem@0__:myhash\nmyfield", "hset")
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.event_type == "hset"
+        assert n.database == 0
+        assert n.is_keyspace is True
+        assert n.subkeys == ["myfield"]
+
+    def test_subkeyspaceitem_with_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspaceitem@0__:prefix:myhash\nmyfield",
+            "hset",
+            key_prefix="prefix:",
+        )
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.subkeys == ["myfield"]
+
+    def test_subkeyspaceitem_filtered_by_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspaceitem@0__:other:myhash\nmyfield",
+            "hset",
+            key_prefix="prefix:",
+        )
+        assert n is None
+
+    def test_subkeyspaceitem_wildcard_db(self):
+        n = KeyNotification.try_parse("__subkeyspaceitem@*__:myhash\nmyfield", "hset")
+        assert n is not None
+        assert n.database == -1
+
+    # --- subkeyspaceevent ---
+
+    def test_subkeyspaceevent_parse(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspaceevent@0__:hset|myhash", "5:field,6:field2"
+        )
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.event_type == "hset"
+        assert n.database == 0
+        assert n.is_keyspace is False
+        assert n.subkeys == ["field", "field2"]
+
+    def test_subkeyspaceevent_single_subkey(self):
+        n = KeyNotification.try_parse("__subkeyspaceevent@0__:hdel|myhash", "3:foo")
+        assert n.key == "myhash"
+        assert n.event_type == "hdel"
+        assert n.subkeys == ["foo"]
+
+    def test_subkeyspaceevent_with_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspaceevent@0__:hset|prefix:myhash",
+            "5:field",
+            key_prefix="prefix:",
+        )
+        assert n is not None
+        assert n.key == "myhash"
+
+    def test_subkeyspaceevent_filtered_by_key_prefix(self):
+        n = KeyNotification.try_parse(
+            "__subkeyspaceevent@0__:hset|other:myhash",
+            "5:field",
+            key_prefix="prefix:",
+        )
+        assert n is None
+
+    # --- from_message integration ---
+
+    def test_from_message_subkeyspace(self):
+        message = {
+            "type": "message",
+            "pattern": None,
+            "channel": "__subkeyspace@0__:myhash",
+            "data": "hset|5:field",
+        }
+        n = KeyNotification.from_message(message)
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.event_type == "hset"
+        assert n.subkeys == ["field"]
+
+    def test_from_message_subkeyspaceitem(self):
+        message = {
+            "type": "message",
+            "pattern": None,
+            "channel": "__subkeyspaceitem@0__:myhash\nmyfield",
+            "data": "hset",
+        }
+        n = KeyNotification.from_message(message)
+        assert n is not None
+        assert n.key == "myhash"
+        assert n.event_type == "hset"
+        assert n.subkeys == ["myfield"]
+
+
+@skip_if_server_version_lt("8.7.3")
+class TestSubkeyNotifications:
+    """
+    Integration tests for subkey keyspace notifications with a standalone
+    Redis client.
+
+    These tests require a Redis server with subkey notification support
+    (Redis >= 8.x) and keyspace notifications enabled via the
+    ``r_with_keyspace_notifications`` fixture.
+    """
+
+    @staticmethod
+    def _drain_subscribe_messages(notifications):
+        """Drain subscribe/psubscribe confirmation messages so the next
+        ``get_message`` call returns a real notification."""
+        while True:
+            msg = notifications._pubsub.get_message(timeout=0.01)
+            if msg is None:
+                break
+            if msg["type"] not in ("subscribe", "psubscribe"):
+                break
+
+    def test_create_hash_field_subkeyspace_notification(
+        self, r_with_keyspace_notifications
+    ):
+        """Create a hash field and verify that the Subkeyspace notification
+        contains the field that was created."""
+        r = r_with_keyspace_notifications
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspace("test:hash1")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:hash1", "field1", "value1")
+
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash1"
+        assert msg.event_type == "hset"
+        assert "field1" in msg.subkeys
+
+        notifications.close()
+        r.delete("test:hash1")
+
+    def test_update_hash_field_subkeyspace_notification(
+        self, r_with_keyspace_notifications
+    ):
+        """Update an existing hash field and verify the Subkeyspace notification."""
+        r = r_with_keyspace_notifications
+        r.hset("test:hash2", "field1", "initial")
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspace("test:hash2")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:hash2", "field1", "updated")
+
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash2"
+        assert msg.event_type == "hset"
+        assert "field1" in msg.subkeys
+
+        notifications.close()
+        r.delete("test:hash2")
+
+    def test_update_hash_field_subkeyspaceitem_notification(
+        self, r_with_keyspace_notifications
+    ):
+        """Update a hash field and verify the Subkeyspaceitem notification
+        is received for the specific field."""
+        r = r_with_keyspace_notifications
+        r.hset("test:hash3", "myfield", "initial")
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspaceitem("test:hash3", "myfield")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:hash3", "myfield", "updated")
+
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash3"
+        assert msg.event_type == "hset"
+        assert msg.subkeys == ["myfield"]
+
+        notifications.close()
+        r.delete("test:hash3")
+
+    def test_delete_hash_field_subkeyevent_notification(
+        self, r_with_keyspace_notifications
+    ):
+        """Delete a hash field and verify the Subkeyevent notification
+        is received for the hdel event."""
+        r = r_with_keyspace_notifications
+        r.hset("test:hash4", "field1", "value1")
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyevent("hdel")
+        self._drain_subscribe_messages(notifications)
+
+        r.hdel("test:hash4", "field1")
+
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash4"
+        assert msg.event_type == "hdel"
+        assert "field1" in msg.subkeys
+
+        notifications.close()
+        r.delete("test:hash4")
+
+    def test_delete_hash_field_subkeyspaceevent_notification(
+        self, r_with_keyspace_notifications
+    ):
+        """Delete a hash field and verify the Subkeyspaceevent notification
+        is received for the specific key and event."""
+        r = r_with_keyspace_notifications
+        r.hset("test:hash5", "field1", "value1")
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspaceevent("hdel", "test:hash5")
+        self._drain_subscribe_messages(notifications)
+
+        r.hdel("test:hash5", "field1")
+
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash5"
+        assert msg.event_type == "hdel"
+        assert "field1" in msg.subkeys
+
+        notifications.close()
+        r.delete("test:hash5")
+
+    def test_multiple_hash_fields_subkeyspace_notification(
+        self, r_with_keyspace_notifications
+    ):
+        """Create multiple hash fields at once and verify subkeyspace
+        notification contains all affected fields."""
+        r = r_with_keyspace_notifications
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspace("test:hash6")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:hash6", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
+
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.key == "test:hash6"
+        assert msg.event_type == "hset"
+        assert len(msg.subkeys) == 3
+        assert set(msg.subkeys) == {"f1", "f2", "f3"}
+
+        notifications.close()
+        r.delete("test:hash6")
+
+    def test_subkeyspace_pattern_subscription(self, r_with_keyspace_notifications):
+        """Subscribe to a subkeyspace pattern and verify notifications are
+        received for matching keys."""
+        r = r_with_keyspace_notifications
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspace("test:pattern:*")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:pattern:hash1", "field1", "value1")
+        r.hset("test:pattern:hash2", "field2", "value2")
+
+        messages = []
+        for _ in range(2):
+            msg = notifications.get_message(timeout=2.0)
+            assert msg is not None
+            messages.append(msg)
+
+        keys = {m.key for m in messages}
+        assert "test:pattern:hash1" in keys
+        assert "test:pattern:hash2" in keys
+
+        notifications.close()
+        r.delete("test:pattern:hash1", "test:pattern:hash2")
+
+    def test_subkeyevent_pattern_subscription(self, r_with_keyspace_notifications):
+        """Subscribe to a subkeyevent pattern for all hash events and
+        verify notifications are received."""
+        r = r_with_keyspace_notifications
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyevent("h*")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:hash7", "field1", "value1")
+        r.hdel("test:hash7", "field1")
+
+        messages = []
+        for _ in range(2):
+            msg = notifications.get_message(timeout=2.0)
+            assert msg is not None
+            messages.append(msg)
+
+        event_types = {m.event_type for m in messages}
+        assert "hset" in event_types
+        assert "hdel" in event_types
+
+        notifications.close()
+        r.delete("test:hash7")
+
+    def test_subkeyspaceitem_does_not_receive_other_fields(
+        self, r_with_keyspace_notifications
+    ):
+        """Subscribe to a specific subkeyspaceitem and verify that
+        modifications to other fields do not trigger notifications."""
+        r = r_with_keyspace_notifications
+        r.hset("test:hash8", "watched_field", "initial")
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspaceitem("test:hash8", "watched_field")
+        self._drain_subscribe_messages(notifications)
+
+        # Modify a different field — should NOT trigger a notification
+        r.hset("test:hash8", "other_field", "value")
+        msg = notifications.get_message(timeout=1.0)
+        assert msg is None
+
+        # Modify the watched field — should trigger a notification
+        r.hset("test:hash8", "watched_field", "updated")
+        msg = notifications.get_message(timeout=2.0)
+        assert msg is not None
+        assert msg.subkeys == ["watched_field"]
+
+        notifications.close()
+        r.delete("test:hash8")
+
+    def test_combined_keyspace_and_subkeyspace(self, r_with_keyspace_notifications):
+        """Subscribe to both keyspace and subkeyspace on the same key and
+        verify that both types of notifications are received."""
+        r = r_with_keyspace_notifications
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_keyspace("test:hash9")
+        notifications.subscribe_subkeyspace("test:hash9")
+        self._drain_subscribe_messages(notifications)
+
+        r.hset("test:hash9", "field1", "value1")
+
+        messages = []
+        for _ in range(2):
+            msg = notifications.get_message(timeout=2.0)
+            if msg is not None:
+                messages.append(msg)
+
+        # Should receive both keyspace (hset event, no subkeys) and
+        # subkeyspace (hset event, with subkeys) notifications
+        assert len(messages) == 2
+        has_subkeys = any(len(m.subkeys) > 0 for m in messages)
+        has_no_subkeys = any(len(m.subkeys) == 0 for m in messages)
+        assert has_subkeys
+        assert has_no_subkeys
+
+        notifications.close()
+        r.delete("test:hash9")
+
+    def test_subkeyspaceitem_pattern_receives_matching_fields(
+        self, r_with_keyspace_notifications
+    ):
+        """Subscribe to subkeyspaceitem with a pattern subkey (field*) and
+        verify that notifications are received for field1, field2, and field3
+        but not for unrelated fields."""
+        r = r_with_keyspace_notifications
+
+        notifications = KeyspaceNotifications(r)
+        notifications.subscribe_subkeyspaceitem("test:hash10", "field*")
+        self._drain_subscribe_messages(notifications)
+
+        # These should all match the pattern
+        r.hset("test:hash10", "field1", "value1")
+        r.hset("test:hash10", "field2", "value2")
+        r.hset("test:hash10", "field3", "value3")
+
+        messages = []
+        for _ in range(3):
+            msg = notifications.get_message(timeout=2.0)
+            assert msg is not None
+            messages.append(msg)
+
+        received_subkeys = [m.subkeys[0] for m in messages]
+        assert "field1" in received_subkeys
+        assert "field2" in received_subkeys
+        assert "field3" in received_subkeys
+
+        for msg in messages:
+            assert msg.key == "test:hash10"
+            assert msg.event_type == "hset"
+
+        # A non-matching field should NOT produce a notification
+        r.hset("test:hash10", "other", "value")
+        msg = notifications.get_message(timeout=1.0)
+        assert msg is None
+
+        notifications.close()
+        r.delete("test:hash10")

--- a/tests/test_keyspace_notifications.py
+++ b/tests/test_keyspace_notifications.py
@@ -1540,15 +1540,15 @@ class TestSubkeyNotificationParsing:
         assert n.subkeys == ["myfield"]
 
 
-@skip_if_server_version_lt("8.7.3")
+@skip_if_server_version_lt("8.7.2")
 class TestSubkeyNotifications:
     """
     Integration tests for subkey keyspace notifications with a standalone
     Redis client.
 
     These tests require a Redis server with subkey notification support
-    (Redis >= 8.x) and keyspace notifications enabled via the
-    ``r_with_keyspace_notifications`` fixture.
+    (Redis >= 8.x) and keyspace/subkey notifications enabled via the
+    ``r_with_subkey_notifications`` fixture.
     """
 
     @staticmethod
@@ -1563,11 +1563,11 @@ class TestSubkeyNotifications:
                 break
 
     def test_create_hash_field_subkeyspace_notification(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Create a hash field and verify that the Subkeyspace notification
         contains the field that was created."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         notifications = KeyspaceNotifications(r)
         notifications.subscribe_subkeyspace("test:hash1")
         self._drain_subscribe_messages(notifications)
@@ -1584,10 +1584,10 @@ class TestSubkeyNotifications:
         r.delete("test:hash1")
 
     def test_update_hash_field_subkeyspace_notification(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Update an existing hash field and verify the Subkeyspace notification."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         r.hset("test:hash2", "field1", "initial")
 
         notifications = KeyspaceNotifications(r)
@@ -1606,11 +1606,11 @@ class TestSubkeyNotifications:
         r.delete("test:hash2")
 
     def test_update_hash_field_subkeyspaceitem_notification(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Update a hash field and verify the Subkeyspaceitem notification
         is received for the specific field."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         r.hset("test:hash3", "myfield", "initial")
 
         notifications = KeyspaceNotifications(r)
@@ -1629,11 +1629,11 @@ class TestSubkeyNotifications:
         r.delete("test:hash3")
 
     def test_delete_hash_field_subkeyevent_notification(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Delete a hash field and verify the Subkeyevent notification
         is received for the hdel event."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         r.hset("test:hash4", "field1", "value1")
 
         notifications = KeyspaceNotifications(r)
@@ -1652,11 +1652,11 @@ class TestSubkeyNotifications:
         r.delete("test:hash4")
 
     def test_delete_hash_field_subkeyspaceevent_notification(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Delete a hash field and verify the Subkeyspaceevent notification
         is received for the specific key and event."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         r.hset("test:hash5", "field1", "value1")
 
         notifications = KeyspaceNotifications(r)
@@ -1675,11 +1675,11 @@ class TestSubkeyNotifications:
         r.delete("test:hash5")
 
     def test_multiple_hash_fields_subkeyspace_notification(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Create multiple hash fields at once and verify subkeyspace
         notification contains all affected fields."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         notifications = KeyspaceNotifications(r)
         notifications.subscribe_subkeyspace("test:hash6")
         self._drain_subscribe_messages(notifications)
@@ -1696,10 +1696,10 @@ class TestSubkeyNotifications:
         notifications.close()
         r.delete("test:hash6")
 
-    def test_subkeyspace_pattern_subscription(self, r_with_keyspace_notifications):
+    def test_subkeyspace_pattern_subscription(self, r_with_subkey_notifications):
         """Subscribe to a subkeyspace pattern and verify notifications are
         received for matching keys."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         notifications = KeyspaceNotifications(r)
         notifications.subscribe_subkeyspace("test:pattern:*")
         self._drain_subscribe_messages(notifications)
@@ -1720,10 +1720,10 @@ class TestSubkeyNotifications:
         notifications.close()
         r.delete("test:pattern:hash1", "test:pattern:hash2")
 
-    def test_subkeyevent_pattern_subscription(self, r_with_keyspace_notifications):
+    def test_subkeyevent_pattern_subscription(self, r_with_subkey_notifications):
         """Subscribe to a subkeyevent pattern for all hash events and
         verify notifications are received."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         notifications = KeyspaceNotifications(r)
         notifications.subscribe_subkeyevent("h*")
         self._drain_subscribe_messages(notifications)
@@ -1745,11 +1745,11 @@ class TestSubkeyNotifications:
         r.delete("test:hash7")
 
     def test_subkeyspaceitem_does_not_receive_other_fields(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Subscribe to a specific subkeyspaceitem and verify that
         modifications to other fields do not trigger notifications."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
         r.hset("test:hash8", "watched_field", "initial")
 
         notifications = KeyspaceNotifications(r)
@@ -1770,10 +1770,10 @@ class TestSubkeyNotifications:
         notifications.close()
         r.delete("test:hash8")
 
-    def test_combined_keyspace_and_subkeyspace(self, r_with_keyspace_notifications):
+    def test_combined_keyspace_and_subkeyspace(self, r_with_subkey_notifications):
         """Subscribe to both keyspace and subkeyspace on the same key and
         verify that both types of notifications are received."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
 
         notifications = KeyspaceNotifications(r)
         notifications.subscribe_keyspace("test:hash9")
@@ -1800,12 +1800,12 @@ class TestSubkeyNotifications:
         r.delete("test:hash9")
 
     def test_subkeyspaceitem_pattern_receives_matching_fields(
-        self, r_with_keyspace_notifications
+        self, r_with_subkey_notifications
     ):
         """Subscribe to subkeyspaceitem with a pattern subkey (field*) and
         verify that notifications are received for field1, field2, and field3
         but not for unrelated fields."""
-        r = r_with_keyspace_notifications
+        r = r_with_subkey_notifications
 
         notifications = KeyspaceNotifications(r)
         notifications.subscribe_subkeyspaceitem("test:hash10", "field*")

--- a/tests/test_keyspace_notifications.py
+++ b/tests/test_keyspace_notifications.py
@@ -1543,24 +1543,14 @@ class TestSubkeyNotificationParsing:
 @skip_if_server_version_lt("8.7.2")
 class TestSubkeyNotifications:
     """
-    Integration tests for subkey keyspace notifications with a standalone
-    Redis client.
+    Integration tests for subkey keyspace notifications.
 
     These tests require a Redis server with subkey notification support
-    (Redis >= 8.x) and keyspace/subkey notifications enabled via the
+    (Redis >= 8.7.2) and keyspace/subkey notifications enabled via the
     ``r_with_subkey_notifications`` fixture.
-    """
 
-    @staticmethod
-    def _drain_subscribe_messages(notifications):
-        """Drain subscribe/psubscribe confirmation messages so the next
-        ``get_message`` call returns a real notification."""
-        while True:
-            msg = notifications._pubsub.get_message(timeout=0.01)
-            if msg is None:
-                break
-            if msg["type"] not in ("subscribe", "psubscribe"):
-                break
+    Works for both standalone Redis and RedisCluster.
+    """
 
     def test_create_hash_field_subkeyspace_notification(
         self, r_with_subkey_notifications
@@ -1568,9 +1558,8 @@ class TestSubkeyNotifications:
         """Create a hash field and verify that the Subkeyspace notification
         contains the field that was created."""
         r = r_with_subkey_notifications
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:hash1")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash1", "field1", "value1")
 
@@ -1590,9 +1579,8 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         r.hset("test:hash2", "field1", "initial")
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:hash2")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash2", "field1", "updated")
 
@@ -1613,9 +1601,8 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         r.hset("test:hash3", "myfield", "initial")
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceitem("test:hash3", "myfield")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash3", "myfield", "updated")
 
@@ -1636,9 +1623,8 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         r.hset("test:hash4", "field1", "value1")
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyevent("hdel")
-        self._drain_subscribe_messages(notifications)
 
         r.hdel("test:hash4", "field1")
 
@@ -1659,9 +1645,8 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         r.hset("test:hash5", "field1", "value1")
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceevent("hdel", "test:hash5")
-        self._drain_subscribe_messages(notifications)
 
         r.hdel("test:hash5", "field1")
 
@@ -1680,9 +1665,8 @@ class TestSubkeyNotifications:
         """Create multiple hash fields at once and verify subkeyspace
         notification contains all affected fields."""
         r = r_with_subkey_notifications
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:hash6")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash6", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
 
@@ -1700,9 +1684,8 @@ class TestSubkeyNotifications:
         """Subscribe to a subkeyspace pattern and verify notifications are
         received for matching keys."""
         r = r_with_subkey_notifications
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:pattern:*")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:pattern:hash1", "field1", "value1")
         r.hset("test:pattern:hash2", "field2", "value2")
@@ -1724,9 +1707,8 @@ class TestSubkeyNotifications:
         """Subscribe to a subkeyevent pattern for all hash events and
         verify notifications are received."""
         r = r_with_subkey_notifications
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyevent("h*")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash7", "field1", "value1")
         r.hdel("test:hash7", "field1")
@@ -1752,9 +1734,8 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         r.hset("test:hash8", "watched_field", "initial")
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceitem("test:hash8", "watched_field")
-        self._drain_subscribe_messages(notifications)
 
         # Modify a different field — should NOT trigger a notification
         r.hset("test:hash8", "other_field", "value")
@@ -1775,10 +1756,9 @@ class TestSubkeyNotifications:
         verify that both types of notifications are received."""
         r = r_with_subkey_notifications
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_keyspace("test:hash9")
         notifications.subscribe_subkeyspace("test:hash9")
-        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash9", "field1", "value1")
 
@@ -1807,9 +1787,8 @@ class TestSubkeyNotifications:
         but not for unrelated fields."""
         r = r_with_subkey_notifications
 
-        notifications = KeyspaceNotifications(r)
+        notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceitem("test:hash10", "field*")
-        self._drain_subscribe_messages(notifications)
 
         # These should all match the pattern
         r.hset("test:hash10", "field1", "value1")

--- a/tests/test_keyspace_notifications.py
+++ b/tests/test_keyspace_notifications.py
@@ -1552,6 +1552,27 @@ class TestSubkeyNotifications:
     Works for both standalone Redis and RedisCluster.
     """
 
+    @staticmethod
+    def _drain_subscribe_messages(notifications):
+        """Drain subscribe/psubscribe confirmation messages so the next
+        ``get_message`` call returns a real notification.
+
+        Works for both standalone (``_pubsub``) and cluster
+        (``_node_pubsubs``) notification managers.
+        """
+        pubsubs = (
+            list(notifications._node_pubsubs.values())
+            if hasattr(notifications, "_node_pubsubs")
+            else [notifications._pubsub]
+        )
+        for pubsub in pubsubs:
+            while True:
+                msg = pubsub.get_message(timeout=0.01)
+                if msg is None:
+                    break
+                if msg["type"] not in ("subscribe", "psubscribe"):
+                    break
+
     def test_create_hash_field_subkeyspace_notification(
         self, r_with_subkey_notifications
     ):
@@ -1560,6 +1581,7 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:hash1")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash1", "field1", "value1")
 
@@ -1581,6 +1603,7 @@ class TestSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:hash2")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash2", "field1", "updated")
 
@@ -1603,6 +1626,7 @@ class TestSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceitem("test:hash3", "myfield")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash3", "myfield", "updated")
 
@@ -1625,6 +1649,7 @@ class TestSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyevent("hdel")
+        self._drain_subscribe_messages(notifications)
 
         r.hdel("test:hash4", "field1")
 
@@ -1647,6 +1672,7 @@ class TestSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceevent("hdel", "test:hash5")
+        self._drain_subscribe_messages(notifications)
 
         r.hdel("test:hash5", "field1")
 
@@ -1667,6 +1693,7 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:hash6")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash6", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
 
@@ -1686,6 +1713,7 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspace("test:pattern:*")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:pattern:hash1", "field1", "value1")
         r.hset("test:pattern:hash2", "field2", "value2")
@@ -1709,6 +1737,7 @@ class TestSubkeyNotifications:
         r = r_with_subkey_notifications
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyevent("h*")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash7", "field1", "value1")
         r.hdel("test:hash7", "field1")
@@ -1736,6 +1765,7 @@ class TestSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceitem("test:hash8", "watched_field")
+        self._drain_subscribe_messages(notifications)
 
         # Modify a different field — should NOT trigger a notification
         r.hset("test:hash8", "other_field", "value")
@@ -1759,6 +1789,7 @@ class TestSubkeyNotifications:
         notifications = r.keyspace_notifications()
         notifications.subscribe_keyspace("test:hash9")
         notifications.subscribe_subkeyspace("test:hash9")
+        self._drain_subscribe_messages(notifications)
 
         r.hset("test:hash9", "field1", "value1")
 
@@ -1789,6 +1820,7 @@ class TestSubkeyNotifications:
 
         notifications = r.keyspace_notifications()
         notifications.subscribe_subkeyspaceitem("test:hash10", "field*")
+        self._drain_subscribe_messages(notifications)
 
         # These should all match the pattern
         r.hset("test:hash10", "field1", "value1")


### PR DESCRIPTION
### Description of change

This PR brings a support for subkey notifications feature introduced in Redis 8.8. The design introduces four subkey notification channel families in addition to the existing keyspace and keyevent channels.


Family | Channel | Payload
-- | -- | --
`subkeyspace` | `__subkeyspace@<db>__:<key>` | `<event>\|<subkey_len>:<subkey>[,<subkey_len>:<subkey>...]`
`subkeyevent` | `__subkeyevent@<db>__:<event>` | `<key_len>:<key>\|<subkey_len>:<subkey>[,<subkey_len>:<subkey>...]`
`subkeyspaceitem` | `__subkeyspaceitem@<db>__:<key>\\n<subkey>` | `<event>`
`subkeyspaceevent` | `__subkeyspaceevent@<db>__:<event>\|<key>` | `<subkey_len>:<subkey>[,<subkey_len>:<subkey>...]`

The feature is gated by new notify-keyspace-events flags:

- S -> subkeyspace
- T -> subkeyevent
- I -> subkeyspaceitem
- V -> subkeyspaceevent

For now the subkey notifications supported **only** by hash data structure.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public subscription APIs and extends `KeyNotification` parsing to handle new subkey channel wire formats; mistakes could break notification consumers or mis-parse payloads. Risk is mitigated by extensive new sync/async unit + integration tests and version-gated fixtures.
> 
> **Overview**
> Adds first-class support for Redis 8.8 *subkey-aware* keyspace notifications by introducing four new channel families (`__subkeyspace`, `__subkeyevent`, `__subkeyspaceitem`, `__subkeyspaceevent`) with corresponding channel classes and `subscribe_*` convenience methods in both sync and asyncio notification managers.
> 
> Extends `KeyNotification` to parse these new channel/payload wire formats (including length-prefixed subkey lists), exposes `subkeys` and raw `data`, and updates channel-type detection (`ChannelType`/`get_channel_type`) accordingly; exports the new APIs from `redis.__init__`.
> 
> Updates CI to run Redis `8.8` tests against a newer unstable image, adds fixtures to enable the new `notify-keyspace-events` flags (`KEASTIV`), and adds comprehensive sync/async test coverage for subkey parsing, pattern subscriptions, and backward compatibility with existing keyspace/keyevent notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4eea0a3d369cd81f9a00a2853106c6c013f4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->