### PR TITLE
Fixed async MultiDBClient with underlying RedisCluster

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -269,16 +269,15 @@ runs:
         set -e
 
         echo "::group::Starting second cluster (cluster2)"
-        docker compose up -d cluster2
-        # Wait for cluster2 to form (check from inside the container so we do
-        # not depend on a host-side redis-cli being installed).
-        for i in $(seq 1 60); do
-          if docker exec redis-cluster-2 redis-cli -p 16385 cluster info 2>/dev/null | grep -q 'cluster_state:ok'; then
-            echo "cluster2 is ready"
-            break
-          fi
-          sleep 1
-        done
+        # `--wait` blocks until cluster2's healthcheck reports healthy
+        # (cluster_state:ok) and fails fast if it becomes unhealthy or exits, so
+        # the tests never run against a cluster that did not actually form.
+        if ! docker compose up -d --wait --wait-timeout 120 cluster2; then
+          echo "::error::cluster2 did not become healthy; aborting before running the multi-database integration tests."
+          docker compose logs --no-color --tail 100 cluster2 || true
+          echo "::endgroup::"
+          exit 1
+        fi
         echo "::endgroup::"
 
         eventloop=""

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -156,6 +156,15 @@ runs:
           invoke devenv --endpoints all
         fi
 
+        # Persist the resolved image tags so later steps start containers from
+        # the same Redis image as the rest of this environment. The
+        # multi-database integration step runs `docker compose up cluster2` in a
+        # fresh shell; without this it would fall back to compose's hard-coded
+        # default tag and could start the second cluster on a different Redis
+        # version than the first one.
+        echo "CLIENT_LIBS_TEST_IMAGE_TAG=${CLIENT_LIBS_TEST_IMAGE_TAG}" >> $GITHUB_ENV
+        echo "CLIENT_LIBS_TEST_STACK_IMAGE_TAG=${CLIENT_LIBS_TEST_STACK_IMAGE_TAG}" >> $GITHUB_ENV
+
         sleep 10 # time to settle
         echo "::endgroup::"
       shell: bash

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -31,6 +31,15 @@ inputs:
       Legacy aliases like "2-standalone" are also accepted.
     required: false
     default: 'all'
+  run-multidb-integration:
+    description: |
+      When 'true', also run the MultiDBClient (active-active) integration tests
+      after the main test run. A second cluster (the docker "multidb" profile's
+      cluster2) is started so the client can front two real clusters, in
+      addition to the two standalone servers already up. Enabled for a single
+      existing matrix cell so no extra CI runners are added.
+    required: false
+    default: 'false'
   repository:
     description: 'Repository to checkout'
     required: false
@@ -248,6 +257,39 @@ runs:
         else
           run_tests "${{inputs.test-config}}"
         fi
+      shell: bash
+
+    - name: Run multi-database integration tests
+      # Folded into an existing matrix cell (see the `tests` job) so no extra CI
+      # runners are added. Brings up the second cluster (cluster2) on top of the
+      # already-running environment, then runs the MultiDBClient integration
+      # tests against two clusters and two standalone servers.
+      if: ${{ inputs.run-multidb-integration == 'true' }}
+      run: |
+        set -e
+
+        echo "::group::Starting second cluster (cluster2)"
+        docker compose up -d cluster2
+        # Wait for cluster2 to form (check from inside the container so we do
+        # not depend on a host-side redis-cli being installed).
+        for i in $(seq 1 60); do
+          if docker exec redis-cluster-2 redis-cli -p 16385 cluster info 2>/dev/null | grep -q 'cluster_state:ok'; then
+            echo "cluster2 is ready"
+            break
+          fi
+          sleep 1
+        done
+        echo "::endgroup::"
+
+        eventloop=""
+        if [ "${{inputs.event-loop}}" == "uvloop" ]; then
+          eventloop="--uvloop"
+        fi
+
+        echo "::group::Multi-database integration tests"
+        echo "Running MultiDBClient integration tests against two real Redis deployments (double-cluster and double-standalone)"
+        invoke multidb-integration-tests $eventloop
+        echo "::endgroup::"
       shell: bash
 
     - name: Debug

