### PR TITLE
fix(search): handle list response in _parse_info_resp3_to_legacy

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -870,6 +870,12 @@ class SearchCommands:
         ``legacy_responses=True`` on a RESP3 wire matches RESP2 output.
         """
         info = self._to_string_recursive(res)
+        if not isinstance(info, dict):
+            # In cluster mode or with certain Redis/RediSearch versions,
+            # the response may arrive as a RESP2-style flat array even
+            # though the client negotiated RESP3.  Fall back to the
+            # RESP2 parser (mirrors the guard in _parse_spellcheck_resp3).
+            return self._parse_info(res)
         attrs = info.get("attributes")
         if isinstance(attrs, list):
             info["attributes"] = [


### PR DESCRIPTION

## Summary

Fixes #4104: `FT.INFO` crashes with `AttributeError: 'list' object has no attribute 'get'` when using `RedisCluster` client.

## Reproduction Details

**Environment:**
- redis-py: latest (observed on main branch)
- Python: 3.13 (also reproducible on 3.11, 3.12)
- Redis Server: Redis 7.x / 8.x with RediSearch 2.x module, deployed as a cluster

**Root Cause:** Redis Cluster connections do not support RESP3 — the protocol falls back to RESP2 on cluster topologies. When `FT.INFO` is executed against a cluster, the response is a RESP2 flat array (list), but `_parse_info_resp3_to_legacy` unconditionally called `.get("attributes")` on the result assuming it was always a dict.

**Reproduction:**
```python
from redis import RedisCluster
client = RedisCluster("redis-cluster", 6379, decode_responses=True, ssl=True)
client.ft('myIndex').info()  # AttributeError: 'list' object has no attribute 'get'
```

The same command works fine with a standalone `Redis` client (non-clustered, RESP3).

## Fix

Added a guard at the top of `_parse_info_resp3_to_legacy` that checks whether the decoded result is a dict. If not (i.e., it's a list/array), the method falls back to the RESP2 `_parse_info` parser.

This mirrors the existing pattern in `_parse_spellcheck_resp3` (line 641):
```python
if not isinstance(res, dict):
    return self._parse_spellcheck(res, **kwargs)
```

## Change

- `redis/commands/search/commands.py`: Added `isinstance(info, dict)` guard with RESP2 fallback in `_parse_info_resp3_to_legacy`

## Verification

The fix is defensive — when the response is a proper RESP3 dict, the behavior is unchanged. When the response is a list, it delegates to the well-tested RESP2 parser. The cluster RESP2 fallback is a known protocol behavior, not a version-specific bug, making this guard appropriate regardless of Redis/RediSearch version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive branch in RediSearch response parsing; behavior unchanged for proper RESP3 dicts, only fixes cluster/list wire shapes.
> 
> **Overview**
> Fixes **`FT.INFO`** crashing on **`RedisCluster`** when legacy RESP3-to-RESP2 parsing runs but the wire still returns a RESP2 flat list (cluster does not use RESP3).
> 
> **`_parse_info_resp3_to_legacy`** now checks that the decoded payload is a **`dict`** before calling **`.get("attributes")`**. If it is a list, it delegates to **`_parse_info`**, matching the existing guard in **`_parse_spellcheck_resp3`**. RESP3 dict responses are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fb7c11dc061f7129061365a13d6c3d6933d02c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->