### PR TITLE
docs: fix typos in messages, docstrings, and comments

### DIFF
--- a/redis/_parsers/commands.py
+++ b/redis/_parsers/commands.py
@@ -140,7 +140,7 @@ class CommandsParser(AbstractCommandsParser):
             cmd_name_split = cmd_name.split()
             cmd_name = cmd_name_split[0]
             if cmd_name in self.commands:
-                # save the splitted command to args
+                # save the split command to args
                 args = cmd_name_split + list(args[1:])
             else:
                 # We'll try to reinitialize the commands cache, if the engine
@@ -194,8 +194,8 @@ class CommandsParser(AbstractCommandsParser):
 
         So, don't use this function with EVAL or EVALSHA.
         """
-        # The command name should be splitted into separate arguments,
-        # e.g. 'MEMORY USAGE' will be splitted into ['MEMORY', 'USAGE']
+        # The command name should be split into separate arguments,
+        # e.g. 'MEMORY USAGE' will be split into ['MEMORY', 'USAGE']
         pieces = args[0].split() + list(args[1:])
         try:
             keys = redis_conn.execute_command("COMMAND GETKEYS", *pieces)
@@ -448,7 +448,7 @@ class AsyncCommandsParser(AbstractCommandsParser):
             cmd_name_split = cmd_name.split()
             cmd_name = cmd_name_split[0]
             if cmd_name in self.commands:
-                # save the splitted command to args
+                # save the split command to args
                 args = cmd_name_split + list(args[1:])
             else:
                 # We'll try to reinitialize the commands cache, if the engine

--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -1127,7 +1127,7 @@ def parse_geosearch_generic(response, **options):
     """
     try:
         if options["store"] or options["store_dist"]:
-            # `store` and `store_dist` cant be combined
+            # `store` and `store_dist` can't be combined
             # with other command arguments.
             # relevant to 'GEORADIUS' and 'GEORADIUSBYMEMBER'
             return response

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -1165,7 +1165,7 @@ class ManagementCommands(CommandsProtocol):
     def client_setinfo(self, attr: str, value: str, **kwargs) -> bool | Awaitable[bool]:
         """
         Sets the current connection library name or version
-        For mor information see https://redis.io/commands/client-setinfo
+        For more information see https://redis.io/commands/client-setinfo
         """
         return self.execute_command("CLIENT SETINFO", attr, value, **kwargs)
 
@@ -5136,7 +5136,7 @@ class ListCommands(CommandsProtocol):
             pieces.extend([b"LIMIT", start, num])
         if get is not None:
             # If get is a string assume we want to get a single value.
-            # Otherwise assume it's an interable and we want to get multiple
+            # Otherwise assume it's an iterable and we want to get multiple
             # values. We can't just iterate blindly because strings are
             # iterable.
             if isinstance(get, (bytes, str)):
@@ -10644,7 +10644,7 @@ class GeoCommands(CommandsProtocol):
                 raise DataError("GEORADIUS invalid sort")
 
         if kwargs["store"] and kwargs["store_dist"]:
-            raise DataError("GEORADIUS store and store_dist cant be set together")
+            raise DataError("GEORADIUS store and store_dist can't be set together")
 
         if kwargs["store"]:
             pieces.extend([b"STORE", kwargs["store"]])
@@ -10868,7 +10868,7 @@ class GeoCommands(CommandsProtocol):
         if kwargs["member"]:
             if kwargs["longitude"] or kwargs["latitude"]:
                 raise DataError(
-                    "GEOSEARCH member and longitude or latitude cant be set together"
+                    "GEOSEARCH member and longitude or latitude can't be set together"
                 )
             pieces.extend([b"FROMMEMBER", kwargs["member"]])
         if kwargs["longitude"] is not None and kwargs["latitude"] is not None:
