### PR TITLE
Fix Unix socket maintenance notification handling and tests

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -398,10 +398,21 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:
+                if (
+                    maint_notifications_config
+                    and maint_notifications_config.enabled is True
+                ):
+                    raise RedisError(
+                        "Maintenance notifications are not supported with Unix "
+                        "domain socket connections"
+                    )
                 kwargs.update(
                     {
                         "path": unix_socket_path,
                         "connection_class": UnixDomainSocketConnection,
+                        "maint_notifications_config": MaintNotificationsConfig(
+                            enabled=False
+                        ),
                     }
                 )
             else:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -599,12 +599,13 @@ class MaintNotificationsAbstractConnection:
         # When the maint_notifications_config enabled mode is "auto",
         # we just log a warning if the handshake fails
         # When the mode is enabled=True, we raise an exception in case of failure
+        host = getattr(self, "host", None)
         if (
             self.get_protocol() not in [2, "2"]
             and self.maint_notifications_config
             and self.maint_notifications_config.enabled
             and self._maint_notifications_connection_handler
-            and hasattr(self, "host")
+            and host is not None
         ):
             self._enable_maintenance_notifications(
                 maint_notifications_config=self.maint_notifications_config,
@@ -2886,6 +2887,24 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         self.max_connections = max_connections
         self.cache = None
         self._cache_factory = cache_factory
+
+        try:
+            supports_maint_notifications = issubclass(
+                connection_class, MaintNotificationsAbstractConnection
+            )
+        except TypeError:
+            supports_maint_notifications = False
+
+        if not supports_maint_notifications:
+            if (
+                maint_notifications_config
+                and maint_notifications_config.enabled is True
+            ):
+                raise RedisError(
+                    "Maintenance notifications are not supported with this "
+                    "connection class"
+                )
+            maint_notifications_config = MaintNotificationsConfig(enabled=False)
 
         self._event_dispatcher = self._connection_kwargs.get("event_dispatcher", None)
         if self._event_dispatcher is None:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2892,17 +2892,21 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
             supports_maint_notifications = issubclass(
                 connection_class, MaintNotificationsAbstractConnection
             )
+            is_unix_domain_socket_connection = issubclass(
+                connection_class, UnixDomainSocketConnection
+            )
         except TypeError:
             supports_maint_notifications = False
+            is_unix_domain_socket_connection = False
 
-        if not supports_maint_notifications:
+        if is_unix_domain_socket_connection or not supports_maint_notifications:
             if (
                 maint_notifications_config
                 and maint_notifications_config.enabled is True
             ):
                 raise RedisError(
-                    "Maintenance notifications are not supported with this "
-                    "connection class"
+                    "Maintenance notifications are not supported with "
+                    f"{connection_class}"
                 )
             maint_notifications_config = MaintNotificationsConfig(enabled=False)
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -659,17 +659,23 @@ class TestConnectionPoolUnixSocketURLParsing:
         ]
         socket_mock = mock.MagicMock()
 
