### PR TITLE
fix(pubsub): add timeout parameter to listen() to prevent Redis 8.0 timeout errors

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1430,10 +1430,18 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    async def listen(self) -> AsyncIterator:
-        """Listen for messages on channels this client has been subscribed to"""
+    async def listen(self, timeout: Optional[float] = 0.0) -> AsyncIterator:
+        """
+        Listen for messages on channels this client has been subscribed to.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number or None to wait indefinitely.
+        """
         while self.subscribed:
-            response = await self.handle_message(await self.parse_response(block=True))
+            response = await self.handle_message(
+                await self.parse_response(block=(timeout is None), timeout=timeout)
+            )
             if response is not None:
                 yield response
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1430,7 +1430,7 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    async def listen(self, timeout: Optional[float] = 0.0) -> AsyncIterator:
+    async def listen(self, timeout: Optional[float] = None) -> AsyncIterator:
         """
         Listen for messages on channels this client has been subscribed to.
 
@@ -1438,12 +1438,18 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number or None to wait indefinitely.
         """
+        if timeout is not None:
+            start = time.monotonic()
         while self.subscribed:
             response = await self.handle_message(
                 await self.parse_response(block=(timeout is None), timeout=timeout)
             )
             if response is not None:
                 yield response
+            if timeout is not None:
+                elapsed = time.monotonic() - start
+                if elapsed >= timeout:
+                    break
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1440,9 +1440,12 @@ class PubSub:
         """
         if timeout is not None:
             start = time.monotonic()
+            remaining = timeout
+        else:
+            remaining = None
         while self.subscribed:
             response = await self.handle_message(
-                await self.parse_response(block=(timeout is None), timeout=timeout)
+                await self.parse_response(block=(timeout is None), timeout=remaining)
             )
             if response is not None:
                 yield response
@@ -1450,6 +1453,7 @@ class PubSub:
                 elapsed = time.monotonic() - start
                 if elapsed >= timeout:
                     break
+                remaining = timeout - elapsed
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/client.py
+++ b/redis/client.py
@@ -1439,10 +1439,18 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    def listen(self):
-        "Listen for messages on channels this client has been subscribed to"
+    def listen(self, timeout: float = 0.0):
+        """
+        Listen for messages on channels this client has been subscribed to.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number, or None, to wait indefinitely.
+        """
         while self.subscribed:
-            response = self.handle_message(self.parse_response(block=True))
+            response = self.handle_message(
+                self.parse_response(block=(timeout is None), timeout=timeout)
+            )
             if response is not None:
                 yield response
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1449,9 +1449,12 @@ class PubSub:
         """
         if timeout is not None:
             start = time.monotonic()
+            remaining = timeout
+        else:
+            remaining = None
         while self.subscribed:
             response = self.handle_message(
-                self.parse_response(block=(timeout is None), timeout=timeout)
+                self.parse_response(block=(timeout is None), timeout=remaining)
             )
             if response is not None:
                 yield response
@@ -1459,6 +1462,7 @@ class PubSub:
                 elapsed = time.monotonic() - start
                 if elapsed >= timeout:
                     break
+                remaining = timeout - elapsed
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/redis/client.py
+++ b/redis/client.py
@@ -1439,7 +1439,7 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    def listen(self, timeout: float = 0.0):
+    def listen(self, timeout: Optional[float] = None):
         """
         Listen for messages on channels this client has been subscribed to.
 
@@ -1447,12 +1447,18 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number, or None, to wait indefinitely.
         """
+        if timeout is not None:
+            start = time.monotonic()
         while self.subscribed:
             response = self.handle_message(
                 self.parse_response(block=(timeout is None), timeout=timeout)
             )
             if response is not None:
                 yield response
+            if timeout is not None:
+                elapsed = time.monotonic() - start
+                if elapsed >= timeout:
+                    break
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2230,6 +2230,86 @@ class TestPubSubTimeoutPropagation:
         msg = p.get_message(timeout=0.1)
         assert msg is None
 
