### PR TITLE
fix: Type Lock.extend and Lock.reacquire as Literal[True]

### DIFF
--- a/redis/asyncio/lock.py
+++ b/redis/asyncio/lock.py
@@ -3,7 +3,7 @@ import logging
 import threading
 import uuid
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Awaitable, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Literal, Optional, Union
 
 from redis.exceptions import LockError, LockNotOwnedError
 from redis.typing import Number
@@ -295,7 +295,7 @@ class Lock:
 
     def extend(
         self, additional_time: Number, replace_ttl: bool = False
-    ) -> Awaitable[bool]:
+    ) -> Awaitable[Literal[True]]:
         """
         Adds more time to an already acquired lock.
 
@@ -312,7 +312,7 @@ class Lock:
             raise LockError("Cannot extend a lock with no timeout")
         return self.do_extend(additional_time, replace_ttl)
 
-    async def do_extend(self, additional_time, replace_ttl) -> bool:
+    async def do_extend(self, additional_time, replace_ttl) -> Literal[True]:
         additional_time = int(additional_time * 1000)
         if not bool(
             await self.lua_extend(
@@ -324,7 +324,7 @@ class Lock:
             raise LockNotOwnedError("Cannot extend a lock that's no longer owned")
         return True
 
-    def reacquire(self) -> Awaitable[bool]:
+    def reacquire(self) -> Awaitable[Literal[True]]:
         """
         Resets a TTL of an already acquired lock back to a timeout value.
         """
@@ -334,7 +334,7 @@ class Lock:
             raise LockError("Cannot reacquire a lock with no timeout")
         return self.do_reacquire()
 
-    async def do_reacquire(self) -> bool:
+    async def do_reacquire(self) -> Literal[True]:
         timeout = int(self.timeout * 1000)
         if not bool(
             await self.lua_reacquire(

--- a/redis/lock.py
+++ b/redis/lock.py
@@ -3,7 +3,7 @@ import threading
 import time as mod_time
 import uuid
 from types import SimpleNamespace, TracebackType
-from typing import Optional, Type
+from typing import Literal, Optional, Type
 
 from redis.exceptions import LockError, LockNotOwnedError
 from redis.typing import Number
@@ -284,7 +284,9 @@ class Lock:
                 lock_name=self.name,
             )
 
-    def extend(self, additional_time: Number, replace_ttl: bool = False) -> bool:
+    def extend(
+        self, additional_time: Number, replace_ttl: bool = False
+    ) -> Literal[True]:
         """
         Adds more time to an already acquired lock.
 
@@ -301,7 +303,7 @@ class Lock:
             raise LockError("Cannot extend a lock with no timeout", lock_name=self.name)
         return self.do_extend(additional_time, replace_ttl)
 
-    def do_extend(self, additional_time: Number, replace_ttl: bool) -> bool:
+    def do_extend(self, additional_time: Number, replace_ttl: bool) -> Literal[True]:
         additional_time = int(additional_time * 1000)
         if not bool(
             self.lua_extend(
@@ -316,7 +318,7 @@ class Lock:
             )
         return True
 
-    def reacquire(self) -> bool:
+    def reacquire(self) -> Literal[True]:
         """
         Resets a TTL of an already acquired lock back to a timeout value.
         """
@@ -329,7 +331,7 @@ class Lock:
             )
         return self.do_reacquire()
 
-    def do_reacquire(self) -> bool:
+    def do_reacquire(self) -> Literal[True]:
         timeout = int(self.timeout * 1000)
         if not bool(
             self.lua_reacquire(


### PR DESCRIPTION
### Description of change

`Lock.extend`, `Lock.do_extend`, `Lock.reacquire`, and `Lock.do_reacquire` (both sync and async variants) only ever return `True` on success; every failure path raises `LockError` or `LockNotOwnedError`. Typing them as `bool` suggests callers can meaningfully branch on the return value:
```
    if not lock.extend(10):   # never triggers — a failure raises instead
        handle_failure()
```

Retyping as `Literal[True]` makes the intent explicit at the type layer and preserves full backward compatibility at runtime. The issue calls out `extend`/`do_extend`; `reacquire`/`do_reacquire` have identical semantics and are included for consistency.

### Pull Request check-list

  - [x] Do tests and lints pass with this change?
  - [x] Do the CI tests pass with this change?
  - [x] Is the new or changed code fully tested?
  - [ ] Is a documentation update included?
  - [ ] Is there an example added to the examples folder?

Fixes redis/redis-py#3792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 12f4daca3f4b51ad8c76feda027e2fe4582a50c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->