--- a/.github/workflows/install_and_test.sh
+++ b/.github/workflows/install_and_test.sh
@@ -40,11 +40,13 @@ cd ${TESTDIR}
 # install, run tests
 pip install ${PKG}
 # Redis tests
-pytest -m 'not onlycluster' --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario
+# multidb_integration tests are excluded: they require the dedicated `multidb`
+# docker profile (two clusters + two standalones), which is not provisioned here.
+pytest -m 'not onlycluster and not multidb_integration' --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario
 # RedisCluster tests
 CLUSTER_URL="redis://localhost:16379/0"
 CLUSTER_SSL_URL="rediss://localhost:27379/0"
-pytest -m 'not onlynoncluster and not redismod and not ssl' \
+pytest -m 'not onlynoncluster and not redismod and not ssl and not multidb_integration' \
   --ignore=tests/test_scenario \
   --ignore=tests/test_asyncio/test_scenario \
   --redis-url="${CLUSTER_URL}" \

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -110,6 +110,11 @@ jobs:
             parser-backend: ${{ matrix.parser-backend }}
             redis-version: ${{ matrix.redis-version }}
             test-config: ${{ matrix.test-config }}
+            # Fold the MultiDBClient (active-active) integration tests into an
+            # existing matrix cell instead of a dedicated job, so no extra CI
+            # runners are added. Run them once, on the current Redis version's
+            # cluster cell.
+            run-multidb-integration: ${{ (matrix.redis-version == needs.redis_version.outputs.CURRENT && matrix.test-config == 'default-unified_responses-cluster') && 'true' || 'false' }}
 
   python-compatibility-tests:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - replica
       - all-stack
       - all
+      - multidb
 
   replica:
     <<: *client-libs-image
@@ -72,6 +73,34 @@ services:
       - cluster
       - all-stack
       - all
+      - multidb
+
+  # Second, independent cluster on shifted ports. Used together with `cluster`
+  # by the multi-database (active-active) integration tests so a MultiDBClient
+  # can front two real clusters. Each node announces 127.0.0.1:<port>, so host
+  # ports are mapped 1:1; the cluster bus port (data port + 21000) stays
+  # internal to the container. Only part of the dedicated `multidb` profile so
+  # the regular `all` / `all-stack` test runs are not burdened with a second
+  # cluster.
+  cluster2:
+    <<: *client-libs-image
+    container_name: redis-cluster-2
+    environment:
+      - REDIS_CLUSTER=yes
+      - NODES=6
+      - REPLICAS=1
+      - TLS_ENABLED=yes
+      - TLS_CLIENT_CNS=test_user
+      - PORT=16385
+      - TLS_PORT=27385
+    command: ${REDIS_EXTRA_ARGS:---enable-debug-command yes --enable-module-command yes --tls-auth-clients optional --save "" --tls-cluster yes}
+    ports:
+      - "16385-16390:16385-16390"
+      - "27385-27390:27385-27390"
+    volumes:
+      - "./dockers/cluster2:/redis/work"
+    profiles:
+      - multidb
 
   sentinel:
     <<: *client-libs-image
@@ -110,6 +139,7 @@ services:
       - standalone
       - all-stack
       - all
+      - multidb
 
   redis-proxied:
     <<: *client-libs-image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,15 @@ services:
       - "27385-27390:27385-27390"
     volumes:
       - "./dockers/cluster2:/redis/work"
+    # Report healthy only once the cluster has actually formed
+    # (cluster_state:ok), so `docker compose up --wait` blocks until the cluster
+    # is usable rather than just until the container is running.
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 16385 cluster info | grep -q cluster_state:ok"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
     profiles:
       - multidb
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ markers = [
     "experimental: run only experimental tests",
     "cp_integration: credential provider integration tests",
     "no_mock_connections: skip the autouse mock_health_check_connections fixture",
+    "multidb_integration: MultiDBClient integration tests requiring the docker 'multidb' profile (two clusters + two standalones)",
 ]
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"

