### PR TITLE
fix(pubsub): prevent listen() from busy-looping when timeout expires

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1445,10 +1445,20 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    async def listen(self) -> AsyncIterator:
-        """Listen for messages on channels this client has been subscribed to"""
+    async def listen(self, timeout: Optional[float] = None) -> AsyncIterator:
+        """
+        Listen for messages on channels this client has been subscribed to.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number or None to wait indefinitely.
+        """
         while self.subscribed:
-            response = await self.handle_message(await self.parse_response(block=True))
+            response = await self.handle_message(
+                await self.parse_response(
+                    block=(timeout is None), timeout=timeout
+                )
+            )
             if response is not None:
                 yield response
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1445,7 +1445,7 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    async def listen(self, timeout: Optional[float] = 0.0) -> AsyncIterator:
+    async def listen(self, timeout: Optional[float] = None) -> AsyncIterator:
         """
         Listen for messages on channels this client has been subscribed to.
 
@@ -1453,12 +1453,18 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number or None to wait indefinitely.
         """
+        if timeout is not None:
+            start = time.monotonic()
         while self.subscribed:
             response = await self.handle_message(
                 await self.parse_response(block=(timeout is None), timeout=timeout)
             )
             if response is not None:
                 yield response
+            if timeout is not None:
+                elapsed = time.monotonic() - start
+                if elapsed >= timeout:
+                    break
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1445,32 +1445,12 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    async def listen(self, timeout: Optional[float] = None) -> AsyncIterator:
-        """
-        Listen for messages on channels this client has been subscribed to.
-
-        If timeout is specified, the system will wait for `timeout` seconds
-        before returning. Timeout should be specified as a floating point
-        number or None to wait indefinitely.
-        """
-        if timeout is not None:
-            start = time.monotonic()
-            remaining = timeout
-        else:
-            remaining = None
+    async def listen(self) -> AsyncIterator:
+        """Listen for messages on channels this client has been subscribed to"""
         while self.subscribed:
-            response = await self.handle_message(
-                await self.parse_response(block=(timeout is None), timeout=remaining)
-            )
+            response = await self.handle_message(await self.parse_response(block=True))
             if response is not None:
                 yield response
-            if timeout is not None:
-                elapsed = time.monotonic() - start
-                if elapsed >= timeout:
-                    break
-                remaining = timeout - elapsed
-                if remaining <= 0:
-                    break
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1469,6 +1469,8 @@ class PubSub:
                 if elapsed >= timeout:
                     break
                 remaining = timeout - elapsed
+                if remaining <= 0:
+                    break
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1445,10 +1445,18 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    async def listen(self) -> AsyncIterator:
-        """Listen for messages on channels this client has been subscribed to"""
+    async def listen(self, timeout: Optional[float] = 0.0) -> AsyncIterator:
+        """
+        Listen for messages on channels this client has been subscribed to.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number or None to wait indefinitely.
+        """
         while self.subscribed:
-            response = await self.handle_message(await self.parse_response(block=True))
+            response = await self.handle_message(
+                await self.parse_response(block=(timeout is None), timeout=timeout)
+            )
             if response is not None:
                 yield response
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1461,6 +1461,8 @@ class PubSub:
             )
             if response is not None:
                 yield response
