### PR TITLE
Avoid per-check fd allocation in hiredis `_socket_can_read()` — use `poll()` instead of a per-call selector

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -13,6 +13,7 @@ pytest-cov
 coverage<7.11.1
 pytest-cov==6.0.0 ; platform_python_implementation == "PyPy"
 coverage==7.6.12 ; platform_python_implementation == "PyPy"
+pytest-forked
 pytest-profiling==1.8.1
 pytest-timeout
 pytest-timeout==2.3.1 ; platform_python_implementation == "PyPy"

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -1,3 +1,4 @@
+import select
 import selectors
 import socket
 from logging import getLogger
@@ -23,13 +24,29 @@ from .socket import (
 # return `False` or `None` for legitimate reasons from RESP payloads.
 NOT_ENOUGH_DATA = object()
 
+# select.poll() is unavailable on Windows; fall back to selectors there.
+_HAS_POLL = hasattr(select, "poll")
+
 
 def _socket_can_read(sock, timeout: float) -> bool:
     # SSL sockets can have decrypted bytes buffered above the OS socket layer.
     if hasattr(sock, "pending") and sock.pending():
         return True
-    # timeout=0 must be a non-blocking readiness check only. The selector keeps
-    # this non-destructive while avoiding select.select's low fd limit on Unix.
+    # timeout=0 must be a non-blocking readiness check only; both branches
+    # below are non-destructive and have no FD_SETSIZE limit (select.select
+    # raises ValueError for fds >= 1024).
+    if _HAS_POLL:
+        # Prefer poll() over selectors.DefaultSelector: epoll/kqueue selectors
+        # allocate a file descriptor per check and so fail with EMFILE under
+        # fd exhaustion - the very condition that pushes sockets onto high
+        # fds. poll() allocates nothing.
+        poller = select.poll()
+        poller.register(sock, select.POLLIN)
+        # poll() takes milliseconds (None blocks forever). POLLHUP/POLLERR/
+        # POLLNVAL are always reported regardless of the registered mask, so
+        # closed or errored sockets still count as readable, like select().
+        poll_timeout = None if timeout is None else timeout * 1000
+        return bool(poller.poll(poll_timeout))
     with selectors.DefaultSelector() as selector:
         selector.register(sock, selectors.EVENT_READ)
         return bool(selector.select(timeout))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import platform
+import select
 import selectors
 import socket
 import ssl
@@ -114,14 +115,37 @@ def test_hiredis_can_read_checks_socket_readiness_without_reading():
 
 
 @pytest.mark.fixed_client
-def test_hiredis_socket_can_read_uses_default_selector():
+@pytest.mark.parametrize(
+    "timeout,expected_poll_timeout",
+    [(0, 0), (0.001, 1.0), (None, None)],
+)
+def test_hiredis_socket_can_read_uses_poll(timeout, expected_poll_timeout):
+    if not hasattr(select, "poll"):
+        pytest.skip("select.poll not available on this platform")
+
+    sock = Mock(spec=["fileno"])
+    poller = Mock()
+    poller.poll.return_value = [(7, select.POLLIN)]
+
+    with patch("redis._parsers.hiredis.select.poll", return_value=poller):
+        assert _socket_can_read(sock, timeout=timeout) is True
+
+    poller.register.assert_called_once_with(sock, select.POLLIN)
+    poller.poll.assert_called_once_with(expected_poll_timeout)
+
+
+@pytest.mark.fixed_client
+def test_hiredis_socket_can_read_falls_back_to_default_selector():
     sock = Mock(spec=["fileno"])
     selector = MagicMock()
     selector.select.return_value = [(sock, selectors.EVENT_READ)]
     selector.__enter__.return_value = selector
 
-    with patch(
-        "redis._parsers.hiredis.selectors.DefaultSelector", return_value=selector
+    with (
+        patch("redis._parsers.hiredis._HAS_POLL", False),
+        patch(
+            "redis._parsers.hiredis.selectors.DefaultSelector", return_value=selector
+        ),
     ):
         assert _socket_can_read(sock, timeout=0.001) is True
 
@@ -133,9 +157,10 @@ def test_hiredis_socket_can_read_uses_default_selector():
 def test_hiredis_socket_can_read_handles_high_file_descriptor():
     fcntl = pytest.importorskip("fcntl")
 
-    with selectors.DefaultSelector() as selector:
-        if isinstance(selector, selectors.SelectSelector):
-            pytest.skip("Default selector uses select.select")
+    if not hasattr(select, "poll"):
+        with selectors.DefaultSelector() as selector:
+            if isinstance(selector, selectors.SelectSelector):
+                pytest.skip("No poll and default selector uses select.select")
 
     read_fd, write_fd = os.pipe()
     high_read_fd = None
@@ -151,6 +176,42 @@ def test_hiredis_socket_can_read_handles_high_file_descriptor():
         os.close(write_fd)
         if high_read_fd is not None and high_read_fd != read_fd:
             os.close(high_read_fd)
+
+
+@pytest.mark.fixed_client
+def test_hiredis_socket_can_read_under_fd_exhaustion():
+    # Readiness checks run on every connection acquisition, and fd pressure is
+    # what pushes sockets onto high fds in the first place, so they must not
+    # allocate file descriptors themselves. A per-check epoll/kqueue selector
+    # raises OSError (EMFILE) here; the poll() implementation passes.
+    resource = pytest.importorskip("resource")
+    if not hasattr(select, "poll"):
+        pytest.skip("select.poll not available on this platform")
+
+    readable, writable = socket.socketpair()
+    empty_sock, peer = socket.socketpair()
+    writable.sendall(b"x")
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    held_fds = []
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (min(soft, 256), hard))
+        try:
+            while True:
+                held_fds.append(os.dup(0))
+        except OSError:
+            pass  # fd table is now full
+
+        assert _socket_can_read(readable, timeout=0) is True
+        assert _socket_can_read(empty_sock, timeout=0) is False
+    finally:
+        for fd in held_fds:
+            os.close(fd)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+        readable.close()
+        writable.close()
+        empty_sock.close()
+        peer.close()
 
 
 def test_hiredis_can_read_does_not_decide_disable_decoding():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -115,14 +115,14 @@ def test_hiredis_can_read_checks_socket_readiness_without_reading():
 
 
 @pytest.mark.fixed_client
+@pytest.mark.skipif(
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
+)
 @pytest.mark.parametrize(
     "timeout,expected_poll_timeout",
     [(0, 0), (0.001, 1.0), (None, None)],
 )
 def test_hiredis_socket_can_read_uses_poll(timeout, expected_poll_timeout):
-    if not hasattr(select, "poll"):
-        pytest.skip("select.poll not available on this platform")
-
     sock = Mock(spec=["fileno"])
     poller = Mock()
     poller.poll.return_value = [(7, select.POLLIN)]
@@ -151,16 +151,18 @@ def test_hiredis_socket_can_read_falls_back_to_default_selector():
 
     selector.register.assert_called_once_with(sock, selectors.EVENT_READ)
     selector.select.assert_called_once_with(0.001)
+    # The selector must be used as a context manager so its fd is released; if
+    # the `with` block is dropped from the implementation, this catches it.
+    selector.__exit__.assert_called_once()
 
 
 @pytest.mark.fixed_client
+@pytest.mark.skipif(
+    not hasattr(select, "poll"),
+    reason="No select.poll; default selector falls back to select.select",
+)
 def test_hiredis_socket_can_read_handles_high_file_descriptor():
     fcntl = pytest.importorskip("fcntl")
-
-    if not hasattr(select, "poll"):
-        with selectors.DefaultSelector() as selector:
-            if isinstance(selector, selectors.SelectSelector):
-                pytest.skip("No poll and default selector uses select.select")
 
     read_fd, write_fd = os.pipe()
     high_read_fd = None
@@ -179,14 +181,19 @@ def test_hiredis_socket_can_read_handles_high_file_descriptor():
 
 
 @pytest.mark.fixed_client
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
+)
 def test_hiredis_socket_can_read_under_fd_exhaustion():
     # Readiness checks run on every connection acquisition, and fd pressure is
     # what pushes sockets onto high fds in the first place, so they must not
     # allocate file descriptors themselves. A per-check epoll/kqueue selector
     # raises OSError (EMFILE) here; the poll() implementation passes.