-        with mock.patch.object(
-            redis.UnixDomainSocketConnection, "_connect", return_value=socket_mock
-        ), mock.patch.object(
-            redis.UnixDomainSocketConnection, "can_read", return_value=False
-        ), mock.patch.object(
-            redis.UnixDomainSocketConnection, "send_command"
-        ) as send_command, mock.patch.object(
-            redis.UnixDomainSocketConnection, "read_response", side_effect=responses
-        ), mock.patch.object(
-            redis.UnixDomainSocketConnection, "_enable_maintenance_notifications"
-        ) as enable:
+        with (
+            mock.patch.object(
+                redis.UnixDomainSocketConnection, "_connect", return_value=socket_mock
+            ),
+            mock.patch.object(
+                redis.UnixDomainSocketConnection, "can_read", return_value=False
+            ),
+            mock.patch.object(
+                redis.UnixDomainSocketConnection, "send_command"
+            ) as send_command,
+            mock.patch.object(
+                redis.UnixDomainSocketConnection, "read_response", side_effect=responses
+            ),
+            mock.patch.object(
+                redis.UnixDomainSocketConnection, "_enable_maintenance_notifications"
+            ) as enable,
+        ):
             assert client.ping() is True
             assert client.set(key, "value") is True
             assert client.get(key) == b"value"

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -111,8 +111,7 @@ class TestConnectionPool:
         with pytest.raises(
             redis.RedisError,
             match=(
-                "Maintenance notifications are not supported with "
-                ".*DummyConnection"
+                "Maintenance notifications are not supported with .*DummyConnection"
             ),
         ):
             redis.ConnectionPool(

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -110,7 +110,10 @@ class TestConnectionPool:
     def test_custom_connection_rejects_enabled_maint_notifications_config(self):
         with pytest.raises(
             redis.RedisError,
-            match="Maintenance notifications are not supported with this connection class",
+            match=(
+                "Maintenance notifications are not supported with "
+                ".*DummyConnection"
+            ),
         ):
             redis.ConnectionPool(
                 connection_class=DummyConnection,
@@ -645,6 +648,34 @@ class TestConnectionPoolUnixSocketURLParsing:
                 unix_socket_path="/socket",
                 maint_notifications_config=MaintNotificationsConfig(enabled=True),
             )
+
+    def test_pool_rejects_enabled_maint_notifications_config(self):
+        with pytest.raises(
+            redis.RedisError,
+            match=(
+                "Maintenance notifications are not supported with "
+                ".*UnixDomainSocketConnection"
+            ),
+        ):
+            redis.ConnectionPool(
+                connection_class=redis.UnixDomainSocketConnection,
+                path="/socket",
+                maint_notifications_config=MaintNotificationsConfig(enabled=True),
+            )
+
+    def test_pool_disables_default_maint_notifications(self):
+        pool = redis.ConnectionPool(
+            connection_class=redis.UnixDomainSocketConnection,
+            path="/socket",
+            protocol=3,
+        )
+
+        assert pool.connection_class == redis.UnixDomainSocketConnection
+        assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket", "protocol": 3})
+        assert pool.maint_notifications_enabled() is None
+        assert pool._maint_notifications_pool_handler is None
+        assert "maint_notifications_config" not in pool.connection_kwargs
+        assert "maint_notifications_pool_handler" not in pool.connection_kwargs
 
     def test_default_config_client_executes_commands_without_maint_notifications(self):
         client = redis.Redis(unix_socket_path="/socket")

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -100,6 +100,23 @@ class TestConnectionPool:
         assert isinstance(connection, DummyConnection)
         assert_kwargs_subset(connection.kwargs, connection_kwargs)
 
+    def test_custom_connection_disables_maint_notifications(self):
+        pool = redis.ConnectionPool(connection_class=DummyConnection)
+
+        assert pool.maint_notifications_enabled() is None
+        assert "maint_notifications_config" not in pool.connection_kwargs
+        assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+    def test_custom_connection_rejects_enabled_maint_notifications_config(self):
+        with pytest.raises(
+            redis.RedisError,
+            match="Maintenance notifications are not supported with this connection class",
+        ):
+            redis.ConnectionPool(
+                connection_class=DummyConnection,
+                maint_notifications_config=MaintNotificationsConfig(enabled=True),
+            )
+
     @pytest.mark.fixed_client
     def test_closing(self):
         connection_kwargs = {"foo": "bar", "biz": "baz"}
@@ -589,6 +606,94 @@ class TestConnectionPoolUnixSocketURLParsing:
         pool = redis.ConnectionPool.from_url("unix:///socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
         assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket"})
+
+    def test_client_disables_maint_notifications(self):
+        client = redis.Redis(unix_socket_path="/socket")
+        pool = client.connection_pool
+
+        assert pool.connection_class == redis.UnixDomainSocketConnection
+        assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket"})
+        assert pool.maint_notifications_enabled() is None
+        assert "maint_notifications_config" not in pool.connection_kwargs
+        assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+    def test_client_respects_disabled_maint_notifications_config(self):
+        client = redis.Redis(
+            unix_socket_path="/socket",
+            maint_notifications_config=MaintNotificationsConfig(enabled=False),
+        )
+        pool = client.connection_pool
+
+        assert pool.connection_class == redis.UnixDomainSocketConnection
+        assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket"})
+        assert pool.maint_notifications_enabled() is None
+        assert pool._maint_notifications_pool_handler is None
+        # The disabled config is consumed by ConnectionPool and should not be
+        # propagated to individual Unix socket connections.
+        assert "maint_notifications_config" not in pool.connection_kwargs
+        assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+    def test_client_rejects_enabled_maint_notifications_config(self):
+        with pytest.raises(
+            redis.RedisError,
+            match=(
+                "Maintenance notifications are not supported with Unix "
+                "domain socket connections"
+            ),
+        ):
+            redis.Redis(
+                unix_socket_path="/socket",
+                maint_notifications_config=MaintNotificationsConfig(enabled=True),
+            )
+
+    def test_default_config_client_executes_commands_without_maint_notifications(self):
+        client = redis.Redis(unix_socket_path="/socket")
+        key = "redis-py:unix-socket-default-config"
+        responses = [
+            {"proto": 3},
+            b"OK",
+            b"OK",
+            b"PONG",
+            b"OK",
+            b"value",
+        ]
+        socket_mock = mock.MagicMock()
+
+        with mock.patch.object(
+            redis.UnixDomainSocketConnection, "_connect", return_value=socket_mock
+        ), mock.patch.object(
+            redis.UnixDomainSocketConnection, "can_read", return_value=False
+        ), mock.patch.object(
+            redis.UnixDomainSocketConnection, "send_command"
+        ) as send_command, mock.patch.object(
+            redis.UnixDomainSocketConnection, "read_response", side_effect=responses
+        ), mock.patch.object(
+            redis.UnixDomainSocketConnection, "_enable_maintenance_notifications"
+        ) as enable:
+            assert client.ping() is True
+            assert client.set(key, "value") is True
+            assert client.get(key) == b"value"
+
+        client.close()
+        enable.assert_not_called()
+        sent_commands = [command.args for command in send_command.call_args_list]
+        assert ("PING",) in sent_commands
+        assert ("SET", key, "value") in sent_commands
+        assert ("GET", key) in sent_commands
+        for command in sent_commands:
+            assert command[:2] != ("CLIENT", "MAINT_NOTIFICATIONS")
+
+    def test_connection_does_not_activate_maint_notifications(self):
+        pool = redis.ConnectionPool(
+            connection_class=redis.UnixDomainSocketConnection,
+            path="/socket",
+        )
+        conn = pool.make_connection()
+
+        with mock.patch.object(conn, "_enable_maintenance_notifications") as enable:
+            conn.activate_maint_notifications_handling_if_enabled()
+
+        enable.assert_not_called()
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self):


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

Fixes #4086 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guardrails on connection setup for an unsupported transport; behavior change is disabling incorrect maint-notification handshakes rather than altering TCP/cluster paths.
> 
> **Overview**
> **Maintenance notifications are turned off for Unix domain sockets and connection types that cannot support them**, instead of letting RESP3 defaults enable pool handlers and `CLIENT MAINT_NOTIFICATIONS` handshakes that depend on a TCP `host`.
> 
> `Redis` with `unix_socket_path` now **rejects** `MaintNotificationsConfig(enabled=True)` and passes an **explicit disabled** config into the pool. `ConnectionPool` **detects** `UnixDomainSocketConnection` (and custom classes that are not `MaintNotificationsAbstractConnection`): it raises if maintenance is explicitly enabled, otherwise **forces** maintenance off and skips propagating maint-notification kwargs/handlers. Activation on connect now requires **`host is not None`**, so UDS paths no longer trigger the handshake.
> 
> Tests cover Unix URL/client/pool paths, custom `DummyConnection`, and mocked commands to ensure **`CLIENT MAINT_NOTIFICATIONS` is never sent** on Unix sockets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f176c5896115e7a6859742bf1721ea76e25046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->