--- a/redis/asyncio/multidb/healthcheck.py
+++ b/redis/asyncio/multidb/healthcheck.py
@@ -186,12 +186,22 @@ class AbstractHealthCheckPolicy(HealthCheckPolicy):
                 # Use the first node as the startup node
                 if startup_nodes:
                     first_node = startup_nodes[0]
+                    nodes_manager = database.client.nodes_manager
+                    # The sync and async NodesManager expose this setting under
+                    # different names (``_require_full_coverage`` vs
+                    # ``require_full_coverage``), so resolve it defensively to
+                    # support a sync RedisCluster underlying client too.
+                    require_full_coverage = getattr(
+                        nodes_manager,
+                        "require_full_coverage",
+                        getattr(nodes_manager, "_require_full_coverage", True),
+                    )
                     client = AsyncRedisCluster(
                         host=first_node.host,
                         port=first_node.port,
-                        dynamic_startup_nodes=database.client.nodes_manager._dynamic_startup_nodes,
-                        address_remap=database.client.nodes_manager.address_remap,
-                        require_full_coverage=database.client.nodes_manager._require_full_coverage,
+                        dynamic_startup_nodes=nodes_manager._dynamic_startup_nodes,
+                        address_remap=nodes_manager.address_remap,
+                        require_full_coverage=require_full_coverage,
                         retry=database.client.retry,
                         **filtered_kwargs,
                     )

