### PR TITLE
security: add optional key parameter to JWToken for signature verification

### DIFF
--- a/redis/auth/token.py
+++ b/redis/auth/token.py
@@ -78,7 +78,7 @@ class SimpleToken(TokenInterface):
 class JWToken(TokenInterface):
     REQUIRED_FIELDS = {"exp"}
 
-    def __init__(self, token: str):
+    def __init__(self, token: str, key: str = None, algorithms: list = None):
         try:
             import jwt
         except ImportError as ie:
@@ -86,11 +86,24 @@ class JWToken(TokenInterface):
                 f"The PyJWT library is required for {self.__class__.__name__}.",
             ) from ie
         self._value = token
-        self._decoded = jwt.decode(
-            self._value,
-            options={"verify_signature": False},
-            algorithms=[jwt.get_unverified_header(self._value).get("alg")],
-        )
+        if key is not None:
+            if algorithms is None:
+                algorithms = ["HS256"]
+            self._decoded = jwt.decode(
+                self._value,
+                key,
+                algorithms=algorithms,
+                options={"verify_exp": False},
+            )
+        else:
+            if algorithms is None:
+                header = jwt.get_unverified_header(self._value)
+                algorithms = [header["alg"]]
+            self._decoded = jwt.decode(
+                self._value,
+                options={"verify_signature": False, "verify_exp": False},
+                algorithms=algorithms,
+            )
         self._validate_token()
 
     def is_expired(self) -> bool:

--- a/redis/auth/token.py
+++ b/redis/auth/token.py
@@ -93,7 +93,7 @@ class JWToken(TokenInterface):
                 self._value,
                 key,
                 algorithms=algorithms,
-                options={"verify_exp": False},
+                options={"verify_exp": False, "verify_aud": False, "verify_nbf": False},
             )
         else:
             if algorithms is None:

--- a/redis/auth/token.py
+++ b/redis/auth/token.py
@@ -78,7 +78,28 @@ class SimpleToken(TokenInterface):
 class JWToken(TokenInterface):
     REQUIRED_FIELDS = {"exp"}
 
-    def __init__(self, token: str, key: str = None, algorithms: list = None):
+    def __init__(
+        self, token: str, key: str | None = None, algorithms: list[str] | None = None
+    ):
+        """Initialize a JWT token wrapper.
+
+        Args:
+            token: The encoded JWT string.
+            key: The secret key to verify the token signature. If None,
+                signature verification is skipped (backward compatibility).
+            algorithms: A list of allowed algorithms. Required when key is
+                provided.
+
+        Raises:
+            ImportError: If the PyJWT library is not installed.
+            ValueError: If key is provided but algorithms is None.
+            InvalidTokenSchemaErr: If required fields are missing.
+
+        Note:
+            The old unsafe initialization path (key=None) is still available
+            for backward compatibility. It disables signature verification
+            but still validates the token expiration.
+        """
         try:
             import jwt
         except ImportError as ie:
@@ -88,12 +109,14 @@ class JWToken(TokenInterface):
         self._value = token
         if key is not None:
             if algorithms is None:
-                algorithms = ["HS256"]
+                raise ValueError(
+                    "algorithms must be provided when key is specified"
+                )
             self._decoded = jwt.decode(
                 self._value,
                 key,
                 algorithms=algorithms,
-                options={"verify_exp": False, "verify_aud": False, "verify_nbf": False},
+                options={"verify_aud": False, "verify_nbf": False},
             )
         else:
             if algorithms is None:
@@ -101,7 +124,7 @@ class JWToken(TokenInterface):
                 algorithms = [header["alg"]]
             self._decoded = jwt.decode(
                 self._value,
-                options={"verify_signature": False, "verify_exp": False},
+                options={"verify_signature": False},
                 algorithms=algorithms,
             )
         self._validate_token()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -755,15 +755,6 @@ def mock_identity_provider() -> IdentityProviderInterface:
     return mock_provider
 
 
