### PR TITLE
Fix async cluster connection cleanup on topology refresh

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1423,6 +1423,7 @@ class ClusterNode:
     """
 
     __slots__ = (
+        "_background_tasks",
         "_connections",
         "_free",
         "_lock",
@@ -1464,6 +1465,7 @@ class ClusterNode:
 
         self._connections: List[Connection] = []
         self._free: Deque[Connection] = collections.deque(maxlen=self.max_connections)
+        self._background_tasks: Set[asyncio.Task] = set()
         self._event_dispatcher = self.connection_kwargs.get("event_dispatcher", None)
         if self._event_dispatcher is None:
             self._event_dispatcher = EventDispatcher()
@@ -1549,10 +1551,21 @@ class ClusterNode:
     def release(self, connection: Connection) -> None:
         """
         Release connection back to free queue.
-        If the connection is marked for reconnect, it will be disconnected
-        lazily when next acquired via disconnect_if_needed().
+        If the connection is marked for reconnect, disconnect it before
+        returning it to the free queue.
         """
+        if connection.should_reconnect():
+            task = asyncio.create_task(self._disconnect_and_release(connection))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            return
         self._free.append(connection)
+
+    async def _disconnect_and_release(self, connection: Connection) -> None:
+        try:
+            await connection.disconnect()
+        finally:
+            self._free.append(connection)
 
     def get_encoder(self) -> Encoder:
         """Return an :class:`Encoder` derived from this node's connection kwargs."""
@@ -1568,7 +1581,7 @@ class ClusterNode:
         """
         Mark all in-use (active) connections for reconnect.
         In-use connections are those in _connections but not currently in _free.
-        They will be disconnected when released back to the pool.
+        They will be disconnected after their current operation completes.
         """
         free_set = set(self._free)
         for connection in self._connections:
@@ -1630,7 +1643,7 @@ class ClusterNode:
         finally:
             await self.disconnect_if_needed(connection)
             # Release connection
-            self._free.append(connection)
+            self.release(connection)
 
     async def execute_pipeline(self, commands: List["PipelineCommand"]) -> bool:
         # Acquire connection
@@ -1656,7 +1669,7 @@ class ClusterNode:
 
         # Release connection
         await self.disconnect_if_needed(connection)
-        self._free.append(connection)
+        self.release(connection)
 
         return ret
 
@@ -1762,10 +1775,10 @@ class NodesManager:
                 if name not in new:
                     # Node is removed from cache before disconnect starts,
                     # so it won't be found in lookups during disconnect
-                    # Mark active connections for reconnect so they get disconnected after current command completes
-                    # and disconnect free connections immediately
-                    # the node is removed from the cache before the connections changes so it won't be used and should be safe
-                    # not to wait for the disconnects
+                    # Mark active connections so in-flight commands can
+                    # finish, then disconnect them when their current
+                    # operation completes. Free connections can be
+                    # disconnected immediately.
                     removed_node = old.pop(name)
                     removed_node.update_active_connections_for_reconnect()
                     task = asyncio.create_task(
@@ -1784,6 +1797,7 @@ class NodesManager:
                 # TODO: Make this method async in the next major release to allow
                 # immediate disconnection of free connections.
                 existing_node = old[name]
+                existing_node.server_type = node.server_type
                 existing_node.update_active_connections_for_reconnect()
                 for conn in existing_node._free:
                     conn.mark_for_reconnect()
@@ -2037,8 +2051,11 @@ class NodesManager:
                 )
 
             # Set the tmp variables to the real variables
-            self.slots_cache = tmp_slots
             self.set_nodes(self.nodes_cache, tmp_nodes_cache, remove_old=True)
+            self.slots_cache = {
+                slot: [self.nodes_cache[node.name] for node in nodes]
+                for slot, nodes in tmp_slots.items()
+            }
 
             if self._dynamic_startup_nodes:
                 # Populate the startup nodes with all discovered nodes
@@ -3063,6 +3080,9 @@ class TransactionStrategy(AbstractStrategy):
                     await self._transaction_connection.read_response()
                 # we can safely return the connection to the pool here since we're
                 # sure we're no longer WATCHing anything
