### PR TITLE
ci: least-privilege permissions on spellcheck (read) and stale-issues (job-level write for actions/stale)

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,9 @@
 name: spellcheck
 on:
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   check-spelling:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       issues: write          # required by actions/stale to label/close issues
       pull-requests: write   # required by actions/stale to label/close PRs
+      actions: write         # required by actions/stale@v10 for its cache state
     steps:
       # First step: Handle regular issues (excluding needs-information)
       - name: Mark regular issues as stale

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write          # required by actions/stale to label/close issues
+      pull-requests: write   # required by actions/stale to label/close PRs
     steps:
       # First step: Handle regular issues (excluding needs-information)
       - name: Mark regular issues as stale

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,6 +14,9 @@ env:
   NEEDS_INFO_DAYS_BEFORE_STALE: 30
   NEEDS_INFO_DAYS_BEFORE_CLOSE: 7
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,8 +14,7 @@ env:
   NEEDS_INFO_DAYS_BEFORE_STALE: 30
   NEEDS_INFO_DAYS_BEFORE_CLOSE: 7
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   stale:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level for two workflows, then re-grants the writes needed by `actions/stale` at the job level so behavior is unchanged.

**spellcheck.yml** - read-only, no GitHub API writes; workflow-level `contents: read` is sufficient.

**stale-issues.yml** - the `stale` job uses `actions/stale@v10`, which needs `issues: write` and `pull-requests: write` to label and close stale items. Re-granted at the job level only; the workflow default stays `contents: read`. (Thanks to @petyaslavova for catching the missing description and to the cursor review for flagging that the stale action would break without writes.)

Post-CVE-2025-30066 hardening pattern: declare a least-privilege default and elevate per job only where needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission changes; stale automation keeps the same writes via job-level grants.
> 
> **Overview**
> Tightens **GITHUB_TOKEN** scope on two CI workflows using a least-privilege default plus job-level grants where needed (same pattern as `release-drafter.yml`).
> 
> **`spellcheck.yml`** adds workflow-level `permissions: contents: read` only—checkout and the spelling action need no API writes.
> 
> **`stale-issues.yml`** sets workflow-level `permissions: {}` (no broad defaults) and gives the `stale` job `issues: write`, `pull-requests: write`, and `actions: write` so `actions/stale@v10` can still label/close issues and PRs and use its cache state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ceeca5a89682ef086ee8e2492fbb3ce97b11ffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->