### PR TITLE
Bumping github-actions versions

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -43,17 +43,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       if: ${{ inputs.parser-backend == 'hiredis' && inputs.hiredis-version == 'unstable' }}
       with:
         repository: redis/hiredis-py
@@ -261,7 +261,7 @@ runs:
       shell: bash
 
     - name: Upload test results and profiling data
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results-redis_${{inputs.redis-version}}-python_${{inputs.python-version}}-parser_${{env.PARSER_BACKEND}}-el_${{inputs.event-loop}}-config_${{inputs.test-config}}
         path: |
@@ -272,6 +272,6 @@ runs:
         retention-days: 10
 
     - name: Upload codecov coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
         fail_ci_if_error: false


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI dependency bumps with no application or test logic changes; main risk is upstream action behavior differences surfacing in workflows.
> 
> **Overview**
> Bumps third-party GitHub Action pins in the composite **run-tests** action so CI uses current major releases without changing test commands or inputs.
> 
> **`actions/checkout`** moves from v4 to **v6** for both the main repo checkout and the conditional **hiredis-py** checkout. **`actions/setup-python`** goes from v5 to **v6** (same `python-version` and pip cache). **`actions/upload-artifact`** goes from v4 to **v7** for pytest/profiling uploads, and **`codecov/codecov-action`** goes from v4 to **v6** with the same `fail_ci_if_error: false` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dce313ec23b3f884e6e55b8d6469a5baa1f9500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->