### PR TITLE
Fix db.client.connection.count metric drifting over time

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -3056,11 +3056,7 @@ class BlockingConnectionPool(ConnectionPool):
         except asyncio.TimeoutError as err:
             raise ConnectionError("No connection available.") from err
 
-        # Record state transition for observability. This mirrors the base
-        # ConnectionPool.get_connection() and balances the USED -1 / IDLE +1
-        # recorded in release(); without it the counter drifts USED -1 / IDLE +1
-        # per acquire/release cycle. Recorded before ensure_connection() so the
-        # counters stay balanced if it fails and release() is called.
+        # Record state transition for observability.
         pool_name = get_pool_name(self)
         if is_created:
             # New connection created and acquired: just USED +1

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -3056,6 +3056,32 @@ class BlockingConnectionPool(ConnectionPool):
         except asyncio.TimeoutError as err:
             raise ConnectionError("No connection available.") from err
 
+        # Record state transition for observability. This mirrors the base
+        # ConnectionPool.get_connection() and balances the USED -1 / IDLE +1
+        # recorded in release(); without it the counter drifts USED -1 / IDLE +1
+        # per acquire/release cycle. Recorded before ensure_connection() so the
+        # counters stay balanced if it fails and release() is called.
+        pool_name = get_pool_name(self)
+        if is_created:
+            # New connection created and acquired: just USED +1
+            await record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.USED,
+                counter=1,
+            )
+        else:
+            # Existing connection acquired from pool: IDLE -> USED
+            await record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.IDLE,
+                counter=-1,
+            )
+            await record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.USED,
+                counter=1,
+            )
+
         # We now perform the connection check outside of the lock.
         try:
             await self.ensure_connection(connection)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3300,9 +3300,11 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
                     counter=1,
                 )
             else:
-                # Pool doesn't own this connection, do not add it back
-                # to the pool.
-                # Still need to decrement USED since it was counted in get_connection()
+                # Pool doesn't own this connection (e.g. it was inherited by a
+                # forked child). Do not add it back to the pool. Fork-time
+                # connection.count accounting is handled by reset()/__del__, so
+                # do not record here to avoid double-counting the inherited
+                # connections.
                 connection.disconnect()
                 # Subclasses such as SentinelConnectionPool can override
                 # owns_connection() with a comparison different from local PID
@@ -3310,12 +3312,6 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
                 # connection.pid == self.pid before reclaiming its slot.
                 if connection.pid == self.pid:
                     self._created_connections -= 1
-                pool_name = get_pool_name(self)
-                record_connection_count(
-                    pool_name=pool_name,
-                    connection_state=ConnectionState.USED,
-                    counter=-1,
-                )
                 return
 
     def owns_connection(self, connection: "Connection") -> int:
@@ -3713,15 +3709,11 @@ class BlockingConnectionPool(ConnectionPool):
                 # to the pool. instead add a None value which is a placeholder
                 # that will cause the pool to recreate the connection if
                 # its needed.
+                # Fork-time connection.count accounting is handled by
+                # reset()/__del__, so do not record here to avoid
+                # double-counting the inherited connections.
                 connection.disconnect()
                 self.pool.put_nowait(None)
-                # Still need to decrement USED since it was counted in get_connection()
-                pool_name = get_pool_name(self)
-                record_connection_count(
-                    pool_name=pool_name,
-                    connection_state=ConnectionState.USED,
-                    counter=-1,
-                )
                 return
             if connection.should_reconnect():
                 connection.disconnect()

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3181,20 +3181,28 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
                 is_created = True
             self._in_use_connections.add(connection)
 
-        # Record state transition: IDLE -> USED
-        # (make_connection already recorded IDLE +1 for new connections)
-        # This ensures counters stay balanced if connect() fails and release() is called
+        # Record state transition for observability
         pool_name = get_pool_name(self)