@@ -10885,7 +10885,7 @@ class GeoCommands(CommandsProtocol):
         if kwargs["radius"]:
             if kwargs["width"] or kwargs["height"]:
                 raise DataError(
-                    "GEOSEARCH radius and width or height cant be set together"
+                    "GEOSEARCH radius and width or height can't be set together"
                 )
             pieces.extend([b"BYRADIUS", kwargs["radius"], kwargs["unit"]])
         if kwargs["width"] and kwargs["height"]:

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -1103,7 +1103,7 @@ class SearchCommands:
                          returned. Implies `replace`
             fields: kwargs dictionary of the document fields to be saved
                     and/or indexed.
-                    NOTE: Geo points shoule be encoded as strings of "lon,lat"
+                    NOTE: Geo points should be encoded as strings of "lon,lat"
         """  # noqa
         return self._add_document(
             doc_id,

--- a/redis/credentials.py
+++ b/redis/credentials.py
@@ -15,7 +15,7 @@ class CredentialProvider:
 
     async def get_credentials_async(self) -> Union[Tuple[str], Tuple[str, str]]:
         logger.warning(
-            "This method is added for backward compatability. "
+            "This method is added for backward compatibility. "
             "Please override it in your implementation."
         )
         return self.get_credentials()

--- a/redis/ocsp.py
+++ b/redis/ocsp.py
@@ -98,7 +98,7 @@ def _check_certificate(issuer_cert, ocsp_bytes, validate=True):
 
         ext = responder_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
         if ext is None or x509.oid.ExtendedKeyUsageOID.OCSP_SIGNING not in ext.value:
-            raise ConnectionError("delegate not autorized for ocsp signing")
+            raise ConnectionError("delegate not authorized for ocsp signing")
         cert_to_validate = responder_cert
 
     if validate:
@@ -193,7 +193,7 @@ class OCSPVerifier:
         server in the chain for a socket already wrapped with ssl.
         """
 
-        # convert the binary certifcate to text
+        # convert the binary certificate to text
         der = self.SOCK.getpeercert(True)
         if der is False:
             raise ConnectionError("no certificate found for ssl peer")


### PR DESCRIPTION
### Description of change

Small spelling fixes in user-visible strings and source comments. No behavior changes; only string/comment content is touched.

- `credentials.py`: `compatability` → `compatibility` in the warning emitted by `CredentialProvider.get_credentials_async` fallback.
- `ocsp.py`: `autorized` → `authorized` in the OCSP signing `ConnectionError`; `certifcate` → `certificate` in a comment.
- `commands/core.py`: `mor` → `more` in the `client_setinfo` docstring; `interable` → `iterable` in a `sort()` comment; `cant` → `can't` in three `GEORADIUS` / `GEOSEARCH` `DataError` messages.
- `commands/search/commands.py`: `shoule` → `should` in the `add_document` docstring.
- `_parsers/commands.py`: `splitted` → `split` in three comments (the correct past tense of "split" is "split").
- `_parsers/helpers.py`: `cant` → `can't` in a `parse_geosearch_generic` comment.

I checked `tests/` — none of the test files match the error-message strings being changed, so no test fixtures need updating.

### Pull Request check-list

- [x] Do tests and lints pass with this change? (`ruff check tests redis` and `ruff format --check` are clean on the modified files; modified modules still import.)
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested? (Comment- and string-only changes; existing tests cover the affected code paths and do not assert the changed substrings.)
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (No API change.)
- [x] Is there an example added to the examples folder (if applicable)? (N/A.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only spelling/grammar fixes in comments, docstrings, and a few user-facing warning/error strings; no logic or API behavior changes.
> 
> **Overview**
> Fixes minor typos across the codebase, including comments/docstrings and several user-facing strings.
> 
> Notably updates wording in `CredentialProvider.get_credentials_async`’s warning, OCSP verification `ConnectionError` text, and a few `GEORADIUS`/`GEOSEARCH` `DataError` messages, plus small comment/docstring corrections in command parsers and RediSearch docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7809d522dc19f2439839c0f32307f1d56ce473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->