### PR TITLE
fix(asyncio): release pooled connection when Pipeline.reset() is cancelled

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1680,26 +1680,38 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
     async def reset(self):
         self.command_stack = []
         self.scripts = set()
-        # make sure to reset the connection state in the event that we were
-        # watching something
-        if self.watching and self.connection:
-            try:
-                # call this manually since our unwatch or
-                # immediate_execute_command methods can call reset()
-                await self.connection.send_command("UNWATCH")
-                await self.connection.read_response()
-            except ConnectionError:
-                # disconnect will also remove any previous WATCHes
-                if self.connection:
-                    await self.connection.disconnect()
-        # clean up the other instance attributes
-        self.watching = False
-        self.explicit_transaction = False
-        # we can safely return the connection to the pool here since we're
-        # sure we're no longer WATCHing anything
-        if self.connection:
-            await self.connection_pool.release(self.connection)
-            self.connection = None
+        try:
+            # make sure to reset the connection state in the event that we were
+            # watching something
+            if self.watching and self.connection:
+                try:
+                    # call this manually since our unwatch or
+                    # immediate_execute_command methods can call reset()
+                    await self.connection.send_command("UNWATCH")
+                    await self.connection.read_response()
+                except ConnectionError:
+                    # disconnect will also remove any previous WATCHes
+                    if self.connection:
+                        await self.connection.disconnect()
+                except asyncio.CancelledError:
+                    # Disconnect so any unread UNWATCH reply does not get
+                    # served to the next caller that takes the connection.
+                    if self.connection:
+                        await self.connection.disconnect()
+                    raise
+        finally:
+            self.watching = False
+            self.explicit_transaction = False
+            # We can safely return the connection to the pool here since we're
+            # sure we're no longer WATCHing anything. Detach self.connection
+            # before awaiting release: if a second cancel aborts the await,
+            # the pipeline must not be left holding a reference to a
+            # connection that is being returned to the pool. Shield the
+            # release itself so a second cancel cannot split the pool's
+            # internal in-use/available bookkeeping mid-update.
+            if self.connection:
+                connection, self.connection = self.connection, None
+                await asyncio.shield(self.connection_pool.release(connection))
 
     async def aclose(self) -> None:
         """Alias for reset(), a standard method name for cleanup"""

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -3170,35 +3170,50 @@ class TransactionStrategy(AbstractStrategy):
     async def reset(self):
         self._command_queue = []
 