-        record_connection_count(
-            pool_name=pool_name,
-            connection_state=ConnectionState.IDLE,
-            counter=-1,
-        )
-        record_connection_count(
-            pool_name=pool_name,
-            connection_state=ConnectionState.USED,
-            counter=1,
-        )
+        if is_created:
+            # New connection created and acquired: just USED +1
+            # (connection was never idle in the pool)
+            record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.USED,
+                counter=1,
+            )
+        else:
+            # Existing connection acquired from pool: IDLE -> USED
+            record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.IDLE,
+                counter=-1,
+            )
+            record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.USED,
+                counter=1,
+            )
 
         try:
             # ensure this connection is connected to Redis
@@ -3258,13 +3266,6 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         else:
             connection = self.connection_class(**kwargs)
 
-        # Record new connection created (starts as IDLE) - only after successful construction
-        record_connection_count(
-            pool_name=get_pool_name(self),
-            connection_state=ConnectionState.IDLE,
-            counter=1,
-        )
-
         return connection
 
     def release(self, connection: "Connection") -> None:
@@ -3309,8 +3310,9 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
                 # connection.pid == self.pid before reclaiming its slot.
                 if connection.pid == self.pid:
                     self._created_connections -= 1
+                pool_name = get_pool_name(self)
                 record_connection_count(
-                    pool_name="unknown_pool",
+                    pool_name=pool_name,
                     connection_state=ConnectionState.USED,
                     counter=-1,
                 )
@@ -3573,13 +3575,6 @@ class BlockingConnectionPool(ConnectionPool):
                 connection = self.connection_class(**self.connection_kwargs)
             self._connections.append(connection)
 
-            # Record new connection created (starts as IDLE)
-            record_connection_count(
-                pool_name=get_pool_name(self),
-                connection_state=ConnectionState.IDLE,
-                counter=1,
-            )
-
             return connection
         finally:
             if self._locked:
@@ -3640,20 +3635,28 @@ class BlockingConnectionPool(ConnectionPool):
                     pass
                 self._locked = False
 
-        # Record state transition: IDLE -> USED
-        # (make_connection already recorded IDLE +1 for new connections)
-        # This ensures counters stay balanced if connect() fails and release() is called
+        # Record state transition for observability
         pool_name = get_pool_name(self)
-        record_connection_count(
-            pool_name=pool_name,
-            connection_state=ConnectionState.IDLE,
-            counter=-1,
-        )
-        record_connection_count(
-            pool_name=pool_name,
-            connection_state=ConnectionState.USED,
-            counter=1,
-        )
+        if is_created:
+            # New connection created and acquired: just USED +1
+            # (connection was never idle in the pool)
+            record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.USED,
+                counter=1,
+            )
+        else:
+            # Existing connection acquired from pool: IDLE -> USED
+            record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.IDLE,
+                counter=-1,
+            )
+            record_connection_count(
+                pool_name=pool_name,
+                connection_state=ConnectionState.USED,
+                counter=1,
+            )
 
         try:
             # ensure this connection is connected to Redis
@@ -3713,8 +3716,9 @@ class BlockingConnectionPool(ConnectionPool):
                 connection.disconnect()
                 self.pool.put_nowait(None)
                 # Still need to decrement USED since it was counted in get_connection()
+                pool_name = get_pool_name(self)
                 record_connection_count(
-                    pool_name="unknown_pool",
+                    pool_name=pool_name,
                     connection_state=ConnectionState.USED,
                     counter=-1,
                 )
@@ -3738,7 +3742,15 @@ class BlockingConnectionPool(ConnectionPool):
                     counter=1,
                 )
             except Full:
-                pass
+                # Connection can't go back to pool; discard it.
+                # Still need to decrement USED since it was counted in
+                # get_connection().
+                connection.disconnect()
+                record_connection_count(
+                    pool_name=pool_name,
+                    connection_state=ConnectionState.USED,
+                    counter=-1,
+                )
         finally:
             if self._locked:
                 try:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3743,9 +3743,15 @@ class BlockingConnectionPool(ConnectionPool):
                 )
             except Full:
                 # Connection can't go back to pool; discard it.
