### PR TITLE
Avoid zero-timeout async reads in hiredis connections readiness checks and replace async's can_read_destructive with non-destructive can_read.

### DIFF
--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -1,7 +1,6 @@
 import logging
-import sys
 from abc import ABC
-from asyncio import IncompleteReadError, StreamReader, TimeoutError
+from asyncio import IncompleteReadError, StreamReader
 from typing import Awaitable, Callable, List, Optional, Protocol, Union
 
 from redis.maint_notifications import (
@@ -14,12 +13,7 @@ from redis.maint_notifications import (
     OSSNodeMigratedNotification,
     OSSNodeMigratingNotification,
 )
-from redis.utils import safe_str
-
-if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
-    from asyncio import timeout as async_timeout
-else:
-    from async_timeout import timeout as async_timeout
+from redis.utils import deprecated_function, safe_str
 
 from ..exceptions import (
     AskError,
@@ -169,7 +163,13 @@ class AsyncBaseParser(BaseParser):
         self._stream: Optional[StreamReader] = None
         self._read_size = socket_read_size
 
+    @deprecated_function(
+        version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
+    )
     async def can_read_destructive(self) -> bool:
+        raise NotImplementedError()
+
+    async def can_read(self) -> bool:
         raise NotImplementedError()
 
     async def read_response(
@@ -515,16 +515,20 @@ class _AsyncRESPBase(AsyncBaseParser):
         """Called when the stream disconnects"""
         self._connected = False
 
+    @deprecated_function(
+        version="8.0.0",
+        reason="Use can_read() instead",
+        name="can_read_destructive",
+    )
     async def can_read_destructive(self) -> bool:
+        return await self.can_read()
+
+    async def can_read(self) -> bool:
         if not self._connected:
             raise OSError("Buffer is closed.")
         if self._buffer:
             return True
-        try:
-            async with async_timeout(0):
-                return self._stream.at_eof()
-        except TimeoutError:
-            return False
+        return self._stream.at_eof()
 
     async def _read(self, length: int) -> bytes:
         """

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -120,12 +120,6 @@ class BaseParser(ABC):
     def on_connect(self, connection):
         pass
 
-    @abstractmethod
-    def can_read(self, timeout: float = 0) -> bool:
-        # TODO: Rename this API; it detects pending data or dirty/closed
-        # connection state, not only whether application data can be read.
-        pass
-
 
 class _RESPBase(BaseParser):
     """Base class for sync-based resp parsing"""
@@ -179,11 +173,11 @@ class AsyncBaseParser(BaseParser):
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
     )
     @abstractmethod
-    async def can_read_destructive(self, timeout: float = 0) -> bool:
+    async def can_read_destructive(self) -> bool:
         pass
 
     @abstractmethod
-    async def can_read(self, timeout: float = 0) -> bool:
+    async def can_read(self) -> bool:
         # TODO: Rename this API; it detects pending data or dirty/closed
         # connection state, not only whether application data can be read.
         pass
@@ -536,10 +530,10 @@ class _AsyncRESPBase(AsyncBaseParser):
         reason="Use can_read() instead",
         name="can_read_destructive",
     )
-    async def can_read_destructive(self, timeout: float = 0) -> bool:
-        return await self.can_read(timeout=timeout)
+    async def can_read_destructive(self) -> bool:
+        return await self.can_read()
 
-    async def can_read(self, timeout: float = 0) -> bool:
+    async def can_read(self) -> bool:
         # TODO: Rename this API; it detects pending data or dirty/closed
         # connection state, not only whether application data can be read.
         if not self._connected:

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 from asyncio import IncompleteReadError, StreamReader
 from typing import Awaitable, Callable, List, Optional, Protocol, Union
 
@@ -112,11 +112,19 @@ class BaseParser(ABC):
             return exception_class(response, status_code=error_code)
         return ResponseError(response)
 
+    @abstractmethod
     def on_disconnect(self):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def on_connect(self, connection):
-        raise NotImplementedError()
+        pass
+
+    @abstractmethod
+    def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
+        pass
 
 
 class _RESPBase(BaseParser):
@@ -150,8 +158,12 @@ class _RESPBase(BaseParser):
             self._buffer = None
         self.encoder = None
 
-    def can_read(self, timeout):
-        return self._buffer and self._buffer.can_read(timeout)
+    def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
+        if self._buffer is None:
+            return False
+        return self._buffer.can_read(timeout)
 
 
 class AsyncBaseParser(BaseParser):
@@ -166,11 +178,15 @@ class AsyncBaseParser(BaseParser):
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
     )
-    async def can_read_destructive(self) -> bool:
-        raise NotImplementedError()
+    @abstractmethod
+    async def can_read_destructive(self, timeout: float = 0) -> bool:
+        pass
 
-    async def can_read(self) -> bool:
-        raise NotImplementedError()
+    @abstractmethod
+    async def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
+        pass
 
     async def read_response(
         self, disable_decoding: bool = False
@@ -520,15 +536,20 @@ class _AsyncRESPBase(AsyncBaseParser):
         reason="Use can_read() instead",
         name="can_read_destructive",
     )
-    async def can_read_destructive(self) -> bool:
-        return await self.can_read()
+    async def can_read_destructive(self, timeout: float = 0) -> bool:
+        return await self.can_read(timeout=timeout)
 
-    async def can_read(self) -> bool:
+    async def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
         if self._buffer:
             return True
-        return self._stream.at_eof()
+        # asyncio.StreamReader has no public non-destructive API for checking
+        # buffered bytes. Preserve dirty-connection detection for the Python
+        # parser and fail loudly if the private buffer API changes.
+        return bool(self._stream._buffer) or self._stream.at_eof()
 
     async def _read(self, length: int) -> bytes:
         """

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -230,10 +230,12 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     async def can_read(self):
         if not self._connected:
             raise OSError("Buffer is closed.")
-        if self._reader.has_data():
+        # EOF means the connection is closed and not safe to reuse.
+        if self._reader.has_data() or self._stream.at_eof():
             return True
-        if self._stream.at_eof():
-            return True
+        # asyncio.StreamReader has no public non-destructive API for checking
+        # buffered bytes. Preserve dirty-connection detection for hiredis and
+        # fail loudly if the private buffer API changes.
         return bool(self._stream._buffer)
 
     async def read_from_socket(self):

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -25,7 +25,8 @@ from .socket import (
 NOT_ENOUGH_DATA = object()
 
 
-def _socket_can_read(sock, timeout):
+def _socket_can_read(sock, timeout: float) -> bool:
+    # SSL sockets can have decrypted bytes buffered above the OS socket layer.
     if hasattr(sock, "pending") and sock.pending():
         return True
     return bool(select.select([sock], [], [], timeout)[0])
@@ -90,7 +91,9 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         self._sock = None
         self._reader = None
 
-    def can_read(self, timeout):
+    def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         if not self._reader:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
@@ -224,10 +227,12 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
     )
-    async def can_read_destructive(self):
-        return await self.can_read()
+    async def can_read_destructive(self, timeout: float = 0) -> bool:
+        return await self.can_read(timeout=timeout)
 
-    async def can_read(self):
+    async def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
         # EOF means the connection is closed and not safe to reuse.

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,17 +1,10 @@
-import asyncio
 import socket
-import sys
 from logging import getLogger
 from typing import Callable, List, Optional, TypedDict, Union
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
-    from asyncio import timeout as async_timeout
-else:
-    from async_timeout import timeout as async_timeout
-
 from ..exceptions import ConnectionError, InvalidResponse, RedisError
 from ..typing import EncodableT
-from ..utils import HIREDIS_AVAILABLE
+from ..utils import HIREDIS_AVAILABLE, deprecated_function
 from .base import (
     AsyncBaseParser,
     AsyncPushNotificationsParser,
@@ -243,16 +236,20 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     def on_disconnect(self):
         self._connected = False
 
+    @deprecated_function(
+        version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
+    )
     async def can_read_destructive(self):
+        return await self.can_read()
+
+    async def can_read(self):
         if not self._connected:
             raise OSError("Buffer is closed.")
         if self._reader.gets() is not NOT_ENOUGH_DATA:
             return True
-        try:
-            async with async_timeout(0):
-                return await self.read_from_socket()
-        except asyncio.TimeoutError:
-            return False
+        if self._stream.at_eof():
+            return True
+        return bool(self._stream._buffer)
 
     async def read_from_socket(self):
         buffer = await self._stream.read(self._read_size)

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -3,7 +3,7 @@ import socket
 from logging import getLogger
 from typing import Callable, List, Optional, TypedDict, Union
 
-from ..exceptions import ConnectionError, InvalidResponse, RedisError
+from ..exceptions import ConnectionError, InvalidResponse, RedisError, TimeoutError
 from ..typing import EncodableT
 from ..utils import HIREDIS_AVAILABLE, deprecated_function
 from .base import (
@@ -124,8 +124,11 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
             # there's no data to be read. otherwise raise the
             # original exception.
             allowed = NONBLOCKING_EXCEPTION_ERROR_NUMBERS.get(ex.__class__, -1)
-            if not raise_on_timeout and ex.errno == allowed:
-                return False
+            if ex.errno == allowed:
+                if not raise_on_timeout:
+                    return False
+                if timeout == 0:
+                    raise TimeoutError("Timeout reading from socket")
             raise ConnectionError(f"Error while reading from socket: {ex.args}")
         finally:
             if custom_timeout:

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -225,10 +225,10 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
     )
-    async def can_read_destructive(self, timeout: float = 0) -> bool:
-        return await self.can_read(timeout=timeout)
+    async def can_read_destructive(self) -> bool:
+        return await self.can_read()
 
-    async def can_read(self, timeout: float = 0) -> bool:
+    async def can_read(self) -> bool:
         # TODO: Rename this API; it detects pending data or dirty/closed
         # connection state, not only whether application data can be read.
         if not self._connected:

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -193,13 +193,14 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     """Async implementation of parser class for connections using Hiredis"""
 
-    __slots__ = ("_reader",)
+    __slots__ = ("_reader", "_next_response")
 
     def __init__(self, socket_read_size: int):
         if not HIREDIS_AVAILABLE:
             raise RedisError("Hiredis is not available.")
         super().__init__(socket_read_size=socket_read_size)
         self._reader = None
+        self._next_response = NOT_ENOUGH_DATA
         self.pubsub_push_handler_func = self.handle_pubsub_push_response
         self.invalidation_push_handler_func = None
         self._hiredis_PushNotificationType = None
@@ -223,6 +224,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             kwargs["errors"] = connection.encoder.encoding_errors
 
         self._reader = hiredis.Reader(**kwargs)
+        self._next_response = NOT_ENOUGH_DATA
         self._connected = True
 
         try:
@@ -235,6 +237,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
 
     def on_disconnect(self):
         self._connected = False
+        self._next_response = NOT_ENOUGH_DATA
 
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
@@ -245,7 +248,9 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     async def can_read(self):
         if not self._connected:
             raise OSError("Buffer is closed.")
-        if self._reader.gets() is not NOT_ENOUGH_DATA:
+        if self._next_response is NOT_ENOUGH_DATA:
+            self._next_response = self._reader.gets()
+        if self._next_response is not NOT_ENOUGH_DATA:
             return True
         if self._stream.at_eof():
             return True
@@ -269,17 +274,22 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
 
-        if disable_decoding:
-            response = self._reader.gets(False)
+        # _next_response might be cached from a can_read() call
+        if self._next_response is not NOT_ENOUGH_DATA:
+            response = self._next_response
+            self._next_response = NOT_ENOUGH_DATA
         else:
-            response = self._reader.gets()
-
-        while response is NOT_ENOUGH_DATA:
-            await self.read_from_socket()
             if disable_decoding:
                 response = self._reader.gets(False)
             else:
                 response = self._reader.gets()
+
+            while response is NOT_ENOUGH_DATA:
+                await self.read_from_socket()
+                if disable_decoding:
+                    response = self._reader.gets(False)
+                else:
+                    response = self._reader.gets()
 
         # if the response is a ConnectionError or the response is a list and
         # the first item is a ConnectionError, raise it as something bad

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -168,6 +168,7 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
             return self.read_response(
                 disable_decoding=disable_decoding,
                 push_request=push_request,
+                timeout=timeout,
             )
 
         elif (
@@ -240,8 +241,8 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         if self._reader.has_data() or self._stream.at_eof():
             return True
         # asyncio.StreamReader has no public non-destructive API for checking
-        # buffered bytes. Preserve dirty-connection detection for hiredis and
-        # fail loudly if the private buffer API changes.
+        # buffered bytes. Preserve dirty-connection detection for hiredis; tests
+        # with a real StreamReader guard this private buffer API in CI.
         return bool(self._stream._buffer)
 
     async def read_from_socket(self):

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -99,8 +99,6 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 
         if self._reader.has_data():
             return True
-        if timeout is SENTINEL:
-            timeout = self._socket_timeout
         return _socket_can_read(self._sock, timeout)
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,3 +1,4 @@
+import select
 import socket
 from logging import getLogger
 from typing import Callable, List, Optional, TypedDict, Union
@@ -22,6 +23,12 @@ from .socket import (
 # Using `False` or `None` is not reliable, given that the parser can
 # return `False` or `None` for legitimate reasons from RESP payloads.
 NOT_ENOUGH_DATA = object()
+
+
+def _socket_can_read(sock, timeout):
+    if hasattr(sock, "pending") and sock.pending():
+        return True
+    return bool(select.select([sock], [], [], timeout)[0])
 
 
 class _HiredisReaderArgs(TypedDict, total=False):
@@ -72,7 +79,6 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         if connection.encoder.decode_responses:
             kwargs["encoding"] = connection.encoder.encoding
         self._reader = hiredis.Reader(**kwargs)
-        self._next_response = NOT_ENOUGH_DATA
 
         try:
             self._hiredis_PushNotificationType = hiredis.PushNotification
@@ -83,17 +89,16 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
     def on_disconnect(self):
         self._sock = None
         self._reader = None
-        self._next_response = NOT_ENOUGH_DATA
 
     def can_read(self, timeout):
         if not self._reader:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
-        if self._next_response is NOT_ENOUGH_DATA:
-            self._next_response = self._reader.gets()
-            if self._next_response is NOT_ENOUGH_DATA:
-                return self.read_from_socket(timeout=timeout, raise_on_timeout=False)
-        return True
+        if self._reader.has_data():
+            return True
+        if timeout is SENTINEL:
+            timeout = self._socket_timeout
+        return _socket_can_read(self._sock, timeout)
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
         sock = self._sock
@@ -134,26 +139,6 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         if not self._reader:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
-        # _next_response might be cached from a can_read() call
-        if self._next_response is not NOT_ENOUGH_DATA:
-            response = self._next_response
-            self._next_response = NOT_ENOUGH_DATA
-            if self._hiredis_PushNotificationType is not None and isinstance(
-                response, self._hiredis_PushNotificationType
-            ):
-                response = self.handle_push_response(response)
-
-                # if this is a push request return the push response
-                if push_request:
-                    return response
-
-                return self.read_response(
-                    disable_decoding=disable_decoding,
-                    push_request=push_request,
-                    timeout=timeout,
-                )
-            return response
-
         if disable_decoding:
             response = self._reader.gets(False)
         else:
@@ -193,14 +178,13 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     """Async implementation of parser class for connections using Hiredis"""
 
-    __slots__ = ("_reader", "_next_response")
+    __slots__ = ("_reader",)
 
     def __init__(self, socket_read_size: int):
         if not HIREDIS_AVAILABLE:
             raise RedisError("Hiredis is not available.")
         super().__init__(socket_read_size=socket_read_size)
         self._reader = None
-        self._next_response = NOT_ENOUGH_DATA
         self.pubsub_push_handler_func = self.handle_pubsub_push_response
         self.invalidation_push_handler_func = None
         self._hiredis_PushNotificationType = None
@@ -224,7 +208,6 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
             kwargs["errors"] = connection.encoder.encoding_errors
 
         self._reader = hiredis.Reader(**kwargs)
-        self._next_response = NOT_ENOUGH_DATA
         self._connected = True
 
         try:
@@ -237,7 +220,6 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
 
     def on_disconnect(self):
         self._connected = False
-        self._next_response = NOT_ENOUGH_DATA
 
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
@@ -248,9 +230,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
     async def can_read(self):
         if not self._connected:
             raise OSError("Buffer is closed.")
-        if self._next_response is NOT_ENOUGH_DATA:
-            self._next_response = self._reader.gets()
-        if self._next_response is not NOT_ENOUGH_DATA:
+        if self._reader.has_data():
             return True
         if self._stream.at_eof():
             return True
@@ -274,22 +254,17 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
 
-        # _next_response might be cached from a can_read() call
-        if self._next_response is not NOT_ENOUGH_DATA:
-            response = self._next_response
-            self._next_response = NOT_ENOUGH_DATA
+        if disable_decoding:
+            response = self._reader.gets(False)
         else:
+            response = self._reader.gets()
+
+        while response is NOT_ENOUGH_DATA:
+            await self.read_from_socket()
             if disable_decoding:
                 response = self._reader.gets(False)
             else:
                 response = self._reader.gets()
-
-            while response is NOT_ENOUGH_DATA:
-                await self.read_from_socket()
-                if disable_decoding:
-                    response = self._reader.gets(False)
-                else:
-                    response = self._reader.gets()
 
         # if the response is a ConnectionError or the response is a list and
         # the first item is a ConnectionError, raise it as something bad

--- a/redis/_parsers/socket.py
+++ b/redis/_parsers/socket.py
@@ -83,8 +83,11 @@ class SocketBuffer:
             # there's no data to be read. otherwise raise the
             # original exception.
             allowed = NONBLOCKING_EXCEPTION_ERROR_NUMBERS.get(ex.__class__, -1)
-            if not raise_on_timeout and ex.errno == allowed:
-                return False
+            if ex.errno == allowed:
+                if not raise_on_timeout:
+                    return False
+                if timeout == 0:
+                    raise TimeoutError("Timeout reading from socket")
             raise ConnectionError(f"Error while reading from socket: {ex.args}")
         finally:
             buf.seek(current_pos)

--- a/redis/_parsers/socket.py
+++ b/redis/_parsers/socket.py
@@ -91,7 +91,7 @@ class SocketBuffer:
             if custom_timeout:
                 sock.settimeout(self.socket_timeout)
 
-    def can_read(self, timeout: float) -> bool:
+    def can_read(self, timeout: float = 0) -> bool:
         return bool(self.unread_bytes()) or self._read_from_socket(
             timeout=timeout, raise_on_timeout=False
         )

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -715,21 +715,21 @@ class AbstractConnection:
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
     )
-    async def can_read_destructive(self, timeout: float = 0) -> bool:
+    async def can_read_destructive(self) -> bool:
         """Check the socket to see if there's data loaded in the buffer."""
         try:
-            return await self._parser.can_read(timeout=timeout)
+            return await self._parser.can_read()
         except OSError as e:
             await self.disconnect(nowait=True)
             host_error = self._host_error()
             raise ConnectionError(f"Error while reading from {host_error}: {e.args}")
 
-    async def can_read(self, timeout: float = 0) -> bool:
+    async def can_read(self) -> bool:
         """Check the socket to see if there's data loaded in the buffer."""
         # TODO: Rename this API; it detects pending data or dirty/closed
         # connection state, not only whether application data can be read.
         try:
-            return await self._parser.can_read(timeout=timeout)
+            return await self._parser.can_read()
         except OSError as e:
             await self.disconnect(nowait=True)
             host_error = self._host_error()

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -715,19 +715,21 @@ class AbstractConnection:
     @deprecated_function(
         version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
     )
-    async def can_read_destructive(self):
+    async def can_read_destructive(self, timeout: float = 0) -> bool:
         """Check the socket to see if there's data loaded in the buffer."""
         try:
-            return await self._parser.can_read()
+            return await self._parser.can_read(timeout=timeout)
         except OSError as e:
             await self.disconnect(nowait=True)
             host_error = self._host_error()
             raise ConnectionError(f"Error while reading from {host_error}: {e.args}")
 
-    async def can_read(self):
+    async def can_read(self, timeout: float = 0) -> bool:
         """Check the socket to see if there's data loaded in the buffer."""
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         try:
-            return await self._parser.can_read()
+            return await self._parser.can_read(timeout=timeout)
         except OSError as e:
             await self.disconnect(nowait=True)
             host_error = self._host_error()

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -34,7 +34,7 @@ from ..observability.attributes import (
     ConnectionState,
     get_pool_name,
 )
-from ..utils import SSL_AVAILABLE
+from ..utils import SSL_AVAILABLE, deprecated_function
 
 if SSL_AVAILABLE:
     import ssl
@@ -712,10 +712,22 @@ class AbstractConnection:
             self.pack_command(*args), check_health=kwargs.get("check_health", True)
         )
 
+    @deprecated_function(
+        version="8.0.0", reason="Use can_read() instead", name="can_read_destructive"
+    )
     async def can_read_destructive(self):
-        """Poll the socket to see if there's data that can be read."""
+        """Check the socket to see if there's data loaded in the buffer."""
         try:
-            return await self._parser.can_read_destructive()
+            return await self._parser.can_read()
+        except OSError as e:
+            await self.disconnect(nowait=True)
+            host_error = self._host_error()
+            raise ConnectionError(f"Error while reading from {host_error}: {e.args}")
+
+    async def can_read(self):
+        """Check the socket to see if there's data loaded in the buffer."""
+        try:
+            return await self._parser.can_read()
         except OSError as e:
             await self.disconnect(nowait=True)
             host_error = self._host_error()
@@ -1571,12 +1583,12 @@ class ConnectionPool(ConnectionPoolInterface):
         # pool before all data has been read or the socket has been
         # closed. either way, reconnect and verify everything is good.
         try:
-            if await connection.can_read_destructive():
+            if await connection.can_read():
                 raise ConnectionError("Connection has data") from None
         except (ConnectionError, TimeoutError, OSError):
             await connection.disconnect()
             await connection.connect()
-            if await connection.can_read_destructive():
+            if await connection.can_read():
                 raise ConnectionError("Connection not ready") from None
 
     async def release(self, connection: AbstractConnection):

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -234,7 +234,9 @@ class ConnectionInterface:
         pass
 
     @abstractmethod
-    def can_read(self, timeout=0):
+    def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         pass
 
     @abstractmethod
@@ -1329,8 +1331,10 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             check_health=kwargs.get("check_health", True),
         )
 
-    def can_read(self, timeout=0):
+    def can_read(self, timeout: float = 0) -> bool:
         """Poll the socket to see if there's data that can be read."""
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         sock = self._sock
         if not sock:
             self.connect()
@@ -1733,7 +1737,9 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
         # read-only command that not yet cached.
         self._conn.send_command(*args, **kwargs)
 
-    def can_read(self, timeout=0):
+    def can_read(self, timeout: float = 0) -> bool:
+        # TODO: Rename this API; it detects pending data or dirty/closed
+        # connection state, not only whether application data can be read.
         return self._conn.can_read(timeout)
 
     def read_response(

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1715,7 +1715,12 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
 
                 with self._pool_lock:
                     while entry.connection_ref.can_read():
-                        entry.connection_ref.read_response(push_request=True)
+                        try:
+                            entry.connection_ref.read_response(
+                                push_request=True, timeout=0
+                            )
+                        except TimeoutError:
+                            break
 
                 # Re-check: if the entry was invalidated during the drain,
                 # fall through to send the command over the network.
@@ -1941,7 +1946,10 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
 
     def _process_pending_invalidations(self):
         while self.can_read():
-            self._conn.read_response(push_request=True)
+            try:
+                self._conn.read_response(push_request=True, timeout=0)
+            except TimeoutError:
+                break
 
     def _on_invalidation_callback(self, data: List[Union[str, Optional[List[bytes]]]]):
         with self._cache_lock:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1717,7 +1717,9 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
                     while entry.connection_ref.can_read():
                         try:
                             entry.connection_ref.read_response(
-                                push_request=True, timeout=0
+                                push_request=True,
+                                timeout=0,
+                                disconnect_on_error=False,
                             )
                         except TimeoutError:
                             break
@@ -1947,7 +1949,9 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
     def _process_pending_invalidations(self):
         while self.can_read():
             try:
-                self._conn.read_response(push_request=True, timeout=0)
+                self._conn.read_response(
+                    push_request=True, timeout=0, disconnect_on_error=False
+                )
             except TimeoutError:
                 break
 

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -13,6 +13,7 @@ from redis._parsers import (
     _AsyncRESP3Parser,
     _AsyncRESPBase,
 )
+from redis._parsers.hiredis import NOT_ENOUGH_DATA
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.connection import (
     Connection,
@@ -29,6 +30,36 @@ from tests.conftest import skip_if_server_version_lt
 from .mocks import MockStream
 
 
+class DummyHiredisReader:
+    def __init__(self, response=NOT_ENOUGH_DATA):
+        self.response = response
+
+    def gets(self):
+        return self.response
+
+
+class DummyAsyncStream:
+    def __init__(self, buffer=b"", eof=False):
+        self._buffer = bytearray(buffer)
+        self.eof = eof
+        self.read_called = False
+
+    def at_eof(self):
+        return self.eof and not self._buffer
+
+    async def read(self, _):
+        self.read_called = True
+        raise AssertionError("can_read should not read from the stream")
+
+
+def make_async_hiredis_parser(stream, response=NOT_ENOUGH_DATA):
+    parser = _AsyncHiredisParser.__new__(_AsyncHiredisParser)
+    parser._connected = True
+    parser._reader = DummyHiredisReader(response)
+    parser._stream = stream
+    return parser
+
+
 def test_connection_default_parser_matches_default_protocol():
     conn = Connection()
     expected_parser_class = (
@@ -36,6 +67,32 @@ def test_connection_default_parser_matches_default_protocol():
     )
     assert isinstance(conn._parser, expected_parser_class)
     assert conn.protocol == 3
+
+
+@pytest.mark.parametrize(
+    ("buffer", "eof", "expected"),
+    [
+        (b"", False, False),
+        (b"+OK\r\n", False, True),
+        (b"", True, True),
+    ],
+)
+async def test_async_hiredis_can_read_uses_buffer_without_reading(
+    buffer, eof, expected
+):
+    stream = DummyAsyncStream(buffer=buffer, eof=eof)
+    parser = make_async_hiredis_parser(stream)
+
+    assert await parser.can_read() is expected
+    assert stream.read_called is False
+
+
+async def test_async_hiredis_can_read_detects_reader_response():
+    stream = DummyAsyncStream()
+    parser = make_async_hiredis_parser(stream, response=b"OK")
+
+    assert await parser.can_read() is True
+    assert stream.read_called is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -152,7 +152,7 @@ async def test_async_resp_can_read_detects_stream_buffer(parser_class):
     parser._connected = True
     parser._stream = stream
 
-    assert await parser.can_read(timeout=0) is True
+    assert await parser.can_read() is True
     assert stream.read_called is False
 
 

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -31,9 +31,7 @@ from .mocks import MockStream
 
 
 class DummyHiredisReader:
-    def __init__(
-        self, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
-    ):
+    def __init__(self, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False):
         self.responses = [response]
         self.decoded_response = decoded_response
         self.has_data_value = has_data

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -145,6 +145,17 @@ async def test_async_hiredis_can_read_leaves_decoding_to_read_response():
     assert await parser.read_response() == raw.decode()
 
 
+@pytest.mark.parametrize("parser_class", [_AsyncRESP2Parser, _AsyncRESP3Parser])
+async def test_async_resp_can_read_detects_stream_buffer(parser_class):
+    stream = DummyAsyncStream(buffer=b"+OK\r\n")
+    parser = parser_class(socket_read_size=65536)
+    parser._connected = True
+    parser._stream = stream
+
+    assert await parser.can_read(timeout=0) is True
+    assert stream.read_called is False
+
+
 @pytest.mark.parametrize(
     ("protocol", "parser_class", "expected_parser_class"),
     [

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -31,12 +31,22 @@ from .mocks import MockStream
 
 
 class DummyHiredisReader:
-    def __init__(self, response=NOT_ENOUGH_DATA):
+    def __init__(
+        self, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
+    ):
         self.responses = [response]
+        self.decoded_response = decoded_response
+        self.has_data_value = has_data
+
+    def has_data(self):
+        return self.has_data_value
 
     def gets(self, *args):
         if self.responses:
-            return self.responses.pop(0)
+            response = self.responses.pop(0)
+            if args == (False,) or self.decoded_response is None:
+                return response
+            return self.decoded_response
         return NOT_ENOUGH_DATA
 
 
@@ -54,11 +64,12 @@ class DummyAsyncStream:
         raise AssertionError("can_read should not read from the stream")
 
 
-def make_async_hiredis_parser(stream, response=NOT_ENOUGH_DATA):
+def make_async_hiredis_parser(
+    stream, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
+):
     parser = _AsyncHiredisParser.__new__(_AsyncHiredisParser)
     parser._connected = True
-    parser._reader = DummyHiredisReader(response)
-    parser._next_response = NOT_ENOUGH_DATA
+    parser._reader = DummyHiredisReader(response, decoded_response, has_data)
     parser._stream = stream
     parser._hiredis_PushNotificationType = None
     return parser
@@ -93,19 +104,47 @@ async def test_async_hiredis_can_read_uses_buffer_without_reading(
 
 async def test_async_hiredis_can_read_detects_reader_response():
     stream = DummyAsyncStream()
-    parser = make_async_hiredis_parser(stream, response=b"OK")
+    parser = make_async_hiredis_parser(stream, response=b"OK", has_data=True)
 
     assert await parser.can_read() is True
     assert stream.read_called is False
 
 
-async def test_async_hiredis_can_read_caches_reader_response():
+async def test_async_hiredis_can_read_preserves_reader_response():
     stream = DummyAsyncStream()
-    parser = make_async_hiredis_parser(stream, response=b"OK")
+    parser = make_async_hiredis_parser(stream, response=b"OK", has_data=True)
 
     assert await parser.can_read() is True
     assert await parser.read_response() == b"OK"
     assert stream.read_called is False
+
+
+async def test_async_hiredis_can_read_does_not_decide_disable_decoding():
+    stream = DummyAsyncStream()
+    raw = b"\xe2\x98\x83"
+    parser = make_async_hiredis_parser(
+        stream,
+        response=raw,
+        decoded_response=raw.decode(),
+        has_data=True,
+    )
+
+    assert await parser.can_read() is True
+    assert await parser.read_response(disable_decoding=True) == raw
+
+
+async def test_async_hiredis_can_read_leaves_decoding_to_read_response():
+    stream = DummyAsyncStream()
+    raw = b"\xe2\x98\x83"
+    parser = make_async_hiredis_parser(
+        stream,
+        response=raw,
+        decoded_response=raw.decode(),
+        has_data=True,
+    )
+
+    assert await parser.can_read() is True
+    assert await parser.read_response() == raw.decode()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -108,6 +108,16 @@ async def test_async_hiredis_can_read_detects_reader_response():
     assert stream.read_called is False
 
 
+async def test_async_hiredis_can_read_detects_real_stream_reader_buffer():
+    payload = b"+OK\r\n"
+    stream = asyncio.StreamReader()
+    stream.feed_data(payload)
+    parser = make_async_hiredis_parser(stream)
+
+    assert await parser.can_read() is True
+    assert await stream.read(len(payload)) == payload
+
+
 async def test_async_hiredis_can_read_preserves_reader_response():
     stream = DummyAsyncStream()
     parser = make_async_hiredis_parser(stream, response=b"OK", has_data=True)

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -32,10 +32,12 @@ from .mocks import MockStream
 
 class DummyHiredisReader:
     def __init__(self, response=NOT_ENOUGH_DATA):
-        self.response = response
+        self.responses = [response]
 
-    def gets(self):
-        return self.response
+    def gets(self, *args):
+        if self.responses:
+            return self.responses.pop(0)
+        return NOT_ENOUGH_DATA
 
 
 class DummyAsyncStream:
@@ -56,7 +58,9 @@ def make_async_hiredis_parser(stream, response=NOT_ENOUGH_DATA):
     parser = _AsyncHiredisParser.__new__(_AsyncHiredisParser)
     parser._connected = True
     parser._reader = DummyHiredisReader(response)
+    parser._next_response = NOT_ENOUGH_DATA
     parser._stream = stream
+    parser._hiredis_PushNotificationType = None
     return parser
 
 
@@ -92,6 +96,15 @@ async def test_async_hiredis_can_read_detects_reader_response():
     parser = make_async_hiredis_parser(stream, response=b"OK")
 
     assert await parser.can_read() is True
+    assert stream.read_called is False
+
+
+async def test_async_hiredis_can_read_caches_reader_response():
+    stream = DummyAsyncStream()
+    parser = make_async_hiredis_parser(stream, response=b"OK")
+
+    assert await parser.can_read() is True
+    assert await parser.read_response() == b"OK"
     assert stream.read_called is False
 
 

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -119,7 +119,7 @@ class DummyConnection(Connection):
     def is_connected(self):
         return self._connected
 
-    async def can_read(self, timeout: float = 0) -> bool:
+    async def can_read(self) -> bool:
         return False
 
     def set_re_auth_token(self, token: TokenInterface):

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -119,7 +119,7 @@ class DummyConnection(Connection):
     def is_connected(self):
         return self._connected
 
-    async def can_read(self):
+    async def can_read(self, timeout: float = 0) -> bool:
         return False
 
     def set_re_auth_token(self, token: TokenInterface):

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -119,7 +119,7 @@ class DummyConnection(Connection):
     def is_connected(self):
         return self._connected
 
-    async def can_read_destructive(self, timeout: float = 0):
+    async def can_read(self):
         return False
 
     def set_re_auth_token(self, token: TokenInterface):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -68,6 +68,10 @@ class DummyHiredisReader:
         return NOT_ENOUGH_DATA
 
 
+class DummyPushNotification(list):
+    pass
+
+
 def make_hiredis_parser(
     response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
 ):
@@ -128,6 +132,45 @@ def test_hiredis_can_read_leaves_decoding_to_read_response():
 
     assert parser.can_read(timeout=0) is True
     assert parser.read_response() == raw.decode()
+
+
+def test_hiredis_read_response_returns_initial_push_notification():
+    push_response = DummyPushNotification([b"message", b"channel", b"data"])
+    handled_response = object()
+    parser = make_hiredis_parser()
+    parser._hiredis_PushNotificationType = DummyPushNotification
+    parser._reader.responses = [push_response]
+    parser.pubsub_push_handler_func = Mock(return_value=handled_response)
+
+    assert parser.read_response(push_request=True) is handled_response
+    parser.pubsub_push_handler_func.assert_called_once_with(push_response)
+
+
+def test_hiredis_read_response_skips_initial_push_notification():
+    push_response = DummyPushNotification([b"message", b"channel", b"data"])
+    parser = make_hiredis_parser()
+    parser._hiredis_PushNotificationType = DummyPushNotification
+    parser._reader.responses = [push_response, b"OK"]
+    parser.pubsub_push_handler_func = Mock(return_value=push_response)
+
+    assert parser.read_response() == b"OK"
+    parser.pubsub_push_handler_func.assert_called_once_with(push_response)
+
+
+def test_hiredis_read_response_preserves_timeout_after_initial_push_notification():
+    push_response = DummyPushNotification([b"message", b"channel", b"data"])
+    parser = make_hiredis_parser()
+    parser._hiredis_PushNotificationType = DummyPushNotification
+    parser._reader.responses = [push_response, NOT_ENOUGH_DATA]
+    parser._sock.recv_into.side_effect = BlockingIOError(
+        EWOULDBLOCK, "Resource temporarily unavailable"
+    )
+    parser.pubsub_push_handler_func = Mock(return_value=push_response)
+
+    with pytest.raises(TimeoutError):
+        parser.read_response(timeout=0)
+
+    parser.pubsub_push_handler_func.assert_called_once_with(push_response)
 
 
 def test_hiredis_read_response_timeout_zero_maps_would_block_to_timeout():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -51,9 +51,7 @@ from .mocks import MockSocket
 
 
 class DummyHiredisReader:
-    def __init__(
-        self, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
-    ):
+    def __init__(self, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False):
         self.responses = [response]
         self.decoded_response = decoded_response
         self.has_data_value = has_data

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -800,7 +800,7 @@ class TestUnitCacheProxyConnection:
 
         assert proxy_connection.read_response() == b"bar"
         assert another_conn.can_read.call_count == 2
-        another_conn.read_response.assert_called_once()
+        another_conn.read_response.assert_called_once_with(push_request=True, timeout=0)
 
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
@@ -852,7 +852,7 @@ class TestUnitCacheProxyConnection:
 
         # The drain should have happened on the other connection
         assert another_conn.can_read.call_count == 2
-        another_conn.read_response.assert_called_once()
+        another_conn.read_response.assert_called_once_with(push_request=True, timeout=0)
 
         # The command must have been sent over the wire (not returned early)
         mock_connection.send_command.assert_called_once_with("GET", "foo", keys=["foo"])
@@ -865,6 +865,67 @@ class TestUnitCacheProxyConnection:
                 status=CacheEntryStatus.IN_PROGRESS,
                 connection_ref=mock_connection,
             )
+        )
+
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy",
+        reason="Pypy doesn't support side_effect",
+    )
+    def test_invalidation_processing_on_another_connection_breaks_on_timeout(
+        self, mock_cache, mock_connection
+    ):
+        mock_connection.retry = "mock"
+        mock_connection.host = "mock"
+        mock_connection.port = "mock"
+        mock_connection.db = 0
+        mock_connection.credential_provider = UsernamePasswordCredentialProvider()
+        mock_connection._event_dispatcher = Mock(spec=EventDispatcher)
+
+        another_conn = copy.deepcopy(mock_connection)
+        another_conn.can_read.return_value = True
+        another_conn.read_response.side_effect = TimeoutError("timeout")
+
+        cache_key = CacheKey(
+            command="GET", redis_keys=("foo",), redis_args=("GET", "foo")
+        )
+        cache_entry = CacheEntry(
+            cache_key=cache_key,
+            cache_value=b"bar",
+            status=CacheEntryStatus.VALID,
+            connection_ref=another_conn,
+        )
+
+        mock_cache.is_cachable.return_value = True
+        mock_cache.get.side_effect = [cache_entry, cache_entry, cache_entry]
+        mock_connection.can_read.return_value = False
+
+        proxy_connection = CacheProxyConnection(
+            mock_connection, mock_cache, threading.RLock()
+        )
+        proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
+
+        another_conn.read_response.assert_called_once_with(push_request=True, timeout=0)
+        mock_connection.send_command.assert_not_called()
+
+    def test_process_pending_invalidations_breaks_on_timeout(self, mock_connection):
+        mock_connection.retry = "mock"
+        mock_connection.host = "mock"
+        mock_connection.port = "mock"
+        mock_connection.db = 0
+        mock_connection._event_dispatcher = EventDispatcher()
+        mock_connection.credential_provider = UsernamePasswordCredentialProvider()
+        mock_connection.can_read.return_value = True
+        mock_connection.read_response.side_effect = TimeoutError("timeout")
+
+        cache = DefaultCache(CacheConfig(max_size=10))
+        proxy_connection = CacheProxyConnection(
+            mock_connection, cache, threading.RLock()
+        )
+
+        proxy_connection._process_pending_invalidations()
+
+        mock_connection.read_response.assert_called_once_with(
+            push_request=True, timeout=0
         )
 
     def test_read_response_propagates_timeout_parameter(self, mock_connection):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -12,6 +12,7 @@ import pytest
 import redis
 from redis import ConnectionPool, Redis
 from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
+from redis._parsers.hiredis import NOT_ENOUGH_DATA
 from redis._parsers.socket import SENTINEL
 from redis.backoff import NoBackoff
 from redis.cache import (
@@ -49,6 +50,37 @@ from .conftest import skip_if_server_version_lt
 from .mocks import MockSocket
 
 
+class DummyHiredisReader:
+    def __init__(
+        self, response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
+    ):
+        self.responses = [response]
+        self.decoded_response = decoded_response
+        self.has_data_value = has_data
+
+    def has_data(self):
+        return self.has_data_value
+
+    def gets(self, *args):
+        if self.responses:
+            response = self.responses.pop(0)
+            if args == (False,) or self.decoded_response is None:
+                return response
+            return self.decoded_response
+        return NOT_ENOUGH_DATA
+
+
+def make_hiredis_parser(
+    response=NOT_ENOUGH_DATA, decoded_response=None, has_data=False
+):
+    parser = _HiredisParser.__new__(_HiredisParser)
+    parser._reader = DummyHiredisReader(response, decoded_response, has_data)
+    parser._hiredis_PushNotificationType = None
+    parser._sock = mock.Mock()
+    parser._socket_timeout = None
+    return parser
+
+
 @pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 @pytest.mark.onlynoncluster
 def test_invalid_response(r):
@@ -57,6 +89,46 @@ def test_invalid_response(r):
     with mock.patch.object(parser._buffer, "readline", return_value=raw):
         with pytest.raises(InvalidResponse, match=f"Protocol Error: {raw!r}"):
             parser.read_response()
+
+
+def test_hiredis_can_read_detects_reader_data():
+    parser = make_hiredis_parser(response=b"OK", has_data=True)
+
+    assert parser.can_read(timeout=0) is True
+    assert parser.read_response() == b"OK"
+
+
+def test_hiredis_can_read_checks_socket_readiness_without_reading():
+    parser = make_hiredis_parser(has_data=False)
+
+    with patch("redis._parsers.hiredis._socket_can_read", return_value=True) as ready:
+        assert parser.can_read(timeout=0) is True
+
+    ready.assert_called_once_with(parser._sock, 0)
+
+
+def test_hiredis_can_read_does_not_decide_disable_decoding():
+    raw = b"\xe2\x98\x83"
+    parser = make_hiredis_parser(
+        response=raw,
+        decoded_response=raw.decode(),
+        has_data=True,
+    )
+
+    assert parser.can_read(timeout=0) is True
+    assert parser.read_response(disable_decoding=True) == raw
+
+
+def test_hiredis_can_read_leaves_decoding_to_read_response():
+    raw = b"\xe2\x98\x83"
+    parser = make_hiredis_parser(
+        response=raw,
+        decoded_response=raw.decode(),
+        has_data=True,
+    )
+
+    assert parser.can_read(timeout=0) is True
+    assert parser.read_response() == raw.decode()
 
 
 @skip_if_server_version_lt("4.0.0")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,7 +3,7 @@ import platform
 import socket
 import threading
 import types
-from errno import ECONNREFUSED
+from errno import ECONNREFUSED, EWOULDBLOCK
 from typing import Any
 from unittest import mock
 from unittest.mock import call, patch, MagicMock, Mock
@@ -13,7 +13,7 @@ import redis
 from redis import ConnectionPool, Redis
 from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
 from redis._parsers.hiredis import NOT_ENOUGH_DATA
-from redis._parsers.socket import SENTINEL
+from redis._parsers.socket import SENTINEL, SocketBuffer
 from redis.backoff import NoBackoff
 from redis.cache import (
     CacheConfig,
@@ -75,6 +75,7 @@ def make_hiredis_parser(
     parser._reader = DummyHiredisReader(response, decoded_response, has_data)
     parser._hiredis_PushNotificationType = None
     parser._sock = mock.Mock()
+    parser._buffer = bytearray(65536)
     parser._socket_timeout = None
     return parser
 
@@ -127,6 +128,27 @@ def test_hiredis_can_read_leaves_decoding_to_read_response():
 
     assert parser.can_read(timeout=0) is True
     assert parser.read_response() == raw.decode()
+
+
+def test_hiredis_read_response_timeout_zero_maps_would_block_to_timeout():
+    parser = make_hiredis_parser()
+    parser._sock.recv_into.side_effect = BlockingIOError(
+        EWOULDBLOCK, "Resource temporarily unavailable"
+    )
+
+    with pytest.raises(TimeoutError):
+        parser.read_response(timeout=0)
+
+
+def test_socket_buffer_timeout_zero_maps_would_block_to_timeout():
+    sock = Mock()
+    sock.recv.side_effect = BlockingIOError(
+        EWOULDBLOCK, "Resource temporarily unavailable"
+    )
+    socket_buffer = SocketBuffer(sock, socket_read_size=65536, socket_timeout=None)
+
+    with pytest.raises(TimeoutError):
+        socket_buffer.readline(timeout=0)
 
 
 @skip_if_server_version_lt("4.0.0")
@@ -800,7 +822,9 @@ class TestUnitCacheProxyConnection:
 
         assert proxy_connection.read_response() == b"bar"
         assert another_conn.can_read.call_count == 2
-        another_conn.read_response.assert_called_once_with(push_request=True, timeout=0)
+        another_conn.read_response.assert_called_once_with(
+            push_request=True, timeout=0, disconnect_on_error=False
+        )
 
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
@@ -852,7 +876,9 @@ class TestUnitCacheProxyConnection:
 
         # The drain should have happened on the other connection
         assert another_conn.can_read.call_count == 2
-        another_conn.read_response.assert_called_once_with(push_request=True, timeout=0)
+        another_conn.read_response.assert_called_once_with(
+            push_request=True, timeout=0, disconnect_on_error=False
+        )
 
         # The command must have been sent over the wire (not returned early)
         mock_connection.send_command.assert_called_once_with("GET", "foo", keys=["foo"])
@@ -904,7 +930,9 @@ class TestUnitCacheProxyConnection:
         )
         proxy_connection.send_command(*["GET", "foo"], **{"keys": ["foo"]})
 
-        another_conn.read_response.assert_called_once_with(push_request=True, timeout=0)
+        another_conn.read_response.assert_called_once_with(
+            push_request=True, timeout=0, disconnect_on_error=False
+        )
         mock_connection.send_command.assert_not_called()
 
     def test_process_pending_invalidations_breaks_on_timeout(self, mock_connection):
@@ -925,7 +953,7 @@ class TestUnitCacheProxyConnection:
         proxy_connection._process_pending_invalidations()
 
         mock_connection.read_response.assert_called_once_with(
-            push_request=True, timeout=0
+            push_request=True, timeout=0, disconnect_on_error=False
         )
 
     def test_read_response_propagates_timeout_parameter(self, mock_connection):

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -61,7 +61,7 @@ class DummyConnection:
     def disconnect(self):
         self._sock = None
 
-    def can_read(self):
+    def can_read(self, timeout: float = 0) -> bool:
         return False
 
     def should_reconnect(self):

--- a/tests/test_max_connections_error.py
+++ b/tests/test_max_connections_error.py
@@ -44,7 +44,7 @@ class DummyConnection(ConnectionInterface):
     def send_command(self, *args, **kwargs):
         pass
 
-    def can_read(self, timeout=0):
+    def can_read(self, timeout: float = 0) -> bool:
         return False
 
     def read_response(self, disable_decoding=False, **kwargs):

--- a/tests/test_observability/test_metrics_connection_attributes.py
+++ b/tests/test_observability/test_metrics_connection_attributes.py
@@ -67,7 +67,7 @@ class MockConnectionWithoutHostPort(ConnectionInterface):
     def send_command(self, *args, **kwargs):
         pass
 
-    def can_read(self, timeout=0):
+    def can_read(self, timeout: float = 0) -> bool:
         return False
 
     def read_response(


### PR DESCRIPTION
## Summary

This PR replaces the async hiredis readiness probe with a non-destructive `can_read()` check that only inspects already-buffered parser/stream state or EOF. The previous implementation used `async_timeout(0)` around `StreamReader.read()`, which could create and immediately cancel a read waiter when no data was available.

That zero-timeout read path can interfere with tracing tools such as coverage.py: code after the readiness check may execute normally but still be reported as uncovered. 
The pure-Python async parser already avoided this shape; this brings the async hiredis parser in line with that behavior.

Since the logic inside `can_read_destructive()` is not destructive anymore it is deprecated in favor of `can_read()`, and connection-pool readiness checks now use the new method. 
The deprecated wrapper remains for compatibility.

Tests were added for the async hiredis parser to verify that `can_read()` detects hiredis-buffered responses, asyncio stream-buffered bytes, and EOF without calling `StreamReader.read()`.


**Important !!!** Users with custom async parser classes must implement can_read() instead of relying on can_read_destructive(), because connection readiness checks now use the non-destructive parser API directly.

Fixes #2912 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection pool health checks, hiredis parsing readiness, and client-cache invalidation paths; custom async parsers must add `can_read()`.
> 
> **Overview**
> Replaces async connection readiness checks with a **non-destructive** `can_read()` that only inspects hiredis/parser buffers, `StreamReader` backlog, or EOF—no zero-timeout `StreamReader.read()`, which could skew coverage tools and differ from the pure-Python async parser. **`can_read_destructive()` is deprecated (8.0)** and async pools/connections call `can_read()` instead; custom async parsers must implement it.
> 
> Sync **hiredis** readiness no longer caches partial parses in `can_read()`; it uses `Reader.has_data()`, **`select`** (plus SSL `pending()`), and aligns zero-timeout **would-block** behavior with **`TimeoutError`**. Client-tracking invalidation drains use **`read_response(..., timeout=0, disconnect_on_error=False)`** and stop on timeout. Tests cover buffer/EOF detection without consuming the stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d09db4d9783f16419c4eb6898c18cbc20cff3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->