--- a/tasks.py
+++ b/tasks.py
@@ -133,11 +133,11 @@ def standalone_tests(
 
     if uvloop:
         run(
-            f"pytest {profile_arg} {protocol_arg} {legacy_arg} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_{protocol_tag}{legacy_tag}_uvloop.xml -m 'not onlycluster and not fixed_client{extra_markers}' --uvloop --junit-xml=standalone-{protocol_tag}{legacy_tag}-uvloop-results.xml"
+            f"pytest {profile_arg} {protocol_arg} {legacy_arg} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_{protocol_tag}{legacy_tag}_uvloop.xml -m 'not onlycluster and not fixed_client and not multidb_integration{extra_markers}' --uvloop --junit-xml=standalone-{protocol_tag}{legacy_tag}-uvloop-results.xml"
         )
     else:
         run(
-            f"pytest {profile_arg} {protocol_arg} {legacy_arg} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_{protocol_tag}{legacy_tag}.xml -m 'not onlycluster and not fixed_client{extra_markers}' --junit-xml=standalone-{protocol_tag}{legacy_tag}-results.xml"
+            f"pytest {profile_arg} {protocol_arg} {legacy_arg} {redis_mod_url}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario --cov=./ --cov-report=xml:coverage_{protocol_tag}{legacy_tag}.xml -m 'not onlycluster and not fixed_client and not multidb_integration{extra_markers}' --junit-xml=standalone-{protocol_tag}{legacy_tag}-results.xml"
         )
 
 
@@ -153,12 +153,34 @@ def cluster_tests(c, uvloop=False, protocol="", legacy_responses=True, profile=F
     legacy_tag = _legacy_tag(legacy_responses)
     if uvloop:
         run(
-            f"pytest {profile_arg} {protocol_arg} {legacy_arg}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_{protocol_tag}{legacy_tag}_uvloop.xml -m 'not onlynoncluster and not redismod and not fixed_client' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-{protocol_tag}{legacy_tag}-uvloop-results.xml --uvloop"
+            f"pytest {profile_arg} {protocol_arg} {legacy_arg}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_{protocol_tag}{legacy_tag}_uvloop.xml -m 'not onlynoncluster and not redismod and not fixed_client and not multidb_integration' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-{protocol_tag}{legacy_tag}-uvloop-results.xml --uvloop"
         )
     else:
         run(
-            f"pytest  {profile_arg} {protocol_arg} {legacy_arg}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_{protocol_tag}{legacy_tag}.xml -m 'not onlynoncluster and not redismod and not fixed_client' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-{protocol_tag}{legacy_tag}-results.xml"
+            f"pytest  {profile_arg} {protocol_arg} {legacy_arg}  --ignore=tests/test_scenario --ignore=tests/test_asyncio/test_scenario  --cov=./ --cov-report=xml:coverage_cluster_{protocol_tag}{legacy_tag}.xml -m 'not onlynoncluster and not redismod and not fixed_client and not multidb_integration' --redis-url={cluster_url} --redis-ssl-url={cluster_tls_url} --junit-xml=cluster-{protocol_tag}{legacy_tag}-results.xml"
         )
+
+
+@task
+def multidb_integration_tests(c, uvloop=False, profile=False):
+    """Run the multi-database (active-active) integration tests.
+
+    These exercise ``MultiDBClient`` end to end against two real Redis
+    deployments - both as a double-cluster setup (``cluster`` + ``cluster2``)
+    and as a double-standalone setup (``redis`` + ``redis-stack``).
+
+    Requires the docker test environment to be running with the ``multidb``
+    profile, e.g. ``invoke devenv --endpoints multidb``, so that both clusters
+    (16379, 16385) and both standalone servers (6379, 6479) are reachable.
+    Variants whose endpoints are not reachable are skipped.
+    """
+    profile_arg = "--profile" if profile else ""
+    uvloop_arg = "--uvloop" if uvloop else ""
+    run(
+        f"pytest {profile_arg} {uvloop_arg} -m multidb_integration "
+        f"tests/test_multidb tests/test_asyncio/test_multidb "
+        f"--junit-xml=multidb-integration-results.xml"
+    )
 
 
 @task

--- a/tests/test_asyncio/test_multidb/test_integration.py
+++ b/tests/test_asyncio/test_multidb/test_integration.py
@@ -13,7 +13,10 @@ infrastructure:
 Nothing is mocked here - every multi-db component as well as the underlying
 async ``Redis`` / ``RedisCluster`` clients are real and talk to real servers.
 
-Run with: ``invoke multidb-integration-tests`` (after ``invoke devenv``).
+Run with: ``invoke multidb-integration-tests`` (after
+``invoke devenv --endpoints multidb``, which brings up the two standalone
+servers and two clusters these tests need; the default ``invoke devenv``
+profile does not include the second cluster).
 """
 
 import pytest

--- a/tests/test_asyncio/test_multidb/test_integration.py
+++ b/tests/test_asyncio/test_multidb/test_integration.py
@@ -1,0 +1,76 @@
+"""
+Basic integration test for the (async) ``MultiDBClient`` running on top of two
+real Redis deployments.
+
+The same test runs in two configurations against the local docker-compose
+infrastructure:
+
+* ``double-cluster``    -> two independent ``RedisCluster`` deployments
+  (``cluster`` on 16379 and ``cluster2`` on 16385);
+* ``double-standalone`` -> two independent ``Redis`` deployments
+  (``redis`` on 6379 and ``redis-stack`` on 6479).
+
+Nothing is mocked here - every multi-db component as well as the underlying
+async ``Redis`` / ``RedisCluster`` clients are real and talk to real servers.
+
+Run with: ``invoke multidb-integration-tests`` (after ``invoke devenv``).
+"""
+
+import pytest
+
+from redis.asyncio import Redis, RedisCluster
+from redis.asyncio.multidb.client import MultiDBClient
+from redis.asyncio.multidb.config import DatabaseConfig, MultiDbConfig
+
+from tests.test_multidb._integration_endpoints import get_endpoints
+
+
+def _build_config(client_class, urls):
+    db_configs = [
+        DatabaseConfig(
+            weight=1.0,
+            from_url=urls[0],
+            client_kwargs={"decode_responses": True},
+        ),
+        DatabaseConfig(
+            weight=0.9,
+            from_url=urls[1],
+            client_kwargs={"decode_responses": True},
+        ),
+    ]
+    return MultiDbConfig(
+        client_class=client_class,
+        databases_config=db_configs,
+        # Keep the initial health check quick for the test.
+        health_check_probes=3,
+        health_check_delay=0.1,
+        health_check_interval=5,
+    )
+
+
+@pytest.mark.multidb_integration
+@pytest.mark.no_mock_connections
+@pytest.mark.parametrize(
+    "topology,client_class",
+    [
+        ("cluster", RedisCluster),
+        ("standalone", Redis),
+    ],
+    ids=["double-cluster", "double-standalone"],
+)
+class TestMultiDbClientIntegration:
+    @pytest.mark.asyncio
+    async def test_ping_against_two_databases(self, topology, client_class):
+        urls = get_endpoints(topology)
+
+        async with MultiDBClient(_build_config(client_class, urls)) as client:
+            # PING goes through the real health-check + failover wiring and is
+            # delegated to the active (highest-weighted) underlying client.
+            assert await client.ping() is True
+
+            # A basic round-trip against the active database.
+            assert await client.set("multidb:key", "value") is True
+            assert await client.get("multidb:key") == "value"
+
+            # Two real databases are configured.
+            assert len(list(client.get_databases())) == 2

--- a/tests/test_multidb/_integration_endpoints.py
+++ b/tests/test_multidb/_integration_endpoints.py
@@ -1,0 +1,37 @@
+"""
+Endpoint resolution helpers for the multi-database (active-active) integration
+tests.
+
+Defaults map directly onto the ``docker-compose.yml`` infrastructure:
+
+* ``cluster``    -> the ``cluster`` (``16379``) and ``cluster2`` (``16385``)
+  services, i.e. two independent Redis clusters;
+* ``standalone`` -> the ``redis`` (``6379``) and ``redis-stack`` (``6479``)
+  services, i.e. two independent standalone servers.
+
+Both can be overridden via a comma-separated env var
+``REDIS_MULTIDB_<TOPOLOGY>_URLS`` (e.g. ``REDIS_MULTIDB_CLUSTER_URLS``).
+"""
+
+import os
+
+DEFAULT_ENDPOINTS = {
+    "cluster": ("redis://localhost:16379", "redis://localhost:16385"),
+    "standalone": ("redis://localhost:6379", "redis://localhost:6479"),
+}
+
+
+def get_endpoints(topology: str) -> tuple:
+    """Return the two database URLs for the given topology."""
+    env = os.getenv(f"REDIS_MULTIDB_{topology.upper()}_URLS")
+    if env:
+        urls = tuple(u.strip() for u in env.split(",") if u.strip())
+    else:
+        urls = DEFAULT_ENDPOINTS[topology]
+
+    if len(urls) < 2:
+        raise ValueError(
+            f"MultiDBClient integration tests require at least two endpoints "
+            f"for topology '{topology}', got: {urls}"
+        )
+    return urls

--- a/tests/test_multidb/conftest.py
+++ b/tests/test_multidb/conftest.py
@@ -25,11 +25,18 @@ from redis.asyncio.multidb.healthcheck import (
 
 
 @pytest.fixture(autouse=True)
-def mock_health_check_connections():
+def mock_health_check_connections(request):
     """
     Mock clients for health check policies.
     Uses real policy classes but mocks only the client layer.
+
+    Skip this fixture for tests marked with @pytest.mark.no_mock_connections
+    (e.g. the integration tests that talk to real Redis deployments).
     """
+    # Check if the test is marked to skip connection mocking
+    if request.node.get_closest_marker("no_mock_connections"):
+        yield
+        return
 
     async def mock_get_client(self, database):
         mock_client = AsyncMock()
@@ -39,16 +46,6 @@ def mock_health_check_connections():
 
     with patch.object(AbstractHealthCheckPolicy, "get_client", mock_get_client):
         yield
-
-
-@pytest.fixture()
-def mock_client() -> Redis:
-    return Mock(spec=Redis)
-
-
-@pytest.fixture()
-def mock_cb() -> CircuitBreaker:
-    return Mock(spec=CircuitBreaker)
 
 
 @pytest.fixture()

--- a/tests/test_multidb/test_integration.py
+++ b/tests/test_multidb/test_integration.py
@@ -15,7 +15,10 @@ Nothing is mocked here - every multi-db component as well as the underlying
 exercises the full configuration, health-check (PING) and failover wiring of
 ``MultiDBClient`` end to end.
 
-Run with: ``invoke multidb-integration-tests`` (after ``invoke devenv``).
+Run with: ``invoke multidb-integration-tests`` (after
+``invoke devenv --endpoints multidb``, which brings up the two standalone
+servers and two clusters these tests need; the default ``invoke devenv``
+profile does not include the second cluster).
 """
 
 import pytest

--- a/tests/test_multidb/test_integration.py
+++ b/tests/test_multidb/test_integration.py
@@ -1,0 +1,80 @@
+"""
+Basic integration test for the (sync) ``MultiDBClient`` running on top of two
+real Redis deployments.
+
+The same test runs in two configurations against the local docker-compose
+infrastructure:
+
+* ``double-cluster``    -> two independent ``RedisCluster`` deployments
+  (``cluster`` on 16379 and ``cluster2`` on 16385);
+* ``double-standalone`` -> two independent ``Redis`` deployments
+  (``redis`` on 6379 and ``redis-stack`` on 6479).
+
+Nothing is mocked here - every multi-db component as well as the underlying
+``Redis`` / ``RedisCluster`` clients are real and talk to real servers. This
+exercises the full configuration, health-check (PING) and failover wiring of
+``MultiDBClient`` end to end.
+
+Run with: ``invoke multidb-integration-tests`` (after ``invoke devenv``).
+"""
+
+import pytest
+
+from redis import Redis, RedisCluster
+from redis.multidb.client import MultiDBClient
+from redis.multidb.config import DatabaseConfig, MultiDbConfig
+
+from tests.test_multidb._integration_endpoints import get_endpoints
+
+
+def _build_config(client_class, urls):
+    db_configs = [
+        DatabaseConfig(
+            weight=1.0,
+            from_url=urls[0],
+            client_kwargs={"decode_responses": True},
+        ),
+        DatabaseConfig(
+            weight=0.9,
+            from_url=urls[1],
+            client_kwargs={"decode_responses": True},
+        ),
+    ]
+    return MultiDbConfig(
+        client_class=client_class,
+        databases_config=db_configs,
+        # Keep the initial health check quick for the test.
+        health_check_probes=3,
+        health_check_delay=0.1,
+        health_check_interval=5,
+    )
+
+
+@pytest.mark.multidb_integration
+@pytest.mark.no_mock_connections
+@pytest.mark.parametrize(
+    "topology,client_class",
+    [
+        ("cluster", RedisCluster),
+        ("standalone", Redis),
+    ],
+    ids=["double-cluster", "double-standalone"],
+)
+class TestMultiDbClientIntegration:
+    def test_ping_against_two_databases(self, topology, client_class):
+        urls = get_endpoints(topology)
+
+        client = MultiDBClient(_build_config(client_class, urls))
+        try:
+            # PING goes through the real health-check + failover wiring and is
+            # delegated to the active (highest-weighted) underlying client.
+            assert client.ping() is True
+
+            # A basic round-trip against the active database.
+            assert client.set("multidb:key", "value") is True
+            assert client.get("multidb:key") == "value"
+
+            # Two real databases are configured.
+            assert len(list(client.get_databases())) == 2
+        finally:
+            client.close()


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async multidb health-check cluster client wiring used during failover; risk is limited by new integration coverage and narrow CI enablement, but regressions could affect active-active cluster setups.
> 
> **Overview**
> Fixes **async `MultiDBClient`** when a database uses an underlying **`RedisCluster`**, by building the health-check cluster client with **`require_full_coverage`** resolved from either sync or async `NodesManager` naming (`require_full_coverage` vs `_require_full_coverage`).
> 
> Adds **end-to-end `MultiDBClient` integration tests** (sync and async) against real Redis for **two clusters** (`16379` + `16385`) and **two standalones** (`6379` + `6479`), gated by **`multidb_integration`** and **`no_mock_connections`**. Docker gains a **`multidb`** profile with **`cluster2`** (health-checked `cluster_state:ok`); default test runs **exclude** these tests unless **`invoke multidb-integration-tests`** is used.
> 
> **CI** folds multidb tests into one existing matrix cell via **`run-multidb-integration`**, brings up **`cluster2`** after the main suite, and **persists Redis image tags** so the second cluster matches the matrix Redis version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb776c5a10f747c9aefb8552832543853d7c58d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->