### PR TITLE
Adding support in async standalone client for maintenance notifications

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -328,7 +328,10 @@ class Redis(
         maint_notifications_config:
             configures the pool to support maintenance notifications - see
             `redis.maint_notifications.MaintNotificationsConfig` for details.
-            Only supported with RESP3.
+            Only supported with RESP3
+            If not provided and protocol is RESP3, the maintenance notifications
+            will be enabled by default (logic is included in the connection pool
+            initialization).
             Argument is ignored when connection_pool is provided.
         """
         kwargs: Dict[str, Any]
@@ -383,10 +386,21 @@ class Redis(
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:
+                if (
+                    maint_notifications_config
+                    and maint_notifications_config.enabled is True
+                ):
+                    raise RedisError(
+                        "Maintenance notifications are not supported with Unix "
+                        "domain socket connections"
+                    )
                 kwargs.update(
                     {
                         "path": unix_socket_path,
                         "connection_class": UnixDomainSocketConnection,
+                        "maint_notifications_config": MaintNotificationsConfig(
+                            enabled=False
+                        ),
                     }
                 )
             else:

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -798,7 +798,7 @@ class Redis(
         if close_connection_pool or (
             close_connection_pool is None and self.auto_close_connection_pool
         ):
-            await self.connection_pool.disconnect()
+            await self.connection_pool.aclose()
 
     @deprecated_function(version="5.0.1", reason="Use aclose() instead", name="close")
     async def close(self, close_connection_pool: Optional[bool] = None) -> None:

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -80,12 +80,14 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
+from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
 from redis.typing import ChannelT, EncodableT, KeyT, PubSubHandler, Subscription
 from redis.utils import (
     SENTINEL,
     SSL_AVAILABLE,
     _set_info_logger,
+    check_protocol_version,
     deprecated_args,
     deprecated_function,
     safe_str,
@@ -287,6 +289,7 @@ class Redis(
         protocol: int | None = None,
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
     ):
         """
         Initialize a new Redis client.
@@ -322,6 +325,11 @@ class Redis(
             options that are not available are skipped. Pass `None` or `{}` to
             avoid setting additional TCP keepalive options. Argument is ignored
             when connection_pool is provided.
+        maint_notifications_config:
+            configures the pool to support maintenance notifications - see
+            `redis.maint_notifications.MaintNotificationsConfig` for details.
+            Only supported with RESP3.
+            Argument is ignored when connection_pool is provided.
         """
         kwargs: Dict[str, Any]
         if event_dispatcher is None:
@@ -411,6 +419,19 @@ class Redis(
                             "ssl_password": ssl_password,
                         }
                     )
+            maint_notifications_enabled = (
+                maint_notifications_config and maint_notifications_config.enabled
+            )
+            if maint_notifications_enabled and not check_protocol_version(protocol, 3):
+                raise RedisError(
+                    "Maintenance notifications handlers on connection are only supported with RESP version 3"
+                )
+            if maint_notifications_config:
+                kwargs.update(
+                    {
+                        "maint_notifications_config": maint_notifications_config,
+                    }
+                )
             # This arg only used if no pool is passed in
             self.auto_close_connection_pool = auto_close_connection_pool
             connection_pool = ConnectionPool(**kwargs)
@@ -864,10 +885,15 @@ class Redis(
             )
             raise
         finally:
-            if self.single_connection_client:
-                self._single_conn_lock.release()
-            if not self.connection:
-                await pool.release(conn)
+            try:
+                if self.single_connection_client and conn and conn.should_reconnect():
+                    await self._close_connection(conn)
+                    await conn.connect()
+            finally:
+                if self.single_connection_client:
+                    self._single_conn_lock.release()
+                if not self.connection:
+                    await pool.release(conn)
 
     async def parse_response(
         self, connection: Connection, command_name: Union[str, bytes], **options

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -206,6 +206,10 @@ class AsyncMaintNotificationsAbstractConnection:
     ) -> Any:
         pass
 
+    @abstractmethod
+    def getpeername(self) -> str | None:
+        pass
+
     def _configure_maintenance_notifications(
         self,
         maint_notifications_pool_handler: (
@@ -381,7 +385,7 @@ class AsyncMaintNotificationsAbstractConnection:
         # Method 1: Try to get the actual IP from the established stream.
         # This is most accurate as it shows the exact IP being used.
         try:
-            peer_addr = self._get_peer_address()
+            peer_addr = self.getpeername()
             if peer_addr:
                 return peer_addr
         except (AttributeError, OSError):
@@ -433,18 +437,6 @@ class AsyncMaintNotificationsAbstractConnection:
     def reset_received_notifications(self) -> None:
         self._processed_start_maint_notifications.clear()
         self._skipped_end_maint_notifications.clear()
-
-    def getpeername(self) -> str | None:
-        """
-        Returns the peer name of the connection.
-        """
-        writer = getattr(self, "_writer", None)
-        if writer is None:
-            return None
-        peername = writer.get_extra_info("peername")
-        if isinstance(peername, tuple) and peername:
-            return str(peername[0])
-        return None
 
     def update_current_socket_timeout(
         self, relaxed_timeout: float | None = None
@@ -748,6 +740,18 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
 
     def _get_parser(self) -> BaseParser:
         return self._parser
+
+    def getpeername(self) -> str | None:
+        """
+        Returns the peer name of the connection.
+        """
+        writer = self._writer
+        if writer is None:
+            return None
+        peername = writer.get_extra_info("peername")
+        if isinstance(peername, tuple) and peername:
+            return str(peername[0])
+        return None
 
     async def connect(self):
         """Connects to the Redis server if not already connected"""

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2232,33 +2232,25 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         can move between active/free lists and escape handling.
         """
         async with self._get_pool_lock():
-            # This hook mirrors the sync BlockingConnectionPool behavior:
-            # blocking pools can pause connection creation/release while a
-            # MOVING notification rewrites pool and connection state. Regular
-            # pools do not expose set_in_maintenance, so this is a no-op there.
-            await self._set_in_maintenance(True)
-            try:
-                self._update_connections_settings_without_locking(
-                    state=MaintenanceState.MOVING,
-                    maintenance_notification_hash=hash(notification),
-                    relaxed_timeout=config.relaxed_timeout,
-                    host_address=notification.new_node_host,
-                    matching_address=moving_address_src,
-                    matching_pattern="connected_address",
-                    update_notification_hash=True,
-                    include_free_connections=True,
+            self._update_connections_settings_without_locking(
+                state=MaintenanceState.MOVING,
+                maintenance_notification_hash=hash(notification),
+                relaxed_timeout=config.relaxed_timeout,
+                host_address=notification.new_node_host,
+                matching_address=moving_address_src,
+                matching_pattern="connected_address",
+                update_notification_hash=True,
+                include_free_connections=True,
+            )
+
+            if run_proactive_reconnect:
+                await self._run_proactive_reconnect_without_locking(
+                    moving_address_src
                 )
 
-                if run_proactive_reconnect:
-                    await self._run_proactive_reconnect_without_locking(
-                        moving_address_src
-                    )
-
-                self.update_connection_kwargs(
-                    **_build_moving_connection_kwargs(notification, config)
-                )
-            finally:
-                await self._set_in_maintenance(False)
+            self.update_connection_kwargs(
+                **_build_moving_connection_kwargs(notification, config)
+            )
 
     async def run_proactive_reconnect(
         self,
@@ -2349,14 +2341,6 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         )
         if exc:
             raise exc
-
-    async def _set_in_maintenance(self, in_maintenance: bool) -> None:
-        set_in_maintenance = getattr(self, "set_in_maintenance", None)
-        if not callable(set_in_maintenance):
-            return
-        result = set_in_maintenance(in_maintenance)
-        if inspect.isawaitable(result):
-            await result
 
 
 class ConnectionPool(

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1,7 +1,6 @@
 import asyncio
 import copy
 import inspect
-import logging
 import socket
 import sys
 import time
@@ -15,6 +14,7 @@ from typing import (
     Callable,
     Iterable,
     List,
+    Literal,
     Mapping,
     Optional,
     Protocol,
@@ -105,6 +105,7 @@ from .._defaults import (
     get_default_socket_keepalive_options,
 )
 from .._parsers import (
+    AsyncPushNotificationsParser,
     BaseParser,
     Encoder,
     _AsyncHiredisParser,
@@ -117,9 +118,6 @@ SYM_DOLLAR = b"$"
 SYM_CRLF = b"\r\n"
 SYM_LF = b"\n"
 SYM_EMPTY = b""
-
-logger = logging.getLogger(__name__)
-
 
 DefaultParser: Type[Union[_AsyncRESP2Parser, _AsyncRESP3Parser, _AsyncHiredisParser]]
 if HIREDIS_AVAILABLE:
@@ -162,7 +160,7 @@ class AsyncMaintNotificationsAbstractConnection:
         orig_host_address: str | None = None,
         orig_socket_timeout: float | None = None,
         orig_socket_connect_timeout: float | None = None,
-        parser: _AsyncHiredisParser | _AsyncRESP3Parser | None = None,
+        parser: BaseParser | None = None,
     ) -> None:
         self.maint_notifications_config = maint_notifications_config
         self.maintenance_state = maintenance_state
@@ -177,6 +175,37 @@ class AsyncMaintNotificationsAbstractConnection:
             parser,
         )
 
+    @abstractmethod
+    def _get_parser(self) -> BaseParser:
+        pass
+
+    def _get_push_notifications_parser(self) -> AsyncPushNotificationsParser:
+        parser = self._get_parser()
+        if not isinstance(parser, (_AsyncHiredisParser, _AsyncRESP3Parser)):
+            raise RedisError(
+                "Maintenance notifications are only supported with hiredis and RESP3 parsers!"
+            )
+        return parser
+
+    @abstractmethod
+    def get_protocol(self):
+        pass
+
+    @abstractmethod
+    async def send_command(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    @abstractmethod
+    async def read_response(
+        self,
+        disable_decoding: bool = False,
+        timeout: float | None = None,
+        *,
+        disconnect_on_error: bool = True,
+        push_request: bool | None = False,
+    ) -> Any:
+        pass
+
     def _configure_maintenance_notifications(
         self,
         maint_notifications_pool_handler: (
@@ -185,22 +214,12 @@ class AsyncMaintNotificationsAbstractConnection:
         orig_host_address: str | None = None,
         orig_socket_timeout: float | None = None,
         orig_socket_connect_timeout: float | None = None,
-        parser: _AsyncHiredisParser | _AsyncRESP3Parser | None = None,
+        parser: BaseParser | None = None,
     ) -> None:
         if (
             not self.maint_notifications_config
             or not self.maint_notifications_config.enabled
         ):
-            self._maint_notifications_pool_handler = None
-            self._maint_notifications_connection_handler = None
-            return
-
-        host = getattr(self, "host", None)
-        if host is None:
-            if self.maint_notifications_config.enabled is True:
-                raise RedisError(
-                    "Maintenance notifications are not supported for connections without a host"
-                )
             self._maint_notifications_pool_handler = None
             self._maint_notifications_connection_handler = None
             return
@@ -218,10 +237,16 @@ class AsyncMaintNotificationsAbstractConnection:
             )
 
         if maint_notifications_pool_handler:
+            # Extract a reference to a new pool handler that copies all properties
+            # of the original one and has a different connection reference
+            # This is needed because when we attach the handler to the parser
+            # we need to make sure that the handler has a reference to the
+            # connection that the parser is attached to.
             self._maint_notifications_pool_handler = (
                 maint_notifications_pool_handler.get_handler_for_connection()
             )
             self._maint_notifications_pool_handler.set_connection(self)
+            # Set up pool handler to parser
             parser.set_node_moving_push_handler(
                 self._maint_notifications_pool_handler.handle_notification
             )
@@ -233,11 +258,12 @@ class AsyncMaintNotificationsAbstractConnection:
                 self, self.maint_notifications_config
             )
         )
+        # Set up connection handler
         parser.set_maintenance_push_handler(
             self._maint_notifications_connection_handler.handle_notification
         )
 
-        self.orig_host_address = orig_host_address if orig_host_address else host
+        self.orig_host_address = orig_host_address if orig_host_address else self.host
         self.orig_socket_timeout = (
             orig_socket_timeout if orig_socket_timeout else self.socket_timeout
         )
@@ -250,22 +276,28 @@ class AsyncMaintNotificationsAbstractConnection:
     def set_maint_notifications_pool_handler_for_connection(
         self, maint_notifications_pool_handler: AsyncMaintNotificationsPoolHandler
     ) -> None:
+        # Deep copy the pool handler to avoid sharing the same pool handler
+        # between multiple connections, because otherwise each connection will override
+        # the connection reference and the pool handler will only hold a reference
+        # to the last connection that was set.
         maint_notifications_pool_handler_copy = (
             maint_notifications_pool_handler.get_handler_for_connection()
         )
         maint_notifications_pool_handler_copy.set_connection(self)
-        self._parser.set_node_moving_push_handler(
+        parser = self._get_push_notifications_parser()
+        parser.set_node_moving_push_handler(
             maint_notifications_pool_handler_copy.handle_notification
         )
         self._maint_notifications_pool_handler = maint_notifications_pool_handler_copy
 
+        # Update maintenance notification connection handler if it doesn't exist
         if not self._maint_notifications_connection_handler:
             self._maint_notifications_connection_handler = (
                 AsyncMaintNotificationsConnectionHandler(
                     self, maint_notifications_pool_handler.config
                 )
             )
-            self._parser.set_maintenance_push_handler(
+            parser.set_maintenance_push_handler(
                 self._maint_notifications_connection_handler.handle_notification
             )
         else:
@@ -276,6 +308,12 @@ class AsyncMaintNotificationsAbstractConnection:
     async def activate_maint_notifications_handling_if_enabled(
         self, check_health: bool = True
     ) -> None:
+        # Send maintenance notifications handshake if RESP3 is active
+        # and maintenance notifications are enabled
+        # and we have a host to determine the endpoint type from
+        # When the maint_notifications_config enabled mode is "auto",
+        # we just log a warning if the handshake fails
+        # When the mode is enabled=True, we raise an exception in case of failure
         host = getattr(self, "host", None)
         if (
             check_protocol_version(self.get_protocol(), 3)
@@ -321,28 +359,53 @@ class AsyncMaintNotificationsAbstractConnection:
                 isinstance(e, ResponseError)
                 and maint_notifications_config.enabled == "auto"
             ):
+                # Log warning but don't fail the connection
+                import logging
+
+                logger = logging.getLogger(__name__)
                 logger.debug(f"Failed to enable maintenance notifications: {e}")
             else:
                 raise
 
     def get_resolved_ip(self) -> str | None:
+        """
+        Extract the resolved IP address from an established connection or host.
+
+        First tries to get the actual peer IP from the async stream writer, then
+        falls back to DNS resolution if needed.
+
+        Returns:
+            The resolved IP address, or None if it cannot be determined.
+        """
+
+        # Method 1: Try to get the actual IP from the established stream.
+        # This is most accurate as it shows the exact IP being used.
         try:
             peer_addr = self._get_peer_address()
             if peer_addr:
                 return peer_addr
         except (AttributeError, OSError):
+            # Stream might not be connected or peer address lookup might fail.
             pass
 
+        # Method 2: Fallback to DNS resolution of the host.
+        # This is less accurate but works when stream peer info is not available.
         try:
             host = getattr(self, "host", None)
             port = getattr(self, "port", 6379)
             if host:
+                # Use getaddrinfo to resolve the hostname to IP.
+                # This mimics what the connection would do during _connect().
                 addr_info = socket.getaddrinfo(
                     host, port, socket.AF_UNSPEC, socket.SOCK_STREAM
                 )
                 if addr_info:
+                    # Return the IP from the first result.
+                    # addr_info[0] is (family, socktype, proto, canonname, sockaddr).
+                    # sockaddr[0] is the IP address.
                     return str(addr_info[0][4][0])
         except (AttributeError, OSError, socket.gaierror):
+            # DNS resolution might fail.
             pass
 
         return None
@@ -372,9 +435,9 @@ class AsyncMaintNotificationsAbstractConnection:
         self._skipped_end_maint_notifications.clear()
 
     def getpeername(self) -> str | None:
-        return self._get_peer_address()
-
-    def _get_peer_address(self) -> str | None:
+        """
+        Returns the peer name of the connection.
+        """
         writer = getattr(self, "_writer", None)
         if writer is None:
             return None
@@ -387,41 +450,43 @@ class AsyncMaintNotificationsAbstractConnection:
         self, relaxed_timeout: float | None = None
     ) -> None:
         timeout = relaxed_timeout if relaxed_timeout != -1 else self.socket_timeout
-        self.update_parser_timeout(timeout)
         self._reschedule_active_read_timeout(timeout)
 
     def _reschedule_active_read_timeout(self, timeout: float | None) -> None:
         timeout_context = getattr(self, "_active_read_timeout", None)
         if timeout_context is None:
+            # No read_response call is currently inside its socket timeout
+            # context, so there is no in-flight deadline to relax or restore.
             return
 
         if timeout is None:
+            # A None socket timeout means the active read should become blocking.
+            # Python 3.11's timeout context supports clearing the deadline.
             if hasattr(timeout_context, "reschedule"):
                 timeout_context.reschedule(None)
+            # Older async-timeout contexts cannot clear a deadline, so reject the
+            # current timeout instead of leaving a stale relaxed deadline active.
             elif hasattr(timeout_context, "reject"):
                 timeout_context.reject()
             return
 
+        # Active read timeouts are stored as loop-time deadlines, not durations.
         deadline = asyncio.get_running_loop().time() + timeout
         if hasattr(timeout_context, "reschedule"):
+            # Python 3.11 asyncio.timeout exposes reschedule().
             timeout_context.reschedule(deadline)
         elif hasattr(timeout_context, "update"):
+            # async-timeout exposes update() for the same deadline adjustment.
             timeout_context.update(deadline)
-
-    def update_parser_timeout(self, timeout: float | None = None) -> None:
-        # Keep handler behavior aligned with sync and centralize parser timeout
-        # updates for parser implementations that expose such state.
-        parser = getattr(self, "_parser", None)
-        if isinstance(parser, _AsyncHiredisParser) and hasattr(
-            parser, "_socket_timeout"
-        ):
-            parser._socket_timeout = timeout
 
     def set_tmp_settings(
         self,
         tmp_host_address: str | object | None = SENTINEL,
-        tmp_relaxed_timeout: float | None = None,
+        tmp_relaxed_timeout: float | None = -1,
     ) -> None:
+        """
+        SENTINEL keeps the host unchanged. -1 keeps the relaxed timeout unchanged.
+        """
         if tmp_host_address and tmp_host_address != SENTINEL:
             self.host = str(tmp_host_address)
         if tmp_relaxed_timeout != -1:
@@ -681,6 +746,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         """
         self._parser = parser_class(socket_read_size=self._socket_read_size)
 
+    def _get_parser(self) -> BaseParser:
+        return self._parser
+
     async def connect(self):
         """Connects to the Redis server if not already connected"""
         # try once the socket connect with the handshake, retry the whole
@@ -864,6 +932,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             # ) != self.protocol:
             #     raise ConnectionError("Invalid RESP version")
 
+        # Activate maintenance notifications for this connection
+        # if enabled in the configuration
+        # This is a no-op if maintenance notifications are not enabled
         await self.activate_maint_notifications_handling_if_enabled(
             check_health=check_health
         )
@@ -990,6 +1061,8 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             # connection closes, matching the sync lifecycle.
             self.reset_tmp_settings(reset_relaxed_timeout=True)
             self.maintenance_state = MaintenanceState.NONE
+            # reset the sets that keep track of received start maint
+            # notifications and skipped end maint notifications
             self.reset_received_notifications()
 
     async def _send_ping(self):
@@ -1700,9 +1773,10 @@ class AsyncMaintNotificationsAbstractConnectionPool:
     """
     Internal mixin for async maintenance notification pool wiring.
 
-    The handler owns notification policy. This mixin owns pool state mutation
-    because `_available_connections`, `_in_use_connections`, `connection_kwargs`,
-    and the non-reentrant `asyncio.Lock` all live on the pool.
+    The handler owns notification policy.
+    This mixin owns pool state mutation because `_available_connections`,
+    `_in_use_connections`, `connection_kwargs`, and the non-reentrant `asyncio.Lock`
+    all live on the pool.
     """
 
     def __init__(
@@ -1724,8 +1798,31 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         if maint_notifications_config and maint_notifications_config.enabled:
             if not is_connection_supported:
                 if maint_notifications_config.enabled is True:
+                    # Unix sockets do not have a host endpoint for CLIENT
+                    # MAINT_NOTIFICATIONS to describe.
+                    if "path" in self.connection_kwargs:
+                        raise RedisError(
+                            "Maintenance notifications are not supported for "
+                            "Unix domain socket connections"
+                        )
+
+                    # Custom connection classes must inherit the async maintenance
+                    # mixin so handlers can update connection state safely.
+                    if not self._maintenance_notifications_connection_class_supported():
+                        connection_class = getattr(self, "connection_class", None)
+                        connection_class_name = getattr(
+                            connection_class, "__name__", connection_class
+                        )
+                        raise RedisError(
+                            "Maintenance notifications are not supported for "
+                            f"connection class {connection_class_name}"
+                        )
+
+                    # TCP-like connections still need a host to identify the
+                    # endpoint that can move during maintenance.
                     raise RedisError(
-                        self._maintenance_notifications_unsupported_error_message()
+                        "Maintenance notifications are not supported for connections "
+                        "without a host"
                     )
                 self._maint_notifications_pool_handler = None
                 return
@@ -1744,18 +1841,53 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         else:
             self._maint_notifications_pool_handler = None
 
-    def _maintenance_notifications_supported(self) -> bool:
-        return "path" not in self.connection_kwargs
+    @property
+    @abstractmethod
+    def connection_kwargs(self) -> dict[str, Any]:
+        pass
 
-    def _maintenance_notifications_unsupported_error_message(self) -> str:
+    @connection_kwargs.setter
+    @abstractmethod
+    def connection_kwargs(self, value: dict[str, Any]) -> None:
+        pass
+
+    @abstractmethod
+    def _get_pool_lock(self) -> asyncio.Lock:
+        pass
+
+    @abstractmethod
+    def _get_free_connections(self) -> Iterable["AbstractConnection"]:
+        pass
+
+    @abstractmethod
+    def _get_in_use_connections(self) -> Iterable["AbstractConnection"]:
+        pass
+
+    def _maintenance_notifications_supported(self) -> bool:
+        if "path" in self.connection_kwargs:
+            return False
+        if not self._maintenance_notifications_connection_class_supported():
+            return False
+        return bool(self.connection_kwargs.get("host"))
+
+    def _maintenance_notifications_connection_class_supported(self) -> bool:
         connection_class = getattr(self, "connection_class", None)
-        connection_class_name = getattr(connection_class, "__name__", connection_class)
-        return (
-            "Maintenance notifications are not supported for connection class "
-            f"{connection_class_name}"
-        )
+        if connection_class is None:
+            return False
+        try:
+            return issubclass(
+                connection_class, AsyncMaintNotificationsAbstractConnection
+            )
+        except TypeError:
+            return False
 
     def maint_notifications_enabled(self):
+        """
+        Returns:
+            True if the maintenance notifications are enabled, False otherwise.
+            The maintenance notifications config is stored in the pool handler.
+            If the pool handler is not set, the maintenance notifications are not enabled.
+        """
         maint_notifications_config = (
             self._maint_notifications_pool_handler.config
             if self._maint_notifications_pool_handler
@@ -1767,6 +1899,13 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         self,
         maint_notifications_config: MaintNotificationsConfig,
     ) -> None:
+        """
+        Updates the maintenance notifications configuration.
+        This method should be called only if the pool was created
+        without enabling the maintenance notifications and
+        in a later point in time maintenance notifications
+        are requested to be enabled.
+        """
         if (
             self.maint_notifications_enabled()
             and not maint_notifications_config.enabled
@@ -1780,8 +1919,31 @@ class AsyncMaintNotificationsAbstractConnectionPool:
             and not self._maintenance_notifications_supported()
         ):
             if maint_notifications_config.enabled is True:
+                # Unix sockets do not have a host endpoint for CLIENT
+                # MAINT_NOTIFICATIONS to describe.
+                if "path" in self.connection_kwargs:
+                    raise RedisError(
+                        "Maintenance notifications are not supported for "
+                        "Unix domain socket connections"
+                    )
+
+                # Custom connection classes must inherit the async maintenance
+                # mixin so handlers can update connection state safely.
+                if not self._maintenance_notifications_connection_class_supported():
+                    connection_class = getattr(self, "connection_class", None)
+                    connection_class_name = getattr(
+                        connection_class, "__name__", connection_class
+                    )
+                    raise RedisError(
+                        "Maintenance notifications are not supported for "
+                        f"connection class {connection_class_name}"
+                    )
+
+                # TCP-like connections still need a host to identify the
+                # endpoint that can move during maintenance.
                 raise RedisError(
-                    self._maintenance_notifications_unsupported_error_message()
+                    "Maintenance notifications are not supported for connections "
+                    "without a host"
                 )
             self._maint_notifications_pool_handler = None
             return
@@ -1806,6 +1968,9 @@ class AsyncMaintNotificationsAbstractConnectionPool:
             AsyncMaintNotificationsPoolHandler | None
         ) = None,
     ) -> None:
+        """
+        Update the connection kwargs for all future connections.
+        """
         if not self.maint_notifications_enabled():
             return
 
@@ -1817,7 +1982,10 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 }
             )
 
+        # Store original connection parameters for maintenance notifications.
         if self.connection_kwargs.get("orig_host_address", None) is None:
+            # If orig_host_address is None it means we haven't
+            # configured the original values yet
             self.connection_kwargs.update(
                 {
                     "orig_host_address": self.connection_kwargs.get("host"),
@@ -1836,7 +2004,8 @@ class AsyncMaintNotificationsAbstractConnectionPool:
             AsyncMaintNotificationsPoolHandler | None
         ) = None,
     ) -> None:
-        async with self._lock:
+        """Update the maintenance notifications config for all connections in the pool."""
+        async with self._get_pool_lock():
             for conn in self._get_free_connections():
                 if not maint_notifications_pool_handler:
                     raise ValueError("maint_notifications_pool_handler must be set")
@@ -1859,12 +2028,6 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 )
                 conn.mark_for_reconnect()
 
-    def _get_free_connections(self) -> Iterable["AbstractConnection"]:
-        return self._available_connections
-
-    def _get_in_use_connections(self) -> Iterable["AbstractConnection"]:
-        return self._in_use_connections
-
     def _should_update_connection(
         self,
         conn: "AbstractConnection",
@@ -1872,11 +2035,14 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         matching_address: str | None = None,
         matching_notification_hash: int | None = None,
     ) -> bool:
+        """
+        Check if the connection should be updated based on the matching criteria.
+        """
         if matching_pattern == "connected_address":
             if matching_address and conn.getpeername() != matching_address:
                 return False
         elif matching_pattern == "configured_address":
-            if matching_address and getattr(conn, "host", None) != matching_address:
+            if matching_address and conn.host != matching_address:
                 return False
         elif matching_pattern == "notification_hash":
             if (
@@ -1888,7 +2054,7 @@ class AsyncMaintNotificationsAbstractConnectionPool:
 
     def update_connection_settings(
         self,
-        conn: "AbstractConnection",
+        conn: "AsyncMaintNotificationsAbstractConnection",
         state: MaintenanceState | None = None,
         maintenance_notification_hash: int | None = None,
         host_address: str | None = None,
@@ -1897,10 +2063,14 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         reset_host_address: bool = False,
         reset_relaxed_timeout: bool = False,
     ) -> None:
+        """
+        Update the settings for a single connection.
+        """
         if state:
             conn.maintenance_state = state
 
         if update_notification_hash:
+            # update the notification hash only if requested
             conn.maintenance_notification_hash = maintenance_notification_hash
 
         if host_address is not None:
@@ -1925,14 +2095,35 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         relaxed_timeout: float | None = None,
         matching_address: str | None = None,
         matching_notification_hash: int | None = None,
-        matching_pattern: str = "connected_address",
+        matching_pattern: Literal[
+            "connected_address", "configured_address", "notification_hash"
+        ] = "connected_address",
         update_notification_hash: bool = False,
         reset_host_address: bool = False,
         reset_relaxed_timeout: bool = False,
         include_free_connections: bool = True,
     ) -> None:
-        async with self._lock:
-            self._update_connections_settings_locked(
+        """
+        Update the settings for all matching connections in the pool.
+
+        This method does not create new connections.
+        This method does not affect the connection kwargs.
+
+        :param state: The maintenance state to set for the connection.
+        :param maintenance_notification_hash: The hash of the maintenance notification
+                                               to set for the connection.
+        :param host_address: The host address to set for the connection.
+        :param relaxed_timeout: The relaxed timeout to set for the connection.
+        :param matching_address: The address to match for the connection.
+        :param matching_notification_hash: The notification hash to match for the connection.
+        :param matching_pattern: The pattern to match for the connection.
+        :param update_notification_hash: Whether to update the notification hash for the connection.
+        :param reset_host_address: Whether to reset the host address to the original address.
+        :param reset_relaxed_timeout: Whether to reset the relaxed timeout to the original timeout.
+        :param include_free_connections: Whether to include free/available connections.
+        """
+        async with self._get_pool_lock():
+            self._update_connections_settings_without_locking(
                 state=state,
                 maintenance_notification_hash=maintenance_notification_hash,
                 host_address=host_address,
@@ -1946,7 +2137,7 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 include_free_connections=include_free_connections,
             )
 
-    def _update_connections_settings_locked(
+    def _update_connections_settings_without_locking(
         self,
         state: MaintenanceState | None = None,
         maintenance_notification_hash: int | None = None,
@@ -1954,12 +2145,21 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         relaxed_timeout: float | None = None,
         matching_address: str | None = None,
         matching_notification_hash: int | None = None,
-        matching_pattern: str = "connected_address",
+        matching_pattern: Literal[
+            "connected_address", "configured_address", "notification_hash"
+        ] = "connected_address",
         update_notification_hash: bool = False,
         reset_host_address: bool = False,
         reset_relaxed_timeout: bool = False,
         include_free_connections: bool = True,
     ) -> None:
+        """
+        Update matching connections while the caller already holds the pool lock.
+
+        This helper intentionally does not acquire the pool lock so callers can
+        compose several pool mutations inside one critical section without
+        deadlocking the non-reentrant `asyncio.Lock`.
+        """
         for conn in self._get_in_use_connections():
             if self._should_update_connection(
                 conn,
@@ -1998,6 +2198,12 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                     )
 
     def update_connection_kwargs(self, **kwargs: Any) -> None:
+        """
+        Update the connection kwargs for all future connections.
+
+        This method updates the connection kwargs for all future connections created by the pool.
+        Existing connections are not affected.
+        """
         self.connection_kwargs.update(kwargs)
 
     async def apply_moving_notification(
@@ -2016,10 +2222,14 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         changes must happen under one pool-owned lock; otherwise a connection
         can move between active/free lists and escape handling.
         """
-        async with self._lock:
+        async with self._get_pool_lock():
+            # This hook mirrors the sync BlockingConnectionPool behavior:
+            # blocking pools can pause connection creation/release while a
+            # MOVING notification rewrites pool and connection state. Regular
+            # pools do not expose set_in_maintenance, so this is a no-op there.
             await self._set_in_maintenance(True)
             try:
-                self._update_connections_settings_locked(
+                self._update_connections_settings_without_locking(
                     state=MaintenanceState.MOVING,
                     maintenance_notification_hash=hash(notification),
                     relaxed_timeout=config.relaxed_timeout,
@@ -2031,7 +2241,9 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 )
 
                 if run_proactive_reconnect:
-                    await self._run_proactive_reconnect_locked(moving_address_src)
+                    await self._run_proactive_reconnect_without_locking(
+                        moving_address_src
+                    )
 
                 self.update_connection_kwargs(
                     **_build_moving_connection_kwargs(notification, config)
@@ -2051,13 +2263,20 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         pass under one lock avoids a connection moving between lists between
         separately locked calls.
         """
-        async with self._lock:
-            await self._run_proactive_reconnect_locked(moving_address_src)
+        async with self._get_pool_lock():
+            await self._run_proactive_reconnect_without_locking(moving_address_src)
 
-    async def _run_proactive_reconnect_locked(
+    async def _run_proactive_reconnect_without_locking(
         self,
         moving_address_src: str | None = None,
     ) -> None:
+        """
+        Mark and disconnect matching connections while the caller holds the pool lock.
+
+        This helper intentionally does not acquire the pool lock so it can be
+        reused by larger atomic operations that already hold the non-reentrant
+        `asyncio.Lock`.
+        """
         for conn in self._get_in_use_connections():
             if self._should_update_connection(
                 conn, "connected_address", moving_address_src
@@ -2087,14 +2306,14 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         acquire/release interleave, which can leave stale MOVING state or undo a
         newer overlapping MOVING notification.
         """
-        async with self._lock:
+        async with self._get_pool_lock():
             kwargs = _build_moving_cleanup_connection_kwargs(
                 self.connection_kwargs, notification_hash
             )
             if kwargs is not None:
                 self.update_connection_kwargs(**kwargs)
 
-            self._update_connections_settings_locked(
+            self._update_connections_settings_without_locking(
                 relaxed_timeout=-1,
                 state=MaintenanceState.NONE,
                 maintenance_notification_hash=None,
@@ -2207,7 +2426,7 @@ class ConnectionPool(
             raise ValueError('"max_connections" must be a positive integer')
 
         self.connection_class = connection_class
-        self.connection_kwargs = connection_kwargs
+        self._connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
         self._available_connections: List[AbstractConnection] = []
@@ -2246,6 +2465,23 @@ class ConnectionPool(
             f"(<{self.connection_class.__module__}.{self.connection_class.__name__}"
             f"({conn_kwargs})>)>"
         )
+
+    @property
+    def connection_kwargs(self) -> dict[str, Any]:
+        return self._connection_kwargs
+
+    @connection_kwargs.setter
+    def connection_kwargs(self, value: dict[str, Any]) -> None:
+        self._connection_kwargs = value
+
+    def _get_pool_lock(self) -> asyncio.Lock:
+        return self._lock
+
+    def _get_free_connections(self) -> Iterable[AbstractConnection]:
+        return self._available_connections
+
+    def _get_in_use_connections(self) -> Iterable[AbstractConnection]:
+        return self._in_use_connections
 
     def get_protocol(self):
         """

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import copy
 import inspect
 import socket
@@ -11,6 +12,7 @@ from itertools import chain
 from types import MappingProxyType
 from typing import (
     Any,
+    AsyncIterator,
     Callable,
     Iterable,
     List,
@@ -2232,25 +2234,32 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         can move between active/free lists and escape handling.
         """
         async with self._get_pool_lock():
-            self._update_connections_settings_without_locking(
-                state=MaintenanceState.MOVING,
-                maintenance_notification_hash=hash(notification),
-                relaxed_timeout=config.relaxed_timeout,
-                host_address=notification.new_node_host,
-                matching_address=moving_address_src,
-                matching_pattern="connected_address",
-                update_notification_hash=True,
-                include_free_connections=True,
-            )
-
-            if run_proactive_reconnect:
-                await self._run_proactive_reconnect_without_locking(
-                    moving_address_src
+            # Opt BlockingConnectionPool into serializing its get/release
+            # with this critical section. Other pools do not define
+            # set_in_maintenance and this is a no-op for them.
+            self._set_in_maintenance(True)
+            try:
+                self._update_connections_settings_without_locking(
+                    state=MaintenanceState.MOVING,
+                    maintenance_notification_hash=hash(notification),
+                    relaxed_timeout=config.relaxed_timeout,
+                    host_address=notification.new_node_host,
+                    matching_address=moving_address_src,
+                    matching_pattern="connected_address",
+                    update_notification_hash=True,
+                    include_free_connections=True,
                 )
 
-            self.update_connection_kwargs(
-                **_build_moving_connection_kwargs(notification, config)
-            )
+                if run_proactive_reconnect:
+                    await self._run_proactive_reconnect_without_locking(
+                        moving_address_src
+                    )
+
+                self.update_connection_kwargs(
+                    **_build_moving_connection_kwargs(notification, config)
+                )
+            finally:
+                self._set_in_maintenance(False)
 
     async def run_proactive_reconnect(
         self,
@@ -2341,6 +2350,12 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         )
         if exc:
             raise exc
+
+    def _set_in_maintenance(self, in_maintenance: bool) -> None:
+        """Flip the pool's maintenance flag if it exposes one (BlockingConnectionPool)."""
+        set_in_maintenance = getattr(self, "set_in_maintenance", None)
+        if callable(set_in_maintenance):
+            set_in_maintenance(in_maintenance)
 
 
 class ConnectionPool(
@@ -2663,6 +2678,7 @@ class ConnectionPool(
                 await connection.disconnect()
 
             self._available_connections.append(connection)
+
         await self._event_dispatcher.dispatch_async(
             AsyncAfterConnectionReleasedEvent(connection)
         )
@@ -2816,6 +2832,28 @@ class BlockingConnectionPool(ConnectionPool):
         )
         self._condition = asyncio.Condition()
         self.timeout = timeout
+        self._in_maintenance = False
+
+    def set_in_maintenance(self, in_maintenance: bool) -> None:
+        """
+        Toggle the pool's maintenance mode.
+
+        While maintenance mode is on, ``get_connection`` and ``release``
+        serialize their pool mutations through ``self._lock`` so they cannot
+        interleave with a MOVING notification handler that is currently
+        rewriting pool state under the same lock. Outside of maintenance the
+        mutations skip the lock, since their critical sections are pure-Python
+        and already atomic under asyncio's single-threaded scheduling.
+        """
+        self._in_maintenance = in_maintenance
+
+    @contextlib.asynccontextmanager
+    async def _maybe_pool_lock(self) -> AsyncIterator[None]:
+        if self._in_maintenance:
+            async with self._lock:
+                yield
+        else:
+            yield
 
     @deprecated_args(
         args_to_warn=["*"],
@@ -2831,7 +2869,7 @@ class BlockingConnectionPool(ConnectionPool):
             async with self._condition:
                 async with async_timeout(self.timeout):
                     await self._condition.wait_for(self.can_get_connection)
-                    async with self._lock:
+                    async with self._maybe_pool_lock():
                         # Track connection count before to detect if a new connection is created
                         connections_before = len(self._available_connections) + len(
                             self._in_use_connections

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1845,6 +1845,11 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         else:
             self._maint_notifications_pool_handler = None
 
+    async def _on_close(self) -> None:
+        """Hook invoked from the pool's ``aclose()`` before the pool is shut down."""
+        if self._maint_notifications_pool_handler is not None:
+            await self._maint_notifications_pool_handler.cancel_scheduled_tasks()
+
     @property
     @abstractmethod
     def connection_kwargs(self) -> dict[str, Any]:
@@ -2724,6 +2729,7 @@ class ConnectionPool(
 
     async def aclose(self) -> None:
         """Close the pool, disconnecting all connections"""
+        await self._on_close()
         await self.disconnect()
 
     def set_retry(self, retry: "Retry") -> None:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import inspect
+import logging
 import socket
 import sys
 import time
@@ -56,6 +57,10 @@ if sys.version_info >= (3, 11, 3):
 else:
     from async_timeout import timeout as async_timeout
 
+from redis.asyncio.maint_notifications import (
+    AsyncMaintNotificationsConnectionHandler,
+    AsyncMaintNotificationsPoolHandler,
+)
 from redis.asyncio.observability.recorder import (
     record_connection_closed,
     record_connection_count,
@@ -76,12 +81,20 @@ from redis.exceptions import (
     ResponseError,
     TimeoutError,
 )
+from redis.maint_notifications import (
+    MaintenanceState,
+    MaintNotificationsConfig,
+    NodeMovingNotification,
+    _build_moving_cleanup_connection_kwargs,
+    _build_moving_connection_kwargs,
+)
 from redis.observability.metrics import CloseReason
 from redis.typing import EncodableT
 from redis.utils import (
     DEFAULT_RESP_VERSION,
     HIREDIS_AVAILABLE,
     SENTINEL,
+    check_protocol_version,
     str_if_bytes,
 )
 
@@ -105,6 +118,8 @@ SYM_CRLF = b"\r\n"
 SYM_LF = b"\n"
 SYM_EMPTY = b""
 
+logger = logging.getLogger(__name__)
+
 
 DefaultParser: Type[Union[_AsyncRESP2Parser, _AsyncRESP3Parser, _AsyncHiredisParser]]
 if HIREDIS_AVAILABLE:
@@ -124,7 +139,308 @@ class AsyncConnectCallbackProtocol(Protocol):
 ConnectCallbackT = Union[ConnectCallbackProtocol, AsyncConnectCallbackProtocol]
 
 
-class AbstractConnection:
+class AsyncMaintNotificationsAbstractConnection:
+    """
+    Internal mixin for async maintenance notification state and parser handlers.
+
+    The sync implementation uses the same mixin-style structure. The async
+    version keeps the notification state and parser handler installation close
+    to the connection without sending the server-side handshake; that is wired
+    in a later step.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        maint_notifications_config: MaintNotificationsConfig | None,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        maintenance_state: MaintenanceState = MaintenanceState.NONE,
+        maintenance_notification_hash: int | None = None,
+        orig_host_address: str | None = None,
+        orig_socket_timeout: float | None = None,
+        orig_socket_connect_timeout: float | None = None,
+        parser: _AsyncHiredisParser | _AsyncRESP3Parser | None = None,
+    ) -> None:
+        self.maint_notifications_config = maint_notifications_config
+        self.maintenance_state = maintenance_state
+        self.maintenance_notification_hash = maintenance_notification_hash
+        self._processed_start_maint_notifications: set[int] = set()
+        self._skipped_end_maint_notifications: set[int] = set()
+        self._configure_maintenance_notifications(
+            maint_notifications_pool_handler,
+            orig_host_address,
+            orig_socket_timeout,
+            orig_socket_connect_timeout,
+            parser,
+        )
+
+    def _configure_maintenance_notifications(
+        self,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        orig_host_address: str | None = None,
+        orig_socket_timeout: float | None = None,
+        orig_socket_connect_timeout: float | None = None,
+        parser: _AsyncHiredisParser | _AsyncRESP3Parser | None = None,
+    ) -> None:
+        if (
+            not self.maint_notifications_config
+            or not self.maint_notifications_config.enabled
+        ):
+            self._maint_notifications_pool_handler = None
+            self._maint_notifications_connection_handler = None
+            return
+
+        host = getattr(self, "host", None)
+        if host is None:
+            if self.maint_notifications_config.enabled is True:
+                raise RedisError(
+                    "Maintenance notifications are not supported for connections without a host"
+                )
+            self._maint_notifications_pool_handler = None
+            self._maint_notifications_connection_handler = None
+            return
+
+        if not parser:
+            raise RedisError(
+                "To configure maintenance notifications, a parser must be provided!"
+            )
+
+        if not isinstance(parser, _AsyncHiredisParser) and not isinstance(
+            parser, _AsyncRESP3Parser
+        ):
+            raise RedisError(
+                "Maintenance notifications are only supported with hiredis and RESP3 parsers!"
+            )
+
+        if maint_notifications_pool_handler:
+            self._maint_notifications_pool_handler = (
+                maint_notifications_pool_handler.get_handler_for_connection()
+            )
+            self._maint_notifications_pool_handler.set_connection(self)
+            parser.set_node_moving_push_handler(
+                self._maint_notifications_pool_handler.handle_notification
+            )
+        else:
+            self._maint_notifications_pool_handler = None
+
+        self._maint_notifications_connection_handler = (
+            AsyncMaintNotificationsConnectionHandler(
+                self, self.maint_notifications_config
+            )
+        )
+        parser.set_maintenance_push_handler(
+            self._maint_notifications_connection_handler.handle_notification
+        )
+
+        self.orig_host_address = orig_host_address if orig_host_address else host
+        self.orig_socket_timeout = (
+            orig_socket_timeout if orig_socket_timeout else self.socket_timeout
+        )
+        self.orig_socket_connect_timeout = (
+            orig_socket_connect_timeout
+            if orig_socket_connect_timeout
+            else self.socket_connect_timeout
+        )
+
+    def set_maint_notifications_pool_handler_for_connection(
+        self, maint_notifications_pool_handler: AsyncMaintNotificationsPoolHandler
+    ) -> None:
+        maint_notifications_pool_handler_copy = (
+            maint_notifications_pool_handler.get_handler_for_connection()
+        )
+        maint_notifications_pool_handler_copy.set_connection(self)
+        self._parser.set_node_moving_push_handler(
+            maint_notifications_pool_handler_copy.handle_notification
+        )
+        self._maint_notifications_pool_handler = maint_notifications_pool_handler_copy
+
+        if not self._maint_notifications_connection_handler:
+            self._maint_notifications_connection_handler = (
+                AsyncMaintNotificationsConnectionHandler(
+                    self, maint_notifications_pool_handler.config
+                )
+            )
+            self._parser.set_maintenance_push_handler(
+                self._maint_notifications_connection_handler.handle_notification
+            )
+        else:
+            self._maint_notifications_connection_handler.config = (
+                maint_notifications_pool_handler.config
+            )
+
+    async def activate_maint_notifications_handling_if_enabled(
+        self, check_health: bool = True
+    ) -> None:
+        host = getattr(self, "host", None)
+        if (
+            check_protocol_version(self.get_protocol(), 3)
+            and self.maint_notifications_config
+            and self.maint_notifications_config.enabled
+            and self._maint_notifications_connection_handler
+            and host is not None
+        ):
+            await self._enable_maintenance_notifications(
+                maint_notifications_config=self.maint_notifications_config,
+                check_health=check_health,
+            )
+
+    async def _enable_maintenance_notifications(
+        self,
+        maint_notifications_config: MaintNotificationsConfig,
+        check_health: bool = True,
+    ) -> None:
+        try:
+            host = getattr(self, "host", None)
+            if host is None:
+                raise ValueError(
+                    "Cannot enable maintenance notifications for connection"
+                    " object that doesn't have a host attribute."
+                )
+
+            endpoint_type = maint_notifications_config.get_endpoint_type(host, self)
+            await self.send_command(
+                "CLIENT",
+                "MAINT_NOTIFICATIONS",
+                "ON",
+                "moving-endpoint-type",
+                endpoint_type.value,
+                check_health=check_health,
+            )
+            response = await self.read_response()
+            if not response or str_if_bytes(response) != "OK":
+                raise ResponseError(
+                    "The server doesn't support maintenance notifications"
+                )
+        except Exception as e:
+            if (
+                isinstance(e, ResponseError)
+                and maint_notifications_config.enabled == "auto"
+            ):
+                logger.debug(f"Failed to enable maintenance notifications: {e}")
+            else:
+                raise
+
+    def get_resolved_ip(self) -> str | None:
+        try:
+            peer_addr = self._get_peer_address()
+            if peer_addr:
+                return peer_addr
+        except (AttributeError, OSError):
+            pass
+
+        try:
+            host = getattr(self, "host", None)
+            port = getattr(self, "port", 6379)
+            if host:
+                addr_info = socket.getaddrinfo(
+                    host, port, socket.AF_UNSPEC, socket.SOCK_STREAM
+                )
+                if addr_info:
+                    return str(addr_info[0][4][0])
+        except (AttributeError, OSError, socket.gaierror):
+            pass
+
+        return None
+
+    @property
+    def maintenance_state(self) -> MaintenanceState:
+        return self._maintenance_state
+
+    @maintenance_state.setter
+    def maintenance_state(self, state: MaintenanceState) -> None:
+        self._maintenance_state = state
+
+    def add_maint_start_notification(self, id: int) -> None:
+        self._processed_start_maint_notifications.add(id)
+
+    def get_processed_start_notifications(self) -> set[int]:
+        return self._processed_start_maint_notifications
+
+    def add_skipped_end_notification(self, id: int) -> None:
+        self._skipped_end_maint_notifications.add(id)
+
+    def get_skipped_end_notifications(self) -> set[int]:
+        return self._skipped_end_maint_notifications
+
+    def reset_received_notifications(self) -> None:
+        self._processed_start_maint_notifications.clear()
+        self._skipped_end_maint_notifications.clear()
+
+    def getpeername(self) -> str | None:
+        return self._get_peer_address()
+
+    def _get_peer_address(self) -> str | None:
+        writer = getattr(self, "_writer", None)
+        if writer is None:
+            return None
+        peername = writer.get_extra_info("peername")
+        if isinstance(peername, tuple) and peername:
+            return str(peername[0])
+        return None
+
+    def update_current_socket_timeout(
+        self, relaxed_timeout: float | None = None
+    ) -> None:
+        timeout = relaxed_timeout if relaxed_timeout != -1 else self.socket_timeout
+        self.update_parser_timeout(timeout)
+        self._reschedule_active_read_timeout(timeout)
+
+    def _reschedule_active_read_timeout(self, timeout: float | None) -> None:
+        timeout_context = getattr(self, "_active_read_timeout", None)
+        if timeout_context is None:
+            return
+
+        if timeout is None:
+            if hasattr(timeout_context, "reschedule"):
+                timeout_context.reschedule(None)
+            elif hasattr(timeout_context, "reject"):
+                timeout_context.reject()
+            return
+
+        deadline = asyncio.get_running_loop().time() + timeout
+        if hasattr(timeout_context, "reschedule"):
+            timeout_context.reschedule(deadline)
+        elif hasattr(timeout_context, "update"):
+            timeout_context.update(deadline)
+
+    def update_parser_timeout(self, timeout: float | None = None) -> None:
+        # Keep handler behavior aligned with sync and centralize parser timeout
+        # updates for parser implementations that expose such state.
+        parser = getattr(self, "_parser", None)
+        if isinstance(parser, _AsyncHiredisParser) and hasattr(
+            parser, "_socket_timeout"
+        ):
+            parser._socket_timeout = timeout
+
+    def set_tmp_settings(
+        self,
+        tmp_host_address: str | object | None = SENTINEL,
+        tmp_relaxed_timeout: float | None = None,
+    ) -> None:
+        if tmp_host_address and tmp_host_address != SENTINEL:
+            self.host = str(tmp_host_address)
+        if tmp_relaxed_timeout != -1:
+            self.socket_timeout = tmp_relaxed_timeout
+            self.socket_connect_timeout = tmp_relaxed_timeout
+
+    def reset_tmp_settings(
+        self,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+    ) -> None:
+        if reset_host_address:
+            self.host = self.orig_host_address
+        if reset_relaxed_timeout:
+            self.socket_timeout = self.orig_socket_timeout
+            self.socket_connect_timeout = self.orig_socket_connect_timeout
+
+
+class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
     """Manages communication to and from a Redis server"""
 
     __slots__ = (
@@ -149,6 +465,7 @@ class AbstractConnection:
         "_reader",
         "_writer",
         "_parser",
+        "_active_read_timeout",
         "_connect_callbacks",
         "_buffer_cutoff",
         "_lock",
@@ -188,6 +505,15 @@ class AbstractConnection:
         protocol: int | None = None,
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        maintenance_state: MaintenanceState = MaintenanceState.NONE,
+        maintenance_notification_hash: int | None = None,
+        orig_host_address: str | None = None,
+        orig_socket_timeout: float | None = None,
+        orig_socket_connect_timeout: float | None = None,
     ):
         """
         Initialize a new async Connection.
@@ -252,6 +578,7 @@ class AbstractConnection:
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._socket_read_size = socket_read_size
+        self._active_read_timeout = None
         self._connect_callbacks: List[weakref.WeakMethod[ConnectCallbackT]] = []
         self._buffer_cutoff = 6000
         self._re_auth_token: Optional[TokenInterface] = None
@@ -275,6 +602,17 @@ class AbstractConnection:
             elif self.protocol == 2 and parser_class == _AsyncRESP3Parser:
                 parser_class = _AsyncRESP2Parser
         self.set_parser(parser_class)
+        AsyncMaintNotificationsAbstractConnection.__init__(
+            self,
+            maint_notifications_config,
+            maint_notifications_pool_handler,
+            maintenance_state,
+            maintenance_notification_hash,
+            orig_host_address,
+            orig_socket_timeout,
+            orig_socket_connect_timeout,
+            self._parser,
+        )
 
     def __del__(self, _warnings: Any = warnings):
         # For some reason, the individual streams don't get properly garbage
@@ -476,7 +814,7 @@ class AbstractConnection:
 
             # if resp version is specified and we have auth args,
             # we need to send them via HELLO
-        if auth_args and self.protocol not in [2, "2"]:
+        if auth_args and check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _AsyncRESP2Parser):
                 self.set_parser(_AsyncRESP3Parser)
                 # update cluster exception classes
@@ -513,7 +851,7 @@ class AbstractConnection:
                 raise AuthenticationError("Invalid Username or Password")
 
         # if resp version is specified, switch to it
-        elif self.protocol not in [2, "2"]:
+        elif check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _AsyncRESP2Parser):
                 self.set_parser(_AsyncRESP3Parser)
                 # update cluster exception classes
@@ -525,6 +863,10 @@ class AbstractConnection:
             #     "proto"
             # ) != self.protocol:
             #     raise ConnectionError("Invalid RESP version")
+
+        await self.activate_maint_notifications_handling_if_enabled(
+            check_health=check_health
+        )
 
         # if a client_name is given, set it
         if self.client_name:
@@ -642,6 +984,14 @@ class AbstractConnection:
                 close_reason=CloseReason.APPLICATION_CLOSE,
             )
 
+        if self.maintenance_state == MaintenanceState.MAINTENANCE:
+            # MOVING state is owned by the pool-level TTL cleanup. Regular
+            # maintenance timeout relaxation can be restored when this
+            # connection closes, matching the sync lifecycle.
+            self.reset_tmp_settings(reset_relaxed_timeout=True)
+            self.maintenance_state = MaintenanceState.NONE
+            self.reset_received_notifications()
+
     async def _send_ping(self):
         """Send PING, expect PONG in return"""
         await self.send_command("PING", check_health=False)
@@ -741,32 +1091,37 @@ class AbstractConnection:
     async def read_response(
         self,
         disable_decoding: bool = False,
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
         *,
         disconnect_on_error: bool = True,
-        push_request: Optional[bool] = False,
+        push_request: bool | None = False,
     ):
         """Read the response from a previously sent command"""
         read_timeout = timeout if timeout is not None else self.socket_timeout
         host_error = self._host_error()
         try:
-            if read_timeout is not None and self.protocol in ["3", 3]:
-                async with async_timeout(read_timeout):
-                    response = await self._parser.read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
-                    )
-            elif read_timeout is not None:
-                async with async_timeout(read_timeout):
-                    response = await self._parser.read_response(
-                        disable_decoding=disable_decoding
-                    )
-            elif self.protocol in ["3", 3]:
-                response = await self._parser.read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
-                )
+            if read_timeout is not None:
+                timeout_context = async_timeout(read_timeout)
+                if timeout is None:
+                    async with timeout_context as active_timeout:
+                        self._active_read_timeout = active_timeout
+                        try:
+                            response = await self._read_response_from_parser(
+                                disable_decoding=disable_decoding,
+                                push_request=push_request,
+                            )
+                        finally:
+                            self._active_read_timeout = None
+                else:
+                    async with timeout_context:
+                        response = await self._read_response_from_parser(
+                            disable_decoding=disable_decoding,
+                            push_request=push_request,
+                        )
             else:
-                response = await self._parser.read_response(
-                    disable_decoding=disable_decoding
+                response = await self._read_response_from_parser(
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
                 )
         except asyncio.TimeoutError:
             if timeout is not None:
@@ -795,6 +1150,15 @@ class AbstractConnection:
         if isinstance(response, ResponseError):
             raise response from None
         return response
+
+    async def _read_response_from_parser(
+        self, disable_decoding: bool = False, push_request: bool | None = False
+    ):
+        if check_protocol_version(self.protocol, 3):
+            return await self._parser.read_response(
+                disable_decoding=disable_decoding, push_request=push_request
+            )
+        return await self._parser.read_response(disable_decoding=disable_decoding)
 
     def pack_command(self, *args: EncodableT) -> List[bytes]:
         """Pack a series of arguments into the Redis protocol"""
@@ -1332,7 +1696,444 @@ class ConnectionPoolInterface(ABC):
         pass
 
 
-class ConnectionPool(ConnectionPoolInterface):
+class AsyncMaintNotificationsAbstractConnectionPool:
+    """
+    Internal mixin for async maintenance notification pool wiring.
+
+    The handler owns notification policy. This mixin owns pool state mutation
+    because `_available_connections`, `_in_use_connections`, `connection_kwargs`,
+    and the non-reentrant `asyncio.Lock` all live on the pool.
+    """
+
+    def __init__(
+        self,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        protocol = kwargs.get("protocol")
+        is_protocol_supported = check_protocol_version(protocol, 3)
+        is_connection_supported = self._maintenance_notifications_supported()
+
+        if (
+            maint_notifications_config is None
+            and is_protocol_supported
+            and is_connection_supported
+        ):
+            maint_notifications_config = MaintNotificationsConfig()
+
+        if maint_notifications_config and maint_notifications_config.enabled:
+            if not is_connection_supported:
+                if maint_notifications_config.enabled is True:
+                    raise RedisError(
+                        self._maintenance_notifications_unsupported_error_message()
+                    )
+                self._maint_notifications_pool_handler = None
+                return
+
+            if not is_protocol_supported:
+                raise RedisError(
+                    "Maintenance notifications handlers on connection are only supported with RESP version 3"
+                )
+
+            self._maint_notifications_pool_handler = AsyncMaintNotificationsPoolHandler(
+                self, maint_notifications_config
+            )
+            self._update_connection_kwargs_for_maint_notifications(
+                maint_notifications_pool_handler=self._maint_notifications_pool_handler
+            )
+        else:
+            self._maint_notifications_pool_handler = None
+
+    def _maintenance_notifications_supported(self) -> bool:
+        return "path" not in self.connection_kwargs
+
+    def _maintenance_notifications_unsupported_error_message(self) -> str:
+        connection_class = getattr(self, "connection_class", None)
+        connection_class_name = getattr(connection_class, "__name__", connection_class)
+        return (
+            "Maintenance notifications are not supported for connection class "
+            f"{connection_class_name}"
+        )
+
+    def maint_notifications_enabled(self):
+        maint_notifications_config = (
+            self._maint_notifications_pool_handler.config
+            if self._maint_notifications_pool_handler
+            else None
+        )
+        return maint_notifications_config and maint_notifications_config.enabled
+
+    async def update_maint_notifications_config(
+        self,
+        maint_notifications_config: MaintNotificationsConfig,
+    ) -> None:
+        if (
+            self.maint_notifications_enabled()
+            and not maint_notifications_config.enabled
+        ):
+            raise ValueError(
+                "Cannot disable maintenance notifications after enabling them"
+            )
+
+        if (
+            maint_notifications_config.enabled
+            and not self._maintenance_notifications_supported()
+        ):
+            if maint_notifications_config.enabled is True:
+                raise RedisError(
+                    self._maintenance_notifications_unsupported_error_message()
+                )
+            self._maint_notifications_pool_handler = None
+            return
+
+        if not self._maint_notifications_pool_handler:
+            self._maint_notifications_pool_handler = AsyncMaintNotificationsPoolHandler(
+                self, maint_notifications_config
+            )
+        else:
+            self._maint_notifications_pool_handler.config = maint_notifications_config
+
+        self._update_connection_kwargs_for_maint_notifications(
+            maint_notifications_pool_handler=self._maint_notifications_pool_handler
+        )
+        await self._update_maint_notifications_configs_for_connections(
+            maint_notifications_pool_handler=self._maint_notifications_pool_handler
+        )
+
+    def _update_connection_kwargs_for_maint_notifications(
+        self,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+    ) -> None:
+        if not self.maint_notifications_enabled():
+            return
+
+        if maint_notifications_pool_handler:
+            self.connection_kwargs.update(
+                {
+                    "maint_notifications_pool_handler": maint_notifications_pool_handler,
+                    "maint_notifications_config": maint_notifications_pool_handler.config,
+                }
+            )
+
+        if self.connection_kwargs.get("orig_host_address", None) is None:
+            self.connection_kwargs.update(
+                {
+                    "orig_host_address": self.connection_kwargs.get("host"),
+                    "orig_socket_timeout": self.connection_kwargs.get(
+                        "socket_timeout", DEFAULT_SOCKET_TIMEOUT
+                    ),
+                    "orig_socket_connect_timeout": self.connection_kwargs.get(
+                        "socket_connect_timeout", DEFAULT_SOCKET_CONNECT_TIMEOUT
+                    ),
+                }
+            )
+
+    async def _update_maint_notifications_configs_for_connections(
+        self,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+    ) -> None:
+        async with self._lock:
+            for conn in self._get_free_connections():
+                if not maint_notifications_pool_handler:
+                    raise ValueError("maint_notifications_pool_handler must be set")
+                conn.set_maint_notifications_pool_handler_for_connection(
+                    maint_notifications_pool_handler
+                )
+                conn.maint_notifications_config = (
+                    maint_notifications_pool_handler.config
+                )
+                await conn.disconnect()
+
+            for conn in self._get_in_use_connections():
+                if not maint_notifications_pool_handler:
+                    raise ValueError("maint_notifications_pool_handler must be set")
+                conn.set_maint_notifications_pool_handler_for_connection(
+                    maint_notifications_pool_handler
+                )
+                conn.maint_notifications_config = (
+                    maint_notifications_pool_handler.config
+                )
+                conn.mark_for_reconnect()
+
+    def _get_free_connections(self) -> Iterable["AbstractConnection"]:
+        return self._available_connections
+
+    def _get_in_use_connections(self) -> Iterable["AbstractConnection"]:
+        return self._in_use_connections
+
+    def _should_update_connection(
+        self,
+        conn: "AbstractConnection",
+        matching_pattern: str = "connected_address",
+        matching_address: str | None = None,
+        matching_notification_hash: int | None = None,
+    ) -> bool:
+        if matching_pattern == "connected_address":
+            if matching_address and conn.getpeername() != matching_address:
+                return False
+        elif matching_pattern == "configured_address":
+            if matching_address and getattr(conn, "host", None) != matching_address:
+                return False
+        elif matching_pattern == "notification_hash":
+            if (
+                matching_notification_hash
+                and conn.maintenance_notification_hash != matching_notification_hash
+            ):
+                return False
+        return True
+
+    def update_connection_settings(
+        self,
+        conn: "AbstractConnection",
+        state: MaintenanceState | None = None,
+        maintenance_notification_hash: int | None = None,
+        host_address: str | None = None,
+        relaxed_timeout: float | None = None,
+        update_notification_hash: bool = False,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+    ) -> None:
+        if state:
+            conn.maintenance_state = state
+
+        if update_notification_hash:
+            conn.maintenance_notification_hash = maintenance_notification_hash
+
+        if host_address is not None:
+            conn.set_tmp_settings(tmp_host_address=host_address)
+
+        if relaxed_timeout is not None:
+            conn.set_tmp_settings(tmp_relaxed_timeout=relaxed_timeout)
+
+        if reset_relaxed_timeout or reset_host_address:
+            conn.reset_tmp_settings(
+                reset_host_address=reset_host_address,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+            )
+
+        conn.update_current_socket_timeout(relaxed_timeout)
+
+    async def update_connections_settings(
+        self,
+        state: MaintenanceState | None = None,
+        maintenance_notification_hash: int | None = None,
+        host_address: str | None = None,
+        relaxed_timeout: float | None = None,
+        matching_address: str | None = None,
+        matching_notification_hash: int | None = None,
+        matching_pattern: str = "connected_address",
+        update_notification_hash: bool = False,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+        include_free_connections: bool = True,
+    ) -> None:
+        async with self._lock:
+            self._update_connections_settings_locked(
+                state=state,
+                maintenance_notification_hash=maintenance_notification_hash,
+                host_address=host_address,
+                relaxed_timeout=relaxed_timeout,
+                matching_address=matching_address,
+                matching_notification_hash=matching_notification_hash,
+                matching_pattern=matching_pattern,
+                update_notification_hash=update_notification_hash,
+                reset_host_address=reset_host_address,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+                include_free_connections=include_free_connections,
+            )
+
+    def _update_connections_settings_locked(
+        self,
+        state: MaintenanceState | None = None,
+        maintenance_notification_hash: int | None = None,
+        host_address: str | None = None,
+        relaxed_timeout: float | None = None,
+        matching_address: str | None = None,
+        matching_notification_hash: int | None = None,
+        matching_pattern: str = "connected_address",
+        update_notification_hash: bool = False,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+        include_free_connections: bool = True,
+    ) -> None:
+        for conn in self._get_in_use_connections():
+            if self._should_update_connection(
+                conn,
+                matching_pattern,
+                matching_address,
+                matching_notification_hash,
+            ):
+                self.update_connection_settings(
+                    conn,
+                    state=state,
+                    maintenance_notification_hash=maintenance_notification_hash,
+                    host_address=host_address,
+                    relaxed_timeout=relaxed_timeout,
+                    update_notification_hash=update_notification_hash,
+                    reset_host_address=reset_host_address,
+                    reset_relaxed_timeout=reset_relaxed_timeout,
+                )
+
+        if include_free_connections:
+            for conn in self._get_free_connections():
+                if self._should_update_connection(
+                    conn,
+                    matching_pattern,
+                    matching_address,
+                    matching_notification_hash,
+                ):
+                    self.update_connection_settings(
+                        conn,
+                        state=state,
+                        maintenance_notification_hash=maintenance_notification_hash,
+                        host_address=host_address,
+                        relaxed_timeout=relaxed_timeout,
+                        update_notification_hash=update_notification_hash,
+                        reset_host_address=reset_host_address,
+                        reset_relaxed_timeout=reset_relaxed_timeout,
+                    )
+
+    def update_connection_kwargs(self, **kwargs: Any) -> None:
+        self.connection_kwargs.update(kwargs)
+
+    async def apply_moving_notification(
+        self,
+        notification: NodeMovingNotification,
+        config: MaintNotificationsConfig,
+        moving_address_src: str | None,
+        run_proactive_reconnect: bool = False,
+    ) -> None:
+        """
+        Apply the pool state transition for a MOVING notification atomically.
+
+        Async pools use a non-reentrant `asyncio.Lock`, so the handler cannot
+        safely compose several separately locked calls. Existing connection
+        updates, optional proactive reconnect, and future `connection_kwargs`
+        changes must happen under one pool-owned lock; otherwise a connection
+        can move between active/free lists and escape handling.
+        """
+        async with self._lock:
+            await self._set_in_maintenance(True)
+            try:
+                self._update_connections_settings_locked(
+                    state=MaintenanceState.MOVING,
+                    maintenance_notification_hash=hash(notification),
+                    relaxed_timeout=config.relaxed_timeout,
+                    host_address=notification.new_node_host,
+                    matching_address=moving_address_src,
+                    matching_pattern="connected_address",
+                    update_notification_hash=True,
+                    include_free_connections=True,
+                )
+
+                if run_proactive_reconnect:
+                    await self._run_proactive_reconnect_locked(moving_address_src)
+
+                self.update_connection_kwargs(
+                    **_build_moving_connection_kwargs(notification, config)
+                )
+            finally:
+                await self._set_in_maintenance(False)
+
+    async def run_proactive_reconnect(
+        self,
+        moving_address_src: str | None = None,
+    ) -> None:
+        """
+        Mark active connections and disconnect free connections atomically.
+
+        This operation is pool-owned because the active/free lists can change
+        while tasks acquire or release connections. Keeping the mark/disconnect
+        pass under one lock avoids a connection moving between lists between
+        separately locked calls.
+        """
+        async with self._lock:
+            await self._run_proactive_reconnect_locked(moving_address_src)
+
+    async def _run_proactive_reconnect_locked(
+        self,
+        moving_address_src: str | None = None,
+    ) -> None:
+        for conn in self._get_in_use_connections():
+            if self._should_update_connection(
+                conn, "connected_address", moving_address_src
+            ):
+                conn.mark_for_reconnect()
+
+        free_connections = [
+            conn
+            for conn in self._get_free_connections()
+            if self._should_update_connection(
+                conn, "connected_address", moving_address_src
+            )
+        ]
+        await self._disconnect_connections(free_connections)
+
+    async def cleanup_moving_notification(
+        self,
+        notification_hash: int,
+        reset_relaxed_timeout: bool,
+        reset_host_address: bool,
+    ) -> None:
+        """
+        Revert MOVING pool state atomically after the notification TTL.
+
+        Future connection kwargs and existing connection state must be cleaned
+        up in the same critical section. Splitting the cleanup lets an
+        acquire/release interleave, which can leave stale MOVING state or undo a
+        newer overlapping MOVING notification.
+        """
+        async with self._lock:
+            kwargs = _build_moving_cleanup_connection_kwargs(
+                self.connection_kwargs, notification_hash
+            )
+            if kwargs is not None:
+                self.update_connection_kwargs(**kwargs)
+
+            self._update_connections_settings_locked(
+                relaxed_timeout=-1,
+                state=MaintenanceState.NONE,
+                maintenance_notification_hash=None,
+                matching_notification_hash=notification_hash,
+                matching_pattern="notification_hash",
+                update_notification_hash=True,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+                reset_host_address=reset_host_address,
+                include_free_connections=True,
+            )
+
+    async def _disconnect_connections(
+        self, connections: Iterable["AbstractConnection"]
+    ) -> None:
+        connections = tuple(connections)
+        if not connections:
+            return
+        results = await asyncio.gather(
+            *(connection.disconnect() for connection in connections),
+            return_exceptions=True,
+        )
+        exc = next(
+            (result for result in results if isinstance(result, BaseException)), None
+        )
+        if exc:
+            raise exc
+
+    async def _set_in_maintenance(self, in_maintenance: bool) -> None:
+        set_in_maintenance = getattr(self, "set_in_maintenance", None)
+        if not callable(set_in_maintenance):
+            return
+        result = set_in_maintenance(in_maintenance)
+        if inspect.isawaitable(result):
+            await result
+
+
+class ConnectionPool(
+    AsyncMaintNotificationsAbstractConnectionPool, ConnectionPoolInterface
+):
     """
     Create a connection pool. ``If max_connections`` is set, then this
     object raises :py:class:`~redis.ConnectionError` when the pool's
@@ -1398,6 +2199,7 @@ class ConnectionPool(ConnectionPoolInterface):
         self,
         connection_class: Type[AbstractConnection] = Connection,
         max_connections: Optional[int] = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
         **connection_kwargs,
     ):
         max_connections = max_connections or 100
@@ -1415,6 +2217,12 @@ class ConnectionPool(ConnectionPoolInterface):
         self._event_dispatcher = self.connection_kwargs.get("event_dispatcher", None)
         if self._event_dispatcher is None:
             self._event_dispatcher = EventDispatcher()
+
+        AsyncMaintNotificationsAbstractConnectionPool.__init__(
+            self,
+            maint_notifications_config=maint_notifications_config,
+            **connection_kwargs,
+        )
 
     # Keys that should be redacted in __repr__ to avoid exposing sensitive information
     SENSITIVE_REPR_KEYS = frozenset(
@@ -1607,7 +2415,7 @@ class ConnectionPool(ConnectionPoolInterface):
         # pool before all data has been read or the socket has been
         # closed. either way, reconnect and verify everything is good.
         try:
-            if await connection.can_read():
+            if await connection.can_read() and not self.maint_notifications_enabled():
                 raise ConnectionError("Connection has data") from None
         except (ConnectionError, TimeoutError, OSError):
             await connection.disconnect()
@@ -1619,12 +2427,13 @@ class ConnectionPool(ConnectionPoolInterface):
         """Releases the connection back to the pool"""
         # Connections should always be returned to the correct pool,
         # not doing so is an error that will cause an exception here.
-        self._in_use_connections.remove(connection)
+        async with self._lock:
+            self._in_use_connections.remove(connection)
 
-        if connection.should_reconnect():
-            await connection.disconnect()
+            if connection.should_reconnect():
+                await connection.disconnect()
 
-        self._available_connections.append(connection)
+            self._available_connections.append(connection)
         await self._event_dispatcher.dispatch_async(
             AsyncAfterConnectionReleasedEvent(connection)
         )
@@ -1792,16 +2601,17 @@ class BlockingConnectionPool(ConnectionPool):
             async with self._condition:
                 async with async_timeout(self.timeout):
                     await self._condition.wait_for(self.can_get_connection)
-                    # Track connection count before to detect if a new connection is created
-                    connections_before = len(self._available_connections) + len(
-                        self._in_use_connections
-                    )
-                    start_time_created = time.monotonic()
-                    connection = super().get_available_connection()
-                    connections_after = len(self._available_connections) + len(
-                        self._in_use_connections
-                    )
-                    is_created = connections_after > connections_before
+                    async with self._lock:
+                        # Track connection count before to detect if a new connection is created
+                        connections_before = len(self._available_connections) + len(
+                            self._in_use_connections
+                        )
+                        start_time_created = time.monotonic()
+                        connection = super().get_available_connection()
+                        connections_after = len(self._available_connections) + len(
+                            self._in_use_connections
+                        )
+                        is_created = connections_after > connections_before
         except asyncio.TimeoutError as err:
             raise ConnectionError("No connection available.") from err
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2660,7 +2660,7 @@ class ConnectionPool(
         except (ConnectionError, TimeoutError, OSError):
             await connection.disconnect()
             await connection.connect()
-            if await connection.can_read():
+            if await connection.can_read() and not self.maint_notifications_enabled():
                 raise ConnectionError("Connection not ready") from None
 
     async def release(self, connection: AbstractConnection):

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -1,0 +1,336 @@
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable
+
+from redis.asyncio.observability.recorder import (
+    record_connection_handoff,
+    record_connection_relaxed_timeout,
+    record_maint_notification_count,
+)
+from redis.maint_notifications import (
+    MaintenanceNotification,
+    MaintenanceState,
+    MaintNotificationsConfig,
+    NodeMovingNotification,
+    OSSNodeMigratedNotification,
+    OSSNodeMigratingNotification,
+    _get_maintenance_notification_name,
+    _get_maintenance_notification_type,
+    _should_skip_connection_timeout_update,
+)
+from redis.observability.attributes import get_pool_name
+
+logger = logging.getLogger(__name__)
+
+_ScheduledCallback = Callable[..., Awaitable[None]]
+
+
+def _add_debug_log_for_notification(
+    connection: object,
+    notification: str | MaintenanceNotification,
+) -> None:
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    socket_address = None
+    try:
+        writer = getattr(connection, "_writer", None)
+        socket_name = writer.get_extra_info("sockname") if writer else None
+        socket_address = (
+            socket_name[1] if socket_name and len(socket_name) > 1 else None
+        )
+    except (AttributeError, OSError, TypeError):
+        pass
+
+    resolved_ip = None
+    try:
+        get_resolved_ip = getattr(connection, "get_resolved_ip", None)
+        if callable(get_resolved_ip):
+            resolved_ip = get_resolved_ip()
+    except (AttributeError, OSError):
+        pass
+
+    logger.debug(
+        f"Handling maintenance notification: {notification}, "
+        f"with connection: {connection}, connected to ip {resolved_ip}, "
+        f"local socket port: {socket_address}",
+    )
+
+
+class AsyncMaintNotificationsPoolHandler:
+    def __init__(
+        self,
+        pool: Any,
+        config: MaintNotificationsConfig,
+    ) -> None:
+        self.pool = pool
+        self.config = config
+        self._processed_notifications: set[MaintenanceNotification] = set()
+        self._scheduled_tasks: set[asyncio.Task[None]] = set()
+        self._lock = asyncio.Lock()
+        self.connection: Any | None = None
+
+    def set_connection(self, connection: Any) -> None:
+        self.connection = connection
+
+    def get_handler_for_connection(self) -> "AsyncMaintNotificationsPoolHandler":
+        # Copy all data that should be shared between connections, while each
+        # connection gets its own handler instance and current connection state.
+        copy = AsyncMaintNotificationsPoolHandler(self.pool, self.config)
+        copy._processed_notifications = self._processed_notifications
+        copy._scheduled_tasks = self._scheduled_tasks
+        copy._lock = self._lock
+        copy.connection = None
+        return copy
+
+    async def remove_expired_notifications(self) -> None:
+        async with self._lock:
+            for notification in tuple(self._processed_notifications):
+                if notification.is_expired():
+                    self._processed_notifications.remove(notification)
+
+    async def handle_notification(self, notification: MaintenanceNotification) -> None:
+        await self.remove_expired_notifications()
+
+        if isinstance(notification, NodeMovingNotification):
+            await self.handle_node_moving_notification(notification)
+        else:
+            logger.error(f"Unhandled notification type: {notification}")
+
+    async def handle_node_moving_notification(
+        self, notification: NodeMovingNotification
+    ) -> None:
+        if (
+            not self.config.proactive_reconnect
+            and not self.config.is_relaxed_timeouts_enabled()
+        ):
+            return
+
+        async with self._lock:
+            if notification in self._processed_notifications:
+                # nothing to do in the connection pool handling
+                # the notification has already been handled or is expired
+                # just return
+                return
+
+            logger.debug(
+                f"Handling node MOVING notification: {notification}, "
+                f"with connection: {self.connection}, connected to ip "
+                f"{self.connection.get_resolved_ip() if self.connection else None}"
+            )
+            # Get the current connected address - if any
+            # This is the address that is being moved
+            # and we need to handle only connections
+            # connected to the same address
+            moving_address_src = (
+                self.connection.getpeername() if self.connection else None
+            )
+
+            # The async pool owns the active/free connection collections and
+            # asyncio.Lock is not reentrant, so the whole MOVING pool mutation
+            # has to be one pool-owned atomic operation. The handler still owns
+            # the notification policy and passes the already-decided inputs.
+            await self.pool.apply_moving_notification(
+                notification=notification,
+                config=self.config,
+                moving_address_src=moving_address_src,
+                run_proactive_reconnect=(
+                    self.config.proactive_reconnect
+                    and notification.new_node_host is not None
+                ),
+            )
+
+            if self.config.proactive_reconnect and notification.new_node_host is None:
+                self._schedule(
+                    notification.ttl / 2,
+                    self.run_proactive_reconnect,
+                    moving_address_src,
+                )
+
+            self._schedule(
+                notification.ttl,
+                self.handle_node_moved_notification,
+                notification,
+            )
+
+            await record_connection_handoff(
+                pool_name=get_pool_name(self.pool),
+            )
+
+            self._processed_notifications.add(notification)
+
+    async def run_proactive_reconnect(
+        self, moving_address_src: str | None = None
+    ) -> None:
+        """
+        Run proactive reconnect for the pool.
+        Active connections are marked for reconnect after they complete the current command.
+        Inactive connections are disconnected and will be connected on next use.
+        """
+        async with self._lock:
+            # This delayed reconnect must be atomic for the same reason as the
+            # initial MOVING mutation: a connection can move between active and
+            # free lists while another task is acquiring or releasing it.
+            await self.pool.run_proactive_reconnect(
+                moving_address_src=moving_address_src,
+            )
+
+    async def handle_node_moved_notification(
+        self, notification: NodeMovingNotification
+    ) -> None:
+        """
+        Handle the cleanup after a node moving notification expires.
+        """
+        notification_hash = hash(notification)
+
+        async with self._lock:
+            logger.debug(
+                f"Reverting temporary changes related to notification: {notification}, "
+                f"with connection: {self.connection}, connected to ip "
+                f"{self.connection.get_resolved_ip() if self.connection else None}"
+            )
+            reset_relaxed_timeout = self.config.is_relaxed_timeouts_enabled()
+            reset_host_address = self.config.proactive_reconnect
+
+            # Cleanup has to reset future connection kwargs and existing
+            # matching connections together under the pool lock. Splitting it
+            # lets an acquire/release interleave and leaves stale MOVING state.
+            await self.pool.cleanup_moving_notification(
+                notification_hash=notification_hash,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+                reset_host_address=reset_host_address,
+            )
+
+    def _schedule(
+        self,
+        delay: float,
+        callback: _ScheduledCallback,
+        *args: Any,
+    ) -> None:
+        task = asyncio.create_task(self._run_after(delay, callback, *args))
+        self._scheduled_tasks.add(task)
+        task.add_done_callback(self._scheduled_tasks.discard)
+        task.add_done_callback(self._log_scheduled_task_result)
+
+    async def _run_after(
+        self,
+        delay: float,
+        callback: _ScheduledCallback,
+        *args: Any,
+    ) -> None:
+        await asyncio.sleep(delay)
+        await callback(*args)
+
+    @staticmethod
+    def _log_scheduled_task_result(task: asyncio.Task[None]) -> None:
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc:
+            logger.error(
+                "Error handling scheduled maintenance notification", exc_info=exc
+            )
+
+
+class AsyncMaintNotificationsConnectionHandler:
+    def __init__(
+        self,
+        connection: Any,
+        config: MaintNotificationsConfig,
+    ) -> None:
+        self.connection = connection
+        self.config = config
+
+    def _get_pool_name(self) -> str:
+        """
+        Get the pool name from the connection's pool handler.
+        Falls back to connection representation if pool is not available.
+        """
+        pool_handler = getattr(
+            self.connection, "_maint_notifications_pool_handler", None
+        )
+        if pool_handler and getattr(pool_handler, "pool", None):
+            return get_pool_name(pool_handler.pool)
+        return repr(self.connection)
+
+    async def handle_notification(self, notification: MaintenanceNotification) -> None:
+        # 1 for start, 0 for end notification type, None for unknown.
+        notification_type = _get_maintenance_notification_type(notification)
+        maint_notification = _get_maintenance_notification_name(notification)
+
+        await record_maint_notification_count(
+            server_address=self.connection.host,
+            server_port=self.connection.port,
+            network_peer_address=self.connection.host,
+            network_peer_port=self.connection.port,
+            maint_notification=maint_notification,
+        )
+
+        if isinstance(
+            notification,
+            (OSSNodeMigratingNotification, OSSNodeMigratedNotification),
+        ):
+            logger.error(f"Unhandled notification type: {notification}")
+            return
+
+        if notification_type is None:
+            logger.error(f"Unhandled notification type: {notification}")
+            return
+
+        if notification_type:
+            await self.handle_maintenance_start_notification(
+                MaintenanceState.MAINTENANCE, notification
+            )
+        else:
+            await self.handle_maintenance_completed_notification(
+                notification=notification
+            )
+
+    async def handle_maintenance_start_notification(
+        self,
+        maintenance_state: MaintenanceState,
+        notification: MaintenanceNotification,
+    ) -> None:
+        _add_debug_log_for_notification(self.connection, notification)
+
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
+        ):
+            return
+
+        self.connection.maintenance_state = maintenance_state
+        self.connection.set_tmp_settings(
+            tmp_relaxed_timeout=self.config.relaxed_timeout
+        )
+        self.connection.update_current_socket_timeout(self.config.relaxed_timeout)
+
+        maint_notification = _get_maintenance_notification_name(notification)
+        await record_connection_relaxed_timeout(
+            connection_name=self._get_pool_name(),
+            maint_notification=maint_notification,
+            relaxed=True,
+        )
+
+    async def handle_maintenance_completed_notification(self, **kwargs: Any) -> None:
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
+        ):
+            return
+
+        notification = kwargs.get("notification")
+        _add_debug_log_for_notification(
+            self.connection, notification if notification else "MAINTENANCE_COMPLETED"
+        )
+        self.connection.reset_tmp_settings(reset_relaxed_timeout=True)
+        self.connection.update_current_socket_timeout(-1)
+        self.connection.maintenance_state = MaintenanceState.NONE
+        self.connection.reset_received_notifications()
+
+        if notification:
+            maint_notification = _get_maintenance_notification_name(notification)
+            await record_connection_relaxed_timeout(
+                connection_name=self._get_pool_name(),
+                maint_notification=maint_notification,
+                relaxed=False,
+            )

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -227,6 +227,14 @@ class AsyncMaintNotificationsPoolHandler:
         await asyncio.sleep(delay)
         await callback(*args)
 
+    async def cancel_scheduled_tasks(self) -> None:
+        if not self._scheduled_tasks:
+            return
+        tasks = tuple(self._scheduled_tasks)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
     @staticmethod
     def _log_scheduled_task_result(task: asyncio.Task[None]) -> None:
         try:

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from redis.asyncio.observability.recorder import (
     record_connection_handoff,
@@ -20,12 +20,15 @@ from redis.maint_notifications import (
 )
 from redis.observability.attributes import get_pool_name
 
+if TYPE_CHECKING:
+    from redis.asyncio.connection import AsyncMaintNotificationsAbstractConnection
+
 logger = logging.getLogger(__name__)
 
 _ScheduledCallback = Callable[..., Awaitable[None]]
 
 
-def _add_debug_log_for_notification(
+def add_debug_log_for_notification(
     connection: object,
     notification: str | MaintenanceNotification,
 ) -> None:
@@ -70,7 +73,9 @@ class AsyncMaintNotificationsPoolHandler:
         self._lock = asyncio.Lock()
         self.connection: Any | None = None
 
-    def set_connection(self, connection: Any) -> None:
+    def set_connection(
+        self, connection: "AsyncMaintNotificationsAbstractConnection"
+    ) -> None:
         self.connection = connection
 
     def get_handler_for_connection(self) -> "AsyncMaintNotificationsPoolHandler":
@@ -112,12 +117,12 @@ class AsyncMaintNotificationsPoolHandler:
                 # the notification has already been handled or is expired
                 # just return
                 return
-
-            logger.debug(
-                f"Handling node MOVING notification: {notification}, "
-                f"with connection: {self.connection}, connected to ip "
-                f"{self.connection.get_resolved_ip() if self.connection else None}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Handling node MOVING notification: {notification}, "
+                    f"with connection: {self.connection}, connected to ip "
+                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                )
             # Get the current connected address - if any
             # This is the address that is being moved
             # and we need to handle only connections
@@ -184,11 +189,12 @@ class AsyncMaintNotificationsPoolHandler:
         notification_hash = hash(notification)
 
         async with self._lock:
-            logger.debug(
-                f"Reverting temporary changes related to notification: {notification}, "
-                f"with connection: {self.connection}, connected to ip "
-                f"{self.connection.get_resolved_ip() if self.connection else None}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Reverting temporary changes related to notification: {notification}, "
+                    f"with connection: {self.connection}, connected to ip "
+                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                )
             reset_relaxed_timeout = self.config.is_relaxed_timeouts_enabled()
             reset_host_address = self.config.proactive_reconnect
 
@@ -236,7 +242,7 @@ class AsyncMaintNotificationsPoolHandler:
 class AsyncMaintNotificationsConnectionHandler:
     def __init__(
         self,
-        connection: Any,
+        connection: "AsyncMaintNotificationsAbstractConnection",
         config: MaintNotificationsConfig,
     ) -> None:
         self.connection = connection
@@ -252,6 +258,7 @@ class AsyncMaintNotificationsConnectionHandler:
         )
         if pool_handler and getattr(pool_handler, "pool", None):
             return get_pool_name(pool_handler.pool)
+        # Fallback for standalone connections without a pool
         return repr(self.connection)
 
     async def handle_notification(self, notification: MaintenanceNotification) -> None:
@@ -292,7 +299,7 @@ class AsyncMaintNotificationsConnectionHandler:
         maintenance_state: MaintenanceState,
         notification: MaintenanceNotification,
     ) -> None:
-        _add_debug_log_for_notification(self.connection, notification)
+        add_debug_log_for_notification(self.connection, notification)
 
         if _should_skip_connection_timeout_update(
             self.connection.maintenance_state, self.config
@@ -313,18 +320,25 @@ class AsyncMaintNotificationsConnectionHandler:
         )
 
     async def handle_maintenance_completed_notification(self, **kwargs: Any) -> None:
+        # Only reset timeouts if state is not MOVING and relaxed timeouts are enabled
         if _should_skip_connection_timeout_update(
             self.connection.maintenance_state, self.config
         ):
             return
 
-        notification = kwargs.get("notification")
-        _add_debug_log_for_notification(
+        notification = None
+        if kwargs.get("notification"):
+            notification = kwargs["notification"]
+        add_debug_log_for_notification(
             self.connection, notification if notification else "MAINTENANCE_COMPLETED"
         )
         self.connection.reset_tmp_settings(reset_relaxed_timeout=True)
+        # Maintenance completed - reset the connection
+        # timeouts by providing -1 as the relaxed timeout
         self.connection.update_current_socket_timeout(-1)
         self.connection.maintenance_state = MaintenanceState.NONE
+        # reset the sets that keep track of received start maint
+        # notifications and skipped end maint notifications
         self.connection.reset_received_notifications()
 
         if notification:

--- a/redis/client.py
+++ b/redis/client.py
@@ -846,13 +846,15 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             raise
 
         finally:
-            if conn and conn.should_reconnect():
-                self._close_connection(conn)
-                conn.connect()
-            if self._single_connection_client:
-                self.single_connection_lock.release()
-            if not self.connection:
-                pool.release(conn)
+            try:
+                if conn and conn.should_reconnect():
+                    self._close_connection(conn)
+                    conn.connect()
+            finally:
+                if self._single_connection_client:
+                    self.single_connection_lock.release()
+                if not self.connection:
+                    pool.release(conn)
 
     def parse_response(self, connection, command_name, **options):
         """Parses a response from the Redis server"""

--- a/redis/client.py
+++ b/redis/client.py
@@ -754,7 +754,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             self.connection_pool.release(conn)
 
         if self.auto_close_connection_pool:
-            self.connection_pool.disconnect()
+            self.connection_pool.close()
 
     def _send_command_parse_response(self, conn, command_name, *args, **options):
         """

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3189,7 +3189,11 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
             except (ConnectionError, TimeoutError, OSError):
                 connection.disconnect()
                 connection.connect()
-                if connection.can_read():
+                if (
+                    connection.can_read()
+                    and self.cache is None
+                    and not self.maint_notifications_enabled()
+                ):
                     raise ConnectionError("Connection not ready")
         except BaseException:
             # release the connection back to the pool so that we don't
@@ -3625,12 +3629,20 @@ class BlockingConnectionPool(ConnectionPool):
             # pool before all data has been read or the socket has been
             # closed. either way, reconnect and verify everything is good.
             try:
-                if connection.can_read():
+                if (
+                    connection.can_read()
+                    and self.cache is None
+                    and not self.maint_notifications_enabled()
+                ):
                     raise ConnectionError("Connection has data")
             except (ConnectionError, TimeoutError, OSError):
                 connection.disconnect()
                 connection.connect()
-                if connection.can_read():
+                if (
+                    connection.can_read()
+                    and self.cache is None
+                    and not self.maint_notifications_enabled()
+                ):
                     raise ConnectionError("Connection not ready")
         except BaseException:
             # release the connection back to the pool so that we don't leak it

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -38,7 +38,7 @@ from ._defaults import (
     DEFAULT_SOCKET_TIMEOUT,
     get_default_socket_keepalive_options,
 )
-from ._parsers import Encoder, _HiredisParser, _RESP2Parser, _RESP3Parser
+from ._parsers import BaseParser, Encoder, _HiredisParser, _RESP2Parser, _RESP3Parser
 from .auth.token import TokenInterface
 from .backoff import NoBackoff
 from .credentials import CredentialProvider, UsernamePasswordCredentialProvider
@@ -336,7 +336,7 @@ class MaintNotificationsAbstractConnection:
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
-        parser: Optional[Union[_HiredisParser, _RESP3Parser]] = None,
+        parser: Optional[BaseParser] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
     ):
         """
@@ -351,7 +351,7 @@ class MaintNotificationsAbstractConnection:
             orig_socket_timeout (Optional[float]): The original socket timeout of the connection.
             orig_socket_connect_timeout (Optional[float]): The original socket connect timeout of the connection.
             oss_cluster_maint_notifications_handler (Optional[OSSMaintNotificationsHandler]): The OSS cluster handler for maintenance notifications.
-            parser (Optional[Union[_HiredisParser, _RESP3Parser]]): The parser to use for maintenance notifications.
+            parser (Optional[BaseParser]): The parser to use for maintenance notifications.
                     If not provided, the parser from the connection is used.
                     This is useful when the parser is created after this object.
         """
@@ -376,8 +376,16 @@ class MaintNotificationsAbstractConnection:
         self._skipped_end_maint_notifications = set()
 
     @abstractmethod
-    def _get_parser(self) -> Union[_HiredisParser, _RESP3Parser]:
+    def _get_parser(self) -> BaseParser:
         pass
+
+    def _get_push_notifications_parser(self) -> Union[_HiredisParser, _RESP3Parser]:
+        parser = self._get_parser()
+        if not isinstance(parser, (_HiredisParser, _RESP3Parser)):
+            raise RedisError(
+                "Maintenance notifications are only supported with hiredis and RESP3 parsers!"
+            )
+        return parser
 
     @abstractmethod
     def _get_socket(self) -> Optional[socket.socket]:
@@ -441,6 +449,10 @@ class MaintNotificationsAbstractConnection:
     def disconnect(self, *args, **kwargs):
         pass
 
+    @abstractmethod
+    def mark_for_reconnect(self):
+        pass
+
     def _configure_maintenance_notifications(
         self,
         maint_notifications_pool_handler: Optional[
@@ -452,7 +464,7 @@ class MaintNotificationsAbstractConnection:
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
-        parser: Optional[Union[_HiredisParser, _RESP3Parser]] = None,
+        parser: Optional[BaseParser] = None,
     ):
         """
         Enable maintenance notifications by setting up
@@ -545,7 +557,8 @@ class MaintNotificationsAbstractConnection:
         )
 
         maint_notifications_pool_handler_copy.set_connection(self)
-        self._get_parser().set_node_moving_push_handler(
+        parser = self._get_push_notifications_parser()
+        parser.set_node_moving_push_handler(
             maint_notifications_pool_handler_copy.handle_notification
         )
 
@@ -558,7 +571,7 @@ class MaintNotificationsAbstractConnection:
                     self, maint_notifications_pool_handler.config
                 )
             )
-            self._get_parser().set_maintenance_push_handler(
+            parser.set_maintenance_push_handler(
                 self._maint_notifications_connection_handler.handle_notification
             )
         else:
@@ -569,7 +582,8 @@ class MaintNotificationsAbstractConnection:
     def set_maint_notifications_cluster_handler_for_connection(
         self, oss_cluster_maint_notifications_handler: OSSMaintNotificationsHandler
     ):
-        self._get_parser().set_oss_cluster_maint_push_handler(
+        parser = self._get_push_notifications_parser()
+        parser.set_oss_cluster_maint_push_handler(
             oss_cluster_maint_notifications_handler.handle_notification
         )
 
@@ -584,7 +598,7 @@ class MaintNotificationsAbstractConnection:
                     self, oss_cluster_maint_notifications_handler.config
                 )
             )
-            self._get_parser().set_maintenance_push_handler(
+            parser.set_maintenance_push_handler(
                 self._maint_notifications_connection_handler.handle_notification
             )
         else:
@@ -758,10 +772,10 @@ class MaintNotificationsAbstractConnection:
     def set_tmp_settings(
         self,
         tmp_host_address: Optional[Union[str, object]] = SENTINEL,
-        tmp_relaxed_timeout: Optional[float] = None,
+        tmp_relaxed_timeout: Optional[float] = -1,
     ):
         """
-        The value of SENTINEL is used to indicate that the property should not be updated.
+        SENTINEL keeps the host unchanged. -1 keeps the relaxed timeout unchanged.
         """
         if tmp_host_address and tmp_host_address != SENTINEL:
             self.host = str(tmp_host_address)
@@ -1946,7 +1960,7 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
     def set_tmp_settings(
         self,
         tmp_host_address: Optional[str] = None,
-        tmp_relaxed_timeout: Optional[float] = None,
+        tmp_relaxed_timeout: Optional[float] = -1,
     ):
         con = self._get_maint_notifications_connection_instance(self._conn)
         con.set_tmp_settings(tmp_host_address, tmp_relaxed_timeout)

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -601,7 +601,7 @@ class MaintNotificationsAbstractConnection:
         # When the mode is enabled=True, we raise an exception in case of failure
         host = getattr(self, "host", None)
         if (
-            self.get_protocol() not in [2, "2"]
+            check_protocol_version(self.get_protocol(), 3)
             and self.maint_notifications_config
             and self.maint_notifications_config.enabled
             and self._maint_notifications_connection_handler
@@ -1107,7 +1107,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
 
         # if resp version is specified and we have auth args,
         # we need to send them via HELLO
-        if auth_args and self.protocol not in [2, "2"]:
+        if auth_args and check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _RESP2Parser):
                 self.set_parser(_RESP3Parser)
                 # update cluster exception classes
@@ -1144,7 +1144,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 raise AuthenticationError("Invalid Username or Password")
 
         # if resp version is specified, switch to it
-        elif self.protocol not in [2, "2"]:
+        elif check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _RESP2Parser):
                 self.set_parser(_RESP3Parser)
                 # update cluster exception classes

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -51,6 +51,7 @@ class EndpointType(enum.Enum):
 
 
 if TYPE_CHECKING:
+    from redis.asyncio.connection import AsyncMaintNotificationsAbstractConnection
     from redis.connection import (
         MaintNotificationsAbstractConnection,
         MaintNotificationsAbstractConnectionPool,
@@ -684,7 +685,9 @@ class MaintNotificationsConfig:
         return self.relaxed_timeout != -1
 
     def get_endpoint_type(
-        self, host: str, connection: "MaintNotificationsAbstractConnection"
+        self,
+        host: str,
+        connection: "MaintNotificationsAbstractConnection | AsyncMaintNotificationsAbstractConnection",
     ) -> EndpointType:
         """
         Determine the appropriate endpoint type for CLIENT MAINT_NOTIFICATIONS command.
@@ -872,11 +875,12 @@ class MaintNotificationsPoolHandler:
                 return
 
             with self.pool._lock:
-                logger.debug(
-                    f"Handling node MOVING notification: {notification}, "
-                    f"with connection: {self.connection}, connected to ip "
-                    f"{self.connection.get_resolved_ip() if self.connection else None}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"Handling node MOVING notification: {notification}, "
+                        f"with connection: {self.connection}, connected to ip "
+                        f"{self.connection.get_resolved_ip() if self.connection else None}"
+                    )
                 # Get the current connected address - if any
                 # This is the address that is being moved
                 # and we need to handle only connections
@@ -962,11 +966,12 @@ class MaintNotificationsPoolHandler:
         notification_hash = hash(notification)
 
         with self._lock:
-            logger.debug(
-                f"Reverting temporary changes related to notification: {notification}, "
-                f"with connection: {self.connection}, connected to ip "
-                f"{self.connection.get_resolved_ip() if self.connection else None}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Reverting temporary changes related to notification: {notification}, "
+                    f"with connection: {self.connection}, connected to ip "
+                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                )
             kwargs = _build_moving_cleanup_connection_kwargs(
                 self.pool.connection_kwargs, notification_hash
             )
@@ -1076,12 +1081,13 @@ class MaintNotificationsConnectionHandler:
             relaxed=True,
         )
 
-    def handle_maintenance_completed_notification(self, **kwargs):
+    def handle_maintenance_completed_notification(self, **kwargs: Any) -> None:
         # Only reset timeouts if state is not MOVING and relaxed timeouts are enabled
         if _should_skip_connection_timeout_update(
             self.connection.maintenance_state, self.config
         ):
             return
+
         notification = None
         if kwargs.get("notification"):
             notification = kwargs["notification"]

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -5,7 +5,16 @@ import re
 import threading
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Union,
+)
 
 from redis.observability.attributes import get_pool_name
 from redis.observability.recorder import (
@@ -729,6 +738,86 @@ class MaintNotificationsConfig:
         return EndpointType.INTERNAL_FQDN if is_private else EndpointType.EXTERNAL_FQDN
 
 
+_MAINTENANCE_START_NOTIFICATION_TYPES = (
+    NodeMigratingNotification,
+    NodeFailingOverNotification,
+    OSSNodeMigratingNotification,
+)
+_MAINTENANCE_COMPLETED_NOTIFICATION_TYPES = (
+    NodeMigratedNotification,
+    NodeFailedOverNotification,
+    OSSNodeMigratedNotification,
+)
+
+
+def _get_maintenance_notification_type(
+    notification: MaintenanceNotification,
+) -> Optional[int]:
+    if notification.__class__ in _MAINTENANCE_START_NOTIFICATION_TYPES:
+        return 1
+    if notification.__class__ in _MAINTENANCE_COMPLETED_NOTIFICATION_TYPES:
+        return 0
+    return None
+
+
+def _get_maintenance_notification_name(
+    notification: MaintenanceNotification,
+) -> str:
+    return notification_types_mapping.get(notification.__class__, "")
+
+
+def _should_skip_connection_timeout_update(
+    maintenance_state: MaintenanceState,
+    config: MaintNotificationsConfig,
+) -> bool:
+    return (
+        maintenance_state == MaintenanceState.MOVING
+        or not config.is_relaxed_timeouts_enabled()
+    )
+
+
+def _build_moving_connection_kwargs(
+    notification: NodeMovingNotification,
+    config: MaintNotificationsConfig,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "maintenance_state": MaintenanceState.MOVING,
+        "maintenance_notification_hash": hash(notification),
+    }
+    if notification.new_node_host is not None:
+        # the host is not updated if the new node host is None
+        # this happens when the MOVING push notification does not contain
+        # the new node host - in this case we only update the timeouts
+        kwargs["host"] = notification.new_node_host
+    if config.is_relaxed_timeouts_enabled():
+        kwargs.update(
+            {
+                "socket_timeout": config.relaxed_timeout,
+                "socket_connect_timeout": config.relaxed_timeout,
+            }
+        )
+    return kwargs
+
+
+def _build_moving_cleanup_connection_kwargs(
+    connection_kwargs: Mapping[str, Any],
+    notification_hash: int,
+) -> Optional[dict[str, Any]]:
+    # if the current maintenance_notification_hash in kwargs is not matching the notification
+    # it means there has been a new moving notification after this one
+    # and we don't need to revert the kwargs yet
+    if connection_kwargs.get("maintenance_notification_hash") != notification_hash:
+        return None
+
+    return {
+        "maintenance_state": MaintenanceState.NONE,
+        "maintenance_notification_hash": None,
+        "host": connection_kwargs.get("orig_host_address"),
+        "socket_timeout": connection_kwargs.get("orig_socket_timeout"),
+        "socket_connect_timeout": connection_kwargs.get("orig_socket_connect_timeout"),
+    }
+
+
 class MaintNotificationsPoolHandler:
     def __init__(
         self,
@@ -774,6 +863,7 @@ class MaintNotificationsPoolHandler:
             and not self.config.is_relaxed_timeouts_enabled()
         ):
             return
+
         with self._lock:
             if notification in self._processed_notifications:
                 # nothing to do in the connection pool handling
@@ -787,74 +877,52 @@ class MaintNotificationsPoolHandler:
                     f"with connection: {self.connection}, connected to ip "
                     f"{self.connection.get_resolved_ip() if self.connection else None}"
                 )
-                if (
-                    self.config.proactive_reconnect
-                    or self.config.is_relaxed_timeouts_enabled()
-                ):
-                    # Get the current connected address - if any
-                    # This is the address that is being moved
-                    # and we need to handle only connections
-                    # connected to the same address
-                    moving_address_src = (
-                        self.connection.getpeername() if self.connection else None
-                    )
+                # Get the current connected address - if any
+                # This is the address that is being moved
+                # and we need to handle only connections
+                # connected to the same address
+                moving_address_src = (
+                    self.connection.getpeername() if self.connection else None
+                )
 
-                    if getattr(self.pool, "set_in_maintenance", False):
-                        # Set pool in maintenance mode - executed only if
-                        # BlockingConnectionPool is used
-                        self.pool.set_in_maintenance(True)
+                if getattr(self.pool, "set_in_maintenance", False):
+                    # Set pool in maintenance mode - executed only if
+                    # BlockingConnectionPool is used
+                    self.pool.set_in_maintenance(True)
 
-                    # Update maintenance state, timeout and optionally host address
-                    # connection settings for matching connections
-                    self.pool.update_connections_settings(
-                        state=MaintenanceState.MOVING,
-                        maintenance_notification_hash=hash(notification),
-                        relaxed_timeout=self.config.relaxed_timeout,
-                        host_address=notification.new_node_host,
-                        matching_address=moving_address_src,
-                        matching_pattern="connected_address",
-                        update_notification_hash=True,
-                        include_free_connections=True,
-                    )
+                # Update maintenance state, timeout and optionally host address
+                # connection settings for matching connections
+                self.pool.update_connections_settings(
+                    state=MaintenanceState.MOVING,
+                    maintenance_notification_hash=hash(notification),
+                    relaxed_timeout=self.config.relaxed_timeout,
+                    host_address=notification.new_node_host,
+                    matching_address=moving_address_src,
+                    matching_pattern="connected_address",
+                    update_notification_hash=True,
+                    include_free_connections=True,
+                )
 
-                    if self.config.proactive_reconnect:
-                        if notification.new_node_host is not None:
-                            self.run_proactive_reconnect(moving_address_src)
-                        else:
-                            threading.Timer(
-                                notification.ttl / 2,
-                                self.run_proactive_reconnect,
-                                args=(moving_address_src,),
-                            ).start()
-
-                    # Update config for new connections:
-                    # Set state to MOVING
-                    # update host
-                    # if relax timeouts are enabled - update timeouts
-                    kwargs: dict = {
-                        "maintenance_state": MaintenanceState.MOVING,
-                        "maintenance_notification_hash": hash(notification),
-                    }
+                if self.config.proactive_reconnect:
                     if notification.new_node_host is not None:
-                        # the host is not updated if the new node host is None
-                        # this happens when the MOVING push notification does not contain
-                        # the new node host - in this case we only update the timeouts
-                        kwargs.update(
-                            {
-                                "host": notification.new_node_host,
-                            }
-                        )
-                    if self.config.is_relaxed_timeouts_enabled():
-                        kwargs.update(
-                            {
-                                "socket_timeout": self.config.relaxed_timeout,
-                                "socket_connect_timeout": self.config.relaxed_timeout,
-                            }
-                        )
-                    self.pool.update_connection_kwargs(**kwargs)
+                        self.run_proactive_reconnect(moving_address_src)
+                    else:
+                        threading.Timer(
+                            notification.ttl / 2,
+                            self.run_proactive_reconnect,
+                            args=(moving_address_src,),
+                        ).start()
 
-                    if getattr(self.pool, "set_in_maintenance", False):
-                        self.pool.set_in_maintenance(False)
+                # Update config for new connections:
+                # Set state to MOVING
+                # update host
+                # if relax timeouts are enabled - update timeouts
+                self.pool.update_connection_kwargs(
+                    **_build_moving_connection_kwargs(notification, self.config)
+                )
+
+                if getattr(self.pool, "set_in_maintenance", False):
+                    self.pool.set_in_maintenance(False)
 
             threading.Timer(
                 notification.ttl,
@@ -899,27 +967,10 @@ class MaintNotificationsPoolHandler:
                 f"with connection: {self.connection}, connected to ip "
                 f"{self.connection.get_resolved_ip() if self.connection else None}"
             )
-            # if the current maintenance_notification_hash in kwargs is not matching the notification
-            # it means there has been a new moving notification after this one
-            # and we don't need to revert the kwargs yet
-            if (
-                self.pool.connection_kwargs.get("maintenance_notification_hash")
-                == notification_hash
-            ):
-                orig_host = self.pool.connection_kwargs.get("orig_host_address")
-                orig_socket_timeout = self.pool.connection_kwargs.get(
-                    "orig_socket_timeout"
-                )
-                orig_connect_timeout = self.pool.connection_kwargs.get(
-                    "orig_socket_connect_timeout"
-                )
-                kwargs: dict = {
-                    "maintenance_state": MaintenanceState.NONE,
-                    "maintenance_notification_hash": None,
-                    "host": orig_host,
-                    "socket_timeout": orig_socket_timeout,
-                    "socket_connect_timeout": orig_connect_timeout,
-                }
+            kwargs = _build_moving_cleanup_connection_kwargs(
+                self.pool.connection_kwargs, notification_hash
+            )
+            if kwargs is not None:
                 self.pool.update_connection_kwargs(**kwargs)
 
             with self.pool._lock:
@@ -972,9 +1023,10 @@ class MaintNotificationsConnectionHandler:
         return repr(self.connection)
 
     def handle_notification(self, notification: MaintenanceNotification):
-        # get the notification type by checking its class in the _NOTIFICATION_TYPES dict
-        notification_type = self._NOTIFICATION_TYPES.get(notification.__class__, None)
-        maint_notification = notification_types_mapping.get(notification.__class__, "")
+        # get the notification type by checking its class
+        # 1 for start, 0 for end notification type, None for unknown
+        notification_type = _get_maintenance_notification_type(notification)
+        maint_notification = _get_maintenance_notification_name(notification)
 
         record_maint_notification_count(
             server_address=self.connection.host,
@@ -1000,9 +1052,8 @@ class MaintNotificationsConnectionHandler:
     ):
         add_debug_log_for_notification(self.connection, notification)
 
-        if (
-            self.connection.maintenance_state == MaintenanceState.MOVING
-            or not self.config.is_relaxed_timeouts_enabled()
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
         ):
             return
 
@@ -1018,7 +1069,7 @@ class MaintNotificationsConnectionHandler:
             # one start notification before the the final end notification
             self.connection.add_maint_start_notification(notification.id)
 
-        maint_notification = notification_types_mapping.get(notification.__class__, "")
+        maint_notification = _get_maintenance_notification_name(notification)
         record_connection_relaxed_timeout(
             connection_name=self._get_pool_name(),
             maint_notification=maint_notification,
@@ -1027,9 +1078,8 @@ class MaintNotificationsConnectionHandler:
 
     def handle_maintenance_completed_notification(self, **kwargs):
         # Only reset timeouts if state is not MOVING and relaxed timeouts are enabled
-        if (
-            self.connection.maintenance_state == MaintenanceState.MOVING
-            or not self.config.is_relaxed_timeouts_enabled()
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
         ):
             return
         notification = None
@@ -1048,9 +1098,7 @@ class MaintNotificationsConnectionHandler:
         self.connection.reset_received_notifications()
 
         if notification:
-            maint_notification = notification_types_mapping.get(
-                notification.__class__, ""
-            )
+            maint_notification = _get_maintenance_notification_name(notification)
             record_connection_relaxed_timeout(
                 connection_name=self._get_pool_name(),
                 maint_notification=maint_notification,

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -284,9 +284,9 @@ DEFAULT_RESP_VERSION = 3
 
 
 def check_protocol_version(
-    protocol: Optional[Union[str, int]], expected_version: int = 3
+    protocol: str | int | object | None, expected_version: int = 3
 ) -> bool:
-    if protocol is None:
+    if protocol is None or protocol is SENTINEL:
         protocol = DEFAULT_RESP_VERSION
     if isinstance(protocol, str):
         try:

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -1,0 +1,1390 @@
+import asyncio
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import redis.asyncio as redis
+from redis._defaults import DEFAULT_SOCKET_CONNECT_TIMEOUT, DEFAULT_SOCKET_TIMEOUT
+from redis.asyncio.connection import (
+    BlockingConnectionPool,
+    Connection,
+    ConnectionPool,
+    UnixDomainSocketConnection,
+)
+from redis.asyncio.maint_notifications import (
+    AsyncMaintNotificationsConnectionHandler,
+    AsyncMaintNotificationsPoolHandler,
+)
+from redis.exceptions import RedisError, ResponseError
+from redis.maint_notifications import (
+    EndpointType,
+    MaintenanceState,
+    MaintNotificationsConfig,
+    NodeFailedOverNotification,
+    NodeFailingOverNotification,
+    NodeMigratedNotification,
+    NodeMigratingNotification,
+    NodeMovingNotification,
+    OSSNodeMigratingNotification,
+)
+from redis.utils import SENTINEL
+
+
+DEFAULT_HOST = "12.45.34.56"
+DEFAULT_PORT = 6379
+MOVED_HOST = "1.2.3.4"
+MOVED_PORT = 6380
+RELAXED_TIMEOUT = 30
+
+
+class DummyAsyncConnection:
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, peer=DEFAULT_HOST):
+        self.host = host
+        self.port = port
+        self.peer = peer
+        self.socket_timeout = DEFAULT_SOCKET_TIMEOUT
+        self.socket_connect_timeout = DEFAULT_SOCKET_CONNECT_TIMEOUT
+        self.orig_host_address = host
+        self.orig_socket_timeout = DEFAULT_SOCKET_TIMEOUT
+        self.orig_socket_connect_timeout = DEFAULT_SOCKET_CONNECT_TIMEOUT
+        self.maintenance_state = MaintenanceState.NONE
+        self.maintenance_notification_hash = None
+        self.connected = True
+        self.disconnect_calls = 0
+        self.timeout_updates = []
+        self.reset_notifications_calls = 0
+        self._should_reconnect = False
+
+    def __repr__(self):
+        return f"<DummyAsyncConnection(host={self.host},port={self.port})>"
+
+    def getpeername(self):
+        return self.peer
+
+    def get_resolved_ip(self):
+        return self.peer
+
+    def set_tmp_settings(
+        self,
+        tmp_host_address: str | object | None = SENTINEL,
+        tmp_relaxed_timeout: float | None = None,
+    ):
+        if tmp_host_address and tmp_host_address != SENTINEL:
+            self.host = str(tmp_host_address)
+        if tmp_relaxed_timeout != -1:
+            self.socket_timeout = tmp_relaxed_timeout
+            self.socket_connect_timeout = tmp_relaxed_timeout
+
+    def reset_tmp_settings(
+        self,
+        reset_host_address=False,
+        reset_relaxed_timeout=False,
+    ):
+        if reset_host_address:
+            self.host = self.orig_host_address
+        if reset_relaxed_timeout:
+            self.socket_timeout = self.orig_socket_timeout
+            self.socket_connect_timeout = self.orig_socket_connect_timeout
+
+    def update_current_socket_timeout(self, relaxed_timeout=None):
+        self.timeout_updates.append(relaxed_timeout)
+
+    def reset_received_notifications(self):
+        self.reset_notifications_calls += 1
+
+    def mark_for_reconnect(self):
+        self._should_reconnect = True
+
+    def should_reconnect(self):
+        return self._should_reconnect
+
+    async def disconnect(self, *args, **kwargs):
+        self.disconnect_calls += 1
+        self.connected = False
+
+
+def _assert_connection_in_moving_state(
+    connection,
+    *,
+    expected_host=MOVED_HOST,
+    expected_timeout=RELAXED_TIMEOUT,
+    expected_notification_hash=None,
+):
+    assert connection.maintenance_state == MaintenanceState.MOVING
+    if expected_notification_hash is not None:
+        assert connection.maintenance_notification_hash == expected_notification_hash
+    assert connection.host == expected_host
+    assert connection.socket_timeout == expected_timeout
+    assert connection.socket_connect_timeout == expected_timeout
+
+
+def _assert_connection_in_default_state(connection, *, expected_host=DEFAULT_HOST):
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.maintenance_notification_hash is None
+    assert connection.host == expected_host
+    assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+    assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_applies_start_and_end_notifications():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ) as notification_count,
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeMigratingNotification(id=1, ttl=5))
+        await handler.handle_notification(NodeMigratedNotification(id=1))
+
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+    assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+    assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
+    assert connection.reset_notifications_calls == 1
+    assert notification_count.await_count == 2
+    assert relaxed_timeout_metric.await_count == 2
+    assert relaxed_timeout_metric.await_args_list[0].kwargs["relaxed"] is True
+    assert relaxed_timeout_metric.await_args_list[1].kwargs["relaxed"] is False
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_skips_timeout_changes_when_moving():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    connection.maintenance_state = MaintenanceState.MOVING
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeFailingOverNotification(id=1, ttl=5))
+
+    assert connection.maintenance_state == MaintenanceState.MOVING
+    assert connection.timeout_updates == []
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_handles_failover_start_and_end():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeFailingOverNotification(id=2, ttl=5))
+        await handler.handle_notification(NodeFailedOverNotification(id=2))
+
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
+    assert relaxed_timeout_metric.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_ignores_oss_cluster_notifications():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ) as notification_count,
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(OSSNodeMigratingNotification(id=1))
+
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.timeout_updates == []
+    notification_count.assert_awaited_once()
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "start_notification,end_notification",
+    [
+        (NodeMigratingNotification(id=1, ttl=5), NodeMigratedNotification(id=1)),
+        (
+            NodeFailingOverNotification(id=2, ttl=5),
+            NodeFailedOverNotification(id=2),
+        ),
+    ],
+)
+async def test_async_connection_handler_ignores_relaxed_timeout_when_disabled(
+    start_notification, end_notification
+):
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=-1)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ) as notification_count,
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(start_notification)
+        await handler.handle_notification(end_notification)
+
+    _assert_connection_in_default_state(connection)
+    assert connection.timeout_updates == []
+    assert notification_count.await_count == 2
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_handler_logs_non_moving_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+    pool = MagicMock()
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+
+    with (
+        mock.patch.object(handler, "remove_expired_notifications", new=AsyncMock()),
+        mock.patch.object(
+            handler, "handle_node_moving_notification", new=AsyncMock()
+        ) as handle_moving,
+        mock.patch("redis.asyncio.maint_notifications.logger.error") as log_error,
+    ):
+        await handler.handle_notification(NodeMigratingNotification(id=1, ttl=5))
+
+    handle_moving.assert_not_awaited()
+    log_error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_parser_routes_maintenance_push_notifications_to_connection_handler():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ),
+    ):
+        await connection._parser.handle_push_response(["MIGRATING", 1, 5])
+        assert connection.maintenance_state == MaintenanceState.MAINTENANCE
+        assert connection.socket_timeout == RELAXED_TIMEOUT
+
+        await connection._parser.handle_push_response(["MIGRATED", 1])
+        assert connection.maintenance_state == MaintenanceState.NONE
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+
+        await connection._parser.handle_push_response(["FAILING_OVER", 2, 5])
+        assert connection.maintenance_state == MaintenanceState.MAINTENANCE
+        assert connection.socket_timeout == RELAXED_TIMEOUT
+
+        await connection._parser.handle_push_response(["FAILED_OVER", 2])
+        assert connection.maintenance_state == MaintenanceState.NONE
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_async_parser_routes_moving_push_notification_to_pool_handler():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = pool.make_connection()
+    pool._in_use_connections.add(connection)
+    connection._maint_notifications_pool_handler._schedule = MagicMock()
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ):
+        await connection._parser.handle_push_response(
+            ["MOVING", 1, 5, f"{MOVED_HOST}:{MOVED_PORT}"]
+        )
+
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    assert pool.connection_kwargs["maintenance_notification_hash"] == hash(
+        NodeMovingNotification(1, MOVED_HOST, MOVED_PORT, 5)
+    )
+    assert pool.connection_kwargs["host"] == MOVED_HOST
+
+
+@pytest.mark.asyncio
+async def test_async_parser_routes_moving_push_without_target():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = pool.make_connection()
+    pool._in_use_connections.add(connection)
+    connection._maint_notifications_pool_handler._schedule = MagicMock()
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ):
+        await connection._parser.handle_push_response(["MOVING", 1, 5, None])
+
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    assert pool.connection_kwargs["host"] == DEFAULT_HOST
+    connection._maint_notifications_pool_handler._schedule.assert_has_calls(
+        [
+            mock.call(
+                2.5,
+                connection._maint_notifications_pool_handler.run_proactive_reconnect,
+                None,
+            ),
+            mock.call(
+                5,
+                connection._maint_notifications_pool_handler.handle_node_moved_notification,
+                mock.ANY,
+            ),
+        ]
+    )
+
+
+def test_async_connection_installs_maintenance_parser_handlers():
+    config = MaintNotificationsConfig(enabled=True)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+
+    connection = pool.make_connection()
+    pool_handler = pool._maint_notifications_pool_handler
+
+    node_moving_handler = connection._parser.node_moving_push_handler_func
+    maintenance_handler = connection._parser.maintenance_push_handler_func
+
+    assert node_moving_handler is not None
+    assert node_moving_handler.__self__.connection is connection
+    assert node_moving_handler.__self__.pool is pool
+    assert node_moving_handler.__self__._lock is pool_handler._lock
+    assert (
+        node_moving_handler.__self__._processed_notifications
+        is pool_handler._processed_notifications
+    )
+
+    assert maintenance_handler is not None
+    assert (
+        maintenance_handler.__self__
+        is connection._maint_notifications_connection_handler
+    )
+    assert connection._maint_notifications_connection_handler.config is config
+
+
+@pytest.mark.asyncio
+async def test_async_pool_update_config_wires_existing_connections():
+    disabled_config = MaintNotificationsConfig(enabled=False)
+    enabled_config = MaintNotificationsConfig(enabled=True)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=disabled_config,
+    )
+    free_connection = pool.make_connection()
+    in_use_connection = pool.make_connection()
+    pool._available_connections.append(free_connection)
+    pool._in_use_connections.add(in_use_connection)
+
+    await pool.update_maint_notifications_config(enabled_config)
+
+    assert free_connection._parser.node_moving_push_handler_func is not None
+    assert free_connection._parser.maintenance_push_handler_func is not None
+    assert free_connection.maint_notifications_config is enabled_config
+    assert not free_connection.should_reconnect()
+
+    assert in_use_connection._parser.node_moving_push_handler_func is not None
+    assert in_use_connection._parser.maintenance_push_handler_func is not None
+    assert in_use_connection.maint_notifications_config is enabled_config
+    assert in_use_connection.should_reconnect()
+
+    assert pool.connection_kwargs["maint_notifications_config"] is enabled_config
+    assert pool.connection_kwargs["maint_notifications_pool_handler"] is (
+        pool._maint_notifications_pool_handler
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_sends_maint_notifications_command():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        endpoint_type=EndpointType.INTERNAL_FQDN,
+    )
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection.send_command = AsyncMock()
+    connection.read_response = AsyncMock(return_value=b"OK")
+
+    await connection.activate_maint_notifications_handling_if_enabled(
+        check_health=False
+    )
+
+    connection.send_command.assert_awaited_once_with(
+        "CLIENT",
+        "MAINT_NOTIFICATIONS",
+        "ON",
+        "moving-endpoint-type",
+        "internal-fqdn",
+        check_health=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_auto_suppresses_response_error():
+    config = MaintNotificationsConfig(enabled="auto")
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection.send_command = AsyncMock()
+    connection.read_response = AsyncMock(side_effect=ResponseError("unsupported"))
+
+    await connection.activate_maint_notifications_handling_if_enabled()
+
+    connection.send_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_enabled_raises_response_error():
+    config = MaintNotificationsConfig(enabled=True)
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection.send_command = AsyncMock()
+    connection.read_response = AsyncMock(side_effect=ResponseError("unsupported"))
+
+    with pytest.raises(ResponseError):
+        await connection.activate_maint_notifications_handling_if_enabled()
+
+
+def test_async_unix_socket_connection_auto_maint_notifications_disabled():
+    config = MaintNotificationsConfig(enabled="auto")
+    connection = UnixDomainSocketConnection(
+        path="/tmp/redis.sock",
+        protocol=3,
+        maint_notifications_config=config,
+    )
+
+    assert connection._maint_notifications_pool_handler is None
+    assert connection._maint_notifications_connection_handler is None
+
+
+def test_async_unix_socket_connection_rejects_enabled_maint_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported for connections without a host",
+    ):
+        UnixDomainSocketConnection(
+            path="/tmp/redis.sock",
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+def test_async_pool_auto_enables_maint_notifications_for_default_resp3():
+    pool = ConnectionPool(host=DEFAULT_HOST, port=DEFAULT_PORT)
+
+    assert pool.maint_notifications_enabled() == "auto"
+    assert isinstance(
+        pool.connection_kwargs["maint_notifications_config"],
+        MaintNotificationsConfig,
+    )
+    assert pool.connection_kwargs["maint_notifications_pool_handler"] is (
+        pool._maint_notifications_pool_handler
+    )
+
+
+def test_async_unix_socket_pool_does_not_auto_enable_maint_notifications():
+    pool = ConnectionPool(
+        connection_class=UnixDomainSocketConnection,
+        path="/tmp/redis.sock",
+        protocol=3,
+    )
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+    assert "orig_host_address" not in pool.connection_kwargs
+
+
+@pytest.mark.asyncio
+async def test_async_unix_socket_pool_auto_maint_notifications_noop():
+    config = MaintNotificationsConfig(enabled="auto")
+    pool = ConnectionPool(
+        connection_class=UnixDomainSocketConnection,
+        path="/tmp/redis.sock",
+        protocol=3,
+    )
+
+    await pool.update_maint_notifications_config(config)
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+
+def test_async_unix_socket_pool_rejects_enabled_maint_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported for connection class UnixDomainSocketConnection",
+    ):
+        ConnectionPool(
+            connection_class=UnixDomainSocketConnection,
+            path="/tmp/redis.sock",
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+def test_async_redis_unix_socket_rejects_enabled_maint_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported for connection class UnixDomainSocketConnection",
+    ):
+        redis.Redis(
+            unix_socket_path="/tmp/redis.sock",
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+async def test_async_pool_applies_and_cleans_up_moving_notification(pool_class):
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = pool_class(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    active_matching = DummyAsyncConnection(peer=DEFAULT_HOST)
+    active_other = DummyAsyncConnection(peer="8.8.8.8")
+    free_matching = DummyAsyncConnection(peer=DEFAULT_HOST)
+    free_other = DummyAsyncConnection(peer="8.8.8.8")
+    pool._in_use_connections.update({active_matching, active_other})
+    pool._available_connections.extend([free_matching, free_other])
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+
+    for connection in (active_matching, free_matching):
+        assert connection.maintenance_state == MaintenanceState.MOVING
+        assert connection.maintenance_notification_hash == hash(notification)
+        assert connection.host == MOVED_HOST
+        assert connection.socket_timeout == RELAXED_TIMEOUT
+        assert connection.socket_connect_timeout == RELAXED_TIMEOUT
+        assert connection.timeout_updates == [RELAXED_TIMEOUT]
+
+    assert active_matching.should_reconnect()
+    assert free_matching.disconnect_calls == 1
+    assert active_other.maintenance_state == MaintenanceState.NONE
+    assert free_other.maintenance_state == MaintenanceState.NONE
+
+    assert pool.connection_kwargs["host"] == MOVED_HOST
+    assert pool.connection_kwargs["port"] == DEFAULT_PORT
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    assert pool.connection_kwargs["maintenance_notification_hash"] == hash(notification)
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(notification),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    for connection in (active_matching, free_matching):
+        assert connection.maintenance_state == MaintenanceState.NONE
+        assert connection.maintenance_notification_hash is None
+        assert connection.host == DEFAULT_HOST
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+        assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+        assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
+
+    assert pool.connection_kwargs["host"] == DEFAULT_HOST
+    assert pool.connection_kwargs["port"] == DEFAULT_PORT
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.NONE
+    assert pool.connection_kwargs["maintenance_notification_hash"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+async def test_async_new_connections_inherit_moving_settings_until_cleanup(pool_class):
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = pool_class(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+
+    moving_connection = pool.make_connection()
+    _assert_connection_in_moving_state(
+        moving_connection,
+        expected_notification_hash=hash(notification),
+    )
+    assert moving_connection.orig_host_address == DEFAULT_HOST
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(notification),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    restored_connection = pool.make_connection()
+    _assert_connection_in_default_state(restored_connection)
+    assert restored_connection.orig_host_address == DEFAULT_HOST
+
+
+@pytest.mark.asyncio
+async def test_async_migrated_after_moving_does_not_clear_moving_state():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    connection = DummyAsyncConnection()
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    pool._in_use_connections.add(connection)
+    moving_notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=moving_notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeMigratedNotification(id=2))
+
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(moving_notification),
+    )
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_overlapping_moving_cleanup_only_reverts_latest_notification():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    first = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+    second_host = "5.6.7.8"
+    second = NodeMovingNotification(
+        id=2,
+        new_node_host=second_host,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(first, config, DEFAULT_HOST)
+    await pool.apply_moving_notification(second, config, DEFAULT_HOST)
+
+    assert pool.connection_kwargs["host"] == second_host
+    _assert_connection_in_moving_state(
+        connection,
+        expected_host=second_host,
+        expected_notification_hash=hash(second),
+    )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(first),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    assert pool.connection_kwargs["host"] == second_host
+    assert pool.connection_kwargs["maintenance_notification_hash"] == hash(second)
+    _assert_connection_in_moving_state(
+        connection,
+        expected_host=second_host,
+        expected_notification_hash=hash(second),
+    )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(second),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    assert pool.connection_kwargs["host"] == DEFAULT_HOST
+    _assert_connection_in_default_state(connection)
+
+
+@pytest.mark.asyncio
+async def test_async_moving_without_target_marks_for_reconnect_on_delayed_run():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    active = DummyAsyncConnection(peer=DEFAULT_HOST)
+    free = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(active)
+    pool._available_connections.append(free)
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=None,
+        new_node_port=None,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+
+    assert not active.should_reconnect()
+    assert free.disconnect_calls == 0
+    _assert_connection_in_moving_state(
+        active,
+        expected_host=DEFAULT_HOST,
+        expected_notification_hash=hash(notification),
+    )
+
+    await pool.run_proactive_reconnect(DEFAULT_HOST)
+
+    assert active.should_reconnect()
+    assert free.disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_moving_notifications_only_update_matching_address_connections():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host="test.address.com",
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    key1_connections = [
+        DummyAsyncConnection(host="test.address.com", peer="1.2.3.4"),
+        DummyAsyncConnection(host="test.address.com", peer="1.2.3.4"),
+    ]
+    key2_connections = [
+        DummyAsyncConnection(host="test.address.com", peer="5.6.7.8"),
+        DummyAsyncConnection(host="test.address.com", peer="5.6.7.8"),
+    ]
+    key3_connection = DummyAsyncConnection(host="test.address.com", peer="9.10.11.12")
+    pool._in_use_connections.update(
+        {key1_connections[0], key2_connections[0], key3_connection}
+    )
+    pool._available_connections.extend([key1_connections[1], key2_connections[1]])
+    first = NodeMovingNotification(
+        id=1,
+        new_node_host="13.14.15.16",
+        new_node_port=DEFAULT_PORT,
+        ttl=5,
+    )
+    second = NodeMovingNotification(
+        id=2,
+        new_node_host="17.18.19.20",
+        new_node_port=DEFAULT_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(first, config, "1.2.3.4")
+
+    for connection in key1_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="13.14.15.16",
+            expected_notification_hash=hash(first),
+        )
+    for connection in (*key2_connections, key3_connection):
+        _assert_connection_in_default_state(
+            connection, expected_host="test.address.com"
+        )
+
+    await pool.apply_moving_notification(second, config, "5.6.7.8")
+
+    for connection in key1_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="13.14.15.16",
+            expected_notification_hash=hash(first),
+        )
+    for connection in key2_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="17.18.19.20",
+            expected_notification_hash=hash(second),
+        )
+    _assert_connection_in_default_state(
+        key3_connection, expected_host="test.address.com"
+    )
+
+    key2_handler = AsyncMaintNotificationsConnectionHandler(key2_connections[0], config)
+    key3_handler = AsyncMaintNotificationsConnectionHandler(key3_connection, config)
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ),
+    ):
+        await key2_handler.handle_notification(NodeMigratingNotification(id=3, ttl=5))
+        await key2_handler.handle_notification(NodeMigratedNotification(id=3))
+        await key3_handler.handle_notification(NodeMigratingNotification(id=4, ttl=5))
+        await key3_handler.handle_notification(NodeMigratedNotification(id=4))
+
+    _assert_connection_in_moving_state(
+        key2_connections[0],
+        expected_host="17.18.19.20",
+        expected_notification_hash=hash(second),
+    )
+    _assert_connection_in_default_state(
+        key3_connection, expected_host="test.address.com"
+    )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(first),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    for connection in key1_connections:
+        _assert_connection_in_default_state(
+            connection, expected_host="test.address.com"
+        )
+    for connection in key2_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="17.18.19.20",
+            expected_notification_hash=hash(second),
+        )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(second),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    for connection in (*key1_connections, *key2_connections, key3_connection):
+        _assert_connection_in_default_state(
+            connection, expected_host="test.address.com"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_moving_migrating_migrated_failed_over_state_transitions():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    free_connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    pool._available_connections.append(free_connection)
+    moving = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        moving,
+        config,
+        DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(moving),
+    )
+    _assert_connection_in_moving_state(
+        free_connection,
+        expected_notification_hash=hash(moving),
+    )
+
+    connection_handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await connection_handler.handle_notification(
+            NodeMigratingNotification(id=2, ttl=5)
+        )
+        await connection_handler.handle_notification(NodeMigratedNotification(id=2))
+        await connection_handler.handle_notification(
+            NodeFailingOverNotification(id=3, ttl=5)
+        )
+        await connection_handler.handle_notification(NodeFailedOverNotification(id=3))
+
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(moving),
+    )
+    relaxed_timeout_metric.assert_not_awaited()
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(moving),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    _assert_connection_in_default_state(connection)
+    _assert_connection_in_default_state(free_connection)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ),
+    ):
+        await connection_handler.handle_notification(
+            NodeFailingOverNotification(id=4, ttl=5)
+        )
+        assert connection.maintenance_state == MaintenanceState.MAINTENANCE
+        await connection_handler.handle_notification(NodeFailedOverNotification(id=4))
+
+    _assert_connection_in_default_state(connection)
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_moving_notification_handling_is_deduplicated():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+    handler.set_connection(connection)
+    handler._schedule = MagicMock()
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ) as handoff_metric:
+        await asyncio.gather(
+            *(handler.handle_notification(notification) for _ in range(5))
+        )
+
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(notification),
+    )
+    assert len(handler._processed_notifications) == 1
+    handler._schedule.assert_called_once_with(
+        notification.ttl,
+        handler.handle_node_moved_notification,
+        notification,
+    )
+    handoff_metric.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_handler_deduplicates_moving_notifications():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    pool = MagicMock()
+    pool.apply_moving_notification = AsyncMock()
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+    handler.set_connection(DummyAsyncConnection())
+    handler._schedule = MagicMock()
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ) as handoff_metric:
+        await handler.handle_notification(notification)
+        await handler.handle_notification(notification)
+
+    pool.apply_moving_notification.assert_awaited_once_with(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+    handler._schedule.assert_called_once_with(
+        notification.ttl,
+        handler.handle_node_moved_notification,
+        notification,
+    )
+    handoff_metric.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_handler_schedules_delayed_reconnect_for_unknown_target():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    pool = MagicMock()
+    pool.apply_moving_notification = AsyncMock()
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+    handler.set_connection(DummyAsyncConnection())
+    handler._schedule = MagicMock()
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=None,
+        new_node_port=None,
+        ttl=10,
+    )
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ):
+        await handler.handle_notification(notification)
+
+    pool.apply_moving_notification.assert_awaited_once_with(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+    handler._schedule.assert_has_calls(
+        [
+            mock.call(
+                notification.ttl / 2, handler.run_proactive_reconnect, DEFAULT_HOST
+            ),
+            mock.call(
+                notification.ttl, handler.handle_node_moved_notification, notification
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_pool_ensure_connection_allows_pending_push_when_enabled():
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(enabled=True),
+    )
+    connection = MagicMock()
+    connection.connect = AsyncMock()
+    connection.can_read = AsyncMock(return_value=True)
+    connection.disconnect = AsyncMock()
+
+    await pool.ensure_connection(connection)
+
+    connection.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_read_response_reschedules_active_socket_timeout():
+    connection = Connection(socket_timeout=0.01)
+
+    class RelaxingParser:
+        async def read_response(self, disable_decoding=False, push_request=False):
+            connection.update_current_socket_timeout(0.2)
+            await asyncio.sleep(0.05)
+            return b"OK"
+
+    connection._parser = RelaxingParser()
+
+    assert await connection.read_response() == b"OK"
+    assert connection._active_read_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_read_response_reschedules_active_socket_timeout_to_blocking():
+    connection = Connection(socket_timeout=0.01)
+
+    class RelaxingParser:
+        async def read_response(self, disable_decoding=False, push_request=False):
+            connection.update_current_socket_timeout(None)
+            await asyncio.sleep(0.05)
+            return b"OK"
+
+    connection._parser = RelaxingParser()
+
+    assert await connection.read_response() == b"OK"
+    assert connection._active_read_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_read_response_does_not_reschedule_explicit_timeout():
+    connection = Connection(socket_timeout=0.2)
+
+    class RelaxingParser:
+        async def read_response(self, disable_decoding=False, push_request=False):
+            connection.update_current_socket_timeout(0.2)
+            await asyncio.sleep(0.05)
+            return b"OK"
+
+    connection._parser = RelaxingParser()
+
+    assert await connection.read_response(timeout=0.01) is None
+
+
+def test_async_redis_maint_notifications_config_forwarded_to_internal_pool():
+    config = MaintNotificationsConfig(enabled=True)
+    client = redis.Redis(protocol=3, maint_notifications_config=config)
+
+    assert (
+        client.connection_pool.connection_kwargs["maint_notifications_config"] is config
+    )
+    assert client.connection_pool._maint_notifications_pool_handler.config is config
+
+
+def test_async_redis_maint_notifications_config_requires_resp3():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications handlers on connection are only supported",
+    ):
+        redis.Redis(protocol=2, maint_notifications_config=config)
+
+
+def test_async_redis_maint_notifications_config_ignored_with_explicit_pool():
+    pool = MagicMock()
+    pool.connection_kwargs = {"protocol": 2, "legacy_responses": True}
+    pool.get_encoder.return_value = MagicMock()
+    config = MaintNotificationsConfig(enabled=True)
+
+    client = redis.Redis(connection_pool=pool, maint_notifications_config=config)
+
+    assert client.connection_pool is pool
+    assert "maint_notifications_config" not in pool.connection_kwargs
+
+
+async def _make_retry_call(do, fail, is_retryable=None, with_failure_count=False):
+    return await do()
+
+
+def _mock_single_connection_pool(connection):
+    pool = MagicMock()
+    pool.get_connection = AsyncMock(return_value=connection)
+    pool.release = AsyncMock()
+    pool.get_encoder.return_value = MagicMock()
+    pool.get_protocol.return_value = 2
+    return pool
+
+
+def _mock_single_connection(should_reconnect):
+    connection = MagicMock()
+    connection.host = "localhost"
+    connection.port = DEFAULT_PORT
+    connection.db = 0
+    connection.should_reconnect.return_value = should_reconnect
+    connection.disconnect = AsyncMock()
+    connection.connect = AsyncMock()
+    connection.retry = MagicMock()
+    connection.retry.call_with_retry = _make_retry_call
+    connection.retry.get_retries.return_value = 0
+    return connection
+
+
+@pytest.mark.asyncio
+async def test_single_connection_client_reconnects_marked_connection():
+    connection = _mock_single_connection(should_reconnect=True)
+    pool = _mock_single_connection_pool(connection)
+    client = redis.Redis(connection_pool=pool, single_connection_client=True)
+
+    async def mock_send(*args, **kwargs):
+        return b"PONG"
+
+    client._send_command_parse_response = mock_send
+
+    assert await client.execute_command("PING") == b"PONG"
+    connection.disconnect.assert_awaited_once_with(error=None, failure_count=None)
+    connection.connect.assert_awaited_once()
+    pool.release.assert_not_awaited()
+
+    await client.aclose(close_connection_pool=False)
+
+
+@pytest.mark.asyncio
+async def test_single_connection_client_does_not_reconnect_unmarked_connection():
+    connection = _mock_single_connection(should_reconnect=False)
+    pool = _mock_single_connection_pool(connection)
+    client = redis.Redis(connection_pool=pool, single_connection_client=True)
+
+    async def mock_send(*args, **kwargs):
+        return b"PONG"
+
+    client._send_command_parse_response = mock_send
+
+    assert await client.execute_command("PING") == b"PONG"
+    connection.disconnect.assert_not_awaited()
+    connection.connect.assert_not_awaited()
+    pool.release.assert_not_awaited()
+
+    await client.aclose(close_connection_pool=False)

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -1305,6 +1305,75 @@ async def test_async_pool_handler_schedules_delayed_reconnect_for_unknown_target
 
 
 @pytest.mark.asyncio
+async def test_blocking_pool_locks_get_only_during_maintenance():
+    pool = BlockingConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+
+    real_lock = pool._lock
+    pool._lock = MagicMock(wraps=real_lock)
+
+    fake_conn = MagicMock()
+    fake_conn.connect = AsyncMock()
+    fake_conn.can_read = AsyncMock(return_value=False)
+    fake_conn.should_reconnect = MagicMock(return_value=False)
+    fake_conn.re_auth = AsyncMock()
+    pool._available_connections.append(fake_conn)
+
+    # Outside maintenance: get_connection does not acquire _lock,
+    # but release() still does (it goes through ConnectionPool.release).
+    conn = await pool.get_connection()
+    await pool.release(conn)
+    assert pool._lock.__aenter__.call_count == 1
+
+    # Inside maintenance: get_connection now also acquires _lock.
+    pool.set_in_maintenance(True)
+    try:
+        conn = await pool.get_connection()
+        await pool.release(conn)
+    finally:
+        pool.set_in_maintenance(False)
+    assert pool._lock.__aenter__.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_apply_moving_notification_toggles_set_in_maintenance():
+    pool = BlockingConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+    observed = []
+    original = pool.set_in_maintenance
+
+    def spy(value: bool) -> None:
+        observed.append(value)
+        original(value)
+
+    pool.set_in_maintenance = spy  # type: ignore[assignment]
+
+    notification = NodeMovingNotification(
+        id=1, new_node_host=MOVED_HOST, new_node_port=MOVED_PORT, ttl=5
+    )
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=pool._maint_notifications_pool_handler.config,
+        moving_address_src=None,
+        run_proactive_reconnect=False,
+    )
+
+    assert observed == [True, False]
+
+
+@pytest.mark.asyncio
 async def test_cancel_scheduled_tasks_cancels_pending_and_awaits():
     config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
     handler = AsyncMaintNotificationsPoolHandler(MagicMock(), config)

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -68,7 +68,7 @@ class DummyAsyncConnection:
     def set_tmp_settings(
         self,
         tmp_host_address: str | object | None = SENTINEL,
-        tmp_relaxed_timeout: float | None = None,
+        tmp_relaxed_timeout: float | None = -1,
     ):
         if tmp_host_address and tmp_host_address != SENTINEL:
             self.host = str(tmp_host_address)
@@ -102,6 +102,12 @@ class DummyAsyncConnection:
     async def disconnect(self, *args, **kwargs):
         self.disconnect_calls += 1
         self.connected = False
+
+
+class UnsupportedAsyncConnection:
+    def __init__(self, host=DEFAULT_HOST, **kwargs):
+        self.host = host
+        self.kwargs = kwargs
 
 
 def _assert_connection_in_moving_state(
@@ -514,32 +520,6 @@ async def test_async_handshake_enabled_raises_response_error():
         await connection.activate_maint_notifications_handling_if_enabled()
 
 
-def test_async_unix_socket_connection_auto_maint_notifications_disabled():
-    config = MaintNotificationsConfig(enabled="auto")
-    connection = UnixDomainSocketConnection(
-        path="/tmp/redis.sock",
-        protocol=3,
-        maint_notifications_config=config,
-    )
-
-    assert connection._maint_notifications_pool_handler is None
-    assert connection._maint_notifications_connection_handler is None
-
-
-def test_async_unix_socket_connection_rejects_enabled_maint_notifications():
-    config = MaintNotificationsConfig(enabled=True)
-
-    with pytest.raises(
-        RedisError,
-        match="Maintenance notifications are not supported for connections without a host",
-    ):
-        UnixDomainSocketConnection(
-            path="/tmp/redis.sock",
-            protocol=3,
-            maint_notifications_config=config,
-        )
-
-
 def test_async_pool_auto_enables_maint_notifications_for_default_resp3():
     pool = ConnectionPool(host=DEFAULT_HOST, port=DEFAULT_PORT)
 
@@ -551,6 +531,61 @@ def test_async_pool_auto_enables_maint_notifications_for_default_resp3():
     assert pool.connection_kwargs["maint_notifications_pool_handler"] is (
         pool._maint_notifications_pool_handler
     )
+
+
+def test_async_pool_does_not_auto_enable_maint_notifications_without_valid_host():
+    pool = ConnectionPool(host=None, port=DEFAULT_PORT, protocol=3)
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+
+def test_async_pool_rejects_enabled_maint_notifications_without_valid_host():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported for connections without a host",
+    ):
+        ConnectionPool(
+            host=None,
+            port=DEFAULT_PORT,
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+def test_async_custom_connection_does_not_auto_enable_maint_notifications():
+    pool = ConnectionPool(
+        connection_class=UnsupportedAsyncConnection,
+        host=DEFAULT_HOST,
+        protocol=3,
+    )
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+
+def test_async_custom_connection_rejects_enabled_maint_notifications_config():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match=(
+            "Maintenance notifications are not supported for connection class "
+            "UnsupportedAsyncConnection"
+        ),
+    ):
+        ConnectionPool(
+            connection_class=UnsupportedAsyncConnection,
+            host=DEFAULT_HOST,
+            protocol=3,
+            maint_notifications_config=config,
+        )
 
 
 def test_async_unix_socket_pool_does_not_auto_enable_maint_notifications():
@@ -589,7 +624,7 @@ def test_async_unix_socket_pool_rejects_enabled_maint_notifications():
 
     with pytest.raises(
         RedisError,
-        match="Maintenance notifications are not supported for connection class UnixDomainSocketConnection",
+        match="Maintenance notifications are not supported for Unix domain socket connections",
     ):
         ConnectionPool(
             connection_class=UnixDomainSocketConnection,
@@ -604,7 +639,7 @@ def test_async_redis_unix_socket_rejects_enabled_maint_notifications():
 
     with pytest.raises(
         RedisError,
-        match="Maintenance notifications are not supported for connection class UnixDomainSocketConnection",
+        match="Maintenance notifications are not supported with Unix domain socket connections",
     ):
         redis.Redis(
             unix_socket_path="/tmp/redis.sock",
@@ -683,6 +718,46 @@ async def test_async_pool_applies_and_cleans_up_moving_notification(pool_class):
     assert pool.connection_kwargs["port"] == DEFAULT_PORT
     assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.NONE
     assert pool.connection_kwargs["maintenance_notification_hash"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+async def test_async_pool_moving_with_disabled_relaxed_timeout_preserves_timeouts(
+    pool_class,
+):
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=-1,
+    )
+    pool = pool_class(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+
+    assert connection.maintenance_state == MaintenanceState.MOVING
+    assert connection.maintenance_notification_hash == hash(notification)
+    assert connection.host == MOVED_HOST
+    assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+    assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+    assert connection.timeout_updates == [-1]
 
 
 @pytest.mark.asyncio

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -16,6 +16,7 @@ from redis.asyncio.maint_notifications import (
     AsyncMaintNotificationsConnectionHandler,
     AsyncMaintNotificationsPoolHandler,
 )
+from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError, ResponseError
 from redis.maint_notifications import (
     EndpointType,
@@ -1319,6 +1320,32 @@ async def test_async_pool_ensure_connection_allows_pending_push_when_enabled():
     await pool.ensure_connection(connection)
 
     connection.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled, raises", [(True, False), (False, True)])
+async def test_async_pool_ensure_connection_handles_pending_push_after_reconnect(
+    enabled, raises
+):
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(enabled=enabled),
+    )
+    connection = MagicMock()
+    connection.connect = AsyncMock()
+    connection.can_read = AsyncMock(side_effect=[RedisConnectionError("closed"), True])
+    connection.disconnect = AsyncMock()
+
+    if raises:
+        with pytest.raises(RedisConnectionError, match="Connection not ready"):
+            await pool.ensure_connection(connection)
+    else:
+        await pool.ensure_connection(connection)
+
+    assert connection.connect.await_count == 2
+    connection.disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -1305,6 +1305,84 @@ async def test_async_pool_handler_schedules_delayed_reconnect_for_unknown_target
 
 
 @pytest.mark.asyncio
+async def test_cancel_scheduled_tasks_cancels_pending_and_awaits():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    handler = AsyncMaintNotificationsPoolHandler(MagicMock(), config)
+
+    callback = AsyncMock()
+    handler._schedule(60, callback)
+    handler._schedule(60, callback)
+    tasks = tuple(handler._scheduled_tasks)
+    assert len(tasks) == 2
+
+    await handler.cancel_scheduled_tasks()
+
+    for task in tasks:
+        assert task.done()
+        assert task.cancelled()
+    callback.assert_not_awaited()
+    assert handler._scheduled_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_tasks_noop_when_empty():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    handler = AsyncMaintNotificationsPoolHandler(MagicMock(), config)
+    await handler.cancel_scheduled_tasks()
+    assert handler._scheduled_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_pool_aclose_cancels_handler_scheduled_tasks():
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+    handler = pool._maint_notifications_pool_handler
+    assert handler is not None
+
+    callback = AsyncMock()
+    handler._schedule(60, callback)
+    handler._schedule(60, callback)
+    tasks = tuple(handler._scheduled_tasks)
+    assert len(tasks) == 2
+
+    await pool.aclose()
+
+    for task in tasks:
+        assert task.cancelled()
+    callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pool_disconnect_does_not_cancel_scheduled_tasks():
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+    handler = pool._maint_notifications_pool_handler
+    assert handler is not None
+
+    handler._schedule(60, AsyncMock())
+    tasks = tuple(handler._scheduled_tasks)
+
+    try:
+        await pool.disconnect()
+        for task in tasks:
+            assert not task.done()
+    finally:
+        await handler.cancel_scheduled_tasks()
+
+
+@pytest.mark.asyncio
 async def test_async_pool_ensure_connection_allows_pending_push_when_enabled():
     pool = ConnectionPool(
         host=DEFAULT_HOST,

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -626,6 +626,40 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
 
         self._validate_connection_handlers(conn, pool_handler, self.config)
 
+    def test_moving_update_with_disabled_relaxed_timeout_preserves_timeouts(self):
+        config = MaintNotificationsConfig(
+            enabled=True,
+            proactive_reconnect=True,
+            relaxed_timeout=-1,
+        )
+        pool = ConnectionPool(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            protocol=3,
+            maint_notifications_config=config,
+        )
+        connection = Connection(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+        pool.update_connection_settings(
+            connection,
+            state=MaintenanceState.MOVING,
+            maintenance_notification_hash=hash(MOVING_NOTIFICATION),
+            host_address=AFTER_MOVING_ADDRESS.split(":")[0],
+            relaxed_timeout=config.relaxed_timeout,
+            update_notification_hash=True,
+        )
+
+        assert connection.maintenance_state == MaintenanceState.MOVING
+        assert connection.maintenance_notification_hash == hash(MOVING_NOTIFICATION)
+        assert connection.host == AFTER_MOVING_ADDRESS.split(":")[0]
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+        assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+
     def test_maint_handler_init_for_existing_connections(self):
         """Test that maintenance notification handlers are properly set on existing and new connections
         when configuration is enabled after client creation."""

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -1,7 +1,7 @@
 import socket
 import threading
 from typing import List, Union
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from time import sleep
@@ -16,6 +16,7 @@ from redis.connection import (
     BlockingConnectionPool,
     MaintenanceState,
 )
+from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import ResponseError
 from redis.maint_notifications import (
     EndpointType,
@@ -742,6 +743,47 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
         finally:
             if hasattr(test_pool, "disconnect"):
                 test_pool.disconnect()
+
+    @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+    @pytest.mark.parametrize("enabled, raises", [(True, False), (False, True)])
+    def test_pool_get_connection_handles_pending_push_after_reconnect(
+        self, pool_class, enabled, raises
+    ):
+        max_connections = 3 if pool_class == BlockingConnectionPool else 10
+        pool = pool_class(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            max_connections=max_connections,
+            protocol=3,
+            maint_notifications_config=MaintNotificationsConfig(enabled=enabled),
+        )
+        connection = MagicMock()
+        connection.pid = pool.pid
+        connection.can_read.side_effect = [RedisConnectionError("closed"), True]
+        connection.should_reconnect.return_value = False
+
+        if pool_class == BlockingConnectionPool:
+            pool.pool.get_nowait()
+            pool.pool.put_nowait(connection)
+            pool._connections.append(connection)
+        else:
+            pool._available_connections.append(connection)
+
+        returned_connection = None
+        try:
+            if raises:
+                with pytest.raises(RedisConnectionError, match="Connection not ready"):
+                    pool.get_connection()
+            else:
+                returned_connection = pool.get_connection()
+                assert returned_connection is connection
+
+            assert connection.connect.call_count == 2
+            connection.disconnect.assert_called_once()
+        finally:
+            if returned_connection is connection:
+                pool.release(connection)
+            pool.disconnect()
 
     @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
     def test_redis_operations_with_mock_sockets(self, pool_class):

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -187,6 +187,21 @@ def test_connection_parser_matches_protocol(
     assert isinstance(conn._parser, expected_parser_class)
 
 
+def test_get_resolved_ip_uses_async_writer_peer_before_dns():
+    conn = Connection(host="redis.example.test")
+    writer = mock.Mock()
+    writer.get_extra_info.return_value = ("10.0.0.7", 6379)
+    conn._writer = writer
+
+    with mock.patch.object(socket, "getaddrinfo") as getaddrinfo:
+        try:
+            assert conn.get_resolved_ip() == "10.0.0.7"
+        finally:
+            conn._writer = None
+
+    getaddrinfo.assert_not_called()
+
+
 @pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "client_kwargs",

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -23,6 +23,14 @@ from .conftest import asynccontextmanager
 from .test_pubsub import wait_for_message
 
 
+def assert_kwargs_subset(actual, expected):
+    for key, value in expected.items():
+        assert key in actual, f"missing key {key!r} in {actual!r}"
+        assert (
+            actual[key] == value
+        ), f"value mismatch for {key!r}: {actual[key]!r} != {value!r}"
+
+
 @pytest.mark.onlynoncluster
 class TestRedisAutoReleaseConnectionPool:
     @pytest_asyncio.fixture
@@ -159,7 +167,7 @@ class TestConnectionPool:
         ) as pool:
             connection = await pool.get_connection()
             assert isinstance(connection, DummyConnection)
-            assert connection.kwargs == connection_kwargs
+            assert_kwargs_subset(connection.kwargs, connection_kwargs)
 
     @pytest.mark.fixed_client
     async def test_aclosing(self):
@@ -261,9 +269,9 @@ class TestConnectionPool:
 
             # Verify the lock was NOT held during connect
             assert len(lock_states) > 0, "connect() should have been called"
-            assert lock_states[0] is False, (
-                "Lock should not be held during connection establishment"
-            )
+            assert (
+                lock_states[0] is False
+            ), "Lock should not be held during connection establishment"
 
             await pool.release(connection)
 
@@ -338,7 +346,7 @@ class TestBlockingConnectionPool:
         async with self.get_pool(connection_kwargs=connection_kwargs) as pool:
             connection = await pool.get_connection()
             assert isinstance(connection, DummyConnection)
-            assert connection.kwargs == connection_kwargs
+            assert_kwargs_subset(connection.kwargs, connection_kwargs)
 
     async def test_pool_disconnect(self, master_host):
         connection_kwargs = {
@@ -458,23 +466,27 @@ class TestConnectionPoolURLParsing:
     def test_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my.host")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "my.host"}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
     def test_quoted_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my %2F host %2B%3D+")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "my / host +=+"}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my / host +=+"})
 
     def test_port(self):
         pool = redis.ConnectionPool.from_url("redis://localhost:6380")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "port": 6380}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "port": 6380}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self):
         pool = redis.ConnectionPool.from_url("redis://myuser:@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "username": "myuser"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "username": "myuser"}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_quoted_username(self):
@@ -482,50 +494,61 @@ class TestConnectionPoolURLParsing:
             "redis://%2Fmyuser%2F%2B name%3D%24+:@localhost"
         )
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "username": "/myuser/+ name=$+",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "username": "/myuser/+ name=$+",
+            },
+        )
 
     def test_password(self):
         pool = redis.ConnectionPool.from_url("redis://:mypassword@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "password": "mypassword"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "password": "mypassword"}
+        )
 
     def test_quoted_password(self):
         pool = redis.ConnectionPool.from_url(
             "redis://:%2Fmypass%2F%2B word%3D%24+@localhost"
         )
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "password": "/mypass/+ word=$+",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "password": "/mypass/+ word=$+",
+            },
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_username_and_password(self):
         pool = redis.ConnectionPool.from_url("redis://myuser:mypass@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "username": "myuser",
-            "password": "mypass",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "username": "myuser",
+                "password": "mypass",
+            },
+        )
 
     def test_db_as_argument(self):
         pool = redis.ConnectionPool.from_url("redis://localhost", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 1}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "localhost", "db": 1})
 
     def test_db_in_path(self):
         pool = redis.ConnectionPool.from_url("redis://localhost/2", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 2}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "localhost", "db": 2})
 
     def test_db_in_querystring(self):
         pool = redis.ConnectionPool.from_url("redis://localhost/2?db=3", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 3}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "localhost", "db": 3})
 
     def test_extra_typed_querystring_options(self):
         pool = redis.ConnectionPool.from_url(
@@ -534,13 +557,16 @@ class TestConnectionPoolURLParsing:
         )
 
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "db": 2,
-            "socket_timeout": 20.0,
-            "socket_connect_timeout": 10.0,
-            "retry_on_timeout": True,
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "db": 2,
+                "socket_timeout": 20.0,
+                "socket_connect_timeout": 10.0,
+                "retry_on_timeout": True,
+            },
+        )
         assert pool.max_connections == 10
 
     def test_boolean_parsing(self):
