### PR TITLE
perf: cache default response callbacks instead of rebuilding on every client init (standalone sync and async clients)

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -36,7 +36,7 @@ from redis._defaults import (
     DEFAULT_SOCKET_READ_SIZE,
     DEFAULT_SOCKET_TIMEOUT,
 )
-from redis._parsers.helpers import bool_ok, get_response_callbacks
+from redis._parsers.helpers import bool_ok
 from redis.asyncio.connection import (
     Connection,
     ConnectionPool,
@@ -55,7 +55,7 @@ from redis.client import (
     EMPTY_RESPONSE,
     NEVER_DECODE,
     AbstractRedis,
-    CaseInsensitiveDict,
+    _get_default_response_callbacks,
 )
 from redis.commands import (
     AsyncCoreCommands,
@@ -434,12 +434,10 @@ class Redis(
         self.connection: Optional[Connection] = None
 
         connection_kwargs = self.connection_pool.connection_kwargs
-        self.response_callbacks = CaseInsensitiveDict(
-            get_response_callbacks(
-                user_protocol=connection_kwargs.get("protocol"),
-                legacy_responses=connection_kwargs.get("legacy_responses", True),
-            )
-        )
+        self.response_callbacks = _get_default_response_callbacks(
+            connection_kwargs.get("protocol"),
+            connection_kwargs.get("legacy_responses", True),
+        ).copy()
 
         # If using a single connection client, we need to lock creation-of and use-of
         # the client in order to avoid race conditions such as using asyncio.gather

--- a/redis/client.py
+++ b/redis/client.py
@@ -3,6 +3,7 @@ import logging
 import re
 import threading
 import time
+from functools import lru_cache
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
@@ -138,6 +139,34 @@ class CaseInsensitiveDict(dict):
     def update(self, data):
         data = CaseInsensitiveDict(data)
         super().update(data)
+
+    def copy(self) -> "CaseInsensitiveDict":
+        # Keys are already upper-cased; bypass __init__/__setitem__ so we don't
+        # re-run ``str.upper`` on every entry when copying (see #3624).
+        new = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
+        dict.update(new, self)
+        return new
+
+
+@lru_cache(maxsize=None)
+def _get_default_response_callbacks(
+    user_protocol: Optional[Union[int, str]],
+    legacy_responses: bool,
+) -> CaseInsensitiveDict:
+    """Build the canonical response-callback table for a given
+    ``(protocol, legacy_responses)`` combination exactly once.
+
+    The returned mapping is shared and MUST NOT be mutated; callers take a cheap
+    :meth:`CaseInsensitiveDict.copy` so each client owns an independent, mutable
+    mapping. This avoids rebuilding and re-upper-casing the ~165-entry callback
+    table on every client construction (see #3624).
+    """
+    return CaseInsensitiveDict(
+        get_response_callbacks(
+            user_protocol=user_protocol,
+            legacy_responses=legacy_responses,
+        )
+    )
 
 
 class AbstractRedis:
@@ -511,12 +540,10 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             )
 
         connection_kwargs = self.connection_pool.connection_kwargs
-        self.response_callbacks = CaseInsensitiveDict(
-            get_response_callbacks(
-                user_protocol=connection_kwargs.get("protocol"),
-                legacy_responses=connection_kwargs.get("legacy_responses", True),
-            )
-        )
+        self.response_callbacks = _get_default_response_callbacks(
+            connection_kwargs.get("protocol"),
+            connection_kwargs.get("legacy_responses", True),
+        ).copy()
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_response_callbacks_cache.py
+++ b/tests/test_response_callbacks_cache.py
@@ -1,0 +1,215 @@
+"""Tests for the cached canonical response-callback table (issue #3624).
+
+``Redis.__init__`` and ``redis.asyncio.Redis.__init__`` no longer rebuild and
+re-upper-case the ~165-entry response-callback table on every construction.
+Instead the canonical ``CaseInsensitiveDict`` is memoized once per
+``(protocol, legacy_responses)`` combination via ``lru_cache`` and each client
+receives a cheap ``CaseInsensitiveDict.copy()``.
+
+These tests assert the correctness invariants that the refactor must preserve.
+They are offline: clients are constructed with no Redis server
+(``single_connection_client`` is left at its default ``False`` so no connection
+is opened) and are closed in ``finally``.
+"""
+
+import pytest
+
+import redis
+import redis.asyncio
+from redis._parsers.helpers import get_response_callbacks
+from redis.client import (
+    CaseInsensitiveDict,
+    _get_default_response_callbacks,
+)
+
+# ``None`` represents the "default" case where the caller does not pass
+# ``protocol`` at all and the client resolves the wire to RESP3.
+_PROTOCOL_VARIANTS = [
+    pytest.param(2, id="resp2"),
+    pytest.param(3, id="resp3"),
+    pytest.param(None, id="default"),
+]
+_LEGACY_VARIANTS = [
+    pytest.param(True, id="legacy"),
+    pytest.param(False, id="unified"),
+]
+
+
+def _make_client_kwargs(protocol, legacy_responses):
+    """Build the kwargs dict, omitting ``protocol`` for the default case."""
+    kwargs = {"legacy_responses": legacy_responses}
+    if protocol is not None:
+        kwargs["protocol"] = protocol
+    return kwargs
+
+
+# Invariant 1: identical contents (value-by-identity) against the pre-refactor
+# construction ``CaseInsensitiveDict(get_response_callbacks(...))``, across the
+# full protocol x legacy matrix.
+@pytest.mark.fixed_client
+@pytest.mark.parametrize("legacy_responses", _LEGACY_VARIANTS)
+@pytest.mark.parametrize("protocol", _PROTOCOL_VARIANTS)
+def test_contents_match_old_construction_by_identity(protocol, legacy_responses):
+    # Arrange: reconstruct the table the old code path produced.
+    expected = CaseInsensitiveDict(
+        get_response_callbacks(
+            user_protocol=protocol,
+            legacy_responses=legacy_responses,
+        )
+    )
+
+    # Act
+    client = redis.Redis(**_make_client_kwargs(protocol, legacy_responses))
+    try:
+        actual = client.response_callbacks
+
+        # Assert: same keys, same number of entries, each value identical object.
+        assert isinstance(actual, CaseInsensitiveDict)
+        assert len(actual) == len(expected)
+        assert set(actual.keys()) == set(expected.keys())
+        for command, callback in expected.items():
+            assert actual[command] is callback, (
+                f"callback mismatch for {command!r} "
+                f"(protocol={protocol!r}, legacy_responses={legacy_responses!r})"
+            )
+    finally:
+        client.close()
+
+
+# Invariant 2: case-insensitive lookups preserved on the per-instance dict,
+# including newly-registered callbacks via ``set_response_callback``.
+@pytest.mark.fixed_client
+def test_case_insensitive_lookups_preserved():
+    client = redis.Redis()
+    try:
+        rc = client.response_callbacks
+
+        # Pre-existing key resolves identically regardless of case.
+        assert rc["geohash"] is rc["GEOHASH"]
+        assert rc["geohash"] is rc["GeOhAsH"]
+        assert "geohash" in rc
+        assert "GEOHASH" in rc
+
+        # Newly registered callback is also case-insensitive.
+        def _cb(x):
+            return x
+
+        client.set_response_callback("FOO", _cb)
+        assert rc["FOO"] is _cb
+        assert rc["foo"] is _cb
+        assert "foo" in rc
+    finally:
+        client.close()
+
+
+# Invariant 3: mutation isolation. Mutating one client must not affect another
+# same-combo client, nor the shared cached canonical table.
+@pytest.mark.fixed_client
+def test_mutation_isolation_between_clients_and_canonical():
+    c1 = redis.Redis()
+    c2 = redis.Redis()
+    try:
+        rc1 = c1.response_callbacks
+        rc2 = c2.response_callbacks
+
+        # Same combo -> equal contents but distinct objects.
+        assert rc1 == rc2
+        assert rc1 is not rc2
+
+        # The shared canonical for the same (protocol=None, legacy=True) combo.
+        canonical = _get_default_response_callbacks(None, True)
+        assert rc1 is not canonical
+        assert rc2 is not canonical
+        canonical_len_before = len(canonical)
+
+        # Mutate c1 only.
+        def _cb(x):
+            return x
+
+        c1.set_response_callback("CACHE_TEST_CMD", _cb)
+
+        assert "CACHE_TEST_CMD" in rc1
+        assert "CACHE_TEST_CMD" not in rc2
+        assert "CACHE_TEST_CMD" not in canonical
+        assert len(canonical) == canonical_len_before
+    finally:
+        c1.close()
+        c2.close()
+
+
+# Invariant 4: ``copy()`` returns a ``CaseInsensitiveDict`` (not a plain dict)
+# and is independent of the source.
+@pytest.mark.fixed_client
+def test_copy_returns_caseinsensitivedict_and_is_independent():
+    canonical = _get_default_response_callbacks(None, True)
+
+    copied = canonical.copy()
+
+    # Correct type and equal contents.
+    assert isinstance(copied, CaseInsensitiveDict)
+    assert type(copied) is CaseInsensitiveDict
+    assert copied == canonical
+    assert copied is not canonical
+
+    # Case-insensitivity survives the copy (bypassing __init__ must still leave
+    # keys upper-cased so __getitem__ resolves correctly).
+    assert copied["geohash"] is copied["GEOHASH"]
+
+    # Independence: mutating the copy does not touch the source.
+    canonical_len_before = len(canonical)
+    copied["EXTRA_ONLY_IN_COPY"] = lambda x: x
+    assert "EXTRA_ONLY_IN_COPY" in copied
+    assert "EXTRA_ONLY_IN_COPY" not in canonical
+    assert len(canonical) == canonical_len_before
+
+
+# Invariant 5: sync vs async parity. Both client stacks produce equal contents
+# (value-by-identity) for the same combo, across the full matrix.
+@pytest.mark.fixed_client
+@pytest.mark.parametrize("legacy_responses", _LEGACY_VARIANTS)
+@pytest.mark.parametrize("protocol", _PROTOCOL_VARIANTS)
+async def test_sync_async_parity(protocol, legacy_responses):
+    sync_client = redis.Redis(**_make_client_kwargs(protocol, legacy_responses))
+    async_client = redis.asyncio.Redis(
+        **_make_client_kwargs(protocol, legacy_responses)
+    )
+    try:
+        sync_rc = sync_client.response_callbacks
+        async_rc = async_client.response_callbacks
+
+        assert isinstance(async_rc, CaseInsensitiveDict)
+        assert set(sync_rc.keys()) == set(async_rc.keys())
+        for command, callback in sync_rc.items():
+            assert async_rc[command] is callback, (
+                f"sync/async callback mismatch for {command!r} "
+                f"(protocol={protocol!r}, legacy_responses={legacy_responses!r})"
+            )
+    finally:
+        sync_client.close()
+        await async_client.aclose()
+
+
+# Invariant 6: two same-combo clients share equal-but-not-identical dicts (the
+# whole point of the per-instance ``copy()``), for both sync and async stacks.
+@pytest.mark.fixed_client
+def test_same_combo_sync_clients_equal_not_identical():
+    c1 = redis.Redis(protocol=3, legacy_responses=False)
+    c2 = redis.Redis(protocol=3, legacy_responses=False)
+    try:
+        assert c1.response_callbacks == c2.response_callbacks
+        assert c1.response_callbacks is not c2.response_callbacks
+    finally:
+        c1.close()
+        c2.close()
+
+
+@pytest.mark.fixed_client
+async def test_same_combo_async_clients_equal_not_identical():
+    c1 = redis.asyncio.Redis(protocol=3, legacy_responses=False)
+    c2 = redis.asyncio.Redis(protocol=3, legacy_responses=False)
+    try:
+        assert c1.response_callbacks == c2.response_callbacks
+        assert c1.response_callbacks is not c2.response_callbacks
+    finally:
+        await c1.aclose()
+        await c2.aclose()


### PR DESCRIPTION
Fixes #3624.

`Redis.__init__` (and the async one) builds the whole response-callback table from scratch on every instantiation:

```python
self.response_callbacks = CaseInsensitiveDict(
    get_response_callbacks(
        user_protocol=connection_kwargs.get("protocol"),
        legacy_responses=connection_kwargs.get("legacy_responses", True),
    )
)
```

`get_response_callbacks()` assembles a ~165-key dict, and then `CaseInsensitiveDict.__init__` walks the whole thing again calling `.upper()` on every key, even though those keys are already uppercase. The result only depends on `(protocol, legacy_responses)`, so every client after the first is repeating identical work. In the common "check out a client per request from a shared pool" pattern (FastAPI and friends) this wrap is around 44us, which works out to roughly 80% of the cost of constructing a `Redis(connection_pool=...)`.

## What this changes

Build the canonical table once per `(protocol, legacy_responses)` with `functools.lru_cache`, and hand each client a cheap `CaseInsensitiveDict.copy()` that skips the redundant re-casing:

```python
def copy(self) -> "CaseInsensitiveDict":
    # Keys are already upper-cased; bypass __init__/__setitem__ so we don't
    # re-run str.upper on every entry when copying (see #3624).
    new = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
    dict.update(new, self)
    return new


@lru_cache(maxsize=None)
def _get_default_response_callbacks(user_protocol, legacy_responses):
    return CaseInsensitiveDict(
        get_response_callbacks(
            user_protocol=user_protocol,
            legacy_responses=legacy_responses,
        )
    )
```

Each instance still gets its own mutable dict, so `set_response_callback`, module command registration, and pipelines (which share the client's dict by reference) all behave exactly as before. The cached canonical is never mutated.

## Numbers

Quick local benchmark, 165 callbacks, RESP3/legacy default:

| | before | after |
|---|---|---|
| callback table wrap | ~44us | ~0.7us |
| `Redis(connection_pool=shared)` ctor | ~55us | ~11us |

So roughly 4-5x off client construction in the shared-pool case, and the callback step itself drops by about 40x. The number of `(protocol, legacy_responses)` combinations is tiny and bounded, so the cache stays small.

Repro:

```python
import timeit, redis
pool = redis.ConnectionPool()
print(timeit.timeit(lambda: redis.Redis(connection_pool=pool), number=10000))
```

## Scope and compatibility

Public API and callback contents are unchanged; this is purely about not redoing the same work on every construction. Limited to the base sync and async `Redis` clients. `RedisCluster` assembles its callbacks through a different path and is left alone here, though the same idea could apply as a follow-up.

## Testing

Added `tests/test_response_callbacks_cache.py` covering the invariants that need to hold:

- contents identical to the old `CaseInsensitiveDict(get_response_callbacks(...))` construction, value by identity, across the full `protocol` x `legacy_responses` matrix
- case-insensitive lookups still resolve (`d["geohash"] is d["GEOHASH"]`), including callbacks added later via `set_response_callback`
- mutation isolation: mutating one client's callbacks never leaks into another client with the same combo, and never touches the cached table
- `copy()` returns an independent `CaseInsensitiveDict`
- sync and async stacks produce the same table

Ran the full standalone `protocol` x `legacy_responses` matrix against a dockerized Redis 8 locally, plus `ruff check`, `ruff format --check`, and `vulture`. Everything passes except `test_psync` and `test_ssl_connection_without_ssl`, which fail the same way on an unmodified checkout in my environment (replica/stunnel setup), so they are unrelated to this change.
