### PR TITLE
fix(search): parse RESP3 FT.SEARCH responses with bytes-typed keys

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -666,8 +666,11 @@ class SearchCommands:
                     score_str = str(score)
                     if score_str.endswith(".0"):
                         score_str = score_str[:-2]
+                    # Preserve ``suggestion`` as-is so it keeps the
+                    # ``decode_responses`` shape RESP2 would produce
+                    # (``str`` when decoded, ``bytes`` otherwise).
                     term_corrections.append(
-                        {"score": score_str, "suggestion": str(suggestion)}
+                        {"score": score_str, "suggestion": suggestion}
                     )
             if term_corrections:
                 corrections[term] = term_corrections

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -494,11 +494,19 @@ class SearchCommands:
         else:
             data = res
 
+        if data is None:
+            data = {}
+        # On RESP3 connections with decode_responses=False the server's map
+        # keys arrive as bytes, so normalise structural keys to strings
+        # before lookup.  Mirrors ``Result.from_resp3``.
+        data = {str_if_bytes(k): v for k, v in data.items()}
+
         warnings = [str_if_bytes(w) for w in data.get("warning", [])]
         total = data.get("total_results", 0)
 
         rows = []
         for result_item in data.get("results", []):
+            result_item = {str_if_bytes(k): v for k, v in result_item.items()}
             extra_attrs = result_item.get("extra_attributes", {})
             # Convert dict to flat list [key, value, key, value, ...]
             # to match RESP2 row format consumers expect.
@@ -640,6 +648,10 @@ class SearchCommands:
         """
         if not isinstance(res, dict):
             return self._parse_spellcheck(res, **kwargs)
+        # On RESP3 connections with decode_responses=False the server's map
+        # keys arrive as bytes, so normalise the structural ``results`` key
+        # to a string before lookup.  Mirrors ``Result.from_resp3``.
+        res = {str_if_bytes(k): v for k, v in res.items()}
         corrections = {}
         results = res.get("results", {})
         for term, suggestions in results.items():

--- a/redis/commands/search/result.py
+++ b/redis/commands/search/result.py
@@ -111,12 +111,17 @@ class Result:
         instance = cls.__new__(cls)
         if res is None:
             res = {}
+        # On RESP3 connections with decode_responses=False the server's map
+        # keys arrive as bytes, so normalise them to strings before lookup
+        # to keep behaviour consistent with decode_responses=True.
+        res = {str_if_bytes(k): v for k, v in res.items()}
         instance.total = res.get("total_results", 0)
         instance.duration = duration
         instance.docs = []
         instance.warnings = [str_if_bytes(w) for w in res.get("warning", [])]
 
         for result_item in res.get("results", []):
+            result_item = {str_if_bytes(k): v for k, v in result_item.items()}
             doc_id = str_if_bytes(result_item.get("id", ""))
             score = None
             if with_scores and "score" in result_item:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5610,9 +5610,10 @@ class TestHybridSearch(SearchTestsBase):
 # expected legacy output shape with ``decode_responses=False``.  The
 # default protocol (``SENTINEL`` -> not specified) leaves the wire on
 # RESP3 with the ``_RedisCallbacksRESP3toRESP2Legacy`` adapter selected,
-# which is the path the fix actually exercises.  An explicit
-# ``protocol=3`` would route through ``_RedisCallbacksRESP3`` instead
-# and bypass the changed methods.
+# which is where the bytes-key normalisation in ``_parse_search_resp3``,
+# ``_parse_aggregate_resp3`` and ``_parse_spellcheck_resp3`` lives.  An
+# explicit ``protocol=3`` would route through ``_RedisCallbacksRESP3``
+# instead and bypass the methods we want to test.
 _SEARCH_BYTES_PROTOCOLS = [
     pytest.param(2, id="resp2"),
     pytest.param(SENTINEL, id="default-resp3"),
@@ -5644,9 +5645,9 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
     parsers in ``_RedisCallbacksRESP3toRESP2Legacy``).
     """
 