@@ -576,7 +602,9 @@ class TestConnectionPoolURLParsing:
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("redis://localhost?a=1&b=2")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "a": "1", "b": "2"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "a": "1", "b": "2"}
+        )
 
     def test_calling_from_subclass_returns_correct_instance(self):
         pool = redis.BlockingConnectionPool.from_url("redis://localhost")
@@ -585,7 +613,7 @@ class TestConnectionPoolURLParsing:
     def test_client_creates_connection_pool(self):
         r = redis.Redis.from_url("redis://myhost")
         assert r.connection_pool.connection_class == redis.Connection
-        assert r.connection_pool.connection_kwargs == {"host": "myhost"}
+        assert_kwargs_subset(r.connection_pool.connection_kwargs, {"host": "myhost"})
 
     def test_invalid_scheme_raises_error(self):
         with pytest.raises(ValueError) as cm:
@@ -605,13 +633,16 @@ class TestBlockingConnectionPoolURLParsing:
         )
 
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "db": 2,
-            "socket_timeout": 20.0,
-            "socket_connect_timeout": 10.0,
-            "retry_on_timeout": True,
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "db": 2,
+                "socket_timeout": 20.0,
+                "socket_connect_timeout": 10.0,
+                "retry_on_timeout": True,
+            },
+        )
         assert pool.max_connections == 10
         assert pool.timeout == 13.37
 