-def mock_identity_provider_unsafe() -> IdentityProviderInterface:
-    jwt = pytest.importorskip("jwt")
-    mock_provider = Mock(spec=IdentityProviderInterface)
-    token = {"exp": datetime.now(timezone.utc).timestamp() + 3600, "oid": "username"}
-    encoded = jwt.encode(token, "secret", algorithm="HS256")
-    jwt_token = JWToken(encoded)
-    mock_provider.request_token.return_value = jwt_token
-    return mock_provider
-
 
 def get_credential_provider(request) -> CredentialProvider:
     cred_provider_class = request.param.get("cred_provider_class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -755,6 +755,16 @@ def mock_identity_provider() -> IdentityProviderInterface:
     return mock_provider
 
 
+def mock_identity_provider_unsafe() -> IdentityProviderInterface:
+    jwt = pytest.importorskip("jwt")
+    mock_provider = Mock(spec=IdentityProviderInterface)
+    token = {"exp": datetime.now(timezone.utc).timestamp() + 3600, "oid": "username"}
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded)
+    mock_provider.request_token.return_value = jwt_token
+    return mock_provider
+
+
 def get_credential_provider(request) -> CredentialProvider:
     cred_provider_class = request.param.get("cred_provider_class")
     cred_provider_kwargs = request.param.get("cred_provider_kwargs", {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -755,6 +755,16 @@ def mock_identity_provider() -> IdentityProviderInterface:
     return mock_provider
 
 
+def mock_identity_provider_legacy() -> IdentityProviderInterface:
+    jwt = pytest.importorskip("jwt")
+    mock_provider = Mock(spec=IdentityProviderInterface)
+    token = {"exp": datetime.now(timezone.utc).timestamp() + 3600, "oid": "username"}
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded)
+    mock_provider.request_token.return_value = jwt_token
+    return mock_provider
+
+
 
 def get_credential_provider(request) -> CredentialProvider:
     cred_provider_class = request.param.get("cred_provider_class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -750,7 +750,7 @@ def mock_identity_provider() -> IdentityProviderInterface:
     mock_provider = Mock(spec=IdentityProviderInterface)
     token = {"exp": datetime.now(timezone.utc).timestamp() + 3600, "oid": "username"}
     encoded = jwt.encode(token, "secret", algorithm="HS256")
-    jwt_token = JWToken(encoded)
+    jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
     mock_provider.request_token.return_value = jwt_token
     return mock_provider
 

--- a/tests/entraid_utils.py
+++ b/tests/entraid_utils.py
@@ -22,7 +22,7 @@ from redis_entraid.identity_provider import (
     DefaultAzureCredentialIdentityProviderConfig,
     _create_provider_from_default_azure_credential,
 )
-from tests.conftest import mock_identity_provider
+from tests.conftest import mock_identity_provider, mock_identity_provider_legacy
 
 
 class AuthType(Enum):
@@ -37,7 +37,10 @@ def identity_provider(request) -> IdentityProviderInterface:
     else:
         kwargs = {}
 
-    if request.param.get("mock_idp", None) is not None:
+    mock_idp = request.param.get("mock_idp", None)
+    if mock_idp is not None:
+        if mock_idp == "legacy":
+            return mock_identity_provider_legacy()
         return mock_identity_provider()
 
     auth_type = kwargs.get("auth_type", AuthType.SERVICE_PRINCIPAL)

--- a/tests/test_auth/test_jwt_signature.py
+++ b/tests/test_auth/test_jwt_signature.py
@@ -1,0 +1,34 @@
+"""Tests for JWT signature verification in JWToken."""
+from datetime import datetime, timezone
+
+import pytest
+
+jwt = pytest.importorskip("jwt")
+
+from redis.auth.token import JWToken
+
+
+def test_jwt_token_rejects_forged_token_with_wrong_key():
+    """A token signed with one key must be rejected when verified with another."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+
+    with pytest.raises(jwt.InvalidSignatureError):
+        JWToken(encoded, key="wrong_secret", algorithms=["HS256"])
+
+
+def test_jwt_token_accepts_valid_token_with_correct_key():
+    """A token signed and verified with the same key is accepted."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
+
+    assert jwt_token.try_get("key") == "value"

--- a/tests/test_auth/test_jwt_signature.py
+++ b/tests/test_auth/test_jwt_signature.py
@@ -32,3 +32,55 @@ def test_jwt_token_accepts_valid_token_with_correct_key():
     jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
 
     assert jwt_token.try_get("key") == "value"
+
+
+def test_jwt_token_old_initialization():
+    """Backward-compatible initialization with token only."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded)
+
+    assert jwt_token.try_get("key") == "value"
+
+
+def test_jwt_token_key_and_algorithms():
+    """Initialization with key and algorithms verifies signature."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
+
+    assert jwt_token.try_get("key") == "value"
+
+
+def test_jwt_token_algorithms_only():
+    """Initialization with algorithms only (no key) skips verification."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded, algorithms=["HS256"])
+
+    assert jwt_token.try_get("key") == "value"
+
+
+def test_jwt_token_key_without_algorithms_raises():
+    """Initialization with key but no algorithms should raise ValueError."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+
+    with pytest.raises(ValueError, match="algorithms must be provided"):
+        JWToken(encoded, key="secret")

--- a/tests/test_auth/test_jwt_signature.py
+++ b/tests/test_auth/test_jwt_signature.py
@@ -84,3 +84,57 @@ def test_jwt_token_key_without_algorithms_raises():
 
     with pytest.raises(ValueError, match="algorithms must be provided"):
         JWToken(encoded, key="secret")
+
+
+def test_jwt_token_legacy_never_expires_sentinel():
+    """Legacy initialization handles exp=-1 sentinel correctly."""
+    token = {
+        "exp": -1,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded)
+
+    assert not jwt_token.is_expired()
+    assert jwt_token.ttl() == -1
+
+
+def test_jwt_token_verified_never_expires_sentinel():
+    """Verified initialization handles exp=-1 sentinel correctly."""
+    token = {
+        "exp": -1,
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
+
+    assert not jwt_token.is_expired()
+    assert jwt_token.ttl() == -1
+
+
+def test_jwt_token_legacy_with_audience_claim():
+    """Legacy initialization skips aud verification."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "aud": "some-audience",
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded)
+
+    assert jwt_token.try_get("key") == "value"
+
+
+def test_jwt_token_verified_with_audience_claim():
+    """Verified initialization skips aud verification."""
+    token = {
+        "exp": datetime.now(timezone.utc).timestamp() + 100,
+        "aud": "some-audience",
+        "key": "value",
+    }
+    encoded = jwt.encode(token, "secret", algorithm="HS256")
+    jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
+
+    assert jwt_token.try_get("key") == "value"

--- a/tests/test_auth/test_token.py
+++ b/tests/test_auth/test_token.py
@@ -46,7 +46,7 @@ class TestToken:
             "key": "value",
         }
         encoded = jwt.encode(token, "secret", algorithm="HS256")
-        jwt_token = JWToken(encoded)
+        jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
 
         assert jwt_token.ttl() == pytest.approx(100000, 10)
         assert jwt_token.is_expired() is False
@@ -65,7 +65,7 @@ class TestToken:
             "key": "value",
         }
         encoded = jwt.encode(token, "secret", algorithm="HS256")
-        jwt_token = JWToken(encoded)
+        jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
 
         assert jwt_token.ttl() == -1
         assert jwt_token.is_expired() is False
@@ -74,4 +74,4 @@ class TestToken:
         with pytest.raises(InvalidTokenSchemaErr):
             token = {"key": "value"}
             encoded = jwt.encode(token, "secret", algorithm="HS256")
-            JWToken(encoded)
+            JWToken(encoded, key="secret", algorithms=["HS256"])

--- a/tests/test_auth/test_token.py
+++ b/tests/test_auth/test_token.py
@@ -75,3 +75,37 @@ class TestToken:
             token = {"key": "value"}
             encoded = jwt.encode(token, "secret", algorithm="HS256")
             JWToken(encoded, key="secret", algorithms=["HS256"])
+
+    def test_jwt_token_with_audience(self):
+        jwt = pytest.importorskip("jwt")
+
+        token = {
+            "exp": datetime.now(timezone.utc).timestamp() + 100,
+            "iat": datetime.now(timezone.utc).timestamp(),
+            "aud": "test-audience",
+            "key": "value",
+        }
+        encoded = jwt.encode(token, "secret", algorithm="HS256")
+        jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
+
+        assert jwt_token.try_get("aud") == "test-audience"
+        assert jwt_token.try_get("key") == "value"
+        assert jwt_token.is_expired() is False
+
+    def test_jwt_token_with_nbf(self):
+        jwt = pytest.importorskip("jwt")
+
+        token = {
+            "exp": datetime.now(timezone.utc).timestamp() + 100,
+            "iat": datetime.now(timezone.utc).timestamp(),
+            "nbf": datetime.now(timezone.utc).timestamp() - 10,
+            "key": "value",
+        }
+        encoded = jwt.encode(token, "secret", algorithm="HS256")
+        jwt_token = JWToken(encoded, key="secret", algorithms=["HS256"])
+
+        assert jwt_token.try_get("nbf") == pytest.approx(
+            datetime.now(timezone.utc).timestamp() - 10, 1
+        )
+        assert jwt_token.try_get("key") == "value"
+        assert jwt_token.is_expired() is False

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -23,6 +23,7 @@ from tests.conftest import (
     _get_client,
     get_credential_provider,
     get_endpoint,
+    mock_identity_provider_legacy,
     skip_if_redis_enterprise,
 )
 from tests.entraid_utils import AuthType
@@ -711,3 +712,16 @@ class TestClusterEntraIdCredentialsProvider:
     @pytest.mark.cp_integration
     def test_auth_pool_with_credential_provider(self, r_entra: redis.Redis):
         assert r_entra.ping() is True
+
+
+
+class TestLegacyMockIdentityProvider:
+    """Tests for legacy (unverified) JWToken initialization via mock identity provider."""
+
+    def test_legacy_mock_identity_provider_returns_valid_token(self):
+        """Legacy mock returns a JWToken initialized without key/algorithms."""
+        provider = mock_identity_provider_legacy()
+        token = provider.request_token()
+        assert token is not None
+        assert token.try_get("oid") == "username"
+        assert not token.is_expired()


### PR DESCRIPTION
This PR fixes a JWT signature verification bypass in JWToken.

**CWE:** CWE-345 (Insufficient Verification of Cryptographic Signature)
**File:** redis/auth/token.py

JWToken.__init__() previously decoded JWTs with verify_signature=False, meaning any forged token would be accepted regardless of the signing key. An attacker could craft arbitrary JWT payloads and have them accepted by downstream authorization decisions that rely on is_expired(), ttl(), and try_get().

**Fix:**
- Added an optional key parameter to JWToken.__init__()
- When key is provided, the JWT signature is verified using standard PyJWT verification
- When key is None, existing behavior is preserved for backward compatibility
- Updated existing tests to pass the signing key
- Added new test verifying forged tokens are rejected with wrong key

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a real signature-bypass (CWE-345) in auth code, but callers who still use `JWToken(token)` alone remain unverified until they pass `key` and `algorithms`.
> 
> **Overview**
> **`JWToken`** now accepts optional **`key`** and **`algorithms`**. When **`key`** is set, PyJWT verifies the signature (and requires **`algorithms`**); **`aud`** / **`nbf`** checks stay off. With no **`key`**, behavior is unchanged: decode without signature verification for backward compatibility.
> 
> Tests and mocks were updated so the default mock identity provider uses verified tokens; a **`legacy`** mock path and dedicated signature tests cover the old init and forged-token rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee2ff9f2c7169808eff578973d8764e4e9d8f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->