+                await self._transaction_node.disconnect_if_needed(
+                    self._transaction_connection
+                )
                 self._transaction_node.release(self._transaction_connection)
                 self._transaction_connection = None
             except self.CONNECTION_ERRORS:
@@ -3155,6 +3175,7 @@ class _ClusterNodePoolAdapter(ConnectionPoolInterface):
         # PubSub.aclose() disconnects the connection before calling
         # release(), so it is safe to put it back in the node's free
         # queue – it will reconnect lazily on next use.
+        await self._node.disconnect_if_needed(connection)
         self._node.release(connection)
 
     # -- no-op stubs for the rest of ConnectionPoolInterface -------------------

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1564,8 +1564,19 @@ class ClusterNode:
     async def _disconnect_and_release(self, connection: Connection) -> None:
         try:
             await connection.disconnect()
-        finally:
-            self._free.append(connection)
+        except Exception as exc:
+            logger.debug(
+                "disconnecting released cluster connection failed: %r",
+                exc,
+                exc_info=True,
+            )
+            try:
+                self._connections.remove(connection)
+            except ValueError:
+                pass
+            return
+
+        self._free.append(connection)
 
     def get_encoder(self) -> Encoder:
         """Return an :class:`Encoder` derived from this node's connection kwargs."""
@@ -2052,10 +2063,22 @@ class NodesManager:
 
             # Set the tmp variables to the real variables
             self.set_nodes(self.nodes_cache, tmp_nodes_cache, remove_old=True)
-            self.slots_cache = {
-                slot: [self.nodes_cache[node.name] for node in nodes]
-                for slot, nodes in tmp_slots.items()
-            }
+            # tmp_slots was built from CLUSTER SLOTS responses and can contain
+            # newly-created ClusterNode objects for nodes we already know about.
+            # Rebuild the slots cache with the preserved nodes_cache instances
+            # so existing per-node connection pools stay in use after refresh.
+            # Keep the shared node-list-per-slot-range shape from tmp_slots to
+            # avoid allocating a separate list for every slot.
+            node_lists_by_id: Dict[int, List["ClusterNode"]] = {}
+            new_slots_cache: Dict[int, List["ClusterNode"]] = {}
+            for slot, nodes in tmp_slots.items():
+                node_list_id = id(nodes)
+                slot_nodes = node_lists_by_id.get(node_list_id)
+                if slot_nodes is None:
+                    slot_nodes = [self.nodes_cache[node.name] for node in nodes]
+                    node_lists_by_id[node_list_id] = slot_nodes
+                new_slots_cache[slot] = slot_nodes
+            self.slots_cache = new_slots_cache
 
             if self._dynamic_startup_nodes:
                 # Populate the startup nodes with all discovered nodes

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1,6 +1,7 @@
 import asyncio
 import binascii
 import datetime
+import logging
 import ssl
 import warnings
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, Union
@@ -2804,6 +2805,7 @@ class TestNodesManager:
             await nodes_manager.initialize()
             first_node = nodes_manager.nodes_cache[get_node_name(default_host, 7000)]
             assert nodes_manager.slots_cache[0][0] is first_node
+            assert nodes_manager.slots_cache[0] is nodes_manager.slots_cache[16383]
 
             cluster_slots[0] = second_slots
             await nodes_manager.initialize()
@@ -2813,8 +2815,11 @@ class TestNodesManager:
                 is first_node
             )
             assert nodes_manager.slots_cache[0][0] is first_node
+            assert nodes_manager.slots_cache[0] is nodes_manager.slots_cache[8191]
             second_node = nodes_manager.nodes_cache[get_node_name(default_host, 7001)]
             assert nodes_manager.slots_cache[8192][0] is second_node
+            assert nodes_manager.slots_cache[8192] is nodes_manager.slots_cache[16383]
+            assert nodes_manager.slots_cache[0] is not nodes_manager.slots_cache[8192]
             for nodes in nodes_manager.slots_cache.values():
                 for node in nodes:
                     assert node is nodes_manager.nodes_cache[node.name]
@@ -3391,6 +3396,38 @@ class TestClusterNodeConnectionHandling:
         # Connection should NOT be disconnected but added to _free
         assert conn.disconnect_called is False
         assert conn in node._free
