### PR TITLE
Fix maintenance notifications guard for Unix socket connections

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -604,7 +604,7 @@ class MaintNotificationsAbstractConnection:
             and self.maint_notifications_config
             and self.maint_notifications_config.enabled
             and self._maint_notifications_connection_handler
-            and hasattr(self, "host")
+            and getattr(self, "host", None) is not None
         ):
             self._enable_maintenance_notifications(
                 maint_notifications_config=self.maint_notifications_config,


### PR DESCRIPTION
Fixes #4086.

## What's wrong

`activate_maint_notifications_handling_if_enabled` uses `hasattr(self, "host")` to check whether a connection has a host before attempting the maintenance notifications handshake. For `UnixDomainSocketConnection` this check always passes because the `host` abstract property is defined on the parent class — `hasattr` returns `True` even though the actual value is `None`.

The check was meant to skip Unix socket connections (which have no host), but it doesn't. `_enable_maintenance_notifications` then calls `getattr(self, "host", None)`, gets `None`, and raises:

```
ValueError: Cannot enable maintenance notifications for connection object that doesn't have a host attribute.
```

This happens even when the user explicitly passes `maint_notifications_config=MaintNotificationsConfig(enabled=False)` because the config check earlier in the guard may still evaluate truthy depending on how the pool sets it up.

## Fix

Replace `hasattr(self, "host")` with `getattr(self, "host", None) is not None`. This correctly skips any connection where `host` is `None` rather than relying on attribute existence.

```python
# before
and hasattr(self, "host")

# after
and getattr(self, "host", None) is not None
```

One-line change, no new dependencies, no API surface changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard change in connect-time maintenance notification activation; no API or behavior change for TCP connections with a real host.
> 
> **Overview**
> Fixes a guard in `activate_maint_notifications_handling_if_enabled` so Unix domain socket connections no longer enter the maintenance-notifications handshake path.
> 
> The condition now requires a **non-`None` host** (`getattr(self, "host", None) is not None`) instead of only checking that a `host` attribute exists. That matches the intent to skip connections without a TCP hostname (UDS uses `path` only) and avoids a `ValueError` during connect when RESP3 maintenance handling is configured on the pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4731d9d0b971a4191801c0a412dffb48f0a1a238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->