### PR TITLE
ci: use PyPI Trusted Publishing (OIDC) for releases

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -12,6 +12,12 @@ jobs:
 
   build_and_package:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # mandatory for OIDC trusted publishing
+      contents: read    # needed because this job runs actions/checkout
+    environment:
+      name: pypi
+      url: https://pypi.org/project/redis/
     steps:
       - uses: actions/checkout@v6
       - name: install python
@@ -28,7 +34,4 @@ jobs:
           twine check dist/*
 
       - name: Publish to Pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0


### PR DESCRIPTION
## Summary

Switches PyPI publishing from a long-lived `PYPI_API_TOKEN` secret to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OpenID Connect), as requested in #4008.

Trusted Publishing removes the static API token from CI entirely — there is no credential to leak or exfiltrate — and lets PyPI cryptographically verify that a release was built by this repository's workflow. It also unlocks [PEP 740 attestations](https://docs.pypi.org/attestations/) so users can confirm a published artifact matches what GitHub CI produced.

## Changes (`.github/workflows/pypi-publish.yaml`)

- Add job-level `permissions: id-token: write` (mandatory for OIDC) alongside `contents: read` (still required because the job runs `actions/checkout`).
- Run the publish job in a dedicated `pypi` deployment environment (recommended by the PyPA docs for an extra protection boundary).
- Remove the `with: user/password` block — with OIDC the action authenticates automatically, so no credentials are passed.
- Pin `pypa/gh-action-pypi-publish` to a commit SHA (`cef2210` = `v1.14.0`).

The publish action is SHA-pinned (rather than tag-pinned like the other actions in this repo) specifically because a malicious tag move on the *release* action is a supply-chain risk — which is the exact threat this issue is about. Happy to align the other actions to SHA pins in a follow-up if you'd prefer consistency, or to revert this one to `@release/v1` if you'd rather keep the repo uniform.

## ⚠️ Setup required before this is active

This PR is the CI half of the migration. Two one-time maintainer steps are needed for it to publish successfully (a release run before these are done will fail at the publish step):

1. **Register the Trusted Publisher on PyPI** at `https://pypi.org/manage/project/redis/settings/publishing/`, with exactly:
   - PyPI project: `redis`
   - Owner: `redis`
   - Repository: `redis-py`
   - Workflow filename: `pypi-publish.yaml`
   - Environment name: `pypi`
2. **Create the `pypi` GitHub Environment** (Settings → Environments → New environment → `pypi`). Optional: add required reviewers for release gating.

After the first successful OIDC publish, the old `PYPI_API_TOKEN` secret can be deleted from repo secrets and revoked on PyPI.

Closes #4008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release publishing depends on correct PyPI/GitHub OIDC and environment setup; misconfiguration blocks releases until fixed, but runtime library behavior is unchanged.
> 
> **Overview**
> The **PyPI publish** workflow now uses **Trusted Publishing (OIDC)** instead of a static `PYPI_API_TOKEN`.
> 
> The `build_and_package` job gets **`id-token: write`** plus **`contents: read`**, runs in a **`pypi` GitHub Environment** (with PyPI project URL), and the publish step no longer passes `user`/`password`. **`pypa/gh-action-pypi-publish`** is pinned to commit **`cef2210` (`v1.14.0`)** instead of `@release/v1`.
> 
> **Maintainer setup** (PyPI trusted publisher + `pypi` environment) is required before releases succeed; the old API token can be removed after the first OIDC publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e96e0fb590813e123ab55f2ff94b0e2ebb50640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->