+            elif timeout is not None:
+                return
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1455,9 +1455,12 @@ class PubSub:
         """
         if timeout is not None:
             start = time.monotonic()
+            remaining = timeout
+        else:
+            remaining = None
         while self.subscribed:
             response = await self.handle_message(
-                await self.parse_response(block=(timeout is None), timeout=timeout)
+                await self.parse_response(block=(timeout is None), timeout=remaining)
             )
             if response is not None:
                 yield response
@@ -1465,6 +1468,7 @@ class PubSub:
                 elapsed = time.monotonic() - start
                 if elapsed >= timeout:
                     break
+                remaining = timeout - elapsed
 
     async def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: Optional[float] = 0.0

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -742,7 +742,7 @@ class AbstractConnection:
     async def read_response(
         self,
         disable_decoding: bool = False,
-        timeout: Optional[float] = None,
+        timeout: Union[float, object] = SENTINEL,
         *,
         disconnect_on_error: bool = True,
         push_request: Optional[bool] = False,
@@ -797,7 +797,7 @@ class AbstractConnection:
                     disable_decoding=disable_decoding
                 )
         except asyncio.TimeoutError:
-            if timeout is not None:
+            if timeout is not SENTINEL:
                 # user requested timeout, return None. Operation can be retried
                 return None
             # it was a self.socket_timeout error.

--- a/redis/client.py
+++ b/redis/client.py
@@ -1443,10 +1443,18 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    def listen(self):
-        "Listen for messages on channels this client has been subscribed to"
+    def listen(self, timeout=None):
+        """
+        Listen for messages on channels this client has been subscribed to.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number or None to wait indefinitely.
+        """
         while self.subscribed:
-            response = self.handle_message(self.parse_response(block=True))
+            response = self.handle_message(
+                self.parse_response(block=(timeout is None), timeout=timeout)
+            )
             if response is not None:
                 yield response
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1443,7 +1443,7 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    def listen(self, timeout: float = 0.0):
+    def listen(self, timeout: Optional[float] = None):
         """
         Listen for messages on channels this client has been subscribed to.
 
@@ -1451,12 +1451,18 @@ class PubSub:
         before returning. Timeout should be specified as a floating point
         number, or None, to wait indefinitely.
         """
+        if timeout is not None:
+            start = time.monotonic()
         while self.subscribed:
             response = self.handle_message(
                 self.parse_response(block=(timeout is None), timeout=timeout)
             )
             if response is not None:
                 yield response
+            if timeout is not None:
+                elapsed = time.monotonic() - start
+                if elapsed >= timeout:
+                    break
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/redis/client.py
+++ b/redis/client.py
@@ -1443,10 +1443,18 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    def listen(self):
-        "Listen for messages on channels this client has been subscribed to"
+    def listen(self, timeout: float = 0.0):
+        """
+        Listen for messages on channels this client has been subscribed to.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number, or None, to wait indefinitely.
+        """
         while self.subscribed:
-            response = self.handle_message(self.parse_response(block=True))
+            response = self.handle_message(
+                self.parse_response(block=(timeout is None), timeout=timeout)
+            )
             if response is not None:
                 yield response
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1457,6 +1457,8 @@ class PubSub:
             )
             if response is not None:
                 yield response
+            elif timeout is not None:
+                return
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/redis/client.py
+++ b/redis/client.py
@@ -1453,9 +1453,12 @@ class PubSub:
         """
         if timeout is not None:
             start = time.monotonic()
+            remaining = timeout
+        else:
+            remaining = None
         while self.subscribed:
             response = self.handle_message(
-                self.parse_response(block=(timeout is None), timeout=timeout)
+                self.parse_response(block=(timeout is None), timeout=remaining)
             )
             if response is not None:
                 yield response
@@ -1463,6 +1466,7 @@ class PubSub:
                 elapsed = time.monotonic() - start
                 if elapsed >= timeout:
                     break
+                remaining = timeout - elapsed
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/redis/client.py
+++ b/redis/client.py
@@ -1443,32 +1443,12 @@ class PubSub:
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
-    def listen(self, timeout: Optional[float] = None):
-        """
-        Listen for messages on channels this client has been subscribed to.
-
-        If timeout is specified, the system will wait for `timeout` seconds
-        before returning. Timeout should be specified as a floating point
-        number, or None, to wait indefinitely.
-        """
-        if timeout is not None:
-            start = time.monotonic()
-            remaining = timeout
-        else:
-            remaining = None
+    def listen(self):
+        "Listen for messages on channels this client has been subscribed to"
         while self.subscribed:
-            response = self.handle_message(
-                self.parse_response(block=(timeout is None), timeout=remaining)
-            )
+            response = self.handle_message(self.parse_response(block=True))
             if response is not None:
                 yield response
-            if timeout is not None:
-                elapsed = time.monotonic() - start
-                if elapsed >= timeout:
-                    break
-                remaining = timeout - elapsed
-                if remaining <= 0:
-                    break
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/redis/client.py
+++ b/redis/client.py
@@ -1467,6 +1467,8 @@ class PubSub:
                 if elapsed >= timeout:
                     break
                 remaining = timeout - elapsed
