### PR TITLE
fix: fix DeprecationWarning for `asyncio.iscoroutinefunction`

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -413,7 +413,7 @@ class AbstractConnection:
                 # Use the passed function redis_connect_func
                 (
                     await self.redis_connect_func(self)
-                    if asyncio.iscoroutinefunction(self.redis_connect_func)
+                    if inspect.iscoroutinefunction(self.redis_connect_func)
                     else self.redis_connect_func(self)
                 )
         except RedisError:

--- a/redis/asyncio/multidb/command_executor.py
+++ b/redis/asyncio/multidb/command_executor.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
-from asyncio import iscoroutinefunction
 from datetime import datetime
+from inspect import iscoroutinefunction
 from typing import Any, Awaitable, Callable, List, Optional, Union
 
 from redis.asyncio import RedisCluster


### PR DESCRIPTION
### Description of change
Small PR to handle deprecation in Python3.14

`asyncio.iscoroutinefunction` is deprecated in favor of `inspect.iscoroutinefunction`

<img width="847" height="176" alt="Screenshot from 2026-05-20 20-39-00" src="https://github.com/user-attachments/assets/c2c02d92-05cf-4425-9885-d43d6ffc095b" />


### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk deprecation fix that only changes coroutine-detection helpers without altering Redis command semantics.
> 
> **Overview**
> Updates async callback invocation logic to use `inspect.iscoroutinefunction` instead of the deprecated `asyncio.iscoroutinefunction`, covering both `redis_connect_func` handling in `redis/asyncio/connection.py` and pubsub method detection in `redis/asyncio/multidb/command_executor.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a11976c1f56e42399d3018bfa69023b5acbb89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->