+    def test_listen_with_timeout_returns_none_when_no_message(self, r):
+        """
+        Test that listen() with timeout parameter respects the timeout
+        and yields nothing when no message arrives within the timeout period.
+        Fixes redis/redis-py#4098.
+        """
+        p = r.pubsub()
+        p.subscribe("foo")
+        # Read subscription message
+        msg = wait_for_message(p, timeout=1.0)
+        assert msg is not None
+        assert msg["type"] == "subscribe"
+
+        # listen with timeout should yield nothing and return quickly
+        start = time.monotonic()
+        messages = list(p.listen(timeout=0.1))
+        elapsed = time.monotonic() - start
+        assert len(messages) == 0
+        # Verify timeout was actually respected (within reasonable bounds)
+        assert elapsed < 0.5
+
+    def test_listen_with_timeout_yields_message_when_published(self, r):
+        """
+        Test that listen() with timeout yields a message if one arrives
+        before the timeout expires.
+        Fixes redis/redis-py#4098.
+        """
+        p = r.pubsub()
+        p.subscribe("foo")
+        # Read subscription message
+        msg = wait_for_message(p, timeout=1.0)
+        assert msg is not None
+
+        # Publish a message
+        r.publish("foo", "hello")
+
+        # listen with timeout should yield the message
+        messages = list(p.listen(timeout=1.0))
+        assert len(messages) == 1
+        assert messages[0]["type"] == "message"
+        assert messages[0]["data"] == b"hello"
+
+    def test_listen_timeout_none_blocks_until_message(self, r):
+        """
+        Test that listen(timeout=None) blocks indefinitely until a message arrives.
+        We test this by using a thread to publish a message after a delay.
+        Fixes redis/redis-py#4098.
+        """
+        p = r.pubsub()
+        p.subscribe("foo")
+        # Read subscription message
+        msg = wait_for_message(p, timeout=1.0)
+        assert msg is not None
+
+        # Publish a message after a short delay in a thread
+        start_publishing = threading.Event()
+
+        def publish_after_delay():
+            start_publishing.wait()
+            time.sleep(0.2)
+            r.publish("foo", "delayed_message")
+
+        thread = threading.Thread(target=publish_after_delay, daemon=True)
+        thread.start()
+
+        # listen with timeout=None should block until message arrives
+        start = time.monotonic()
+        start_publishing.set()
+        messages = []
+        for msg in p.listen(timeout=None):
+            messages.append(msg)
+            break
+        elapsed = time.monotonic() - start
+        assert len(messages) == 1
+        assert messages[0]["type"] == "message"
+        assert messages[0]["data"] == b"delayed_message"
+        # Should have waited at least 0.2 seconds
+        assert elapsed >= 0.15
+        thread.join(timeout=1.0)
+
 
 class TestClusterPubSubTimeoutPropagation:
     """


### PR DESCRIPTION
Fixes #4098

Adds an optional  parameter to  (sync and async) that is forwarded to , matching the existing  API. This prevents  on Redis 8.0.0+ when no messages arrive within the connection's  (default 5s).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API default; behavior change is limited to pubsub listen loops and read timeout handling, with dedicated tests.
> 
> **Overview**
> Adds an optional **`timeout`** argument to **`PubSub.listen()`** in both sync and async clients (fixes #4098). Previously **`listen()`** always blocked indefinitely via **`parse_response(block=True)`**, which could surface connection read timeouts on Redis 8.0+ when idle. With a timeout, it now mirrors **`get_message()`**: non-blocking reads with a shrinking **`remaining`** budget using **`time.monotonic()`**, then exits the generator when the budget is exhausted; **`timeout=None`** keeps indefinite blocking.
> 
> New tests cover empty **`listen(timeout=…)`**, delivering a message within the window, and **`timeout=None`** blocking until publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9cb71b90a3dc9361f3d30ab2657f01129dc300b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->