### PR TITLE
Updating lib version + supported Redis versions in README.md + updating the Redis versions in CI test matrix

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -115,8 +115,8 @@ runs:
 
           # Mapping of redis version to stack version
           declare -A redis_stack_version_mapping=(
-            ["7.4.4"]="rs-7.4.0-v5"
-            ["7.2.9"]="rs-7.2.0-v17"
+            ["7.4.9"]="rs-7.4.0-v6"
+            ["7.2.14"]="rs-7.2.0-v20"
           )
 
           if [[ -v redis_stack_version_mapping[$REDIS_VERSION] ]]; then

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -115,7 +115,7 @@ runs:
 
           # Mapping of redis version to stack version
           declare -A redis_stack_version_mapping=(
-            ["7.4.9"]="rs-7.4.0-v6"
+            ["7.4.9"]="rs-7.4.0-v8"
             ["7.2.14"]="rs-7.2.0-v20"
           )
 

--- a/.github/workflows/hiredis-py-integration.yaml
+++ b/.github/workflows/hiredis-py-integration.yaml
@@ -23,8 +23,7 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # this speeds up coverage with Python 3.12: https://github.com/nedbat/coveragepy/issues/1665
   COVERAGE_CORE: sysmon
-  CURRENT_CLIENT_LIBS_TEST_STACK_IMAGE_TAG: '8.6.1'
-  CURRENT_REDIS_VERSION: '8.6.1'
+  CURRENT_REDIS_VERSION: '8.8.0'
 
 jobs:
   redis_version:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -289,7 +289,7 @@ jobs:
       - name: Run installed unit tests
         env:
           CLIENT_LIBS_TEST_IMAGE_TAG: ${{ env.CURRENT_REDIS_VERSION }}
-          CLIENT_LIBS_TEST_STACK_IMAGE_TAG: ${{ env.CURRENT_CLIENT_LIBS_TEST_STACK_IMAGE_TAG }}
+          CLIENT_LIBS_TEST_STACK_IMAGE_TAG: ${{ env.CURRENT_REDIS_VERSION }}
         run: |
           bash .github/workflows/install_and_test.sh ${{ matrix.extension }}
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,9 +29,9 @@ env:
   COVERAGE_CORE: sysmon
   # patch releases get included in the base version image when they are published
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
-  CURRENT_REDIS_VERSION: '8.6.1'
+  CURRENT_REDIS_VERSION: '8.8.0'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.8:custom-26235535976-debian
+    8.8:8.8.0
 
 jobs:
   dependency-audit:
@@ -80,7 +80,7 @@ jobs:
       max-parallel: 30
       fail-fast: false
       matrix:
-        redis-version: ['8.8', '${{ needs.redis_version.outputs.CURRENT }}', '8.4.2', '8.2.5', '8.0.2' ,'7.4.4', '7.2.9']
+        redis-version: ['${{ needs.redis_version.outputs.CURRENT }}', '8.6.3', '8.4.3', '8.2.6', '8.0.2' ,'7.4.9', '7.2.14']
         python-version: ['3.10', '3.14']
         parser-backend: ['plain']
         event-loop: ['asyncio']

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -80,7 +80,7 @@ jobs:
       max-parallel: 30
       fail-fast: false
       matrix:
-        redis-version: ['${{ needs.redis_version.outputs.CURRENT }}', '8.6.3', '8.4.3', '8.2.6', '8.0.2' ,'7.4.9', '7.2.14']
+        redis-version: ['${{ needs.redis_version.outputs.CURRENT }}', '8.6.3', '8.4.3', '8.2.6', '8.0.6' ,'7.4.9', '7.2.14']
         python-version: ['3.10', '3.14']
         parser-backend: ['plain']
         event-loop: ['asyncio']

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Looking for a high-level library to handle object mapping? See [redis-om-python]
 
 ## Supported Redis Versions
 
