### PR TITLE
Preserve explicit None for client metadata config

### DIFF
--- a/redis/_parsers/socket.py
+++ b/redis/_parsers/socket.py
@@ -5,7 +5,9 @@ from io import SEEK_END
 from typing import Optional, Union
 
 from ..exceptions import ConnectionError, TimeoutError
-from ..utils import SSL_AVAILABLE
+from ..utils import SENTINEL, SSL_AVAILABLE
+
+# Re-export SENTINEL from this historical location for compatibility.
 
 NONBLOCKING_EXCEPTION_ERROR_NUMBERS = {BlockingIOError: errno.EWOULDBLOCK}
 
@@ -21,7 +23,6 @@ if SSL_AVAILABLE:
 NONBLOCKING_EXCEPTIONS = tuple(NONBLOCKING_EXCEPTION_ERROR_NUMBERS.keys())
 
 SERVER_CLOSED_CONNECTION_ERROR = "Connection closed by server."
-SENTINEL = object()
 
 SYM_CRLF = b"\r\n"
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -75,6 +75,7 @@ from redis.exceptions import (
 from redis.observability.attributes import PubSubDirection
 from redis.typing import ChannelT, EncodableT, KeyT, PubSubHandler, Subscription
 from redis.utils import (
+    SENTINEL,
     SSL_AVAILABLE,
     _set_info_logger,
     deprecated_args,
@@ -264,9 +265,9 @@ class Redis(
         single_connection_client: bool = False,
         health_check_interval: int = 0,
         client_name: Optional[str] = None,
-        lib_name: Optional[str] = None,
-        lib_version: Optional[str] = None,
-        driver_info: Optional["DriverInfo"] = None,
+        lib_name: Union[Optional[str], object] = SENTINEL,
+        lib_version: Union[Optional[str], object] = SENTINEL,
+        driver_info: Union[Optional["DriverInfo"], object] = SENTINEL,
         username: Optional[str] = None,
         auto_close_connection_pool: Optional[bool] = None,
         redis_connect_func=None,
@@ -321,7 +322,7 @@ class Redis(
             if not retry_on_error:
                 retry_on_error = []
 
-            # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version
+            # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version.
             computed_driver_info = resolve_driver_info(
                 driver_info, lib_name, lib_version
             )

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -112,6 +112,7 @@ from redis.typing import (
     Subscription,
 )
 from redis.utils import (
+    SENTINEL,
     SSL_AVAILABLE,
     deprecated_args,
     deprecated_function,
@@ -328,9 +329,9 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         username: Optional[str] = None,
         password: Optional[str] = None,
         client_name: Optional[str] = None,
-        lib_name: Optional[str] = None,
-        lib_version: Optional[str] = None,
-        driver_info: Optional["DriverInfo"] = None,
+        lib_name: Union[Optional[str], object] = SENTINEL,
+        lib_version: Union[Optional[str], object] = SENTINEL,
+        driver_info: Union[Optional["DriverInfo"], object] = SENTINEL,
         # Encoding related kwargs
         encoding: str = "utf-8",
         encoding_errors: str = "strict",

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -79,7 +79,14 @@ from redis.exceptions import (
 )
 from redis.observability.metrics import CloseReason
 from redis.typing import EncodableT
-from redis.utils import DEFAULT_RESP_VERSION, HIREDIS_AVAILABLE, str_if_bytes
+from redis.utils import (
+    DEFAULT_RESP_VERSION,
+    HIREDIS_AVAILABLE,
+    str_if_bytes,
+)
+from redis.utils import (
+    SENTINEL as DEFAULT_SENTINEL,
+)
 
 from .._parsers import (
     BaseParser,
@@ -174,9 +181,9 @@ class AbstractConnection:
         socket_read_size: int = 65536,
         health_check_interval: float = 0,
         client_name: Optional[str] = None,
-        lib_name: Optional[str] = None,
-        lib_version: Optional[str] = None,
-        driver_info: Optional[DriverInfo] = None,
+        lib_name: Union[Optional[str], object] = DEFAULT_SENTINEL,
+        lib_version: Union[Optional[str], object] = DEFAULT_SENTINEL,
+        driver_info: Union[Optional[DriverInfo], object] = DEFAULT_SENTINEL,
         username: Optional[str] = None,
         retry: Optional[Retry] = None,
         redis_connect_func: Optional[ConnectCallbackT] = None,
@@ -194,7 +201,7 @@ class AbstractConnection:
         driver_info : DriverInfo, optional
             Driver metadata for CLIENT SETINFO. If provided, lib_name and lib_version
             are ignored. If not provided, a DriverInfo will be created from lib_name
-            and lib_version (or defaults if those are also None).
+            and lib_version. Explicit None disables CLIENT SETINFO.
         lib_name : str, optional
             **Deprecated.** Use driver_info instead. Library name for CLIENT SETINFO.
         lib_version : str, optional
@@ -214,7 +221,7 @@ class AbstractConnection:
         self.db = db
         self.client_name = client_name
 
-        # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version
+        # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version.
         self.driver_info = resolve_driver_info(driver_info, lib_name, lib_version)
 
         self.credential_provider = credential_provider

--- a/redis/client.py
+++ b/redis/client.py
@@ -20,7 +20,6 @@ from typing import (
 
 from redis._parsers.encoders import Encoder
 from redis._parsers.helpers import bool_ok, get_response_callbacks
-from redis._parsers.socket import SENTINEL
 from redis.backoff import ExponentialWithJitterBackoff
 from redis.cache import CacheConfig, CacheInterface
 from redis.commands import (
@@ -69,6 +68,7 @@ from redis.observability.recorder import (
 from redis.retry import Retry
 from redis.typing import ChannelT, PubSubHandler, Subscription
 from redis.utils import (
+    SENTINEL,
     _set_info_logger,
     check_protocol_version,
     deprecated_args,
@@ -272,9 +272,9 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         single_connection_client: bool = False,
         health_check_interval: int = 0,
         client_name: Optional[str] = None,
-        lib_name: Optional[str] = None,
-        lib_version: Optional[str] = None,
-        driver_info: Optional["DriverInfo"] = None,
+        lib_name: Union[Optional[str], object] = SENTINEL,
+        lib_version: Union[Optional[str], object] = SENTINEL,
+        driver_info: Union[Optional["DriverInfo"], object] = SENTINEL,
         username: Optional[str] = None,
         redis_connect_func: Optional[Callable[[], None]] = None,
         credential_provider: Optional[CredentialProvider] = None,
@@ -321,6 +321,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             Optional DriverInfo object to identify upstream libraries.
             If provided, lib_name and lib_version are ignored.
             If not provided, a DriverInfo will be created from lib_name and lib_version.
+            Explicit None disables CLIENT SETINFO.
             Argument is ignored when connection_pool is provided.
         lib_name:
             **Deprecated.** Use driver_info instead. Library name for CLIENT SETINFO.
@@ -348,7 +349,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             if not retry_on_error:
                 retry_on_error = []
 
-            # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version
+            # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version.
             computed_driver_info = resolve_driver_info(
                 driver_info, lib_name, lib_version
             )

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -272,6 +272,7 @@ REDIS_ALLOWED_KEYS = (
     "encoding",
     "encoding_errors",
     "host",
+    "driver_info",
     "lib_name",
     "lib_version",
     "max_connections",

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -33,7 +33,6 @@ from redis.cache import (
 )
 
 from ._parsers import Encoder, _HiredisParser, _RESP2Parser, _RESP3Parser
-from ._parsers.socket import SENTINEL
 from .auth.token import TokenInterface
 from .backoff import NoBackoff
 from .credentials import CredentialProvider, UsernamePasswordCredentialProvider
@@ -84,6 +83,7 @@ from .utils import (
     CRYPTOGRAPHY_AVAILABLE,
     DEFAULT_RESP_VERSION,
     HIREDIS_AVAILABLE,
+    SENTINEL,
     SSL_AVAILABLE,
     check_protocol_version,
     compare_versions,
@@ -795,9 +795,9 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         socket_read_size: int = 65536,
         health_check_interval: int = 0,
         client_name: Optional[str] = None,
-        lib_name: Optional[str] = None,
-        lib_version: Optional[str] = None,
-        driver_info: Optional[DriverInfo] = None,
+        lib_name: Union[Optional[str], object] = SENTINEL,
+        lib_version: Union[Optional[str], object] = SENTINEL,
+        driver_info: Union[Optional[DriverInfo], object] = SENTINEL,
         username: Optional[str] = None,
         retry: Union[Any, None] = None,
         redis_connect_func: Optional[Callable[[], None]] = None,
@@ -832,7 +832,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         driver_info : DriverInfo, optional
             Driver metadata for CLIENT SETINFO. If provided, lib_name and lib_version
             are ignored. If not provided, a DriverInfo will be created from lib_name
-            and lib_version (or defaults if those are also None).
+            and lib_version. Explicit None disables CLIENT SETINFO.
         lib_name : str, optional
             **Deprecated.** Use driver_info instead. Library name for CLIENT SETINFO.
         lib_version : str, optional
@@ -853,7 +853,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         self.db = db
         self.client_name = client_name
 
-        # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version
+        # Handle driver_info: if provided, use it; otherwise create from lib_name/lib_version.
         self.driver_info = resolve_driver_info(driver_info, lib_name, lib_version)
 
         self.credential_provider = credential_provider

--- a/redis/driver_info.py
+++ b/redis/driver_info.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from redis.utils import SENTINEL
+
 _BRACES = {"(", ")", "[", "]", "{", "}"}
 
 
@@ -66,10 +68,11 @@ class DriverInfo:
     Parameters
     ----------
     name : str, optional
-        The base library name (default: "redis-py")
+        The base library name. If omitted, defaults to "redis-py". If None,
+        LIB-NAME will not be sent.
     lib_version : str, optional
-        The redis-py library version. If None, the version will be determined
-        automatically from the installed package.
+        The redis-py library version. If omitted, the version will be determined
+        automatically from the installed package. If None, LIB-VER will not be sent.
 
     Examples
     --------
@@ -86,13 +89,15 @@ class DriverInfo:
     '5.0.0'
     """
 
-    name: str = "redis-py"
-    lib_version: Optional[str] = None
+    name: Optional[str] | object = SENTINEL
+    lib_version: Optional[str] | object = SENTINEL
     _upstream: List[str] = field(default_factory=list)
 
     def __post_init__(self):
-        """Initialize lib_version if not provided."""
-        if self.lib_version is None:
+        """Initialize default metadata if not explicitly provided."""
+        if self.name is SENTINEL:
+            self.name = "redis-py"
+        if self.lib_version is SENTINEL:
             from redis.utils import get_lib_version
 
             self.lib_version = get_lib_version()
@@ -128,7 +133,7 @@ class DriverInfo:
         return self
 
     @property
-    def formatted_name(self) -> str:
+    def formatted_name(self) -> Optional[str]:
         """Return the base name with upstream drivers encoded, if any.
 
         With no upstream drivers, this is just :pyattr:`name`. Otherwise::
@@ -136,20 +141,23 @@ class DriverInfo:
             name(driver1_vX;driver2_vY)
         """
 
+        name = self.name
+        if not isinstance(name, str) or not name:
+            return None
         if not self._upstream:
-            return self.name
-        return f"{self.name}({';'.join(self._upstream)})"
+            return name
+        return f"{name}({';'.join(self._upstream)})"
 
 
 def resolve_driver_info(
-    driver_info: Optional[DriverInfo],
-    lib_name: Optional[str],
-    lib_version: Optional[str],
-) -> DriverInfo:
+    driver_info: Optional[DriverInfo] | object = SENTINEL,
+    lib_name: Optional[str] | object = SENTINEL,
+    lib_version: Optional[str] | object = SENTINEL,
+) -> Optional[DriverInfo]:
     """Resolve driver_info from parameters.
 
     If driver_info is provided, use it. Otherwise, create DriverInfo from
-    lib_name and lib_version (using defaults if not provided).
+    lib_name and lib_version (using defaults only for sentinel values).
 
     Parameters
     ----------
@@ -162,15 +170,15 @@ def resolve_driver_info(
 
     Returns
     -------
-    DriverInfo
+    DriverInfo, optional
         The resolved DriverInfo instance
     """
-    if driver_info is not None:
+    if driver_info is SENTINEL:
+        if lib_name is None and lib_version is None:
+            return None
+        return DriverInfo(name=lib_name, lib_version=lib_version)
+
+    if driver_info is None or isinstance(driver_info, DriverInfo):
         return driver_info
 
-    # Fallback: create DriverInfo from lib_name and lib_version
-    from redis.utils import get_lib_version
-
-    name = lib_name if lib_name is not None else "redis-py"
-    version = lib_version if lib_version is not None else get_lib_version()
-    return DriverInfo(name=name, lib_version=version)
+    raise TypeError("driver_info must be a DriverInfo instance or None")

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -43,6 +43,9 @@ except ImportError:
 
 from importlib import metadata
 
+# Marker for omitted arguments. Compare by identity only.
+SENTINEL = object()
+
 
 def from_url(url: str, **kwargs: Any) -> "Redis":
     """

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -29,6 +29,35 @@ from tests.conftest import skip_if_server_version_lt
 from .mocks import MockStream
 
 
+@pytest.mark.fixed_client
+@pytest.mark.parametrize(
+    "client_kwargs",
+    [
+        {"driver_info": None},
+        {"lib_name": None, "lib_version": None},
+    ],
+)
+async def test_redis_client_preserves_explicit_none_driver_info(client_kwargs):
+    if "lib_name" in client_kwargs:
+        with pytest.warns(DeprecationWarning):
+            client = Redis(**client_kwargs)
+    else:
+        client = Redis(**client_kwargs)
+
+    assert client.connection_pool.connection_kwargs["driver_info"] is None
+    await client.aclose()
+
+
+@pytest.mark.fixed_client
+async def test_redis_client_default_driver_info():
+    client = Redis()
+    driver_info = client.connection_pool.connection_kwargs["driver_info"]
+
+    assert driver_info.formatted_name == "redis-py"
+    assert driver_info.lib_version is not None
+    await client.aclose()
+
+
 def test_connection_default_parser_matches_default_protocol():
     conn = Connection()
     expected_parser_class = (
@@ -56,6 +85,31 @@ def test_connection_parser_matches_protocol(
         kwargs["protocol"] = protocol
     conn = Connection(**kwargs)
     assert isinstance(conn._parser, expected_parser_class)
+
+
+@pytest.mark.fixed_client
+@pytest.mark.parametrize(
+    "connection_kwargs",
+    [
+        {"driver_info": None},
+        {"lib_name": None, "lib_version": None},
+    ],
+)
+async def test_client_setinfo_skipped_with_explicit_none(connection_kwargs):
+    if "lib_name" in connection_kwargs:
+        with pytest.warns(DeprecationWarning):
+            conn = Connection(protocol=2, **connection_kwargs)
+    else:
+        conn = Connection(protocol=2, **connection_kwargs)
+    conn._parser.on_connect = mock.Mock()
+    conn.send_command = mock.AsyncMock()
+    conn.read_response = mock.AsyncMock(return_value="OK")
+
+    await conn.on_connect_check_health()
+
+    assert conn.driver_info is None
+    conn.send_command.assert_not_awaited()
+    conn.read_response.assert_not_awaited()
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -154,7 +154,7 @@ async def test_async_hiredis_can_read_leaves_decoding_to_read_response():
     assert await parser.can_read() is True
     assert await parser.read_response() == raw.decode()
 
-    
+
 @pytest.mark.parametrize("parser_class", [_AsyncRESP2Parser, _AsyncRESP3Parser])
 async def test_async_resp_can_read_detects_stream_buffer(parser_class):
     stream = DummyAsyncStream(buffer=b"+OK\r\n")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -49,6 +49,35 @@ from .conftest import skip_if_server_version_lt
 from .mocks import MockSocket
 
 
+@pytest.mark.fixed_client
+@pytest.mark.parametrize(
+    "client_kwargs",
+    [
+        {"driver_info": None},
+        {"lib_name": None, "lib_version": None},
+    ],
+)
+def test_redis_client_preserves_explicit_none_driver_info(client_kwargs):
+    if "lib_name" in client_kwargs:
+        with pytest.warns(DeprecationWarning):
+            client = Redis(**client_kwargs)
+    else:
+        client = Redis(**client_kwargs)
+
+    assert client.connection_pool.connection_kwargs["driver_info"] is None
+    client.close()
+
+
+@pytest.mark.fixed_client
+def test_redis_client_default_driver_info():
+    client = Redis()
+    driver_info = client.connection_pool.connection_kwargs["driver_info"]
+
+    assert driver_info.formatted_name == "redis-py"
+    assert driver_info.lib_version is not None
+    client.close()
+
+
 @pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 @pytest.mark.onlynoncluster
 def test_invalid_response(r):
@@ -113,6 +142,29 @@ class TestConnection:
         mock_sock.shutdown.assert_called_once()
         mock_sock.close.assert_called_once()
         assert conn._sock is None
+
+    @pytest.mark.parametrize(
+        "connection_kwargs",
+        [
+            {"driver_info": None},
+            {"lib_name": None, "lib_version": None},
+        ],
+    )
+    def test_client_setinfo_skipped_with_explicit_none(self, connection_kwargs):
+        if "lib_name" in connection_kwargs:
+            with pytest.warns(DeprecationWarning):
+                conn = Connection(protocol=2, **connection_kwargs)
+        else:
+            conn = Connection(protocol=2, **connection_kwargs)
+        conn._parser.on_connect = mock.Mock()
+        conn.send_command = mock.Mock()
+        conn.read_response = mock.Mock(return_value="OK")
+
+        conn.on_connect_check_health()
+
+        assert conn.driver_info is None
+        conn.send_command.assert_not_called()
+        conn.read_response.assert_not_called()
 
     def clear(self, conn):
         conn.retry_on_error.clear()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -244,6 +244,7 @@ def test_redis_client_default_driver_info():
     assert driver_info.lib_version is not None
     client.close()
 
+
 @pytest.mark.fixed_client
 class TestConnection:
     def test_disconnect(self):

--- a/tests/test_driver_info.py
+++ b/tests/test_driver_info.py
@@ -1,7 +1,8 @@
 import pytest
 
-from redis.driver_info import DriverInfo
-from redis.utils import get_lib_version
+from redis._parsers.socket import SENTINEL as PARSER_SENTINEL
+from redis.driver_info import DriverInfo, resolve_driver_info
+from redis.utils import SENTINEL, get_lib_version
 
 
 @pytest.mark.fixed_client
@@ -17,6 +18,50 @@ def test_driver_info_custom_lib_version():
     info = DriverInfo(lib_version="5.0.0")
     assert info.lib_version == "5.0.0"
     assert info.formatted_name == "redis-py"
+
+
+@pytest.mark.fixed_client
+def test_driver_info_explicit_none_values_are_preserved():
+    info = DriverInfo(name=None, lib_version=None)
+    assert info.formatted_name is None
+    assert info.lib_version is None
+
+
+@pytest.mark.fixed_client
+def test_resolve_driver_info_default_values():
+    info = resolve_driver_info()
+    assert info.formatted_name == "redis-py"
+    assert info.lib_version == get_lib_version()
+
+
+@pytest.mark.fixed_client
+def test_parser_sentinel_uses_shared_sentinel():
+    assert PARSER_SENTINEL is SENTINEL
+
+
+@pytest.mark.fixed_client
+@pytest.mark.parametrize(
+    ("driver_info", "lib_name", "lib_version"),
+    [
+        (None, SENTINEL, SENTINEL),
+        (SENTINEL, None, None),
+    ],
+)
+def test_resolve_driver_info_explicit_none_skips_config(
+    driver_info, lib_name, lib_version
+):
+    assert resolve_driver_info(driver_info, lib_name, lib_version) is None
+
+
+@pytest.mark.fixed_client
+def test_resolve_driver_info_explicit_none_values_are_individual():
+    info = resolve_driver_info(lib_name=None)
+    assert info.formatted_name is None
+    assert info.lib_version == get_lib_version()
+
+    info = resolve_driver_info(lib_version=None)
+    assert info.formatted_name == "redis-py"
+    assert info.lib_version is None
 
 
 @pytest.mark.fixed_client


### PR DESCRIPTION

Commit d411a475 introduced `DriverInfo` for CLIENT SETINFO metadata, but it also made omitted metadata values indistinguishable from values explicitly set to `None`. That meant users could no longer pass `None` to disable client metadata setup, because `None` was resolved into the default redis-py name/version before connection setup.

This change introduces a shared `SENTINEL` marker for omitted arguments and uses it for `driver_info`, `lib_name`, and `lib_version` across sync, async, and cluster client paths. Omitted values still resolve to the previous defaults (`redis-py` and the installed redis-py version), while explicit `None` is preserved. When `driver_info=None`, or both legacy metadata values are explicitly `None`, the resolved config remains `None` so `CLIENT SETINFO` is skipped.

The shared sentinel lives in `redis.utils`, and `redis._parsers.socket.SENTINEL` now re-exports the same object to preserve compatibility with existing internal/library imports from the older path. Sync cluster kwargs were also updated to allow `driver_info` through the existing cleanup path.

Tests were added for default resolution, explicit `None` behavior, shared sentinel compatibility, client-level propagation, and sync/async connection handshakes that should skip CLIENT SETINFO when metadata is disabled. 





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to client metadata resolution and connection handshake SETINFO; defaults for omitted args stay the same, with tests covering explicit None and skip paths.
> 
> **Overview**
> Introduces a shared **`SENTINEL`** marker in `redis.utils` (re-exported from `redis._parsers.socket` for compatibility) so **omitted** `driver_info` / `lib_name` / `lib_version` arguments are distinct from **explicit `None`**.
> 
> Sync, async, cluster, and connection constructors now default those parameters to `SENTINEL` instead of `None`. **`resolve_driver_info`** and **`DriverInfo`** only apply the usual `redis-py` defaults when values are omitted; explicit `None` is preserved so **`CLIENT SETINFO` is skipped** on connect. Cluster client kwargs were updated to pass **`driver_info`** through the existing cleanup path.
> 
> Tests cover default resolution, explicit-`None` propagation, sentinel identity, and sync/async handshakes that must not send SETINFO when metadata is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a6010eb77d68786f52199f65aacbc9c943c2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->