### PR TITLE
fix(typing): correct type annotation for XReadResponse

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -77,6 +77,7 @@ from redis.typing import (
     TimeoutSecT,
     XClaimResponse,
     XPendingRangeResponse,
+    XReadGroupResponse,
     XReadResponse,
     ZMPopResponse,
     ZRandMemberResponse,
@@ -7710,7 +7711,7 @@ class StreamCommands(CommandsProtocol):
         block: int | None = None,
         noack: bool = False,
         claim_min_idle_time: int | None = None,
-    ) -> XReadResponse: ...
+    ) -> XReadGroupResponse: ...
 
     @overload
     def xreadgroup(
@@ -7722,7 +7723,7 @@ class StreamCommands(CommandsProtocol):
         block: int | None = None,
         noack: bool = False,
         claim_min_idle_time: int | None = None,
-    ) -> Awaitable[XReadResponse]: ...
+    ) -> Awaitable[XReadGroupResponse]: ...
 
     def xreadgroup(
         self,
@@ -7733,7 +7734,7 @@ class StreamCommands(CommandsProtocol):
         block: int | None = None,
         noack: bool = False,
         claim_min_idle_time: int | None = None,
-    ) -> XReadResponse | Awaitable[XReadResponse]:
+    ) -> XReadGroupResponse | Awaitable[XReadGroupResponse]:
         """
         Read from a stream via a consumer group.
 

--- a/redis/typing.py
+++ b/redis/typing.py
@@ -83,7 +83,23 @@ StreamRangeResponse = list[StreamEntry]
 XClaimResponse = StreamRangeResponse | list[bytes | str]
 XPendingRangeEntry = dict[str, bytes | str | int]
 XPendingRangeResponse = list[XPendingRangeEntry]
-XReadResponse = list[list[Any]] | dict[bytes | str, list[StreamRangeResponse]]
+XReadGroupClaimEntry = tuple[
+    bytes | str,
+    dict[bytes | str, bytes | str],
+    bytes | str | int,
+    bytes | str | int,
+]
+XReadGroupStreamResponse = StreamRangeResponse | list[XReadGroupClaimEntry]
+XReadResponse = (
+    list[list[Any]]
+    | dict[bytes | str, list[StreamRangeResponse]]
+    | dict[bytes | str, StreamRangeResponse]
+)
+XReadGroupResponse = (
+    list[list[Any]]
+    | dict[bytes | str, list[XReadGroupStreamResponse]]
+    | dict[bytes | str, XReadGroupStreamResponse]
+)
 ClusterNodeDetail = dict[str, str | bool | list[list[str]] | list[dict[str, str]]]
 ClusterLink = dict[str, Any] | list[Any]
 ClusterLinksResponse = list[ClusterLink]


### PR DESCRIPTION
XReadResponse type is incorrect. 

### Description of change

unlist the StreamRangeResponse in the value of XReadResponse 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes to annotations and imports; no runtime command behavior is modified.
> 
> **Overview**
> This PR **tightens stream read typings** so static analysis matches what Redis actually returns.
> 
> **`XREAD` (`XReadResponse`)** now allows each stream’s value in the dict form to be a **`StreamRangeResponse`** directly, not only `list[StreamRangeResponse]`—fixing the incorrect extra list wrapper in the type.
> 
> **`XREADGROUP`** is switched from `XReadResponse` to a dedicated **`XReadGroupResponse`**, with supporting aliases for **auto-claim** entries (`XReadGroupClaimEntry`) and per-stream payloads that can be normal stream entries or claim tuples (`XReadGroupStreamResponse`). Sync/async overloads and the implementation signature in `core.py` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58e233a52403e24aa4738eea93865ff4d67114c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->