### PR TITLE
Updating INCREX command arg - SATURATE now controls overflow behaviour

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.6.1'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.8:8.8-rc1
+    8.8:custom-26235535976-debian
 
 jobs:
   dependency-audit:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3403,7 +3403,7 @@ class BasicKeyCommands(CommandsProtocol):
         byint: EncodableT | None = None,
         lbound: EncodableT | None = None,
         ubound: EncodableT | None = None,
-        overflow: Literal["FAIL", "REJECT", "SAT"] | None = None,
+        saturate: bool = False,
         ex: ExpiryT | None = None,
         px: ExpiryT | None = None,
         exat: AbsExpiryT | None = None,
@@ -3421,7 +3421,7 @@ class BasicKeyCommands(CommandsProtocol):
         byint: EncodableT | None = None,
         lbound: EncodableT | None = None,
         ubound: EncodableT | None = None,
-        overflow: Literal["FAIL", "REJECT", "SAT"] | None = None,
+        saturate: bool = False,
         ex: ExpiryT | None = None,
         px: ExpiryT | None = None,
         exat: AbsExpiryT | None = None,
@@ -3438,7 +3438,7 @@ class BasicKeyCommands(CommandsProtocol):
         byint: EncodableT | None = None,
         lbound: EncodableT | None = None,
         ubound: EncodableT | None = None,
-        overflow: Literal["FAIL", "REJECT", "SAT"] | None = None,
+        saturate: bool = False,
         ex: ExpiryT | None = None,
         px: ExpiryT | None = None,
         exat: AbsExpiryT | None = None,
@@ -3459,8 +3459,11 @@ class BasicKeyCommands(CommandsProtocol):
 
         ``lbound`` and ``ubound`` constrain the valid range of the result.
 
-        ``overflow`` controls bound handling and can be ``FAIL``, ``REJECT``,
-        or ``SAT``.
+        If ``saturate`` is True, out-of-bounds results are saturated to the
+        specified bound, or to the type limit when no bound is specified.
+        Otherwise, out-of-bounds results are rejected, leaving the value and
+        TTL unchanged and returning the current value and zero as the actual
+        increment.
 
         ``enx`` applies the expiration only when the key does not already
         have an expiration, and requires ``ex``, ``px``, ``exat``, or ``pxat``.
@@ -3487,9 +3490,6 @@ class BasicKeyCommands(CommandsProtocol):
                 "and ``persist`` are mutually exclusive."
             )
 