-        # make sure to reset the connection state in the event that we were
-        # watching something
-        if self._transaction_connection:
-            try:
-                if self._watching:
-                    # call this manually since our unwatch or
-                    # immediate_execute_command methods can call reset()
-                    await self._transaction_connection.send_command("UNWATCH")
-                    await self._transaction_connection.read_response()
-                # we can safely return the connection to the pool here since we're
-                # sure we're no longer WATCHing anything
-                await self._transaction_node.disconnect_if_needed(
-                    self._transaction_connection
+        try:
+            # make sure to reset the connection state in the event that we
+            # were watching something
+            if self._transaction_connection:
+                try:
+                    if self._watching:
+                        # call this manually since our unwatch or
+                        # immediate_execute_command methods can call reset()
+                        await self._transaction_connection.send_command("UNWATCH")
+                        await self._transaction_connection.read_response()
+                except self.CONNECTION_ERRORS:
+                    # disconnect will also remove any previous WATCHes
+                    if self._transaction_connection:
+                        await self._transaction_connection.disconnect()
+                except asyncio.CancelledError:
+                    # Disconnect so any unread UNWATCH reply does not get
+                    # served to the next caller that takes the connection.
+                    if self._transaction_connection:
+                        await self._transaction_connection.disconnect()
+                    raise
+                else:
+                    # On the happy path, honor lazy reconnect before release.
+                    await self._transaction_node.disconnect_if_needed(
+                        self._transaction_connection
+                    )
+        finally:
+            # Always return the connection to the node's free queue, even on
+            # cancellation, so cancelled resets do not leak pooled
+            # connections. Detach the reference before releasing so the
+            # strategy never holds a pointer to a returned connection.
+            # ClusterNode.release is synchronous, so no shield is required.
+            if self._transaction_connection and self._transaction_node:
+                connection, self._transaction_connection = (
+                    self._transaction_connection,
+                    None,
                 )
-                self._transaction_node.release(self._transaction_connection)
-                self._transaction_connection = None
-            except self.CONNECTION_ERRORS:
-                # disconnect will also remove any previous WATCHes
-                if self._transaction_connection and self._transaction_node:
-                    await self._transaction_connection.disconnect()
-                    self._transaction_node.release(self._transaction_connection)
-                    self._transaction_connection = None
-
-        # clean up the other instance attributes
-        self._transaction_node = None
-        self._watching = False
-        self._explicit_transaction = False
-        self._pipeline_slots = set()
-        self._executing = False
+                self._transaction_node.release(connection)
+            # clean up the other instance attributes
+            self._transaction_connection = None
+            self._transaction_node = None
+            self._watching = False
+            self._explicit_transaction = False
+            self._pipeline_slots = set()
+            self._executing = False
 
     def multi(self):
         if self._explicit_transaction:

--- a/tests/test_asyncio/test_cluster_transaction.py
+++ b/tests/test_asyncio/test_cluster_transaction.py
@@ -1,4 +1,6 @@
+import asyncio
 from typing import Tuple
+from unittest import mock
 from unittest.mock import patch, Mock
 
 import pytest
@@ -110,6 +112,41 @@ class TestClusterTransaction:
             pipe.multi()
             pipe.set("a", int(a) + 1)
             assert await pipe.execute() == [True]
+
+    @pytest.mark.onlycluster
+    async def test_pipeline_reset_releases_connection_when_cancelled(self, r):
+        # Regression test for https://github.com/redis/redis-py/issues/4121
+        # (cluster variant): cancelling reset() while it awaits the UNWATCH
+        # reply must still return the node-pooled connection.
+        await r.set("a", 0)
+
+        pipe = r.pipeline(transaction=True)
+        await pipe.watch("a")
+
+        strategy = pipe._execution_strategy
+        leased = strategy._transaction_connection
+        node = strategy._transaction_node
+        assert leased is not None
+        assert node is not None
+        assert leased not in node._free
+
+        started = asyncio.Event()
+
+        async def hang(*_args, **_kwargs):
+            started.set()
+            await asyncio.sleep(60)
+
+        with mock.patch.object(leased, "read_response", side_effect=hang):
+            task = asyncio.ensure_future(pipe.reset())
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert strategy._transaction_connection is None
+        assert strategy._transaction_node is None
+        assert strategy._watching is False
+        assert leased in node._free
 
     @pytest.mark.onlycluster
     async def test_retry_transaction_during_unfinished_slot_migration(self, r):

--- a/tests/test_asyncio/test_pipeline.py
+++ b/tests/test_asyncio/test_pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import pytest
@@ -93,6 +94,37 @@ class TestPipeline:
                 await pipe.execute()
 
             assert await r.get("a") == b"bad"
+
+    @pytest.mark.onlynoncluster
+    async def test_pipeline_reset_releases_connection_when_cancelled(self, r):
+        # Regression test for https://github.com/redis/redis-py/issues/4121:
+        # cancelling reset() while it awaits the UNWATCH reply must still
+        # return the pooled connection to the pool.
+        await r.set("a", 0)
+
+        pool = r.connection_pool
+        pipe = r.pipeline()
+        await pipe.watch("a")
+        assert pipe.connection is not None
+        assert pipe.connection in pool._in_use_connections
+        leased = pipe.connection
+
+        # Block read_response on the UNWATCH reply so we can cancel mid-call.
+        started = asyncio.Event()
+
+        async def hang(*_args, **_kwargs):
+            started.set()
+            await asyncio.sleep(60)
+
+        with mock.patch.object(leased, "read_response", side_effect=hang):
+            task = asyncio.ensure_future(pipe.reset())
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert pipe.connection is None
+        assert leased not in pool._in_use_connections
 
     async def test_exec_error_in_response(self, r):
         """


### PR DESCRIPTION
Pipeline.reset() in both the standalone and cluster async clients only caught ConnectionError (and CONNECTION_ERRORS in the cluster path) around the UNWATCH send/read. 
If the surrounding task was cancelled while awaiting the UNWATCH reply, CancelledError bypassed the handler and skipped the subsequent connection_pool.release() / ClusterNode.release() call, pinning the connection in the pool's in-use list forever. Repeated cancellations exhausted a BlockingConnectionPool with "No connection available." errors.

Standalone (redis/asyncio/client.py, Pipeline.reset):
- Wrap watched-state cleanup in try/finally and handle CancelledError
  explicitly: disconnect (so any unread UNWATCH reply does not poison
  the next caller), then re-raise.
- Move pool release into the finally; detach self.connection before
  awaiting; wrap the release in asyncio.shield so a second cancel
  cannot split the pool's in-use/available bookkeeping mid-update.

Cluster (redis/asyncio/cluster.py, TransactionStrategy.reset):
- Same structural treatment. ClusterNode.release is synchronous, so no
  shield is required; the finally clears _transaction_connection,
  _transaction_node, and the rest of the state on every exit path.


Fixes #4121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async pipeline teardown and connection-pool release on cancellation paths; incorrect shield/detach logic could still leak connections or corrupt pool state, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **connection pool exhaustion** when `Pipeline.reset()` is cancelled mid-`UNWATCH` (issue #4121). Previously only `ConnectionError` was handled during UNWATCH cleanup; **`asyncio.CancelledError`** skipped `release()`, leaving connections stuck in the pool’s in-use set.
> 
> **Standalone** `Pipeline.reset()` now uses `try`/`finally` so pool release always runs. On cancel it **disconnects** (avoids a stale UNWATCH reply on reuse), re-raises, **clears `self.connection` before** `release()`, and **`asyncio.shield`s** `connection_pool.release()` so a second cancel cannot corrupt pool bookkeeping.
> 
> **Cluster** `TransactionStrategy.reset()` gets the same structure: cancel/connection-error paths disconnect; the happy path still calls `disconnect_if_needed` before release; **`finally`** always calls synchronous `ClusterNode.release()` and clears transaction state.
> 
> Regression tests cancel `reset()` while `read_response` is hung and assert the leased connection returns to the pool / node free queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72fded7d86158a048a92b3b896447bc2eea35fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->