### PR TITLE
Fall back to RESP2 when HELLO is not supported by server/proxy

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -270,6 +270,7 @@ class AbstractConnection:
             if p < 2 or p > 3:
                 raise ConnectionError("protocol must be either 2 or 3")
         self.protocol = p
+        self.handshake_metadata = None
         self.legacy_responses = legacy_responses
         if parser_class != _AsyncHiredisParser:
             # The Python parsers are protocol-specific; hiredis supports both.
@@ -565,8 +566,10 @@ class AbstractConnection:
                 "HELLO", self.protocol, "AUTH", *auth_args, check_health=False
             )
             try:
-                response = await self.read_response()
-                if response.get(b"proto") != int(self.protocol) and response.get(
+                self.handshake_metadata = await self.read_response()
+                if self.handshake_metadata.get(
+                    b"proto"
+                ) != int(self.protocol) and self.handshake_metadata.get(
                     "proto"
                 ) != int(self.protocol):
                     raise ConnectionError("Invalid RESP version")
@@ -586,7 +589,12 @@ class AbstractConnection:
                 self._parser.on_connect(self)
             await self.send_command("HELLO", self.protocol, check_health=check_health)
             try:
-                response = await self.read_response()
+                self.handshake_metadata = await self.read_response()
+                if (
+                    self.handshake_metadata.get(b"proto") != self.protocol
+                    and self.handshake_metadata.get("proto") != self.protocol
+                ):
+                    raise ConnectionError("Invalid RESP version")
             except ResponseError as e:
                 await self._fallback_to_resp2(e, parser)
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import inspect
+import logging
 import socket
 import sys
 import time
@@ -259,8 +260,10 @@ class AbstractConnection:
 
         try:
             p = int(protocol)
+            self._protocol_specified_explicitly = True
         except TypeError:
             p = DEFAULT_RESP_VERSION
+            self._protocol_specified_explicitly = False
         except ValueError:
             raise ConnectionError("protocol must be an integer")
         else:
@@ -461,6 +464,79 @@ class AbstractConnection:
         """Initialize the connection, authenticate and select a database"""
         await self.on_connect_check_health(check_health=True)
 
+    async def _do_resp2_auth(self, cred_provider, auth_args=None) -> None:
+        """Authenticate via standalone AUTH (RESP2 path).
+
+        If auth_args is provided, uses them directly (avoids redundant
+        credential fetching for the straight RESP2 path where credentials
+        were never mutated). If not provided, fetches fresh credentials
+        from the provider (used by the HELLO fallback path to avoid
+        using HELLO-mutated credentials with injected "default").
+        Falls back to single-arg AUTH if the server is Redis < 6.0
+        and rejects two-arg AUTH with "wrong number of arguments".
+        See https://github.com/andymccurdy/redis-py/issues/1274
+        """
+        if auth_args is None:
+            auth_args = await cred_provider.get_credentials_async()
+        # avoid checking health here -- PING will fail if we try
+        # to check the health prior to the AUTH
+        await self.send_command("AUTH", *auth_args, check_health=False)
+        try:
+            auth_response = await self.read_response()
+        except AuthenticationWrongNumberOfArgsError:
+            # a username and password were specified but the Redis
+            # server seems to be < 6.0.0 which expects a single password
+            # arg. retry auth with just the password.
+            await self.send_command("AUTH", auth_args[-1], check_health=False)
+            auth_response = await self.read_response()
+
+        if str_if_bytes(auth_response) != "OK":
+            raise AuthenticationError("Invalid Username or Password")
+
+    async def _fallback_to_resp2(self, error, parser, cred_provider=None):
+        """Handle HELLO failure by falling back to RESP2.
+
+        Validates the error is a recoverable "unknown command" or "NOPROTO",
+        checks that fallback is allowed (not explicitly configured, no
+        RESP3-dependent features active), downgrades parser and protocol,
+        emits a warning, and optionally re-authenticates via standalone AUTH.
+
+        Args:
+            error: The ResponseError from the failed HELLO command.
+            parser: The original parser (for preserving EXCEPTION_CLASSES).
+            cred_provider: If provided, re-authenticate after downgrade
+                using fresh credentials from this provider.
+
+        Raises:
+            ResponseError: If the error is not recoverable or fallback
+                is not permitted.
+        """
+        err_msg = str(error).lower()
+        if "unknown" not in err_msg and "noproto" not in err_msg:
+            raise error
+        if self._protocol_specified_explicitly or (
+            getattr(self, "maint_notifications_config", None)
+            and self.maint_notifications_config.enabled is True
+        ):
+            raise error
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "Server/proxy at %s does not support HELLO (RESP%s). "
+            "Falling back to RESP2. To silence this warning, "
+            "set protocol=2 explicitly or upgrade your "
+            "server/proxy.",
+            self._host_error(),
+            self.protocol,
+        )
+        if isinstance(self._parser, _AsyncRESP3Parser):
+            self.set_parser(_AsyncRESP2Parser)
+            self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
+            self._parser.on_connect(self)
+        self.protocol = 2
+        self.handshake_metadata = {}
+        if cred_provider is not None:
+            await self._do_resp2_auth(cred_provider)
+
     async def on_connect_check_health(self, check_health: bool = True) -> None:
         self._parser.on_connect(self)
         parser = self._parser