+    #
+    # RLIMIT_NOFILE is process-wide, so @pytest.mark.forked runs this in its own
+    # process to avoid starving other threads/tests of file descriptors.
     resource = pytest.importorskip("resource")
-    if not hasattr(select, "poll"):
-        pytest.skip("select.poll not available on this platform")
 
     readable, writable = socket.socketpair()
     empty_sock, peer = socket.socketpair()


### PR DESCRIPTION
Follow-up to #4115, which fixed the `ValueError: filedescriptor out of range in select()` in the hiredis parser by replacing `select.select()` with `selectors.DefaultSelector()`. This relates also to #4117

The selector approach has a residual failure mode: `DefaultSelector` resolves to `EpollSelector` on Linux and `KqueueSelector` on macOS, both of which **allocate a new file descriptor on every call**. `_socket_can_read()` constructs a fresh selector per readiness check, and `Connection.can_read()` runs on every connection acquisition — so every command now allocates (and frees) an fd just to check readiness.

This matters because fd pressure is exactly the condition that triggers this bug class: a socket only lands on fd >= 1024 in a process holding many descriptors. In a process at or near `RLIMIT_NOFILE`, the readiness check itself now fails with `OSError: [Errno 24] Too many open files` (raised from `epoll_create`/`kqueue` inside `selectors.py`), so a worker that runs out of fds loses the ability to talk to Redis entirely even though its connection socket is healthy.

