### PR TITLE
Fix async cluster node connection release on write errors

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1683,47 +1683,52 @@ class ClusterNode:
     async def execute_command(self, *args: Any, **kwargs: Any) -> Any:
         # Acquire connection
         connection = self.acquire_connection()
-        # Handle lazy disconnect for connections marked for reconnect
-        await self.disconnect_if_needed(connection)
-
-        # Execute command
-        await connection.send_packed_command(connection.pack_command(*args))
-
-        # Read response
         try:
+            # Handle lazy disconnect for connections marked for reconnect
+            await self.disconnect_if_needed(connection)
+
+            # Execute command
+            await connection.send_packed_command(connection.pack_command(*args))
+
+            # Read response
             return await self.parse_response(connection, args[0], **kwargs)
         finally:
-            await self.disconnect_if_needed(connection)
-            # Release connection
-            self.release(connection)
+            try:
+                await self.disconnect_if_needed(connection)
+            finally:
+                # Release connection
+                self.release(connection)
 
     async def execute_pipeline(self, commands: List["PipelineCommand"]) -> bool:
         # Acquire connection
         connection = self.acquire_connection()
-        # Handle lazy disconnect for connections marked for reconnect
-        await self.disconnect_if_needed(connection)
+        try:
+            # Handle lazy disconnect for connections marked for reconnect
+            await self.disconnect_if_needed(connection)
 
-        # Execute command
-        await connection.send_packed_command(
-            connection.pack_commands(cmd.args for cmd in commands)
-        )
+            # Execute command
+            await connection.send_packed_command(
+                connection.pack_commands(cmd.args for cmd in commands)
+            )
 
-        # Read responses
-        ret = False
-        for cmd in commands:
+            # Read responses
+            ret = False
+            for cmd in commands:
+                try:
+                    cmd.result = await self.parse_response(
+                        connection, cmd.args[0], **cmd.kwargs
+                    )
+                except Exception as e:
+                    cmd.result = e
+                    ret = True
+
+            return ret
+        finally:
             try:
-                cmd.result = await self.parse_response(
-                    connection, cmd.args[0], **cmd.kwargs
-                )
-            except Exception as e:
-                cmd.result = e
-                ret = True
-
-        # Release connection
-        await self.disconnect_if_needed(connection)
-        self.release(connection)
-
-        return ret
+                await self.disconnect_if_needed(connection)
+            finally:
+                # Release connection
+                self.release(connection)
 
     async def re_auth_callback(self, token: TokenInterface):
         tmp_queue = collections.deque()

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -12,7 +12,12 @@ import pytest
 import pytest_asyncio
 from _pytest.fixtures import FixtureRequest
 from redis._parsers import AsyncCommandsParser