+                # Remove it from self._connections so that a later reset() or
+                # __del__ does not count it as in-use and decrement USED again.
+                try:
+                    self._connections.remove(connection)
+                except ValueError:
+                    pass
+                connection.disconnect()
                 # Still need to decrement USED since it was counted in
                 # get_connection().
-                connection.disconnect()
                 record_connection_count(
                     pool_name=pool_name,
                     connection_state=ConnectionState.USED,

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import socket
 import ssl
 import types
@@ -17,6 +18,7 @@ from redis._parsers import (
 from redis._parsers.hiredis import NOT_ENOUGH_DATA
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.connection import (
+    BlockingConnectionPool,
     Connection,
     SSLConnection,
     UnixDomainSocketConnection,
@@ -25,6 +27,7 @@ from redis.asyncio.connection import (
 from redis.asyncio.retry import Retry
 from redis.backoff import NoBackoff
 from redis.exceptions import ConnectionError, InvalidResponse, TimeoutError
+from redis.observability.attributes import ConnectionState, get_pool_name
 from redis.utils import HIREDIS_AVAILABLE
 from tests.conftest import skip_if_server_version_lt
 
@@ -872,3 +875,117 @@ async def test_disconnect_no_current_task_calls_close(request):
             mock_on_disconnect.assert_called_once()
 
     assert not conn.is_connected
+
+
+class _DummyAsyncConnection:
+    """Minimal async connection stub for pool metric tests (no real socket)."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.pid = os.getpid()
+        self._sock = None
+
+    async def connect(self):
+        self._sock = mock.MagicMock()
+
+    async def disconnect(self, *args, **kwargs):
+        self._sock = None
+
+    async def can_read(self, *args, **kwargs):
+        return False
+
+    def should_reconnect(self):
+        return False
+
+    def mark_for_reconnect(self):
+        pass
+
+    def set_re_auth_token(self, *args, **kwargs):
+        pass
+
+    async def re_auth(self, *args, **kwargs):
+        pass
+
+
+def _async_pool_metric_calls(mock_fn, pool_name):
+    """Extract (state, delta) tuples from record_connection_count calls for a pool."""
+    result = []
+    for c in mock_fn.call_args_list:
+        p = c.kwargs.get("pool_name", c.args[0] if c.args else None)
+        if p != pool_name:
+            continue
+        state = c.kwargs.get("connection_state", c.args[1] if len(c.args) > 1 else None)
+        counter = c.kwargs.get("counter", c.args[2] if len(c.args) > 2 else 1)
+        result.append((state, counter))
+    return result
+
+
+def _async_net(calls):
+    """Return (idle_net, used_net) from a list of (state, delta) tuples."""
+    idle = sum(d for s, d in calls if s == ConnectionState.IDLE)
+    used = sum(d for s, d in calls if s == ConnectionState.USED)
+    return idle, used
+
+
+class TestAsyncBlockingConnectionPoolMetricCount:
+    """db.client.connection.count accuracy for async BlockingConnectionPool.
+
+    get_connection() must record the acquire-side transition so it balances the
+    USED -1 / IDLE +1 recorded in release(). Without it, every acquire/release
+    cycle drifts USED -1 / IDLE +1 (regression: heavy async + Sentinel apps saw
+    the counter run to large -used / +idle values over time).
+    """
+
+    def _pool(self, max_connections=10):
+        return BlockingConnectionPool(
+            connection_class=_DummyAsyncConnection,
+            max_connections=max_connections,
+            timeout=0.1,
+        )
+
+    @patch("redis.asyncio.connection.record_connection_count")
+    async def test_new_connection_records_only_used(self, mock_rec):
+        pool = self._pool()
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = await pool.get_connection()
+
+        idle_net, used_net = _async_net(_async_pool_metric_calls(mock_rec, pn))
+        assert idle_net == 0, f"New conn should not touch IDLE, got {idle_net}"
+        assert used_net == 1
+        await pool.release(conn)
+
+    @patch("redis.asyncio.connection.record_connection_count")
+    async def test_reused_connection_transitions_idle_to_used(self, mock_rec):
+        pool = self._pool()
+        pn = get_pool_name(pool)
+        conn = await pool.get_connection()
+        await pool.release(conn)
+        mock_rec.reset_mock()
+
+        conn2 = await pool.get_connection()
+        assert conn2 is conn
+
+        idle_net, used_net = _async_net(_async_pool_metric_calls(mock_rec, pn))
+        assert idle_net == -1
+        assert used_net == 1
+        await pool.release(conn2)
+
+    @patch("redis.asyncio.connection.record_connection_count")
+    async def test_full_lifecycle_nets_to_zero(self, mock_rec):
+        """acquire -> release cycles must not drift the counter."""
+        pool = self._pool()
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        for _ in range(5):
+            conn = await pool.get_connection()
+            await pool.release(conn)
+
+        idle_net, used_net = _async_net(_async_pool_metric_calls(mock_rec, pn))
+        # reset()/__del__ record IDLE -len(available) for the idle connections
+        # still pooled; account for that so the whole lifecycle nets to zero.
+        idle_net -= len(pool._available_connections)
+        assert idle_net == 0, f"Lifecycle IDLE should net 0, got {idle_net}"
+        assert used_net == 0, f"Lifecycle USED should net 0, got {used_net}"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1742,9 +1742,7 @@ def _pool_metric_calls(mock_fn, pool_name):
         p = c.kwargs.get("pool_name", c.args[0] if c.args else None)
         if p != pool_name:
             continue
-        state = c.kwargs.get(
-            "connection_state", c.args[1] if len(c.args) > 1 else None
-        )
+        state = c.kwargs.get("connection_state", c.args[1] if len(c.args) > 1 else None)
         counter = c.kwargs.get("counter", c.args[2] if len(c.args) > 2 else 1)
         result.append((state, counter))
     return result
@@ -1824,24 +1822,20 @@ class TestConnectionPoolMetricCount:
         assert used_net == 0, f"Lifecycle USED should net 0, got {used_net}"
 
     @patch("redis.connection.record_connection_count")
-    def test_release_unowned_uses_real_pool_name(self, mock_rec):
-        """release() with owns_connection()=False must use the real pool name."""
+    def test_release_unowned_does_not_record(self, mock_rec):
+        """release() of a connection the pool no longer owns (e.g. inherited by
+        a forked child) must not record connection.count. Fork-time accounting
+        is owned by reset()/__del__; recording here would double-count."""
         pool = ConnectionPool(connection_class=_DummyConnection, max_connections=10)
-        pn = get_pool_name(pool)
-        mock_rec.reset_mock()
 
         conn = pool.get_connection()
         mock_rec.reset_mock()
-        conn.pid = -1  # simulate fork
+        conn.pid = -1  # simulate a connection inherited across a fork
         pool.release(conn)
 
-        used_decs = [
-            c for c in mock_rec.call_args_list
-            if c.kwargs.get("connection_state") == ConnectionState.USED
-            and c.kwargs.get("counter", 1) == -1
-        ]
-        assert len(used_decs) == 1
-        assert used_decs[0].kwargs["pool_name"] == pn
+        assert mock_rec.call_args_list == [], (
+            "unowned release must not record connection.count"
+        )
 
 
 class TestBlockingConnectionPoolMetricCount:
@@ -1849,7 +1843,9 @@ class TestBlockingConnectionPoolMetricCount:
 
     def _pool(self):
         return BlockingConnectionPool(
-            connection_class=_DummyConnection, max_connections=10, timeout=0.1,
+            connection_class=_DummyConnection,
+            max_connections=10,
+            timeout=0.1,
         )
 
     @patch("redis.connection.record_connection_count")
@@ -1870,7 +1866,9 @@ class TestBlockingConnectionPoolMetricCount:
     def test_release_full_queue_decrements_used(self, mock_rec):
         """When queue is full, release() must still decrement USED."""
         pool = BlockingConnectionPool(
-            connection_class=_DummyConnection, max_connections=1, timeout=0.1,
+            connection_class=_DummyConnection,
+            max_connections=1,
+            timeout=0.1,
         )
         pn = get_pool_name(pool)
         mock_rec.reset_mock()
@@ -1891,7 +1889,9 @@ class TestBlockingConnectionPoolMetricCount:
         """A connection dropped on a full queue must be removed from
         _connections so a later reset() does not decrement USED again."""
         pool = BlockingConnectionPool(
-            connection_class=_DummyConnection, max_connections=1, timeout=0.1,
+            connection_class=_DummyConnection,
+            max_connections=1,
+            timeout=0.1,
         )
         pn = get_pool_name(pool)
 
@@ -1911,9 +1911,10 @@ class TestBlockingConnectionPoolMetricCount:
         assert idle_net == 0, f"reset() must not touch IDLE, got {idle_net}"
 
     @patch("redis.connection.record_connection_count")
-    def test_release_unowned_uses_real_pool_name(self, mock_rec):
+    def test_release_unowned_does_not_record(self, mock_rec):
+        """Unowned (inherited-across-fork) release must not record; fork-time
+        accounting is owned by reset()/__del__."""
         pool = self._pool()
-        pn = get_pool_name(pool)
         mock_rec.reset_mock()
 
         conn = pool.get_connection()
@@ -1921,10 +1922,6 @@ class TestBlockingConnectionPoolMetricCount:
         conn.pid = -1
         pool.release(conn)
 
-        used_decs = [
-            c for c in mock_rec.call_args_list
-            if c.kwargs.get("connection_state") == ConnectionState.USED
-            and c.kwargs.get("counter", 1) == -1
-        ]
-        assert len(used_decs) == 1
-        assert used_decs[0].kwargs["pool_name"] == pn
+        assert mock_rec.call_args_list == [], (
+            "unowned release must not record connection.count"
+        )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1887,6 +1887,30 @@ class TestBlockingConnectionPoolMetricCount:
         assert idle_net == 0, f"IDLE must not increase for dropped conn, got {idle_net}"
 
     @patch("redis.connection.record_connection_count")
+    def test_release_full_queue_no_double_decrement_on_reset(self, mock_rec):
+        """A connection dropped on a full queue must be removed from
+        _connections so a later reset() does not decrement USED again."""
+        pool = BlockingConnectionPool(
+            connection_class=_DummyConnection, max_connections=1, timeout=0.1,
+        )
+        pn = get_pool_name(pool)
+
+        conn = pool.get_connection()
+        pool.pool.put_nowait(None)  # fill the queue
+        pool.release(conn)
+
+        # The dropped connection must no longer be tracked.
+        assert conn not in pool._connections
+
+        mock_rec.reset_mock()
+        pool.reset()
+
+        calls = _pool_metric_calls(mock_rec, pn)
+        idle_net, used_net = _net(calls)
+        assert used_net == 0, f"reset() must not decrement USED again, got {used_net}"
+        assert idle_net == 0, f"reset() must not touch IDLE, got {idle_net}"
+
+    @patch("redis.connection.record_connection_count")
     def test_release_unowned_uses_real_pool_name(self, mock_rec):
         pool = self._pool()
         pn = get_pool_name(pool)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -47,6 +47,7 @@ from redis.observability.attributes import (
     DB_CLIENT_CONNECTION_POOL_NAME,
     DB_CLIENT_CONNECTION_STATE,
     ConnectionState,
+    get_pool_name,
 )
 from redis.retry import Retry
 from redis.utils import HIREDIS_AVAILABLE, SENTINEL
@@ -1703,3 +1704,203 @@ class TestBlockingConnectionPoolGetConnectionCount:
         assert used_count == 0
 
         pool.disconnect()
+
+
+class _DummyConnection:
+    """Minimal connection stub for pool metric tests (no real socket)."""
+
+    description_format = "DummyConnection<>"
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.pid = os.getpid()
+        self._sock = None
+
+    def connect(self):
+        self._sock = MagicMock()
+
+    def disconnect(self):
+        self._sock = None
+
+    def can_read(self):
+        return False
+
+    def should_reconnect(self):
+        return False
+
+    def re_auth(self):
+        pass
+
+
+def _pool_metric_calls(mock_fn, pool_name):
+    """Extract (state, delta) tuples from record_connection_count calls for a pool.
+
+    Filters by pool_name to avoid interference from GC of other pools.
+    """
+    result = []
+    for c in mock_fn.call_args_list:
+        p = c.kwargs.get("pool_name", c.args[0] if c.args else None)
+        if p != pool_name:
+            continue
+        state = c.kwargs.get(
+            "connection_state", c.args[1] if len(c.args) > 1 else None
+        )
+        counter = c.kwargs.get("counter", c.args[2] if len(c.args) > 2 else 1)
+        result.append((state, counter))
+    return result
+
+
+def _net(calls):
+    """Return (idle_net, used_net) from a list of (state, delta) tuples."""
+    idle = sum(d for s, d in calls if s == ConnectionState.IDLE)
+    used = sum(d for s, d in calls if s == ConnectionState.USED)
+    return idle, used
+
+
+class TestConnectionPoolMetricCount:
+    """Tests for db.client.connection.count UpDownCounter accuracy.
+
+    Verifies that get_connection / release produce balanced IDLE and USED
+    counter updates across ConnectionPool and BlockingConnectionPool.
+    """
+
+    @patch("redis.connection.record_connection_count")
+    def test_new_connection_records_only_used(self, mock_rec):
+        """A new connection should record USED +1 only (never was idle)."""
+        pool = ConnectionPool(connection_class=_DummyConnection, max_connections=10)
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = pool.get_connection()
+
+        calls = _pool_metric_calls(mock_rec, pn)
+        idle_net, used_net = _net(calls)
+        assert idle_net == 0, f"New conn should not touch IDLE, got {idle_net}"
+        assert used_net == 1
+        pool.release(conn)
+
+    @patch("redis.connection.record_connection_count")
+    def test_reused_connection_transitions_idle_to_used(self, mock_rec):
+        """A reused connection should record IDLE -1, USED +1."""
+        pool = ConnectionPool(connection_class=_DummyConnection, max_connections=10)
+        pn = get_pool_name(pool)
+        conn = pool.get_connection()
+        pool.release(conn)
+        mock_rec.reset_mock()
+
+        conn2 = pool.get_connection()
+        assert conn2 is conn
+
+        calls = _pool_metric_calls(mock_rec, pn)
+        idle_net, used_net = _net(calls)
+        assert idle_net == -1
+        assert used_net == 1
+        pool.release(conn2)
+
+    @patch("redis.connection.record_connection_count")
+    def test_full_lifecycle_nets_to_zero(self, mock_rec):
+        """create -> use -> release -> reuse -> release -> destroy = net 0."""
+        pool = ConnectionPool(connection_class=_DummyConnection, max_connections=10)
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = pool.get_connection()
+        pool.release(conn)
+        conn = pool.get_connection()
+        pool.release(conn)
+
+        # Simulate destruction (what __del__ / reset does)
+        idle_count = len(pool._available_connections)
+        if idle_count:
+            mock_rec(
+                pool_name=pn,
+                connection_state=ConnectionState.IDLE,
+                counter=-idle_count,
+            )
+
+        calls = _pool_metric_calls(mock_rec, pn)
+        idle_net, used_net = _net(calls)
+        assert idle_net == 0, f"Lifecycle IDLE should net 0, got {idle_net}"
+        assert used_net == 0, f"Lifecycle USED should net 0, got {used_net}"
+
+    @patch("redis.connection.record_connection_count")
+    def test_release_unowned_uses_real_pool_name(self, mock_rec):
+        """release() with owns_connection()=False must use the real pool name."""
+        pool = ConnectionPool(connection_class=_DummyConnection, max_connections=10)
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = pool.get_connection()
+        mock_rec.reset_mock()
+        conn.pid = -1  # simulate fork
+        pool.release(conn)
+
+        used_decs = [
+            c for c in mock_rec.call_args_list
+            if c.kwargs.get("connection_state") == ConnectionState.USED
+            and c.kwargs.get("counter", 1) == -1
+        ]
+        assert len(used_decs) == 1
+        assert used_decs[0].kwargs["pool_name"] == pn
+
+
+class TestBlockingConnectionPoolMetricCount:
+    """Same metric-count tests for BlockingConnectionPool."""
+
+    def _pool(self):
+        return BlockingConnectionPool(
+            connection_class=_DummyConnection, max_connections=10, timeout=0.1,
+        )
+
+    @patch("redis.connection.record_connection_count")
+    def test_new_connection_records_only_used(self, mock_rec):
+        pool = self._pool()
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = pool.get_connection()
+
+        calls = _pool_metric_calls(mock_rec, pn)
+        idle_net, used_net = _net(calls)
+        assert idle_net == 0
+        assert used_net == 1
+        pool.release(conn)
+
+    @patch("redis.connection.record_connection_count")
+    def test_release_full_queue_decrements_used(self, mock_rec):
+        """When queue is full, release() must still decrement USED."""
+        pool = BlockingConnectionPool(
+            connection_class=_DummyConnection, max_connections=1, timeout=0.1,
+        )
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = pool.get_connection()
+        mock_rec.reset_mock()
+
+        pool.pool.put_nowait(None)  # fill the queue
+        pool.release(conn)
+
+        calls = _pool_metric_calls(mock_rec, pn)
+        idle_net, used_net = _net(calls)
+        assert used_net == -1, f"USED must be decremented, got {used_net}"
+        assert idle_net == 0, f"IDLE must not increase for dropped conn, got {idle_net}"
+
+    @patch("redis.connection.record_connection_count")
+    def test_release_unowned_uses_real_pool_name(self, mock_rec):
+        pool = self._pool()
+        pn = get_pool_name(pool)
+        mock_rec.reset_mock()
+
+        conn = pool.get_connection()
+        mock_rec.reset_mock()
+        conn.pid = -1
+        pool.release(conn)
+
+        used_decs = [
+            c for c in mock_rec.call_args_list
+            if c.kwargs.get("connection_state") == ConnectionState.USED
+            and c.kwargs.get("counter", 1) == -1
+        ]
+        assert len(used_decs) == 1
+        assert used_decs[0].kwargs["pool_name"] == pn


### PR DESCRIPTION
## Problem

The `db.client.connection.count` UpDownCounter drifts in long-running applications, producing nonsensical values like large positive idle / negative used connection counts that never recover.

## Root cause

The dominant cause is a one-sided recording in the **async** `BlockingConnectionPool`, plus three smaller `±1` accounting bugs in the sync pool.

### Bug 0 — async `BlockingConnectionPool` never records the acquire (the actual drift)

`redis/asyncio/connection.py` — `BlockingConnectionPool.get_connection()` overrides the base `ConnectionPool.get_connection()` but only records `create_time` / `wait_time`; it **never records the acquire-side `connection.count` transition**. Meanwhile `BlockingConnectionPool.release()` (via `super().release()`) still records `USED -1 / IDLE +1`.

So every acquire/release cycle nets `USED -1, IDLE +1`. Under sustained traffic this drifts linearly and never recovers — matching the reported "+N idle / -N used" shape. It affects any app on the async `BlockingConnectionPool`, including Sentinel deployments through `SentinelConnectionPool` + `BlockingConnectionPool` (e.g. a `BlockingSentinelConnectionPool(SentinelConnectionPool, BlockingConnectionPool)` whose `get_connection` resolves to the buggy override). No fork is required.

Reproduced with an in-memory OTel `MeterProvider`: 1000 balanced acquire/release cycles on the async `BlockingConnectionPool` yield `used=-1000, idle=+1000`, while the base async `ConnectionPool` correctly nets to zero.

### Bug 1 — Phantom IDLE transitions (sync)
`ConnectionPool.make_connection()` and `BlockingConnectionPool.make_connection()` recorded `IDLE +1` for new connections, then `get_connection()` unconditionally recorded `IDLE -1`. Balanced in isolation, but creates unnecessary IDLE transitions that drift if any step is disrupted. The async pool already avoids this with an `is_created` check.

### Bug 2 — Wrong pool name on unowned connections (sync)
`release()` recorded `USED -1` against the literal `"unknown_pool"` when `owns_connection()` returned `False` (e.g. after a fork). The real pool's USED counter was never decremented.

### Bug 3 — Full queue silent drop (sync)
`BlockingConnectionPool.release()` swallowed both the `USED -1` and `IDLE +1` recordings when `put_nowait()` raised `Full`. The USED counter leaked +1 permanently and the dropped connection was never disconnected.

## Fix

| Bug | Fix |
|-----|-----|
| Async BlockingConnectionPool (Bug 0) | Record the acquire transition in `get_connection()` — new connections record `USED +1`, reused connections record `IDLE -1, USED +1` — mirroring the base `ConnectionPool` so it balances `release()`. |
| Phantom IDLE | Remove `IDLE +1` from `make_connection()`, add `is_created` check in `get_connection()`. Matches the async pool. |
| Wrong pool name | Use `get_pool_name(self)` instead of `"unknown_pool"`. |
| Full queue drop | In `except Full`, disconnect the connection, remove it from `_connections`, and record `USED -1`. |

## Tests

- `tests/test_asyncio/test_connection.py::TestAsyncBlockingConnectionPoolMetricCount` — new/reused/full-lifecycle (net-zero) recording for the async `BlockingConnectionPool`. These fail before Bug 0's fix (idle drift) and pass after.
- Sync metric-count tests in `tests/test_connection.py` covering the three sync bugs across `ConnectionPool` and `BlockingConnectionPool`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability accounting and release edge cases (full queue, unowned connections) on core connection pools; behavior is test-backed but affects metrics operators rely on for capacity signals.
> 
> **Overview**
> Fixes **drift** in the `db.client.connection.count` UpDownCounter so IDLE/USED stay balanced under real pool traffic.
> 
> **Async `BlockingConnectionPool`** now records acquire-side metrics in `get_connection()` (new connections: `USED +1`; reused: `IDLE -1` / `USED +1`), matching `release()` and fixing linear drift (e.g. large negative USED / positive IDLE) seen on long-running async + Sentinel workloads.
> 
> **Sync pools** stop counting phantom IDLE on brand-new connections by removing `IDLE +1` from `make_connection()` and branching on `is_created` in `get_connection()`. **Unowned** connections (e.g. after fork) no longer emit `USED -1` on `release()`—fork cleanup stays in `reset()`/`__del__`. When **`BlockingConnectionPool.release()`** hits a full queue, the connection is disconnected, removed from `_connections`, and `USED -1` is recorded so metrics and later `reset()` do not double-decrement.
> 
> Adds **metric-count tests** for sync `ConnectionPool` / `BlockingConnectionPool` and async `BlockingConnectionPool`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625115b645c6f5bc6c499c03dc8e565371d40deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->