### PR TITLE
Updating PyJWT dependency.

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -47,8 +47,6 @@ jobs:
             CVE-2026-34073 # DNS name constraints were validated only against SANs, not against the peer name used in verification
                            # Update version when msal dependency in entraid is updated
             CVE-2026-4539  # pygments ReDoS in AdlLexer, local access only, no fix available yet
-            PYSEC-2025-183 # PyJWT weak-encryption advisory disputed by maintainer (key length is the caller's responsibility);
-                           # no fixed version published — 2.12.1 is the latest release.
 
   lint:
     name: Code linters

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -26,7 +26,7 @@ vulture>=2.3.0
 numpy>=1.24.0 ; platform_python_implementation == "CPython"
 numpy>=1.24.0,<2.0 ; platform_python_implementation == "PyPy"
 
-redis-entraid==1.1.2
+redis-entraid==1.2.1
 pybreaker>=1.4.0
 
 xxhash==3.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ ocsp = [
     "requests>=2.31.0",
 ]
 jwt = [
-    "PyJWT>=2.12.0",
+    "PyJWT>=2.13.0",
 ]
 circuit_breaker = [
     "pybreaker>=1.4.0"


### PR DESCRIPTION
Updating dependency version due to security issues: 

- PYSEC-2026-179
- PYSEC-2026-175
- PYSEC-2026-177
- PYSEC-2026-178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-driven JWT dependency floor affects anyone using the optional jwt extra; changes are version pins only with no library code edits.
> 
> **Overview**
> Bumps the optional **`jwt`** extra so installs require **PyJWT ≥2.13.0** (was ≥2.12.0), addressing several **PYSEC-2026** weak-encryption advisories. CI **`pip-audit`** no longer ignores **PYSEC-2025-183** for PyJWT now that a fixed floor is enforced.
> 
> **`dev_requirements.txt`** also pins **`redis-entraid`** **1.1.2 → 1.2.1** (dev/test stack), alongside existing notes to revisit **msal**/**CVE-2026-34073** when Entra ID deps move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce74adb85ba01b1a829999b65a8efce6768a333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->