@@ -696,7 +727,7 @@ class TestSSLConnectionURLParsing:
     def test_host(self):
         pool = redis.ConnectionPool.from_url("rediss://my.host")
         assert pool.connection_class == redis.SSLConnection
-        assert pool.connection_kwargs == {"host": "my.host"}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
     def test_cert_reqs_options(self):
         import ssl
@@ -806,13 +837,14 @@ class TestConnection:
         connection = redis.Redis.from_url("redis://localhost:6379?db=0")
         pool = connection.connection_pool
 
-        assert re.match(
+        conn_name, pool_name, conn_kwargs = re.match(
             r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >", repr(pool), re.VERBOSE
-        ).groups() == (
-            "ConnectionPool",
-            "Connection",
-            "db=0,host=localhost,port=6379",
-        )
+        ).groups()
+        assert conn_name == "ConnectionPool"
+        assert pool_name == "Connection"
+        assert "db=0" in conn_kwargs
+        assert "host=localhost" in conn_kwargs
+        assert "port=6379" in conn_kwargs
 
     @pytest.mark.fixed_client
     def test_connect_from_url_unix(self):

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -26,9 +26,9 @@ from .test_pubsub import wait_for_message
 def assert_kwargs_subset(actual, expected):
     for key, value in expected.items():
         assert key in actual, f"missing key {key!r} in {actual!r}"