-from redis.asyncio.cluster import ClusterNode, NodesManager, RedisCluster
+from redis.asyncio.cluster import (
+    ClusterNode,
+    NodesManager,
+    PipelineCommand,
+    RedisCluster,
+)
 from redis.asyncio.connection import Connection, SSLConnection, async_timeout
 from redis.asyncio.retry import Retry
 from redis.backoff import (
@@ -3306,6 +3311,125 @@ class TestNodesManager:
 @pytest.mark.fixed_client
 class TestClusterNodeConnectionHandling:
     """Tests for ClusterNode connection handling methods."""
+
+    class WriteFailingConnection:
+        def __init__(self, **kwargs: Any) -> None:
+            self.host = kwargs["host"]
+            self.port = kwargs["port"]
+            self.db = kwargs.get("db", 0)
+            self.is_connected = False
+            self.send_count = 0
+
+        def should_reconnect(self) -> bool:
+            return False
+
+        async def disconnect(self) -> None:
+            self.is_connected = False
+
+        def pack_command(self, *args: Any) -> bytes:
+            return b"packed-command"
+
+        def pack_commands(self, commands: Any) -> List[bytes]:
+            list(commands)
+            return [b"packed-commands"]
+
+        async def send_packed_command(self, command: Any) -> None:
+            self.send_count += 1
+            raise ConnectionError("simulated write failure")
+
+    async def test_execute_command_releases_connection_after_send_error(self) -> None:
+        node = ClusterNode(
+            default_host,
+            7000,
+            max_connections=1,
+            connection_class=self.WriteFailingConnection,
+        )
+
+        with pytest.raises(ConnectionError, match="simulated write failure"):
+            await node.execute_command("GET", "key")
+
+        assert len(node._connections) == 1
+        assert len(node._free) == 1
+        connection = node._connections[0]
+        assert node._free[0] is connection
+
+        with pytest.raises(ConnectionError, match="simulated write failure"):
+            await node.execute_command("GET", "key")
+
+        assert len(node._connections) == 1
+        assert len(node._free) == 1
+        assert node._free[0] is connection
+        assert connection.send_count == 2
+
+    async def test_execute_pipeline_releases_connection_after_send_error(self) -> None:
+        node = ClusterNode(
+            default_host,
+            7000,
+            max_connections=1,
+            connection_class=self.WriteFailingConnection,
+        )
+
+        with pytest.raises(ConnectionError, match="simulated write failure"):
+            await node.execute_pipeline([PipelineCommand(0, "GET", "key")])
+
+        assert len(node._connections) == 1
+        assert len(node._free) == 1
+        connection = node._connections[0]
+        assert node._free[0] is connection
+
+        with pytest.raises(ConnectionError, match="simulated write failure"):
+            await node.execute_pipeline([PipelineCommand(0, "GET", "key")])
+
+        assert len(node._connections) == 1
+        assert len(node._free) == 1
+        assert node._free[0] is connection
+        assert connection.send_count == 2
+
+    async def test_execute_command_releases_connection_after_disconnect_error(
+        self,
+    ) -> None:
+        node = ClusterNode(
+            default_host,
+            7000,
+            max_connections=1,
+            connection_class=self.WriteFailingConnection,
+        )
+
+        with mock.patch.object(
+            ClusterNode,
+            "disconnect_if_needed",
+            autospec=True,
+            side_effect=ConnectionError("simulated disconnect failure"),
+        ):
+            with pytest.raises(ConnectionError, match="simulated disconnect failure"):
+                await node.execute_command("GET", "key")
+
+        assert len(node._connections) == 1
+        assert len(node._free) == 1
+        assert node._free[0] is node._connections[0]
+
+    async def test_execute_pipeline_releases_connection_after_disconnect_error(
+        self,
+    ) -> None:
+        node = ClusterNode(
+            default_host,
+            7000,
+            max_connections=1,
+            connection_class=self.WriteFailingConnection,
+        )
+
+        with mock.patch.object(
+            ClusterNode,
+            "disconnect_if_needed",
+            autospec=True,
+            side_effect=ConnectionError("simulated disconnect failure"),
+        ):
+            with pytest.raises(ConnectionError, match="simulated disconnect failure"):
+                await node.execute_pipeline([PipelineCommand(0, "GET", "key")])
+
+        assert len(node._connections) == 1
+        assert len(node._free) == 1
+        assert node._free[0] is node._connections[0]
 
     async def test_update_active_connections_for_reconnect(self) -> None:
         """


### PR DESCRIPTION
This fixes async Redis Cluster node connection handling so acquired connections are returned to the per-node free queue even when write-side setup fails. `ClusterNode.execute_command()` and `ClusterNode.execute_pipeline()` now place lazy disconnect and `send_packed_command()` inside the release-guarded `try` block.

The cleanup path also now releases the connection even if the final `disconnect_if_needed()` raises. This prevents a failed disconnect during cleanup from stranding the connection in `_connections` and eventually exhausting `max_connections`.

Regression tests cover both direct command execution and node pipeline execution with `max_connections=1`. The tests simulate write failures and disconnect failures, then verify the same connection is returned to `_free` and can be reused instead of leaking.

Fixes #4110 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection lifecycle on error paths in async cluster command/pipeline execution; incorrect cleanup could still leak or double-release connections, but scope is limited to ClusterNode pool handling and is covered by new tests.
> 
> **Overview**
> Fixes **async Redis Cluster** per-node connection pooling so acquired connections are always returned to `_free`, even when work fails before a response is read.
> 
> `ClusterNode.execute_command()` and `execute_pipeline()` now wrap lazy disconnect, `send_packed_command`, and response handling in a **`try`/`finally`** cleanup path. **`release(connection)`** runs in a nested `finally` so it still executes if **`disconnect_if_needed()`** raises during teardown—avoiding stranded connections and **`MaxConnectionsError`** under **`max_connections=1`** (fixes #4110).
> 
> Regression tests simulate **write failures** and **disconnect failures** on both single-command and node-pipeline paths and assert the same connection is reused from `_free`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9a0b122b88ebf9386afeada7133fb424ff5f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->