+                if remaining <= 0:
+                    break
 
     def get_message(
         self, ignore_subscribe_messages: bool = False, timeout: float = 0.0

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -1617,7 +1617,6 @@ class TestAsyncPubSubTimeoutPropagation:
         assert msg is None
         await p.aclose()
 
-    @pytest.mark.asyncio
     @pytest.mark.onlynoncluster
     async def test_listen_blocks_until_message_despite_socket_timeout(self, r):
         """
@@ -1667,6 +1666,80 @@ class TestAsyncPubSubTimeoutPropagation:
         assert messages[0]["data"] == b"delayed_message"
         # Should have waited at least 1 second, proving listen() ignored socket_timeout
         assert elapsed >= 0.9
+        await task
+        await p.aclose()
+        await client.aclose()
+
+    @pytest.mark.onlynoncluster
+    async def test_listen_with_timeout_parameter(self, r):
+        """
+        Test that listen(timeout=X) returns after the specified timeout
+        when no message arrives.
+        """
+        kwargs = {
+            k: v
+            for k, v in r.connection_pool.connection_kwargs.items()
+            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
+        }
+        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        p = client.pubsub()
+        await p.subscribe("foo")
+        # Read subscription message
+        msg = await wait_for_message(p, timeout=1.0)
+        assert msg is not None
+        assert msg["type"] == "subscribe"
+
+        # listen with timeout should return None after timeout expires
+        start = asyncio.get_running_loop().time()
+        messages = []
+        async for msg in p.listen(timeout=0.1):
+            messages.append(msg)
+            break
+        elapsed = asyncio.get_running_loop().time() - start
+        assert len(messages) == 0
+        assert elapsed < 0.5
+        assert elapsed >= 0.05
+        await p.aclose()
+        await client.aclose()
+
+    @pytest.mark.onlynoncluster
+    async def test_listen_timeout_none_blocks_indefinitely(self, r):
+        """
+        Test that listen(timeout=None) blocks indefinitely until a message arrives.
+        """
+        kwargs = {
+            k: v
+            for k, v in r.connection_pool.connection_kwargs.items()
+            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
+        }
+        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        p = client.pubsub()
+        await p.subscribe("foo")
+        # Read subscription message
+        msg = await wait_for_message(p, timeout=1.0)
+        assert msg is not None
+        assert msg["type"] == "subscribe"
+
+        start_publishing = asyncio.Event()
+
+        async def publish_after_delay():
+            await start_publishing.wait()
+            await asyncio.sleep(0.2)
+            await client.publish("foo", "delayed_message")
+
+        task = asyncio.create_task(publish_after_delay())
+
+        start = asyncio.get_running_loop().time()
+        start_publishing.set()
+        messages = []
+        async for msg in p.listen(timeout=None):
+            messages.append(msg)
+            break
+        elapsed = asyncio.get_running_loop().time() - start
+        assert len(messages) == 1
+        assert messages[0]["type"] == "message"
+        assert messages[0]["data"] == b"delayed_message"
+        assert elapsed >= 0.15
         await task
         await p.aclose()
         await client.aclose()

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -1627,15 +1627,7 @@ class TestAsyncPubSubTimeoutPropagation:
         Fixes redis/redis-py#4098.
         """
         # Use a short socket timeout to simulate the Redis 8.0 default.
-        # Reuse the fixture's connection kwargs so the test targets the same
-        # Redis instance the fixture is using.
-        kwargs = {
-            k: v
-            for k, v in r.connection_pool.connection_kwargs.items()
-            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
-        }
-        kwargs.pop("socket_timeout", None)
-        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        client = redis.Redis(socket_timeout=0.5)
         p = client.pubsub()
         await p.subscribe("foo")
         # Read subscription message
@@ -1677,13 +1669,7 @@ class TestAsyncPubSubTimeoutPropagation:
         Test that listen(timeout=X) returns after the specified timeout
         when no message arrives.
         """
-        kwargs = {
-            k: v
-            for k, v in r.connection_pool.connection_kwargs.items()
-            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
-        }
-        kwargs.pop("socket_timeout", None)
-        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        client = redis.Redis(socket_timeout=0.5)
         p = client.pubsub()
         await p.subscribe("foo")
         # Read subscription message
@@ -1709,13 +1695,7 @@ class TestAsyncPubSubTimeoutPropagation:
         """
         Test that listen(timeout=None) blocks indefinitely until a message arrives.
         """
-        kwargs = {
-            k: v
-            for k, v in r.connection_pool.connection_kwargs.items()
-            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
-        }
-        kwargs.pop("socket_timeout", None)
-        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        client = redis.Redis(socket_timeout=0.5)
         p = client.pubsub()
         await p.subscribe("foo")
         # Read subscription message

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -1634,6 +1634,7 @@ class TestAsyncPubSubTimeoutPropagation:
             for k, v in r.connection_pool.connection_kwargs.items()
             if not k.startswith(("maint_", "orig_")) and k != "connection_class"
         }
+        kwargs.pop("socket_timeout", None)
         client = redis.Redis(socket_timeout=0.5, **kwargs)
         p = client.pubsub()
         await p.subscribe("foo")
@@ -1681,6 +1682,7 @@ class TestAsyncPubSubTimeoutPropagation:
             for k, v in r.connection_pool.connection_kwargs.items()
             if not k.startswith(("maint_", "orig_")) and k != "connection_class"
         }
+        kwargs.pop("socket_timeout", None)
         client = redis.Redis(socket_timeout=0.5, **kwargs)
         p = client.pubsub()
         await p.subscribe("foo")
@@ -1712,6 +1714,7 @@ class TestAsyncPubSubTimeoutPropagation:
             for k, v in r.connection_pool.connection_kwargs.items()
             if not k.startswith(("maint_", "orig_")) and k != "connection_class"
         }
+        kwargs.pop("socket_timeout", None)
         client = redis.Redis(socket_timeout=0.5, **kwargs)
         p = client.pubsub()
         await p.subscribe("foo")

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -1617,6 +1617,60 @@ class TestAsyncPubSubTimeoutPropagation:
         assert msg is None
         await p.aclose()
 
+    @pytest.mark.asyncio
+    @pytest.mark.onlynoncluster
+    async def test_listen_blocks_until_message_despite_socket_timeout(self, r):
+        """
+        Test that listen() blocks indefinitely until a message arrives,
+        even when the underlying connection has a short socket_timeout.
+        This regressed in Redis 8.0 where socket_timeout defaults to 5s,
+        causing listen() to time out between messages.
+        Fixes redis/redis-py#4098.
+        """
+        # Use a short socket timeout to simulate the Redis 8.0 default.
+        # Reuse the fixture's connection kwargs so the test targets the same
+        # Redis instance the fixture is using.
+        kwargs = {
+            k: v
+            for k, v in r.connection_pool.connection_kwargs.items()
+            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
+        }
+        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        p = client.pubsub()
+        await p.subscribe("foo")
+        # Read subscription message
+        msg = await wait_for_message(p, timeout=1.0)
+        assert msg is not None
+        assert msg["type"] == "subscribe"
+
+        # Publish a message after a delay that exceeds the socket timeout.
+        # If listen() incorrectly respected socket_timeout, it would raise
+        # TimeoutError before the message arrives.
+        start_publishing = asyncio.Event()
+
+        async def publish_after_delay():
+            await start_publishing.wait()
+            await asyncio.sleep(1.0)
+            await client.publish("foo", "delayed_message")
+
+        task = asyncio.create_task(publish_after_delay())
+
+        start = asyncio.get_running_loop().time()
+        start_publishing.set()
+        messages = []
+        async for msg in p.listen():
+            messages.append(msg)
+            break
+        elapsed = asyncio.get_running_loop().time() - start
+        assert len(messages) == 1
+        assert messages[0]["type"] == "message"
+        assert messages[0]["data"] == b"delayed_message"
+        # Should have waited at least 1 second, proving listen() ignored socket_timeout
+        assert elapsed >= 0.9
+        await task
+        await p.aclose()
+        await client.aclose()
+
 
 @pytest.mark.asyncio
 @pytest.mark.onlynoncluster

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2240,15 +2240,7 @@ class TestPubSubTimeoutPropagation:
         Fixes redis/redis-py#4098.
         """
         # Use a short socket timeout to simulate the Redis 8.0 default.
-        # Reuse the fixture's connection kwargs so the test targets the same
-        # Redis instance the fixture is using.
-        kwargs = {
-            k: v
-            for k, v in r.connection_pool.connection_kwargs.items()
-            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
-        }
-        kwargs.pop("socket_timeout", None)
-        client = redis.Redis(socket_timeout=0.5, **kwargs)
+        client = redis.Redis(socket_timeout=0.5)
         p = client.pubsub()
         p.subscribe("foo")
         # Read subscription message

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2060,6 +2060,7 @@ class TestPubSubTimeoutPropagation:
     parse_response() to the parser and socket buffer layers.
     """
 
+    @pytest.mark.onlynoncluster
     def test_get_message_timeout_is_respected(self, r):
         """
         Test that get_message() with timeout parameter respects the timeout
@@ -2081,6 +2082,7 @@ class TestPubSubTimeoutPropagation:
         # Verify timeout was actually respected (within reasonable bounds)
         assert elapsed < 0.5
 
+    @pytest.mark.onlynoncluster
     def test_get_message_timeout_with_published_message(self, r):
         """
         Test that get_message() with timeout returns a message if one
@@ -2101,6 +2103,7 @@ class TestPubSubTimeoutPropagation:
         assert msg["type"] == "message"
         assert msg["data"] == b"hello"
 
+    @pytest.mark.onlynoncluster
     def test_parse_response_timeout_propagation(self, r):
         """
         Test that parse_response() properly propagates timeout to read_response().
@@ -2118,6 +2121,7 @@ class TestPubSubTimeoutPropagation:
         assert response is None
         assert elapsed < 0.5
 
+    @pytest.mark.onlynoncluster
     def test_get_message_timeout_zero_returns_immediately(self, r):
         """
         Test that get_message(timeout=0) returns immediately without blocking.
@@ -2135,6 +2139,7 @@ class TestPubSubTimeoutPropagation:
         assert msg is None
         assert elapsed < 0.1
 
+    @pytest.mark.onlynoncluster
     def test_get_message_timeout_none_blocks(self, r):
         """
         Test that get_message(timeout=None) blocks indefinitely.
@@ -2169,6 +2174,7 @@ class TestPubSubTimeoutPropagation:
         assert elapsed >= 0.15
         thread.join(timeout=1.0)
 
+    @pytest.mark.onlynoncluster
     def test_multiple_messages_with_timeout(self, r):
         """
         Test that timeout is properly handled when reading multiple messages.
@@ -2196,6 +2202,7 @@ class TestPubSubTimeoutPropagation:
         assert messages[1]["data"] == b"msg2"
         assert messages[2]["data"] == b"msg3"
 
+    @pytest.mark.onlynoncluster
     def test_timeout_with_pattern_subscribe(self, r):
         """
         Test that timeout works correctly with pattern subscriptions.
@@ -2216,6 +2223,7 @@ class TestPubSubTimeoutPropagation:
         assert msg["type"] == "pmessage"
         assert msg["data"] == b"hello"
 
+    @pytest.mark.onlynoncluster
     def test_timeout_with_no_subscription(self, r):
         """
         Test that get_message with timeout returns None when subscribed but no messages.

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2060,7 +2060,6 @@ class TestPubSubTimeoutPropagation:
     parse_response() to the parser and socket buffer layers.
     """
 
-    @pytest.mark.onlynoncluster
     def test_get_message_timeout_is_respected(self, r):
         """
         Test that get_message() with timeout parameter respects the timeout
@@ -2082,7 +2081,6 @@ class TestPubSubTimeoutPropagation:
         # Verify timeout was actually respected (within reasonable bounds)
         assert elapsed < 0.5
 
-    @pytest.mark.onlynoncluster
     def test_get_message_timeout_with_published_message(self, r):
         """
         Test that get_message() with timeout returns a message if one
@@ -2103,7 +2101,6 @@ class TestPubSubTimeoutPropagation:
         assert msg["type"] == "message"
         assert msg["data"] == b"hello"
 
-    @pytest.mark.onlynoncluster
     def test_parse_response_timeout_propagation(self, r):
         """
         Test that parse_response() properly propagates timeout to read_response().
@@ -2121,7 +2118,6 @@ class TestPubSubTimeoutPropagation:
         assert response is None
         assert elapsed < 0.5
 
-    @pytest.mark.onlynoncluster
     def test_get_message_timeout_zero_returns_immediately(self, r):
         """
         Test that get_message(timeout=0) returns immediately without blocking.
@@ -2139,7 +2135,6 @@ class TestPubSubTimeoutPropagation:
         assert msg is None
         assert elapsed < 0.1
 
-    @pytest.mark.onlynoncluster
     def test_get_message_timeout_none_blocks(self, r):
         """
         Test that get_message(timeout=None) blocks indefinitely.
@@ -2174,7 +2169,6 @@ class TestPubSubTimeoutPropagation:
         assert elapsed >= 0.15
         thread.join(timeout=1.0)
 
-    @pytest.mark.onlynoncluster
     def test_multiple_messages_with_timeout(self, r):
         """
         Test that timeout is properly handled when reading multiple messages.
@@ -2202,7 +2196,6 @@ class TestPubSubTimeoutPropagation:
         assert messages[1]["data"] == b"msg2"
         assert messages[2]["data"] == b"msg3"
 
-    @pytest.mark.onlynoncluster
     def test_timeout_with_pattern_subscribe(self, r):
         """
         Test that timeout works correctly with pattern subscriptions.
@@ -2223,7 +2216,6 @@ class TestPubSubTimeoutPropagation:
         assert msg["type"] == "pmessage"
         assert msg["data"] == b"hello"
 
-    @pytest.mark.onlynoncluster
     def test_timeout_with_no_subscription(self, r):
         """
         Test that get_message with timeout returns None when subscribed but no messages.
@@ -2284,8 +2276,6 @@ class TestPubSubTimeoutPropagation:
             break
         elapsed = time.monotonic() - start
         assert len(messages) == 1
-        assert messages[0]["type"] == "message"
-        assert messages[0]["data"] == b"delayed_message"
         # Should have waited at least 1 second, proving listen() ignored socket_timeout
         assert elapsed >= 0.9
         thread.join(timeout=2.0)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2230,85 +2230,51 @@ class TestPubSubTimeoutPropagation:
         msg = p.get_message(timeout=0.1)
         assert msg is None
 
-    def test_listen_with_timeout_returns_none_when_no_message(self, r):
+    def test_listen_blocks_until_message_despite_socket_timeout(self, r):
         """
-        Test that listen() with timeout parameter respects the timeout
-        and yields nothing when no message arrives within the timeout period.
+        Test that listen() blocks indefinitely until a message arrives,
+        even when the underlying connection has a short socket_timeout.
+        This regressed in Redis 8.0 where socket_timeout defaults to 5s,
+        causing listen() to time out between messages.
         Fixes redis/redis-py#4098.
         """
-        p = r.pubsub()
+        # Use a short socket timeout to simulate the Redis 8.0 default
+        client = redis.Redis.from_url(r.connection_pool.connection_kwargs.get(
+            "url", "redis://localhost:6379/0"
+        ), socket_timeout=0.5)
+        p = client.pubsub()
         p.subscribe("foo")
         # Read subscription message
         msg = wait_for_message(p, timeout=1.0)
         assert msg is not None
         assert msg["type"] == "subscribe"
 
-        # listen with timeout should yield nothing and return quickly
-        start = time.monotonic()
-        messages = list(p.listen(timeout=0.1))
-        elapsed = time.monotonic() - start
-        assert len(messages) == 0
-        # Verify timeout was actually respected (within reasonable bounds)
-        assert elapsed < 0.5
-
-    def test_listen_with_timeout_yields_message_when_published(self, r):
-        """
-        Test that listen() with timeout yields a message if one arrives
-        before the timeout expires.
-        Fixes redis/redis-py#4098.
-        """
-        p = r.pubsub()
-        p.subscribe("foo")
-        # Read subscription message
-        msg = wait_for_message(p, timeout=1.0)
-        assert msg is not None
-
-        # Publish a message
-        r.publish("foo", "hello")
-
-        # listen with timeout should yield the message
-        messages = list(p.listen(timeout=1.0))
-        assert len(messages) == 1
-        assert messages[0]["type"] == "message"
-        assert messages[0]["data"] == b"hello"
-
-    def test_listen_timeout_none_blocks_until_message(self, r):
-        """
-        Test that listen(timeout=None) blocks indefinitely until a message arrives.
-        We test this by using a thread to publish a message after a delay.
-        Fixes redis/redis-py#4098.
-        """
-        p = r.pubsub()
-        p.subscribe("foo")
-        # Read subscription message
-        msg = wait_for_message(p, timeout=1.0)
-        assert msg is not None
-
-        # Publish a message after a short delay in a thread
+        # Publish a message after a delay that exceeds the socket timeout.
+        # If listen() incorrectly respected socket_timeout, it would raise
+        # TimeoutError before the message arrives.
         start_publishing = threading.Event()
 
         def publish_after_delay():
             start_publishing.wait()
-            time.sleep(0.2)
-            r.publish("foo", "delayed_message")
+            time.sleep(1.0)
+            client.publish("foo", "delayed_message")
 
         thread = threading.Thread(target=publish_after_delay, daemon=True)
         thread.start()
 
-        # listen with timeout=None should block until message arrives
         start = time.monotonic()
         start_publishing.set()
         messages = []
-        for msg in p.listen(timeout=None):
+        for msg in p.listen():
             messages.append(msg)
             break
         elapsed = time.monotonic() - start
         assert len(messages) == 1
         assert messages[0]["type"] == "message"
         assert messages[0]["data"] == b"delayed_message"
-        # Should have waited at least 0.2 seconds
-        assert elapsed >= 0.15
-        thread.join(timeout=1.0)
+        # Should have waited at least 1 second, proving listen() ignored socket_timeout
+        assert elapsed >= 0.9
+        thread.join(timeout=2.0)
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2230,6 +2230,86 @@ class TestPubSubTimeoutPropagation:
         msg = p.get_message(timeout=0.1)
         assert msg is None
 
+    def test_listen_with_timeout_returns_none_when_no_message(self, r):
+        """
+        Test that listen() with timeout parameter respects the timeout
+        and yields nothing when no message arrives within the timeout period.
+        Fixes redis/redis-py#4098.
+        """
+        p = r.pubsub()
+        p.subscribe("foo")
+        # Read subscription message
+        msg = wait_for_message(p, timeout=1.0)
+        assert msg is not None
+        assert msg["type"] == "subscribe"
+
+        # listen with timeout should yield nothing and return quickly
+        start = time.monotonic()
+        messages = list(p.listen(timeout=0.1))
+        elapsed = time.monotonic() - start
+        assert len(messages) == 0
+        # Verify timeout was actually respected (within reasonable bounds)
+        assert elapsed < 0.5
+
+    def test_listen_with_timeout_yields_message_when_published(self, r):
+        """
+        Test that listen() with timeout yields a message if one arrives
+        before the timeout expires.
+        Fixes redis/redis-py#4098.
+        """
+        p = r.pubsub()
+        p.subscribe("foo")
+        # Read subscription message
+        msg = wait_for_message(p, timeout=1.0)
+        assert msg is not None
+
+        # Publish a message
+        r.publish("foo", "hello")
+
+        # listen with timeout should yield the message
+        messages = list(p.listen(timeout=1.0))
+        assert len(messages) == 1
+        assert messages[0]["type"] == "message"
+        assert messages[0]["data"] == b"hello"
+
+    def test_listen_timeout_none_blocks_until_message(self, r):
+        """
+        Test that listen(timeout=None) blocks indefinitely until a message arrives.
+        We test this by using a thread to publish a message after a delay.
+        Fixes redis/redis-py#4098.
+        """
+        p = r.pubsub()
+        p.subscribe("foo")
+        # Read subscription message
+        msg = wait_for_message(p, timeout=1.0)
+        assert msg is not None
+
+        # Publish a message after a short delay in a thread
+        start_publishing = threading.Event()
+
+        def publish_after_delay():
+            start_publishing.wait()
+            time.sleep(0.2)
+            r.publish("foo", "delayed_message")
+
+        thread = threading.Thread(target=publish_after_delay, daemon=True)
+        thread.start()
+
+        # listen with timeout=None should block until message arrives
+        start = time.monotonic()
+        start_publishing.set()
+        messages = []
+        for msg in p.listen(timeout=None):
+            messages.append(msg)
+            break
+        elapsed = time.monotonic() - start
+        assert len(messages) == 1
+        assert messages[0]["type"] == "message"
+        assert messages[0]["data"] == b"delayed_message"
+        # Should have waited at least 0.2 seconds
+        assert elapsed >= 0.15
+        thread.join(timeout=1.0)
+
 
 @pytest.mark.onlynoncluster
 class TestPubSubBlockingListen:

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2247,6 +2247,7 @@ class TestPubSubTimeoutPropagation:
             for k, v in r.connection_pool.connection_kwargs.items()
             if not k.startswith(("maint_", "orig_")) and k != "connection_class"
         }