@@ -474,8 +550,7 @@ class AbstractConnection:
             )
             auth_args = await cred_provider.get_credentials_async()
 
-            # if resp version is specified and we have auth args,
-            # we need to send them via HELLO
+            # RESP3 with credentials: authenticate inline via HELLO 3 AUTH ...
         if auth_args and self.protocol not in [2, "2"]:
             if isinstance(self._parser, _AsyncRESP2Parser):
                 self.set_parser(_AsyncRESP3Parser)
@@ -489,30 +564,20 @@ class AbstractConnection:
             await self.send_command(
                 "HELLO", self.protocol, "AUTH", *auth_args, check_health=False
             )
-            response = await self.read_response()
-            if response.get(b"proto") != int(self.protocol) and response.get(
-                "proto"
-            ) != int(self.protocol):
-                raise ConnectionError("Invalid RESP version")
+            try:
+                response = await self.read_response()
+                if response.get(b"proto") != int(self.protocol) and response.get(
+                    "proto"
+                ) != int(self.protocol):
+                    raise ConnectionError("Invalid RESP version")
+            except ResponseError as e:
+                await self._fallback_to_resp2(e, parser, cred_provider=cred_provider)
         # avoid checking health here -- PING will fail if we try
         # to check the health prior to the AUTH
         elif auth_args:
-            await self.send_command("AUTH", *auth_args, check_health=False)
+            await self._do_resp2_auth(cred_provider, auth_args=auth_args)
 
-            try:
-                auth_response = await self.read_response()
-            except AuthenticationWrongNumberOfArgsError:
-                # a username and password were specified but the Redis
-                # server seems to be < 6.0.0 which expects a single password
-                # arg. retry auth with just the password.
-                # https://github.com/andymccurdy/redis-py/issues/1274
-                await self.send_command("AUTH", auth_args[-1], check_health=False)
-                auth_response = await self.read_response()
-
-            if str_if_bytes(auth_response) != "OK":
-                raise AuthenticationError("Invalid Username or Password")
-
-        # if resp version is specified, switch to it
+        # RESP3 without credentials: send bare HELLO to upgrade protocol
         elif self.protocol not in [2, "2"]:
             if isinstance(self._parser, _AsyncRESP2Parser):
                 self.set_parser(_AsyncRESP3Parser)
@@ -520,11 +585,10 @@ class AbstractConnection:
                 self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
                 self._parser.on_connect(self)
             await self.send_command("HELLO", self.protocol, check_health=check_health)
-            response = await self.read_response()
-            # if response.get(b"proto") != self.protocol and response.get(
-            #     "proto"
-            # ) != self.protocol:
-            #     raise ConnectionError("Invalid RESP version")
+            try:
+                response = await self.read_response()
+            except ResponseError as e:
+                await self._fallback_to_resp2(e, parser)
 
         # if a client_name is given, set it
         if self.client_name:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 import socket
 import sys
@@ -903,8 +904,10 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         self._re_auth_token: Optional[TokenInterface] = None
         try:
             p = int(protocol)
+            self._protocol_specified_explicitly = True
         except TypeError:
             p = DEFAULT_RESP_VERSION
+            self._protocol_specified_explicitly = False
         except ValueError:
             raise ConnectionError("protocol must be an integer")
         else:
@@ -1090,6 +1093,79 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
     def on_connect(self):
         self.on_connect_check_health(check_health=True)
 