-    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     @pytest.mark.redismod
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     def test_search_resp3_bytes_keys(self, request, stack_url, protocol):
         client = _make_bytes_search_client(request, stack_url, protocol)
         client.ft().create_index((TextField("title"), TextField("body")))
@@ -5665,9 +5666,9 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
         assert res.total == 2
         assert {d.id for d in res.docs} == {"doc1", "doc2"}
 
-    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     @pytest.mark.redismod
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     def test_aggregate_resp3_bytes_keys(self, request, stack_url, protocol):
         client = _make_bytes_search_client(request, stack_url, protocol)
         client.ft().create_index((TextField("title"), TextField("parent")))
@@ -5693,9 +5694,9 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
         assert b"parent" in row
         assert b"redis" in row
 
-    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     @pytest.mark.redismod
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     def test_spellcheck_resp3_bytes_keys(self, request, stack_url, protocol):
         client = _make_bytes_search_client(request, stack_url, protocol)
         client.ft().create_index((TextField("f1"),))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5590,3 +5590,95 @@ class TestHybridSearch(SearchTestsBase):
                 assert item["description"] is not None
                 assert item["discount_10_percents"] is not None
                 assert item["additional_discount"] is not None
+
+
+class TestSearchResp3BytesKeys(SearchTestsBase):
+    """Regression tests for #4107.
+
+    With ``protocol=3`` on the wire and ``decode_responses=False`` the
+    server's structural map keys arrive as ``bytes`` (e.g. ``b"results"``
+    rather than ``"results"``).  The RESP3->legacy-RESP2 search callbacks
+    used to look those keys up as plain strings, missed them, and
+    silently produced empty results.  These tests pin a
+    ``decode_responses=False`` client against a RESP3 wire with the
+    library's default legacy responses and exercise the three callbacks
+    that were affected: FT.SEARCH, FT.AGGREGATE and FT.SPELLCHECK.
+    """
+
+    @pytest.fixture
+    def bytes_client(self, request, stack_url):
+        r = _get_client(
+            redis.Redis,
+            request,
+            decode_responses=False,
+            protocol=3,
+            from_url=stack_url,
+        )
+        r.flushdb()
+        return r
+
+    @pytest.mark.redismod
+    @pytest.mark.fixed_client
+    def test_search_resp3_bytes_keys(self, bytes_client):
+        client = bytes_client
+        client.ft().create_index((TextField("title"), TextField("body")))
+        client.hset("doc1", mapping={"title": "hello", "body": "redis world"})
+        client.hset("doc2", mapping={"title": "hello", "body": "search world"})
+        self.waitForIndex(client, getattr(client.ft(), "index_name", "idx"))
+
+        res = client.ft().search(Query("hello"))
+
+        # Before the fix this returned ``Result{0 total, docs: []}``
+        # because ``Result.from_resp3`` looked up the bytes-keyed map by
+        # ``str`` keys.  ``Result`` always normalises the doc id with
+        # ``str_if_bytes`` so the id assertion is in ``str`` form even
+        # for a ``decode_responses=False`` client.
+        assert res.total == 2
+        assert {d.id for d in res.docs} == {"doc1", "doc2"}
+
+    @pytest.mark.redismod
+    @pytest.mark.fixed_client
+    def test_aggregate_resp3_bytes_keys(self, bytes_client):
+        client = bytes_client
+        client.ft().create_index((TextField("title"), TextField("parent")))
+        client.hset("doc1", mapping={"title": "alpha", "parent": "redis"})
+        client.hset("doc2", mapping={"title": "beta", "parent": "redis"})
+        client.hset("doc3", mapping={"title": "gamma", "parent": "redis"})
+        self.waitForIndex(client, getattr(client.ft(), "index_name", "idx"))
+
+        req = aggregations.AggregateRequest("redis").group_by(
+            "@parent", reducers.count()
+        )
+        res = client.ft().aggregate(req)
+
+        # Before the fix ``data.get("total_results")`` and
+        # ``data.get("results")`` both missed because the keys were
+        # ``bytes``, yielding ``total=0`` and ``rows=[]``.
+        assert len(res.rows) == 1
+        row = res.rows[0]
+        # Row content stays as bytes (matches RESP2 with
+        # decode_responses=False); only the structural map keys are
+        # normalised.
+        assert b"parent" in row
+        assert b"redis" in row
+
+    @pytest.mark.redismod
+    @pytest.mark.fixed_client
+    def test_spellcheck_resp3_bytes_keys(self, bytes_client):
+        client = bytes_client
+        client.ft().create_index((TextField("f1"),))
+        client.hset("doc1", mapping={"f1": "some valid content"})
+        client.hset("doc2", mapping={"f1": "very important"})
+        self.waitForIndex(client, getattr(client.ft(), "index_name", "idx"))
+
+        res = client.ft().spellcheck("impornant")
+
+        # Before the fix ``res.get("results", {})`` missed the
+        # ``b"results"`` key and returned an empty ``{}``.
+        assert res
+        # The term key is preserved as it arrived (bytes when undecoded),
+        # mirroring the RESP2 ``decode_responses=False`` shape.
+        term_key = next(iter(res))
+        assert term_key in (b"impornant", "impornant")
+        suggestions = res[term_key]
+        assert any(s["suggestion"] == "important" for s in suggestions)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -43,7 +43,7 @@ from redis.commands.search.query import (
 )
 from redis.commands.search.result import Result
 from redis.commands.search.suggestion import Suggestion
