### PR TITLE
fix(asyncio): prevent Pipeline.reset() connection leak on cancellation

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1680,26 +1680,28 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
     async def reset(self):
         self.command_stack = []
         self.scripts = set()
-        # make sure to reset the connection state in the event that we were
-        # watching something
-        if self.watching and self.connection:
-            try:
-                # call this manually since our unwatch or
-                # immediate_execute_command methods can call reset()
-                await self.connection.send_command("UNWATCH")
-                await self.connection.read_response()
-            except ConnectionError:
-                # disconnect will also remove any previous WATCHes
-                if self.connection:
-                    await self.connection.disconnect()
-        # clean up the other instance attributes
-        self.watching = False
-        self.explicit_transaction = False
-        # we can safely return the connection to the pool here since we're
-        # sure we're no longer WATCHing anything
-        if self.connection:
-            await self.connection_pool.release(self.connection)
-            self.connection = None
+        try:
+            # make sure to reset the connection state in the event that we were
+            # watching something
+            if self.watching and self.connection:
+                try:
+                    # call this manually since our unwatch or
+                    # immediate_execute_command methods can call reset()
+                    await self.connection.send_command("UNWATCH")
+                    await self.connection.read_response()
+                except ConnectionError:
+                    # disconnect will also remove any previous WATCHes
+                    if self.connection:
+                        await self.connection.disconnect()
+            # clean up the other instance attributes
+            self.watching = False
+            self.explicit_transaction = False
+        finally:
+            # we can safely return the connection to the pool here since we're
+            # sure we're no longer WATCHing anything
+            if self.connection:
+                await self.connection_pool.release(self.connection)
+                self.connection = None
 
     async def aclose(self) -> None:
         """Alias for reset(), a standard method name for cleanup"""


### PR DESCRIPTION
## Description

Wrap the UNWATCH/reset logic in \Pipeline.reset()\ with try/finally so \connection_pool.release()\ always runs even when the UNWATCH \ead_response()\ is cancelled.

Without this, a \CancelledError\ delivered at \ead_response()\ during \eset()\ would bypass the release, stranding the connection in \_in_use_connections\ forever and eventually exhausting the pool.

Closes #4121

## Changes

- \edis/asyncio/client.py\: Wrapped \Pipeline.reset()\ cleanup attributes and UNWATCH logic in try/finally, moving the \connection_pool.release()\ into the finally block.

## Testing

Ran the reproduction script from #4121:

\\\
Before:  [ConnectionPool] in_use=1 available=0 leaked=True
         [BlockingPool] in_use=1 available=0 leaked=True
         [BlockingPool] pool exhausted
After:   [ConnectionPool] in_use=0 available=1 leaked=False
         [BlockingPool] in_use=0 available=1 leaked=False
         OK: Pool recovered, acquired connection successfully
\\\

## Notes

The sync \edis/client.py\ Pipeline reset has the same pattern but is not affected by \CancelledError\, so the fix is scoped to the async path only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async pipeline/pool lifecycle; behavior on cancellation changes but scope is a single method and aligns release with other cleanup patterns.
> 
> **Overview**
> Fixes a **connection pool leak** when async `Pipeline.reset()` is interrupted (e.g. `asyncio.CancelledError` during `read_response()` while unwinding a `WATCH`).
> 
> UNWATCH and state cleanup stay in a `try` block; **`connection_pool.release()`** and clearing `self.connection` move into **`finally`**, so the borrowed connection is always returned even if cleanup is cancelled mid-flight.
> 
> This matters on paths that call `reset()` (`execute()`’s `finally`, `__aexit__`, `aclose()`, and error handlers during `WATCH`), where a stranded connection could leave `_in_use_connections` stuck and eventually exhaust the pool. Change is **async-only**; sync `Pipeline.reset()` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27957c5ec3ba93838be27e27fd309dcb4d09f3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->