-        assert (
-            actual[key] == value
-        ), f"value mismatch for {key!r}: {actual[key]!r} != {value!r}"
+        assert actual[key] == value, (
+            f"value mismatch for {key!r}: {actual[key]!r} != {value!r}"
+        )
 
 
 @pytest.mark.onlynoncluster
@@ -269,9 +269,9 @@ class TestConnectionPool:
 
             # Verify the lock was NOT held during connect
             assert len(lock_states) > 0, "connect() should have been called"
-            assert (
-                lock_states[0] is False
-            ), "Lock should not be held during connection establishment"
+            assert lock_states[0] is False, (
+                "Lock should not be held during connection establishment"
+            )
 
             await pool.release(connection)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 from redis.utils import (
     DEFAULT_RESP_VERSION,
+    SENTINEL,
     check_protocol_version,
     compare_versions,
     deprecated_function,
@@ -52,6 +53,11 @@ class TestCheckProtocolVersion:
         assert check_protocol_version(None, DEFAULT_RESP_VERSION) is True
         other = 2 if DEFAULT_RESP_VERSION == 3 else 3
         assert check_protocol_version(None, other) is False
+
+    def test_sentinel_resolves_to_default(self):
+        assert check_protocol_version(SENTINEL, DEFAULT_RESP_VERSION) is True
+        other = 2 if DEFAULT_RESP_VERSION == 3 else 3
+        assert check_protocol_version(SENTINEL, other) is False
 
     @pytest.mark.parametrize("protocol", [3, "3"])
     def test_resp3_matches(self, protocol):


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core async connection pool locking, reconnection, and timeout behavior during server maintenance events; mistakes could cause connection leaks, missed handoffs, or stuck pools.
> 
> **Overview**
> Adds **maintenance notifications** to the async standalone `Redis` client and connection pool, mirroring the sync feature for RESP3 TCP connections: `MaintNotificationsConfig` on `redis.asyncio.Redis`, auto-enable on default RESP3 pools, and guards for Unix sockets, missing hosts, and non-mixin connection classes.
> 
> New **`redis/asyncio/maint_notifications.py`** handles pool- and connection-level push events (MOVING, migrate/failover start/end), schedules TTL cleanup with `asyncio` tasks, and records observability metrics. Async connections gain mixins for the `CLIENT MAINT_NOTIFICATIONS` handshake, parser push handlers, relaxed read timeouts during maintenance (including rescheduling in-flight `read_response` deadlines), and lifecycle cleanup on disconnect.
> 
> The async pool mixin centralizes **atomic MOVING** updates—matching connections, proactive reconnect, and future `connection_kwargs`—under the non-reentrant pool lock; `BlockingConnectionPool` can serialize get/release during maintenance. Related sync paths are aligned via shared helpers in `redis/maint_notifications.py`, `check_protocol_version` (including `SENTINEL`), stricter `can_read` checks when notifications are enabled, and safer single-connection reconnect in `finally` blocks.
> 
> Large new async test suite plus sync/pool test updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efbe247883442c3965fd14648668e69ac9de11a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->