### PR TITLE
Fix hiredis readiness checks for high file descriptors

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,4 +1,4 @@
-import select
+import selectors
 import socket
 from logging import getLogger
 from typing import Callable, List, Optional, TypedDict, Union
@@ -28,7 +28,11 @@ def _socket_can_read(sock, timeout: float) -> bool:
     # SSL sockets can have decrypted bytes buffered above the OS socket layer.
     if hasattr(sock, "pending") and sock.pending():
         return True
-    return bool(select.select([sock], [], [], timeout)[0])
+    # timeout=0 must be a non-blocking readiness check only. The selector keeps
+    # this non-destructive while avoiding select.select's low fd limit on Unix.
+    with selectors.DefaultSelector() as selector:
+        selector.register(sock, selectors.EVENT_READ)
+        return bool(selector.select(timeout))
 
 
 class _HiredisReaderArgs(TypedDict, total=False):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,7 @@
 import copy
+import os
 import platform
+import selectors
 import socket
 import ssl
 import threading
@@ -13,7 +15,7 @@ import pytest
 import redis
 from redis import ConnectionPool, Redis
 from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
-from redis._parsers.hiredis import NOT_ENOUGH_DATA
+from redis._parsers.hiredis import NOT_ENOUGH_DATA, _socket_can_read
 from redis._parsers.socket import SocketBuffer
 from redis.backoff import NoBackoff
 from redis.cache import (
@@ -109,6 +111,46 @@ def test_hiredis_can_read_checks_socket_readiness_without_reading():
         assert parser.can_read(timeout=0) is True
 
     ready.assert_called_once_with(parser._sock, 0)
+
+
+@pytest.mark.fixed_client
+def test_hiredis_socket_can_read_uses_default_selector():
+    sock = Mock(spec=["fileno"])
+    selector = MagicMock()
+    selector.select.return_value = [(sock, selectors.EVENT_READ)]
+    selector.__enter__.return_value = selector
+
+    with patch(
+        "redis._parsers.hiredis.selectors.DefaultSelector", return_value=selector
+    ):
+        assert _socket_can_read(sock, timeout=0.001) is True
+
+    selector.register.assert_called_once_with(sock, selectors.EVENT_READ)
+    selector.select.assert_called_once_with(0.001)
+
+
+@pytest.mark.fixed_client
+def test_hiredis_socket_can_read_handles_high_file_descriptor():
+    fcntl = pytest.importorskip("fcntl")
+
+    with selectors.DefaultSelector() as selector:
+        if isinstance(selector, selectors.SelectSelector):
+            pytest.skip("Default selector uses select.select")
+
+    read_fd, write_fd = os.pipe()
+    high_read_fd = None
+    try:
+        try:
+            high_read_fd = fcntl.fcntl(read_fd, fcntl.F_DUPFD, 1024)
+        except OSError as exc:
+            pytest.skip(f"Could not allocate high file descriptor: {exc}")
+
+        assert _socket_can_read(high_read_fd, timeout=0) is False
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+        if high_read_fd is not None and high_read_fd != read_fd:
+            os.close(high_read_fd)
 
 
 def test_hiredis_can_read_does_not_decide_disable_decoding():


### PR DESCRIPTION
This fixes hiredis connection readiness checks for applications that can have socket file descriptors above `FD_SETSIZE`. The previous implementation used `select.select()`, which can raise `ValueError: filedescriptor out of range in select()` on high-numbered descriptors.

The readiness probe now uses `selectors.DefaultSelector()` instead. This lets Python choose the best platform selector, such as `epoll`, `kqueue`, or `poll`, while preserving the important behavior from #4063: `can_read()` remains non-destructive and does not read from the socket or consume hiredis parser state.

Tests were added to verify that the helper uses the default selector and can handle a real high-numbered file descriptor. 

Fixes: #4113



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to hiredis sync polling only, with new tests; behavior is intended to match prior non-destructive readiness checks on supported platforms.
> 
> **Overview**
> Fixes hiredis sync connection **readiness checks** when Redis sockets use file descriptors above `FD_SETSIZE`, which could raise `ValueError: filedescriptor out of range in select()`.
> 
> **`_socket_can_read`** in `redis/_parsers/hiredis.py` no longer uses `select.select()`; it uses **`selectors.DefaultSelector()`** (epoll/kqueue/poll where available) for the same non-destructive probe. SSL **`pending()`** short-circuit is unchanged, so **`can_read()`** still does not read from the socket or consume hiredis parser state.
> 
> Tests assert the helper registers for **`EVENT_READ`** via the default selector and that a **high-numbered fd** (via `fcntl` dup) can be polled without error when the platform default is not `SelectSelector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778d2441e468ae38797d89b642756da9ce8bbba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->