+
+    async def test_release_debug_logs_disconnect_task_exception(self, caplog) -> None:
+        """
+        Test that release() consumes background disconnect errors.
+        """
+
+        class FakeConnection:
+            def should_reconnect(self) -> bool:
+                return True
+
+            async def disconnect(self) -> None:
+                raise RuntimeError("simulated disconnect failure")
+
+        node = ClusterNode(default_host, 7000)
+        conn = FakeConnection()
+        node._connections = [conn]
+
+        with caplog.at_level(logging.DEBUG, logger="redis.asyncio.cluster"):
+            node.release(conn)
+            assert len(node._background_tasks) == 1
+            (task,) = tuple(node._background_tasks)
+            await task
+            await asyncio.sleep(0)
+
+        assert node._background_tasks == set()
+        assert conn not in node._free
+        assert conn not in node._connections
+        assert any(
+            "disconnecting released cluster connection failed" in rec.message
+            and rec.levelno == logging.DEBUG
+            for rec in caplog.records
+        )
 
     async def test_disconnect_if_needed_disconnects_when_reconnect_needed(
         self,

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -218,6 +218,7 @@ async def get_mocked_redis_client(
 def mock_node_resp(node: ClusterNode, response: Any) -> ClusterNode:
     connection = mock.AsyncMock(spec=Connection)
     connection.is_connected = True
+    connection.should_reconnect.return_value = False
     connection.read_response.return_value = response
     while node._free:
         node._free.pop()
@@ -228,6 +229,7 @@ def mock_node_resp(node: ClusterNode, response: Any) -> ClusterNode:
 def mock_node_resp_exc(node: ClusterNode, exc: Exception) -> ClusterNode:
     connection = mock.AsyncMock(spec=Connection)
     connection.is_connected = True
+    connection.should_reconnect.return_value = False
     connection.read_response.side_effect = exc
     while node._free:
         node._free.pop()
@@ -2762,10 +2764,60 @@ class TestNodesManager:
                 assert n_manager.slots_cache[i][1].host in all_hosts
                 assert n_manager.slots_cache[i][0].port in all_ports
                 assert n_manager.slots_cache[i][1].port in all_ports
+                for node in n_manager.slots_cache[i]:
+                    assert node is n_manager.nodes_cache[node.name]
 
         assert len(n_manager.nodes_cache) == 6
 
         await rc.aclose()
+
+    @pytest.mark.fixed_client
+    async def test_initialize_reuses_nodes_cache_nodes_in_slots_cache(
+        self,
+    ) -> None:
+        """
+        Test that a topology refresh keeps slots_cache pointed at nodes_cache
+        nodes instead of temporary nodes built from CLUSTER SLOTS.
+        """
+        first_slots = [[0, 16383, [default_host, 7000, "node_0"]]]
+        second_slots = [
+            [0, 8191, [default_host, 7000, "node_0"]],
+            [8192, 16383, [default_host, 7001, "node_1"]],
+        ]
+        cluster_slots = [first_slots]
+
+        async def mocked_execute_command(self, *args, **kwargs):
+            if args[0] == "CLUSTER SLOTS":
+                return cluster_slots[0]
+            return None
+
+        with mock.patch.object(
+            ClusterNode, "execute_command", autospec=True
+        ) as execute_command:
+            execute_command.side_effect = mocked_execute_command
+            nodes_manager = NodesManager(
+                startup_nodes=[ClusterNode(default_host, 7000)],
+                require_full_coverage=True,
+                connection_kwargs={},
+            )
+
+            await nodes_manager.initialize()
+            first_node = nodes_manager.nodes_cache[get_node_name(default_host, 7000)]
+            assert nodes_manager.slots_cache[0][0] is first_node
+
+            cluster_slots[0] = second_slots
+            await nodes_manager.initialize()
+
+            assert (
+                nodes_manager.nodes_cache[get_node_name(default_host, 7000)]
+                is first_node
+            )
+            assert nodes_manager.slots_cache[0][0] is first_node
+            second_node = nodes_manager.nodes_cache[get_node_name(default_host, 7001)]
+            assert nodes_manager.slots_cache[8192][0] is second_node
+            for nodes in nodes_manager.slots_cache.values():
+                for node in nodes:
+                    assert node is nodes_manager.nodes_cache[node.name]
 
     @pytest.mark.fixed_client
     async def test_init_slots_cache_cluster_mode_disabled(self) -> None:
@@ -3004,6 +3056,81 @@ class TestNodesManager:
         assert nodes_cache_names == [node2.name, node1.name, node3.name]
 
     @pytest.mark.fixed_client
+    async def test_set_nodes_disconnects_removed_node_connections_after_use(
+        self,
+    ) -> None:
+        """
+        Test removed nodes let in-flight commands finish, then disconnect.
+        """
+
+        class FakeConnection:
+            def __init__(self) -> None:
+                self.disconnect_called = False
+                self.is_connected = True
+                self.reconnect = False
+                self.response_ready = asyncio.Event()
+                self.send_called = asyncio.Event()
+
+            def pack_command(self, *args):
+                return b"packed"
+
+            async def send_packed_command(self, *args) -> None:
+                self.send_called.set()
+
+            async def read_response(self, *args, **kwargs):
+                await self.response_ready.wait()
+                return b"OK"
+
+            async def disconnect(self) -> None:
+                self.disconnect_called = True
+                self.is_connected = False
+                self.reconnect = False
+
+            def mark_for_reconnect(self) -> None:
+                self.reconnect = True
+
+            def should_reconnect(self) -> bool:
+                return self.reconnect
+
+        node = ClusterNode(default_host, 7000)
+        active_conn = FakeConnection()
+        free_conn = FakeConnection()
+        node._connections = [active_conn, free_conn]
+        node._free.append(active_conn)
+        node._free.append(free_conn)
+
+        nodes_manager = NodesManager(
+            startup_nodes=[node],
+            require_full_coverage=False,
+            connection_kwargs={},
+        )
+        nodes_manager.nodes_cache = {node.name: node}
+
+        command = asyncio.create_task(node.execute_command("GET", "key"))
+        await active_conn.send_called.wait()
+
+        nodes_manager.set_nodes(nodes_manager.nodes_cache, {}, remove_old=True)
+        tasks = tuple(nodes_manager._background_tasks)
+        assert len(tasks) == 1
+        await asyncio.gather(*tasks)
+
+        assert nodes_manager.nodes_cache == {}
+        assert free_conn.disconnect_called is True
+        assert free_conn.is_connected is False
+        assert active_conn.reconnect is True
+        assert active_conn.disconnect_called is False
+        assert active_conn.is_connected is True
+
+        active_conn.response_ready.set()
+        assert await command == b"OK"
+
+        assert active_conn.disconnect_called is True
+        assert active_conn.is_connected is False
+        assert active_conn in node._free
+        assert free_conn.reconnect is False
+        assert active_conn.reconnect is False
+
+    @pytest.mark.fixed_client
     async def test_move_node_to_end_of_cached_nodes_nonexistent(self) -> None:
         """
         Test that move_node_to_end_of_cached_nodes does nothing for a
@@ -3141,6 +3268,9 @@ class TestClusterNodeConnectionHandling:
         conn1 = mock.AsyncMock(spec=Connection)
         conn2 = mock.AsyncMock(spec=Connection)
         conn3 = mock.AsyncMock(spec=Connection)
+        conn1.is_connected = False
+        conn2.is_connected = False
+        conn3.is_connected = False
 
         # Add all connections to _connections
         node._connections = [conn1, conn2, conn3]
@@ -3166,6 +3296,9 @@ class TestClusterNodeConnectionHandling:
         conn1 = mock.AsyncMock(spec=Connection)
         conn2 = mock.AsyncMock(spec=Connection)
         conn3 = mock.AsyncMock(spec=Connection)
+        conn1.is_connected = False
+        conn2.is_connected = False
+        conn3.is_connected = False
 
         # Add all connections to _connections
         node._connections = [conn1, conn2, conn3]
@@ -3200,33 +3333,55 @@ class TestClusterNodeConnectionHandling:
 
     async def test_release_with_reconnect_flag(self) -> None:
         """
-        Test that release() adds connection to _free even if marked for reconnect.
-        Disconnect happens lazily via disconnect_if_needed() when next acquired.
+        Test that release() disconnects a connection marked for reconnect before
+        adding it to _free.
         """
-        node = ClusterNode(default_host, 7000)
 
-        # Create a mock connection marked for reconnect
-        conn = mock.AsyncMock(spec=Connection)
-        conn.should_reconnect.return_value = True
+        class FakeConnection:
+            def __init__(self) -> None:
+                self.disconnect_called = False
+                self.is_connected = True
+
+            def should_reconnect(self) -> bool:
+                return True
+
+            async def disconnect(self) -> None:
+                self.disconnect_called = True
+                self.is_connected = False
+
+        node = ClusterNode(default_host, 7000)
+        conn = FakeConnection()
 
         node._connections = [conn]
 
-        # Release the connection - sync, just adds to _free
+        # Release schedules disconnect first because release() is synchronous.
         node.release(conn)
 
-        # Connection should be in _free, disconnect happens lazily on acquire
+        assert conn not in node._free
+        await asyncio.gather(*node._background_tasks)
+
+        assert conn.disconnect_called is True
+        assert conn.is_connected is False
         assert conn in node._free
-        conn.disconnect.assert_not_called()
 
     async def test_release_without_reconnect_flag(self) -> None:
         """
         Test that release() adds connection to _free without disconnect.
         """
-        node = ClusterNode(default_host, 7000)
 
-        # Create a mock connection NOT marked for reconnect
-        conn = mock.AsyncMock(spec=Connection)
-        conn.should_reconnect.return_value = False
+        class FakeConnection:
+            def __init__(self) -> None:
+                self.disconnect_called = False
+                self.is_connected = False
+
+            def should_reconnect(self) -> bool:
+                return False
+
+            async def disconnect(self) -> None:
+                self.disconnect_called = True
+
+        node = ClusterNode(default_host, 7000)
+        conn = FakeConnection()
 
         node._connections = [conn]
 
@@ -3234,7 +3389,7 @@ class TestClusterNodeConnectionHandling:
         node.release(conn)
 
         # Connection should NOT be disconnected but added to _free
-        conn.disconnect.assert_not_called()
+        assert conn.disconnect_called is False
         assert conn in node._free
 
     async def test_disconnect_if_needed_disconnects_when_reconnect_needed(


### PR DESCRIPTION
This PR fixes async cluster connection cleanup during topology refreshes where nodes are removed or preserved across updated `CLUSTER SLOTS` responses. 
Removed nodes now mark checked-out connections for reconnect while disconnecting already-idle connections immediately, allowing in-flight commands to finish before their connections are disconnected on release(important for fitire addition of maintenance notifications to async cluster client).

The async `ClusterNode.release()` path now handles marked connections directly: it schedules a disconnect before returning the connection to the free queue. This prevents marked, still-connected connections from being appended back into `_free` and later reported as unclosed when the node becomes unreachable from the cluster topology.

Topology refresh now also rebuilds `slots_cache` from the canonical `nodes_cache` objects after `set_nodes()` preserves existing nodes. This avoids creating separate `ClusterNode` instances, and therefore separate connection pools, for the same host:port when a node remains in the topology across refreshes.

Tests were added for removed-node in-flight cleanup, release behavior for marked connections, and `slots_cache` / `nodes_cache` identity after topology refresh. Existing connection-handling tests were adjusted to avoid unrelated unclosed-node warnings from mock connections.

Fixes #4053 #3572

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async cluster connection pooling and topology refresh behavior; mistakes could lead to leaked connections or disconnecting in-flight operations under load.
> 
> **Overview**
> Fixes async cluster connection cleanup during topology refreshes by ensuring removed nodes immediately disconnect idle connections while letting in-flight commands finish and then disconnecting on `release()`.
> 
> Updates `ClusterNode.release()` to schedule an async disconnect for connections marked for reconnect (tracking tasks and swallowing/logging failures), and adjusts command/pipeline and transaction/pubsub release paths to route through this logic.
> 
> Rebuilds `slots_cache` after `initialize()` from the canonical `nodes_cache` instances (and updates preserved nodes’ `server_type`) so refreshes don’t create duplicate `ClusterNode` objects/connection pools; adds/updates tests to assert node identity reuse and the new disconnect-on-release behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fdc4f0c2d6199506f62ec80d411819cc1fd04f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->