This PR switches `_socket_can_read()` to `select.poll()`, which:

- has no `FD_SETSIZE` limit (the original bug stays fixed);
- allocates **no** file descriptor — the poll set lives in the syscall arguments, not in a kernel object — so readiness checks keep working under fd exhaustion;
- avoids constructing a selector object per check on the hot path.

Behaviour is preserved: `timeout` seconds is converted to poll's milliseconds, `timeout=0` remains a non-blocking check and `timeout=None` blocks forever; `poll()` always reports `POLLHUP`/`POLLERR`/`POLLNVAL` regardless of the registered mask, so a closed or errored socket still counts as "readable", matching the previous `select()`/selector semantics. On Windows, where `select.poll` is unavailable, the `selectors.DefaultSelector` path from #4115 is retained as the fallback (Windows is not subject to the Unix `FD_SETSIZE` value limit).

The async hiredis parser is unaffected — it reads via asyncio streams and performs no `select`/`poll` calls.

### Changes

- `redis/_parsers/hiredis.py`: `_socket_can_read()` prefers `select.poll()` when available; the selector-based check remains as the Windows fallback.
- `tests/test_connection.py`:
  - `test_hiredis_socket_can_read_uses_poll` (parametrized) — verifies the poll path and the seconds-to-milliseconds timeout conversion for `0`, `0.001`, and `None`.
  - `test_hiredis_socket_can_read_falls_back_to_default_selector` — the existing selector test from #4115, updated to patch `_HAS_POLL = False` so it exercises the fallback path.
  - `test_hiredis_socket_can_read_handles_high_file_descriptor` — kept from #4115; skip condition updated for the new branch order.
  - `test_hiredis_socket_can_read_under_fd_exhaustion` (new) — lowers `RLIMIT_NOFILE`, fills the fd table via `os.dup()` until `EMFILE`, then asserts readiness checks still work for both a readable and an empty socket pair. This test **fails with `OSError: [Errno 24]` against current `master`** and passes with this change.

### How tested

- All hiredis `can_read` unit tests pass (none require a running server).
- Verified the new fd-exhaustion regression test catches the issue: with `redis/_parsers/hiredis.py` reverted to `master`, it fails with `OSError: [Errno 24] Too many open files` raised from `selectors.py`; with this change it passes.
- `ruff check`, `ruff format --check`, and `vulture redis whitelist.py --min-confidence 80` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection hot-path I/O readiness for all sync hiredis users; behavior is intended to match prior semantics but poll vs selector edge cases matter under load and fd pressure.
> 
> **Overview**
> **Hiredis socket readiness** (`_socket_can_read`) now prefers **`select.poll()`** on platforms where it exists, instead of creating a **`selectors.DefaultSelector`** on every check. That keeps the fix for high fds (no `FD_SETSIZE` / `select.select` limit) while avoiding an extra kernel fd per readiness probe—important because `can_read()` runs on the hot path and fd exhaustion was causing **`EMFILE`** when epoll/kqueue selectors were allocated.
> 
> On **Windows** (no `poll`), behavior stays on the **DefaultSelector** fallback. Timeouts are still converted to poll milliseconds; **`timeout=0`** / **`None`** semantics are unchanged.
> 
> **Tests** add poll-path coverage (including timeout conversion), force the selector fallback via `_HAS_POLL`, and a **forked** regression that fills the fd table and asserts readiness checks still work. **`pytest-forked`** was added to dev requirements for that test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b1c859b18aab2304932f8611188932e8caecd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->