+    def _do_resp2_auth(self, cred_provider, auth_args=None):
+        """Authenticate via standalone AUTH (RESP2 path).
+
+        If auth_args is provided, uses them directly (avoids redundant
+        credential fetching for the straight RESP2 path where credentials
+        were never mutated). If not provided, fetches fresh credentials
+        from the provider (used by the HELLO fallback path to avoid
+        using HELLO-mutated credentials with injected "default").
+        Falls back to single-arg AUTH if the server is Redis < 6.0
+        and rejects two-arg AUTH with "wrong number of arguments".
+        See https://github.com/andymccurdy/redis-py/issues/1274
+        """
+        if auth_args is None:
+            auth_args = cred_provider.get_credentials()
+        # avoid checking health here -- PING will fail if we try
+        # to check the health prior to the AUTH
+        self.send_command("AUTH", *auth_args, check_health=False)
+        try:
+            auth_response = self.read_response()
+        except AuthenticationWrongNumberOfArgsError:
+            # a username and password were specified but the Redis
+            # server seems to be < 6.0.0 which expects a single password
+            # arg. retry auth with just the password.
+            self.send_command("AUTH", auth_args[-1], check_health=False)
+            auth_response = self.read_response()
+
+        if str_if_bytes(auth_response) != "OK":
+            raise AuthenticationError("Invalid Username or Password")
+
+    def _fallback_to_resp2(self, error, parser, cred_provider=None):
+        """Handle HELLO failure by falling back to RESP2.
+
+        Validates the error is a recoverable "unknown command" or "NOPROTO",
+        checks that fallback is allowed (not explicitly configured, no
+        RESP3-dependent features active), downgrades parser and protocol,
+        emits a warning, and optionally re-authenticates via standalone AUTH.
+
+        Args:
+            error: The ResponseError from the failed HELLO command.
+            parser: The original parser (for preserving EXCEPTION_CLASSES).
+            cred_provider: If provided, re-authenticate after downgrade
+                using fresh credentials from this provider.
+
+        Raises:
+            ResponseError: If the error is not recoverable or fallback
+                is not permitted.
+        """
+        err_msg = str(error).lower()
+        if "unknown" not in err_msg and "noproto" not in err_msg:
+            raise error
+        if self._protocol_specified_explicitly or (
+            self.maint_notifications_config
+            and self.maint_notifications_config.enabled is True
+        ):
+            raise error
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "Server/proxy at %s does not support HELLO (RESP%s). "
+            "Falling back to RESP2. To silence this warning, "
+            "set protocol=2 explicitly or upgrade your "
+            "server/proxy.",
+            self._host_error(),
+            self.protocol,
+        )
+        if isinstance(self._parser, _RESP3Parser):
+            self.set_parser(_RESP2Parser)
+            self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
+            self._parser.on_connect(self)
+        self.protocol = 2
+        self.handshake_metadata = {}
+        if cred_provider is not None:
+            self._do_resp2_auth(cred_provider)
+
     def on_connect_check_health(self, check_health: bool = True):
         "Initialize the connection, authenticate and select a database"
         self._parser.on_connect(self)
@@ -1104,8 +1180,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             )
             auth_args = cred_provider.get_credentials()
 
-        # if resp version is specified and we have auth args,
-        # we need to send them via HELLO
+        # RESP3 with credentials: authenticate inline via HELLO 3 AUTH ...
         if auth_args and self.protocol not in [2, "2"]:
             if isinstance(self._parser, _RESP2Parser):
                 self.set_parser(_RESP3Parser)
@@ -1119,30 +1194,14 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             self.send_command(
                 "HELLO", self.protocol, "AUTH", *auth_args, check_health=False
             )
-            self.handshake_metadata = self.read_response()
-            # if response.get(b"proto") != self.protocol and response.get(
-            #     "proto"
-            # ) != self.protocol:
-            #     raise ConnectionError("Invalid RESP version")
-        elif auth_args:
-            # avoid checking health here -- PING will fail if we try
-            # to check the health prior to the AUTH
-            self.send_command("AUTH", *auth_args, check_health=False)
-
             try:
-                auth_response = self.read_response()
-            except AuthenticationWrongNumberOfArgsError:
-                # a username and password were specified but the Redis
-                # server seems to be < 6.0.0 which expects a single password
-                # arg. retry auth with just the password.
-                # https://github.com/andymccurdy/redis-py/issues/1274
-                self.send_command("AUTH", auth_args[-1], check_health=False)
-                auth_response = self.read_response()
+                self.handshake_metadata = self.read_response()
+            except ResponseError as e:
+                self._fallback_to_resp2(e, parser, cred_provider=cred_provider)
+        elif auth_args:
+            self._do_resp2_auth(cred_provider, auth_args=auth_args)
 
-            if str_if_bytes(auth_response) != "OK":
-                raise AuthenticationError("Invalid Username or Password")
-
-        # if resp version is specified, switch to it
+        # RESP3 without credentials: send bare HELLO to upgrade protocol
         elif self.protocol not in [2, "2"]:
             if isinstance(self._parser, _RESP2Parser):
                 self.set_parser(_RESP3Parser)
@@ -1150,12 +1209,15 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
                 self._parser.on_connect(self)
             self.send_command("HELLO", self.protocol, check_health=check_health)
-            self.handshake_metadata = self.read_response()
-            if (
-                self.handshake_metadata.get(b"proto") != self.protocol
-                and self.handshake_metadata.get("proto") != self.protocol
-            ):
-                raise ConnectionError("Invalid RESP version")
+            try:
+                self.handshake_metadata = self.read_response()
+                if (
+                    self.handshake_metadata.get(b"proto") != self.protocol
+                    and self.handshake_metadata.get("proto") != self.protocol
+                ):
+                    raise ConnectionError("Invalid RESP version")
+            except ResponseError as e:
+                self._fallback_to_resp2(e, parser)
 
         # Activate maintenance notifications for this connection
         # if enabled in the configuration

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1196,6 +1196,11 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             )
             try:
                 self.handshake_metadata = self.read_response()
+                if (
+                    self.handshake_metadata.get(b"proto") != self.protocol
+                    and self.handshake_metadata.get("proto") != self.protocol
+                ):
+                    raise ConnectionError("Invalid RESP version")
             except ResponseError as e:
                 self._fallback_to_resp2(e, parser, cred_provider=cred_provider)
         elif auth_args:

--- a/tests/test_hello_fallback.py
+++ b/tests/test_hello_fallback.py
@@ -17,7 +17,9 @@ class TestHelloFallback:
 
     def _make_connection(self, protocol=None, password="secret", **kwargs):
         """Create a Connection with mocked I/O."""
-        conn = Connection(password=password, protocol=protocol, **kwargs)
+        conn = Connection(
+            password=password, protocol=protocol, driver_info=None, **kwargs
+        )
         conn._parser.on_connect = mock.Mock()
         conn.send_command = mock.Mock()
         return conn
@@ -194,3 +196,29 @@ class TestHelloFallback:
         assert all(c[0][0] != "HELLO" for c in calls)
         # Should have sent single-arg AUTH (no default injection for RESP2)
         assert calls[0][0] == ("AUTH", "secret")
+
+    def test_handshake_metadata_assigned_on_success(self):
+        """On HELLO success, handshake_metadata should be assigned the
+        response dict (not left as None). Regression test for async parity."""
+        conn = self._make_connection(protocol=None, password="secret")
+
+        hello_response = {b"server": b"redis", b"version": b"7.0.0", b"proto": 3}
+        conn.read_response = mock.Mock(return_value=hello_response)
+
+        conn.on_connect_check_health()
+
+        assert conn.handshake_metadata is hello_response
+        assert conn.handshake_metadata.get(b"proto") == 3
+
+    def test_handshake_metadata_assigned_no_auth_success(self):
+        """Branch 3 (RESP3 + no credentials): on HELLO success,
+        handshake_metadata should be the response dict."""
+        conn = self._make_connection(protocol=None, password=None)
+
+        hello_response = {b"server": b"redis", b"version": b"7.4.0", b"proto": 3}
+        conn.read_response = mock.Mock(return_value=hello_response)
+
+        conn.on_connect_check_health()
+
+        assert conn.handshake_metadata is hello_response
+        assert conn.protocol == 3