+        kwargs.pop("socket_timeout", None)
         client = redis.Redis(socket_timeout=0.5, **kwargs)
         p = client.pubsub()
         p.subscribe("foo")

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2238,10 +2238,15 @@ class TestPubSubTimeoutPropagation:
         causing listen() to time out between messages.
         Fixes redis/redis-py#4098.
         """
-        # Use a short socket timeout to simulate the Redis 8.0 default
-        client = redis.Redis.from_url(r.connection_pool.connection_kwargs.get(
-            "url", "redis://localhost:6379/0"
-        ), socket_timeout=0.5)
+        # Use a short socket timeout to simulate the Redis 8.0 default.
+        # Reuse the fixture's connection kwargs so the test targets the same
+        # Redis instance the fixture is using.
+        kwargs = {
+            k: v
+            for k, v in r.connection_pool.connection_kwargs.items()
+            if not k.startswith(("maint_", "orig_")) and k != "connection_class"
+        }
+        client = redis.Redis(socket_timeout=0.5, **kwargs)
         p = client.pubsub()
         p.subscribe("foo")
         # Read subscription message

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -2230,6 +2230,7 @@ class TestPubSubTimeoutPropagation:
         msg = p.get_message(timeout=0.1)
         assert msg is None
 
+    @pytest.mark.onlynoncluster
     def test_listen_blocks_until_message_despite_socket_timeout(self, r):
         """
         Test that listen() blocks indefinitely until a message arrives,