-        if overflow is not None and overflow not in {"FAIL", "REJECT", "SAT"}:
-            raise DataError("INCREX overflow must be one of: FAIL, REJECT, SAT")
-
         if enx and ex is None and px is None and exat is None and pxat is None:
             raise DataError(
                 "``enx`` requires one of ``ex``, ``px``, ``exat``, or ``pxat``."
@@ -3506,8 +3506,8 @@ class BasicKeyCommands(CommandsProtocol):
             pieces.extend(("LBOUND", lbound))
         if ubound is not None:
             pieces.extend(("UBOUND", ubound))
-        if overflow is not None:
-            pieces.extend(("OVERFLOW", overflow))
+        if saturate:
+            pieces.append("SATURATE")
 
         pieces.extend(extract_expire_flags(ex, px, exat, pxat))
         if persist:

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -1728,17 +1728,19 @@ class TestRedisCommands:
     async def test_increx_saturating_bounds(self, r: redis.Redis):
         key = "increx:sat"
         assert await r.set(key, "1.8")
-        result = await r.increx(key, byfloat=0.7, ubound=2, overflow="SAT")
+        result = await r.increx(key, byfloat=0.7, ubound=2, saturate=True)
         assert [float(value) for value in result] == pytest.approx([2.0, 0.2])
         assert float(await r.get(key)) == pytest.approx(2.0)
 
     @skip_if_server_version_lt("8.7.0")
-    async def test_increx_fail_overflow_keeps_value(self, r: redis.Redis):
+    async def test_increx_overflow_rejected_keeps_value_and_ttl(self, r: redis.Redis):
         key = "increx:overflow"
         assert await r.set(key, 10)
-        with pytest.raises(ResponseError):
-            await r.increx(key, byint=5, ubound=12)
+        assert await r.expire(key, 60)
+        ttl = await r.pttl(key)
+        assert await r.increx(key, byint=5, ubound=12) == [10, 0]
         assert await r.get(key) == b"10"
+        assert 0 < await r.pttl(key) <= ttl
 
     @skip_if_server_version_lt("8.7.0")
     async def test_increx_expiration_enx(self, r: redis.Redis):
@@ -1760,8 +1762,6 @@ class TestRedisCommands:
             await r.increx(key, byfloat=1.0, byint=1)
         with pytest.raises(DataError):
             await r.increx(key, ex=10, px=10)
-        with pytest.raises(DataError):
-            await r.increx(key, overflow="WRAP")
         with pytest.raises(DataError):
             await r.increx(key, enx=True)
 

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -1167,12 +1167,9 @@ class TestPubSubRun:
 
         messages = asyncio.Queue()
         p = pubsub
+        # Establish the connection before run() so CI does not race startup.
+        await p.connect()
         task = asyncio.get_running_loop().create_task(p.run())
-        # Wait until run() has established the PubSub connection. A fixed sleep
-        # can race RESP3 handshakes on slower CI jobs.
-        async with async_timeout(1):
-            while p.connection is None or not p.connection.is_connected:
-                await asyncio.sleep(0)
         await p.subscribe(foo=callback)
         # wait tof the subscribe to finish.  Cannot use _subscribe() because
         # p.run() is already accepting messages

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2321,17 +2321,36 @@ class TestRedisCommands:
     def test_increx_saturating_bounds(self, r):
         key = "increx:sat"
         assert r.set(key, "1.8")
-        result = r.increx(key, byfloat=0.7, ubound=2, overflow="SAT")
+        result = r.increx(key, byfloat=0.7, ubound=2, saturate=True)
         assert [float(value) for value in result] == pytest.approx([2.0, 0.2])
         assert float(r[key]) == pytest.approx(2.0)
 
     @skip_if_server_version_lt("8.7.0")
-    def test_increx_fail_overflow_keeps_value(self, r):
+    def test_increx_overflow_rejected_keeps_value_and_ttl(self, r):
         key = "increx:overflow"
         assert r.set(key, 10)
-        with pytest.raises(ResponseError):
-            r.increx(key, byint=5, ubound=12)
+        assert r.expire(key, 60)
+        ttl = r.pttl(key)
+        assert r.increx(key, byint=5, ubound=12) == [10, 0]
         assert r[key] == b"10"
+        assert 0 < r.pttl(key) <= ttl
+
+    @skip_if_server_version_lt("8.7.0")
+    def test_increx_integer_overflow_uses_type_limits(self, r):
+        key = "increx:type-overflow"
+        max_int = 9223372036854775807
+        almost_max = max_int - 1
+
+        assert r.set(key, almost_max)
+        assert r.expire(key, 60)
+        ttl = r.pttl(key)
+        assert r.increx(key, byint=2) == [almost_max, 0]
+        assert r[key] == str(almost_max).encode()
+        assert 0 < r.pttl(key) <= ttl
+
+        assert r.set(key, almost_max)
+        assert r.increx(key, byint=2, saturate=True) == [max_int, 1]
+        assert r[key] == str(max_int).encode()
 
     @skip_if_server_version_lt("8.7.0")
     def test_increx_expiration_enx(self, r):
@@ -2353,8 +2372,6 @@ class TestRedisCommands:
             r.increx(key, byfloat=1.0, byint=1)
         with pytest.raises(DataError):
             r.increx(key, ex=10, px=10)
-        with pytest.raises(DataError):
-            r.increx(key, overflow="WRAP")
         with pytest.raises(DataError):
             r.increx(key, enx=True)
 


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API change on increx (breaking for overflow= callers) and different error vs return behavior on bound violations; otherwise test and CI wiring.
> 
> **Overview**
> **`increx`** is aligned with the updated Redis command: the **`overflow`** string option (`FAIL` / `REJECT` / `SAT`) is replaced by a boolean **`saturate`** that emits the **`SATURATE`** wire flag when true. Docs and validation for invalid overflow values are removed accordingly.
> 
> **Default out-of-bounds behavior** no longer raises **`ResponseError`** on the client; rejected increments return **`[current_value, 0]`** and leave the key (and TTL) unchanged. Tests were renamed/extended for that semantics, including integer type-limit cases with **`saturate=True`** on the sync path.
> 
> CI runs **Redis 8.8** against a **custom Debian image** instead of **`8.8-rc1`**. Async pub/sub **`test_late_subscribe`** calls **`connect()`** before **`run()`** to avoid a CI race instead of polling for connection readiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4a76493202a7ec3422aae6f188ce8f0a320306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->