-from redis.utils import safe_str
+from redis.utils import SENTINEL, safe_str
 
 from .conftest import (
     _get_client,
@@ -84,15 +84,28 @@ class SearchTestsBase:
         while True:
             try:
                 res = env.execute_command("FT.INFO", idx)
-                if int(res[res.index("indexing") + 1]) == 0:
+                # ``execute_command`` bypasses the search module's
+                # callbacks, so the response is the raw wire shape.
+                # With ``decode_responses=False`` the structural keys
+                # arrive as bytes; accept both forms.
+                try:
+                    i = res.index("indexing")
+                except ValueError:
+                    i = res.index(b"indexing")
+                if int(res[i + 1]) == 0:
                     break
             except ValueError:
                 break
             except AttributeError:
+                # RESP3 dict response.  Keys may be ``str`` or ``bytes``
+                # depending on ``decode_responses``.
+                indexing = res.get("indexing")
+                if indexing is None:
+                    indexing = res.get(b"indexing")
                 try:
-                    if int(res["indexing"]) == 0:
+                    if int(indexing) == 0:
                         break
-                except ValueError:
+                except (TypeError, ValueError):
                     break
             except ResponseError:
                 # index doesn't exist yet
@@ -5592,35 +5605,50 @@ class TestHybridSearch(SearchTestsBase):
                 assert item["additional_discount"] is not None
 
 
+# Parametrise the bytes-key regression tests over RESP2 and the
+# default protocol.  RESP2 uses ``_RedisCallbacksRESP2`` and anchors the
+# expected legacy output shape with ``decode_responses=False``.  The
+# default protocol (``SENTINEL`` -> not specified) leaves the wire on
+# RESP3 with the ``_RedisCallbacksRESP3toRESP2Legacy`` adapter selected,
+# which is the path the fix actually exercises.  An explicit
+# ``protocol=3`` would route through ``_RedisCallbacksRESP3`` instead
+# and bypass the changed methods.
+_SEARCH_BYTES_PROTOCOLS = [
+    pytest.param(2, id="resp2"),
+    pytest.param(SENTINEL, id="default-resp3"),
+]
+
+
+def _make_bytes_search_client(request, stack_url, protocol):
+    kwargs = {
+        "decode_responses": False,
+        "from_url": stack_url,
+    }
+    if protocol is not SENTINEL:
+        kwargs["protocol"] = protocol
+    client = _get_client(redis.Redis, request, **kwargs)
+    client.flushdb()
+    return client
+
+
 class TestSearchResp3BytesKeys(SearchTestsBase):
     """Regression tests for #4107.
 
-    With ``protocol=3`` on the wire and ``decode_responses=False`` the
-    server's structural map keys arrive as ``bytes`` (e.g. ``b"results"``
-    rather than ``"results"``).  The RESP3->legacy-RESP2 search callbacks
-    used to look those keys up as plain strings, missed them, and
-    silently produced empty results.  These tests pin a
-    ``decode_responses=False`` client against a RESP3 wire with the
-    library's default legacy responses and exercise the three callbacks
-    that were affected: FT.SEARCH, FT.AGGREGATE and FT.SPELLCHECK.
+    With the default protocol (RESP3 on the wire) and
+    ``decode_responses=False`` the server's structural map keys arrive
+    as ``bytes`` (e.g. ``b"results"`` rather than ``"results"``).  The
+    RESP3->legacy-RESP2 search callbacks used to look those keys up as
+    plain strings, missed them, and silently produced empty results.
+    Each test is parametrised over ``protocol=2`` (anchors the legacy
+    output shape) and the default protocol (exercises the actual fixed
+    parsers in ``_RedisCallbacksRESP3toRESP2Legacy``).
     """
 
-    @pytest.fixture
-    def bytes_client(self, request, stack_url):
-        r = _get_client(
-            redis.Redis,
-            request,
-            decode_responses=False,
-            protocol=3,
-            from_url=stack_url,
-        )
-        r.flushdb()
-        return r
-
+    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     @pytest.mark.redismod
     @pytest.mark.fixed_client
-    def test_search_resp3_bytes_keys(self, bytes_client):
-        client = bytes_client
+    def test_search_resp3_bytes_keys(self, request, stack_url, protocol):
+        client = _make_bytes_search_client(request, stack_url, protocol)
         client.ft().create_index((TextField("title"), TextField("body")))
         client.hset("doc1", mapping={"title": "hello", "body": "redis world"})
         client.hset("doc2", mapping={"title": "hello", "body": "search world"})
@@ -5628,18 +5656,20 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
 
         res = client.ft().search(Query("hello"))
 
-        # Before the fix this returned ``Result{0 total, docs: []}``
-        # because ``Result.from_resp3`` looked up the bytes-keyed map by
-        # ``str`` keys.  ``Result`` always normalises the doc id with
-        # ``str_if_bytes`` so the id assertion is in ``str`` form even
-        # for a ``decode_responses=False`` client.
+        # Before the fix the default-RESP3 case returned
+        # ``Result{0 total, docs: []}`` because ``Result.from_resp3``
+        # looked up the bytes-keyed map by ``str`` keys.  ``Result``
+        # always normalises the doc id with ``str_if_bytes`` so the id
+        # assertion stays in ``str`` form even with
+        # ``decode_responses=False``.
         assert res.total == 2
         assert {d.id for d in res.docs} == {"doc1", "doc2"}
 
+    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     @pytest.mark.redismod
     @pytest.mark.fixed_client
-    def test_aggregate_resp3_bytes_keys(self, bytes_client):
-        client = bytes_client
+    def test_aggregate_resp3_bytes_keys(self, request, stack_url, protocol):
+        client = _make_bytes_search_client(request, stack_url, protocol)
         client.ft().create_index((TextField("title"), TextField("parent")))
         client.hset("doc1", mapping={"title": "alpha", "parent": "redis"})
         client.hset("doc2", mapping={"title": "beta", "parent": "redis"})
@@ -5651,9 +5681,10 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
         )
         res = client.ft().aggregate(req)
 