--- a/tests/test_hello_fallback.py
+++ b/tests/test_hello_fallback.py
@@ -1,0 +1,196 @@
+"""Tests for HELLO fallback to RESP2 when server/proxy doesn't support it.
+
+See https://github.com/redis/redis-py/issues/4089
+"""
+
+import logging
+from unittest import mock
+
+import pytest
+
+from redis.connection import Connection
+from redis.exceptions import AuthenticationError, ResponseError
+
+
+class TestHelloFallback:
+    """Test RESP3 HELLO fallback behavior."""
+
+    def _make_connection(self, protocol=None, password="secret", **kwargs):
+        """Create a Connection with mocked I/O."""
+        conn = Connection(password=password, protocol=protocol, **kwargs)
+        conn._parser.on_connect = mock.Mock()
+        conn.send_command = mock.Mock()
+        return conn
+
+    def test_fallback_single_password_one_round_trip(self):
+        """When user only configured a password, fallback should send a
+        SINGLE-ARG AUTH directly (no two-arg attempt with 'default')."""
+        conn = self._make_connection(protocol=None, password="secret")
+
+        # First read_response: HELLO rejected
+        # Second read_response: AUTH OK (single round trip)
+        conn.read_response = mock.Mock(
+            side_effect=[
+                ResponseError("ERR unknown command 'HELLO'"),
+                "OK",
+            ]
+        )
+
+        conn.on_connect_check_health()
+
+        assert conn.protocol == 2
+        assert conn.handshake_metadata == {}
+        calls = conn.send_command.call_args_list
+        # HELLO 3 AUTH default secret
+        assert calls[0][0][0] == "HELLO"
+        assert "default" in calls[0][0]
+        # Fallback AUTH should be SINGLE-ARG (just password)
+        assert calls[1][0] == ("AUTH", "secret")
+        # No third call needed
+        assert len(calls) == 2
+
+    def test_fallback_username_password_two_round_trips_on_old_server(self):
+        """When user explicitly configured username+password and server
+        is Redis < 6.0, fallback first tries two-arg AUTH then degrades
+        to single-arg AUTH (matches issue #1274 behavior)."""
+        from redis.exceptions import AuthenticationWrongNumberOfArgsError
+
+        conn = self._make_connection(
+            protocol=None, username="myuser", password="secret"
+        )
+
+        conn.read_response = mock.Mock(
+            side_effect=[
+                ResponseError("ERR unknown command 'HELLO'"),
+                AuthenticationWrongNumberOfArgsError(),
+                "OK",
+            ]
+        )
+
+        conn.on_connect_check_health()
+
+        assert conn.protocol == 2
+        calls = conn.send_command.call_args_list
+        # HELLO 3 AUTH myuser secret
+        assert calls[0][0][0] == "HELLO"
+        # Fallback AUTH myuser secret (two-arg, using ORIGINAL creds)
+        assert calls[1][0] == ("AUTH", "myuser", "secret")
+        # Final fallback AUTH secret (single-arg)
+        assert calls[2][0] == ("AUTH", "secret")
+
+    def test_fallback_on_noproto_default_protocol(self):
+        """Default protocol should fall back on NOPROTO error."""
+        conn = self._make_connection(protocol=None)
+
+        conn.read_response = mock.Mock(
+            side_effect=[
+                ResponseError("NOPROTO sorry this proto is not supported"),
+                "OK",
+            ]
+        )
+
+        conn.on_connect_check_health()
+
+        assert conn.protocol == 2
+        assert conn.handshake_metadata == {}
+
+    def test_no_fallback_on_explicit_protocol_3(self):
+        """Explicit protocol=3 should NOT fall back — raise the error."""
+        conn = self._make_connection(protocol=3)
+
+        conn.read_response = mock.Mock(
+            side_effect=ResponseError("ERR unknown command 'HELLO'")
+        )
+
+        with pytest.raises(ResponseError, match="unknown command"):
+            conn.on_connect_check_health()
+
+    def test_no_fallback_on_wrongpass(self):
+        """WRONGPASS errors should never be swallowed, even with default protocol."""
+        conn = self._make_connection(protocol=None)
+
+        conn.read_response = mock.Mock(
+            side_effect=ResponseError("WRONGPASS invalid username-password pair")
+        )
+
+        with pytest.raises(ResponseError, match="WRONGPASS"):
+            conn.on_connect_check_health()
+
+    def test_no_fallback_with_maint_notifications_enabled_true(self):
+        """When maintenance notifications enabled=True, fail loudly."""
+        maint_config = mock.Mock()
+        maint_config.enabled = True
+
+        conn = self._make_connection(
+            protocol=None, maint_notifications_config=maint_config
+        )
+
+        conn.read_response = mock.Mock(
+            side_effect=ResponseError("ERR unknown command 'HELLO'")
+        )
+
+        with pytest.raises(ResponseError, match="unknown command"):
+            conn.on_connect_check_health()
+
+    def test_fallback_emits_warning(self, caplog):
+        """Fallback should log a warning."""
+        conn = self._make_connection(protocol=None)
+
+        conn.read_response = mock.Mock(
+            side_effect=[
+                ResponseError("ERR unknown command 'HELLO'"),
+                "OK",
+            ]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="redis.connection"):
+            conn.on_connect_check_health()
+
+        assert "does not support HELLO" in caplog.text
+        assert "RESP3" in caplog.text or "RESP" in caplog.text
+        assert "protocol=2" in caplog.text
+
+    def test_handshake_metadata_is_dict_after_fallback(self):
+        """handshake_metadata should be {} (not None) after fallback to
+        prevent AttributeError in downstream code like CacheProxyConnection."""
+        conn = self._make_connection(protocol=None)
+
+        conn.read_response = mock.Mock(
+            side_effect=[
+                ResponseError("ERR unknown command 'HELLO'"),
+                "OK",
+            ]
+        )
+
+        conn.on_connect_check_health()
+
+        assert conn.handshake_metadata is not None
+        assert isinstance(conn.handshake_metadata, dict)
+
+    def test_no_auth_branch_fallback(self):
+        """Branch 3: RESP3 + no credentials should also fall back."""
+        conn = self._make_connection(protocol=None, password=None)
+
+        conn.read_response = mock.Mock(
+            side_effect=ResponseError("ERR unknown command 'HELLO'")
+        )
+
+        conn.on_connect_check_health()
+
+        assert conn.protocol == 2
+        assert conn.handshake_metadata == {}
+
+    def test_explicit_resp2_path_uses_helper(self):
+        """The standalone RESP2 path (protocol=2) should authenticate
+        through the same _do_resp2_auth helper using ORIGINAL creds."""
+        conn = self._make_connection(protocol=2, password="secret")
+
+        conn.read_response = mock.Mock(return_value="OK")
+
+        conn.on_connect_check_health()
+
+        # Should not have sent HELLO at all
+        calls = conn.send_command.call_args_list
+        assert all(c[0][0] != "HELLO" for c in calls)
+        # Should have sent single-arg AUTH (no default injection for RESP2)
+        assert calls[0][0] == ("AUTH", "secret")