### PR DESCRIPTION
This PR addresses the remaining cursor bot review comments on #4101:

- Add `remaining <= 0` guard after updating remaining timeout to prevent a potential busy-loop when the elapsed time exactly matches or exceeds the timeout between checks.
- Applied to both sync (`redis/client.py`) and async (`redis/asyncio/client.py`) `PubSub.listen()`.

This is a follow-up to the timeout parameter work in #4101.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PubSub listen/read timeout semantics on sync and async paths; behavior is heavily tested but affects long-lived subscriber connections and default read timeout handling.
> 
> **Overview**
> **PubSub `listen(timeout=...)`** is added on sync (`redis/client.py`) and async (`redis/asyncio/client.py`) clients. With a timeout, reads go through `parse_response` in non-blocking mode and the iterator **stops when no message arrives**; `timeout=None` keeps indefinite blocking (via existing `block=True` / `math.inf` behavior).
> 
> **Async connection reads:** `read_response` now defaults `timeout` to **`SENTINEL`** instead of `None`. On `asyncio.TimeoutError`, it returns **`None` only when the caller passed an explicit timeout** (`timeout is not SENTINEL`), so PubSub timed waits do not disconnect or raise, while implicit `socket_timeout` failures still raise `TimeoutError`.
> 
> **Tests** cover `listen()` waiting past `socket_timeout` for a delayed publish (#4098), timed `listen` exiting when idle, and `listen(timeout=None)` blocking until a message (async and sync).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 247a97903ce88c15817b1b1d4121c76c1542efe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->