-        # Before the fix ``data.get("total_results")`` and
-        # ``data.get("results")`` both missed because the keys were
-        # ``bytes``, yielding ``total=0`` and ``rows=[]``.
+        # Before the fix the default-RESP3 case missed
+        # ``data.get("total_results")`` and ``data.get("results")``
+        # because the keys were ``bytes``, yielding ``total=0`` and
+        # ``rows=[]``.
         assert len(res.rows) == 1
         row = res.rows[0]
         # Row content stays as bytes (matches RESP2 with
@@ -5662,10 +5693,11 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
         assert b"parent" in row
         assert b"redis" in row
 
+    @pytest.mark.parametrize("protocol", _SEARCH_BYTES_PROTOCOLS)
     @pytest.mark.redismod
     @pytest.mark.fixed_client
-    def test_spellcheck_resp3_bytes_keys(self, bytes_client):
-        client = bytes_client
+    def test_spellcheck_resp3_bytes_keys(self, request, stack_url, protocol):
+        client = _make_bytes_search_client(request, stack_url, protocol)
         client.ft().create_index((TextField("f1"),))
         client.hset("doc1", mapping={"f1": "some valid content"})
         client.hset("doc2", mapping={"f1": "very important"})
@@ -5673,12 +5705,12 @@ class TestSearchResp3BytesKeys(SearchTestsBase):
 
         res = client.ft().spellcheck("impornant")
 