-The most recent version of this library supports Redis version [7.2](https://github.com/redis/redis/blob/7.2/00-RELEASENOTES), [7.4](https://github.com/redis/redis/blob/7.4/00-RELEASENOTES), [8.0](https://github.com/redis/redis/blob/8.0/00-RELEASENOTES) and [8.2](https://github.com/redis/redis/blob/8.2/00-RELEASENOTES).
+The most recent version of this library supports Redis version [7.2](https://github.com/redis/redis/blob/7.2/00-RELEASENOTES), [7.4](https://github.com/redis/redis/blob/7.4/00-RELEASENOTES), [8.0](https://github.com/redis/redis/blob/8.0/00-RELEASENOTES), [8.2](https://github.com/redis/redis/blob/8.2/00-RELEASENOTES), [8.4](https://github.com/redis/redis/blob/8.4/00-RELEASENOTES), [8.6](https://github.com/redis/redis/blob/8.6/00-RELEASENOTES) and [8.8](https://github.com/redis/redis/blob/8.8/00-RELEASENOTES).
 
 The table below highlights version compatibility of the most-recent library versions and redis versions.
 

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -64,7 +64,7 @@ def int_or_str(value):
         return value
 
 
-__version__ = "7.3.0"
+__version__ = "8.0.0"
 
 VERSION = tuple(map(int_or_str, __version__.split(".")))
 

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -1282,7 +1282,7 @@ async def test_mrevrange_with_count_nan_count_all_aggregators(decoded_r: redis.R
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 async def test_range_multiple_aggregators(decoded_r: redis.Redis):
     """Test TS.RANGE with multiple aggregators (Redis 8.8+)."""
     await decoded_r.ts().create("ts:multi_agg")
@@ -1305,7 +1305,7 @@ async def test_range_multiple_aggregators(decoded_r: redis.Redis):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 async def test_revrange_multiple_aggregators(decoded_r: redis.Redis):
     """Test TS.REVRANGE with multiple aggregators (Redis 8.8+)."""
     await decoded_r.ts().create("ts:multi_agg")
@@ -1328,7 +1328,7 @@ async def test_revrange_multiple_aggregators(decoded_r: redis.Redis):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 async def test_mrange_multiple_aggregators(decoded_r: redis.Redis):
     """Test TS.MRANGE with multiple aggregators (Redis 8.8+)."""
     await decoded_r.ts().create("ts:multi_agg_a", labels={"type": "test_multi_agg"})
@@ -1356,7 +1356,7 @@ async def test_mrange_multiple_aggregators(decoded_r: redis.Redis):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 async def test_mrevrange_multiple_aggregators(decoded_r: redis.Redis):
     """Test TS.MREVRANGE with multiple aggregators (Redis 8.8+)."""
     await decoded_r.ts().create("ts:multi_agg_b", labels={"type": "test_multi_agg_rev"})

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1528,7 +1528,7 @@ def test_mrevrange_with_count_nan_count_all_aggregators(client):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 def test_range_multiple_aggregators(client):
     """Test TS.RANGE with multiple aggregators (Redis 8.8+)."""
     client.ts().create("ts:multi_agg")
@@ -1551,7 +1551,7 @@ def test_range_multiple_aggregators(client):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 def test_revrange_multiple_aggregators(client):
     """Test TS.REVRANGE with multiple aggregators (Redis 8.8+)."""
     client.ts().create("ts:multi_agg")
@@ -1574,7 +1574,7 @@ def test_revrange_multiple_aggregators(client):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 def test_mrange_multiple_aggregators(client):
     """Test TS.MRANGE with multiple aggregators (Redis 8.8+)."""
     client.ts().create("ts:multi_agg_a", labels={"type": "test_multi_agg"})
@@ -1602,7 +1602,7 @@ def test_mrange_multiple_aggregators(client):
 
 
 @pytest.mark.redismod
-@skip_if_server_version_lt("8.7.0")
+@skip_if_server_version_lt("8.8.0")
 def test_mrevrange_multiple_aggregators(client):
     """Test TS.MREVRANGE with multiple aggregators (Redis 8.8+)."""
     client.ts().create("ts:multi_agg_b", labels={"type": "test_multi_agg_rev"})


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No client API changes beyond the version string; risk is mainly CI failing if updated Redis/stack image tags are unavailable.
> 
> **Overview**
> Bumps **redis-py to 8.0.0** and aligns docs and CI with **Redis 8.8** as the current test baseline.
> 
> **README** now lists supported server families through **8.4, 8.6, and 8.8** (with release-note links). **GitHub Actions** set `CURRENT_REDIS_VERSION` to `8.8.0`, refresh the integration matrix to newer patch releases (including `7.4.9` / `7.2.14`), point the `8.8` custom image map at `8.8.0`, update **redis-stack** mappings for sub-8 Redis in `run-tests`, and use the same current Redis tag for stack images in package install tests (dropping a separate stack env in hiredis integration).
> 
> **TimeSeries** tests that gate on Redis **8.8+** multi-aggregator behavior now skip below **`8.8.0`** instead of **`8.7.0`** (sync and asyncio).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aefa3594ce408d11343563bdb5ee632b4bb5041d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->