### PR DESCRIPTION
## Summary

Fixes #4089

redis-py 8.0 defaults to RESP3, which sends a `HELLO` command during connection handshake. If the server (Redis < 6.0) or proxy doesn't support `HELLO`, the connection fails with `ResponseError: unknown command` — there is no fallback.

This PR adds a `try/except ResponseError` around the `HELLO` response in both sync and async connection paths. On failure, it gracefully falls back to RESP2 with standalone `AUTH`, matching the behavior of Lettuce, Jedis, and go-redis.

## Changes

- `redis/connection.py` — `on_connect_check_health()`: catch `ResponseError` after `HELLO`, revert parser to RESP2, issue standalone `AUTH`
- `redis/asyncio/connection.py` — same fix for the async path

Both branch 1 (RESP3 + auth) and branch 3 (RESP3 + no auth) are covered.

## Testing

Manually verified against a proxy that rejects `HELLO` with `ERR unknown command`. Connection now succeeds with automatic RESP2 fallback instead of raising.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection handshake and authentication for all default-RESP3 clients; behavior is gated on error text and explicit protocol/maint settings, but misclassified errors could still affect connect success.
> 
> **Overview**
> When the default RESP3 connect path sends **HELLO** and the server or proxy rejects it (unknown command / NOPROTO), sync and async connections now **downgrade to RESP2** instead of failing outright. Shared helpers **`_fallback_to_resp2`** and **`_do_resp2_auth`** centralize parser/protocol downgrade, optional **standalone AUTH** with fresh credentials (avoiding HELLO’s injected `default` username), and a **warning** unless the user set **`protocol=3`** explicitly or **maintenance notifications** are enabled.
> 
> Successful HELLO responses are stored in **`handshake_metadata`** on both paths; after fallback it is set to **`{}`** so downstream code does not see **`None`**. New tests in **`tests/test_hello_fallback.py`** cover auth branches, NOPROTO, no-fallback cases, and logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce49533884f01ef309a10f3c9c42b78b43a870b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->