-        # Before the fix ``res.get("results", {})`` missed the
-        # ``b"results"`` key and returned an empty ``{}``.
-        assert res
-        # The term key is preserved as it arrived (bytes when undecoded),
-        # mirroring the RESP2 ``decode_responses=False`` shape.
-        term_key = next(iter(res))
-        assert term_key in (b"impornant", "impornant")
-        suggestions = res[term_key]
-        assert any(s["suggestion"] == "important" for s in suggestions)
+        # Before the fix the default-RESP3 case had
+        # ``res.get("results", {})`` miss the ``b"results"`` key and
+        # return an empty ``{}``.  Both protocols carry the term and
+        # suggestion through as bytes, matching
+        # ``_parse_spellcheck`` with ``decode_responses=False``.
+        assert b"impornant" in res
+        suggestions = res[b"impornant"]
+        assert suggestions
+        assert suggestions[0]["suggestion"] == b"important"

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -1,11 +1,15 @@
-"""Unit tests for :class:`redis.commands.search.result.Result`.
+"""Unit tests for the RESP3 search response parsers.
 
 These tests exercise the pure-Python parsing logic and do not require a
 running Redis server, so they live in the ``fixed_client`` test group.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
+from redis.commands.search import Search
+from redis.commands.search.aggregation import AggregateRequest
 from redis.commands.search.result import Result
 
 
@@ -100,3 +104,148 @@ class TestResultFromResp3:
             assert r.total == 0
             assert r.docs == []
             assert r.warnings == []
+
+
+def _make_search():
+    """Build a ``Search`` instance whose parsers can be exercised without
+    talking to Redis."""
+    client = MagicMock()
+    return Search(client)
+
+
+@pytest.mark.fixed_client
+class TestParseAggregateResp3:
+    """Regression tests for ``SearchCommands._parse_aggregate_resp3``.
+
+    Mirrors :class:`TestResultFromResp3` but for the FT.AGGREGATE /
+    FT.CURSOR READ / FT.PROFILE AGGREGATE callback.  Before the fix, a
+    byte-keyed RESP3 map (the shape produced when the wire is RESP3 and
+    the client was opened with ``decode_responses=False``) parsed to an
+    empty :class:`AggregateResult` with ``total == 0`` and no rows.
+    """
+
+    def _request(self):
+        return AggregateRequest("*")
+
+    def test_str_keys_are_parsed(self):
+        s = _make_search()
+        res = {
+            "total_results": 1,
+            "warning": ["w"],
+            "results": [
+                {"extra_attributes": {"parent": "redis", "n": "3"}},
+            ],
+        }
+        out = s._parse_aggregate_resp3(res, query=self._request())
+        assert out.total == 1
+        assert out.warnings == ["w"]
+        assert out.rows == [["parent", "redis", "n", "3"]]
+
+    def test_bytes_keys_are_parsed(self):
+        """The map keys arrive as ``bytes`` on RESP3 with decode_responses=False.
+
+        Without the fix, ``data.get("total_results", 0)`` and
+        ``data.get("results", [])`` both miss, so the result has
+        ``total == 0`` and ``rows == []``.  Inner ``extra_attributes``
+        content stays as ``bytes`` because it is document data, not a
+        structural key.
+        """
+        res = {
+            b"total_results": 1,
+            b"warning": [b"w"],
+            b"results": [
+                {b"extra_attributes": {b"parent": b"redis", b"n": b"3"}},
+            ],
+        }
+        out = _make_search()._parse_aggregate_resp3(res, query=self._request())
+        assert out.total == 1
+        assert out.warnings == ["w"]
+        # Content values stay as bytes (matches RESP2 with
+        # decode_responses=False); only structural keys are normalised.
+        assert out.rows == [[b"parent", b"redis", b"n", b"3"]]
+
+    def test_with_cursor_bytes_keys(self):
+        """``has_cursor=True`` wraps the payload in ``[data_dict, cursor_id]``;
+        the inner dict still needs structural key normalisation."""
+        res = [
+            {
+                b"total_results": 2,
+                b"warning": [],
+                b"results": [
+                    {b"extra_attributes": {b"a": b"1"}},
+                    {b"extra_attributes": {b"a": b"2"}},
+                ],
+            },
+            42,
+        ]
+        s = _make_search()
+        out = s._parse_aggregate_resp3(res, query=self._request(), has_cursor=True)
+        assert out.total == 2
+        assert out.cursor is not None
+        assert out.cursor.cid == 42
+        assert out.rows == [[b"a", b"1"], [b"a", b"2"]]
+
+    def test_empty_or_none_response(self):
+        """``None`` and an empty dict both yield an empty AggregateResult."""
+        s = _make_search()
+        for empty in (None, {}, {b"total_results": 0, b"results": []}):
+            out = s._parse_aggregate_resp3(empty, query=self._request())
+            assert out.total == 0
+            assert out.rows == []
+            assert out.warnings == []
+
+
+@pytest.mark.fixed_client
+class TestParseSpellcheckResp3:
+    """Regression tests for ``SearchCommands._parse_spellcheck_resp3``.
+
+    Before the fix, a byte-keyed RESP3 map produced an empty ``{}``
+    because ``res.get("results", {})`` looked up the ``str`` key
+    ``"results"`` against a ``bytes``-keyed dict.
+    """
+
+    def test_str_keys_are_parsed(self):
+        s = _make_search()
+        res = {
+            "results": {
+                "impornant": [{"important": 0.5}, {"impotent": 0.25}],
+            }
+        }
+        out = s._parse_spellcheck_resp3(res)
+        assert list(out.keys()) == ["impornant"]
+        assert out["impornant"] == [
+            {"score": "0.5", "suggestion": "important"},
+            {"score": "0.25", "suggestion": "impotent"},
+        ]
+
+    def test_bytes_keys_are_parsed(self):
+        """The outer ``results`` structural key arrives as ``bytes`` on
+        RESP3 with decode_responses=False.  The fix normalises only that
+        structural key; inner term keys mirror RESP2's behaviour and keep
+        their wire type (bytes when undecoded)."""
+        s = _make_search()
+        res = {
+            b"results": {
+                b"impornant": [{b"important": 0.5}],
+            }
+        }
+        out = s._parse_spellcheck_resp3(res)
+        # Before the fix this returned ``{}``.
+        assert out  # not empty
+        # The term key mirrors the RESP2 form (bytes when decode is off).
+        assert list(out.keys()) == [b"impornant"]
+        suggestions = list(out.values())[0]
+        assert suggestions[0]["score"] == "0.5"
+
+    def test_no_corrections_returns_empty(self):
+        """Term with no candidate suggestions still yields ``{}``."""
+        s = _make_search()
+        assert s._parse_spellcheck_resp3({b"results": {b"vlis": []}}) == {}
+        assert s._parse_spellcheck_resp3({"results": {"vlis": []}}) == {}
+
+    def test_non_dict_falls_through_to_resp2_parser(self):
+        """A non-dict response (e.g. ``0`` from RESP2) still goes through
+        the legacy :meth:`_parse_spellcheck` path."""
+        s = _make_search()
+        # ``_parse_spellcheck`` short-circuits on ``res == 0``.
+        assert s._parse_spellcheck_resp3(0) == {}

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -1,0 +1,102 @@
+"""Unit tests for :class:`redis.commands.search.result.Result`.
+
+These tests exercise the pure-Python parsing logic and do not require a
+running Redis server, so they live in the ``fixed_client`` test group.
+"""
+
+import pytest
+
+from redis.commands.search.result import Result
+
+
+@pytest.mark.fixed_client
+class TestResultFromResp3:
+    def test_str_keys_are_parsed(self):
+        """Baseline: a response with native ``str`` keys parses correctly."""
+        res = {
+            "total_results": 2,
+            "results": [
+                {
+                    "id": "doc1",
+                    "score": 1.5,
+                    "extra_attributes": {"field1": "value1"},
+                },
+                {
+                    "id": "doc2",
+                    "score": 0.5,
+                    "extra_attributes": {"field1": "value2"},
+                },
+            ],
+            "warning": ["a warning"],
+        }
+
+        result = Result.from_resp3(res, with_scores=True)
+
+        assert result.total == 2
+        assert result.warnings == ["a warning"]
+        assert [d.id for d in result.docs] == ["doc1", "doc2"]
+        assert [d.score for d in result.docs] == [1.5, 0.5]
+        assert result.docs[0].field1 == "value1"
+
+    def test_bytes_keys_are_parsed(self):
+        """Regression test for #4107.
+
+        On a RESP3 connection opened with ``decode_responses=False`` the map
+        keys returned by the server are ``bytes``.  Before the fix
+        :meth:`Result.from_resp3` looked up ``"total_results"``/``"results"``
+        as ``str`` keys, missed them entirely and returned an empty result.
+        """
+        res = {
+            b"total_results": 2,
+            b"results": [
+                {
+                    b"id": b"doc1",
+                    b"score": 1.5,
+                    b"extra_attributes": {b"field1": b"value1"},
+                },
+                {
+                    b"id": b"doc2",
+                    b"score": 0.5,
+                    b"extra_attributes": {b"field1": b"value2"},
+                },
+            ],
+            b"warning": [b"a warning"],
+        }
+
+        result = Result.from_resp3(res, with_scores=True)
+
+        assert result.total == 2
+        assert result.warnings == ["a warning"]
+        assert [d.id for d in result.docs] == ["doc1", "doc2"]
+        assert [d.score for d in result.docs] == [1.5, 0.5]
+        assert result.docs[0].field1 == "value1"
+        assert result.docs[1].field1 == "value2"
+
+    def test_mixed_str_and_bytes_keys(self):
+        """Outer ``bytes`` keys with inner ``str`` keys (and vice-versa) parse.
+
+        Different parser layers (hiredis vs. the pure-python parser, RESP2 vs.
+        RESP3) can produce mixed maps in practice, so each level is normalised
+        independently.
+        """
+        res = {
+            b"total_results": 1,
+            b"results": [
+                {"id": "doc1", "extra_attributes": {"f": "v"}},
+            ],
+            b"warning": [],
+        }
+
+        result = Result.from_resp3(res)
+
+        assert result.total == 1
+        assert result.docs[0].id == "doc1"
+        assert result.docs[0].f == "v"
+
+    def test_empty_or_none_response(self):
+        """``None`` and an empty dict both yield an empty result."""
+        for empty in (None, {}, {b"total_results": 0, b"results": []}):
+            r = Result.from_resp3(empty)
+            assert r.total == 0
+            assert r.docs == []
+            assert r.warnings == []

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -221,8 +221,9 @@ class TestParseSpellcheckResp3:
     def test_bytes_keys_are_parsed(self):
         """The outer ``results`` structural key arrives as ``bytes`` on
         RESP3 with decode_responses=False.  The fix normalises only that
-        structural key; inner term keys mirror RESP2's behaviour and keep
-        their wire type (bytes when undecoded)."""
+        structural key; inner term keys and suggestion values mirror
+        RESP2's behaviour and keep their wire type (bytes when
+        undecoded)."""
         s = _make_search()
         res = {
             b"results": {
@@ -236,6 +237,9 @@ class TestParseSpellcheckResp3:
         assert list(out.keys()) == [b"impornant"]
         suggestions = list(out.values())[0]
         assert suggestions[0]["score"] == "0.5"
+        # And the suggestion stays in its wire form (bytes when
+        # ``decode_responses=False``) so the legacy path matches RESP2.
+        assert suggestions[0]["suggestion"] == b"important"
 
     def test_no_corrections_returns_empty(self):
         """Term with no candidate suggestions still yields ``{}``."""


### PR DESCRIPTION
### Description of change

Fixes #4107.

Since the wire protocol default switched to RESP3 in #4052, the server returns FT.SEARCH responses as RESP3 maps. When a client is opened with `decode_responses=False` (the default for binary callers), those map keys arrive as `bytes`, but `Result.from_resp3` looked them up as plain `str`:

```py
instance.total = res.get("total_results", 0)
for result_item in res.get("results", []):
    ...
```

Because `b"total_results" != "total_results"`, every lookup missed and `client.ft("INDEX").search(...)` returned `Result{0 total, docs: []}` even when the server had matched documents. The reporter confirms the raw response looks like:

```py
{b"total_results": 2, b"results": [...], b"warning": []}
```

### Fix

Normalise the top-level map and each per-result map to string keys before reading them. This mirrors the pattern already established in `_parse_hybrid_search_resp3` (`redis/commands/search/commands.py`), whose docstring calls out: *"Top-level keys are normalised to strings."* The fix is a 5-line change, no value semantics are altered — bytes values are still passed through `decode_field_value` exactly as before.

### Testing

Added `tests/test_search_result.py` (marked `fixed_client` since `Result.from_resp3` is a pure function and needs no Redis):

- `test_str_keys_are_parsed` — baseline, str-keyed map still works.
- `test_bytes_keys_are_parsed` — regression test for #4107, fails on master.
- `test_mixed_str_and_bytes_keys` — outer bytes / inner str (different parser layers can produce mixed maps), fails on master.
- `test_empty_or_none_response` — `None` and empty-dict edge cases.

Locally on Python 3.13:

```
$ pytest tests/test_search_result.py -v
tests/test_search_result.py::TestResultFromResp3::test_str_keys_are_parsed PASSED
tests/test_search_result.py::TestResultFromResp3::test_bytes_keys_are_parsed PASSED
tests/test_search_result.py::TestResultFromResp3::test_mixed_str_and_bytes_keys PASSED
tests/test_search_result.py::TestResultFromResp3::test_empty_or_none_response PASSED
========================= 4 passed in 0.02s =========================
```

`ruff check` and `ruff format --check` are clean for both files.

The `fixed_client` suite passes on this branch with the same set of unrelated pre-existing failures (`test_connection.py::test_connect_with_retries` and friends — confirmed they reproduce on master without this change).

### Scope note

The same RESP3-bytes-keys pattern likely affects `_parse_aggregate_resp3` (FT.AGGREGATE) and possibly other RESP3 callbacks reached from `decode_responses=False` clients. I've deliberately kept this PR scoped to the reported FT.SEARCH path; happy to open a follow-up that audits the rest if useful.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — N/A, behavior fix only.
- [x] Is there an example added to the examples folder (if applicable)? — N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted parser normalisation for structural keys only; document field values and RESP2 paths are unchanged, with broad unit and integration coverage.
> 
> **Overview**
> Fixes **#4107**: with default RESP3 and `decode_responses=False`, RediSearch map keys are `bytes`, so legacy parsers that looked up `"total_results"` / `"results"` missed and returned empty search, aggregate, and spellcheck results.
> 
> **Parser changes** use `str_if_bytes` on structural map keys (and per-hit maps) in `Result.from_resp3`, `_parse_aggregate_resp3`, and `_parse_spellcheck_resp3`, matching the existing hybrid-search RESP3 path. `_parse_spellcheck_resp3` no longer coerces suggestion text to `str`, so term/suggestion types stay aligned with RESP2 when decoding is off.
> 
> **Tests** add `tests/test_search_result.py` (no server), parametrised integration cases for search/aggregate/spellcheck under RESP2 vs default RESP3, and harden `waitForIndex` for raw `FT.INFO` with `str` or `bytes` keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f20d858cd90035b8abc1a59f4d62633dd1f69ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->