### PR TITLE
Adding async SCH scenario tests.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -28,6 +28,7 @@ numpy>=1.24.0,<2.0 ; platform_python_implementation == "PyPy"
 
 redis-entraid==1.2.1
 pybreaker>=1.4.0
+aiohttp>=3.9.0
 
 xxhash==3.6.0
 

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -213,18 +213,23 @@ class AsyncMaintNotificationsPoolHandler:
         callback: _ScheduledCallback,
         *args: Any,
     ) -> None:
-        task = asyncio.create_task(self._run_after(delay, callback, *args))
+        # Record the absolute deadline now so that any lag between create_task
+        # and the task's first execution slice does not push the fire time out.
+        deadline = asyncio.get_running_loop().time() + delay
+        task = asyncio.create_task(self._run_after(deadline, callback, *args))
         self._scheduled_tasks.add(task)
         task.add_done_callback(self._scheduled_tasks.discard)
         task.add_done_callback(self._log_scheduled_task_result)
 
     async def _run_after(
         self,
-        delay: float,
+        deadline: float,
         callback: _ScheduledCallback,
         *args: Any,
     ) -> None:
-        await asyncio.sleep(delay)
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
         await callback(*args)
 
     async def cancel_scheduled_tasks(self) -> None:

--- a/tests/maint_notifications/test_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_cluster_maint_notifications_handling.py
@@ -409,35 +409,43 @@ class TestClusterMaintNotificationsHandler(TestClusterMaintNotificationsBase):
     def test_oss_maint_handler_propagation(self):
         """Test that OSSMaintNotificationsHandler is propagated to all connections."""
         cluster = self._create_cluster_client()
-        # Verify all nodes have the handler
-        for node in cluster.nodes_manager.nodes_cache.values():
-            assert node.redis_connection is not None
-            assert node.redis_connection.connection_pool is not None
-            for conn in (
-                *node.redis_connection.connection_pool._get_in_use_connections(),
-                *node.redis_connection.connection_pool._get_free_connections(),
-            ):
-                assert conn._oss_cluster_maint_notifications_handler is not None
-                self._validate_connection_handlers(
-                    conn, cluster, cluster.maint_notifications_config
-                )
+        try:
+            # Verify all nodes have the handler
+            for node in cluster.nodes_manager.nodes_cache.values():
+                assert node.redis_connection is not None
+                assert node.redis_connection.connection_pool is not None
+                for conn in (
+                    *node.redis_connection.connection_pool._get_in_use_connections(),
+                    *node.redis_connection.connection_pool._get_free_connections(),
+                ):
+                    assert conn._oss_cluster_maint_notifications_handler is not None
+                    self._validate_connection_handlers(
+                        conn, cluster, cluster.maint_notifications_config
+                    )
+        finally:
+            cluster.close()
 
     @skip_if_server_version_lt("7.4.0")
     def test_oss_maint_handler_propagation_cache_enabled(self):
         """Test that OSSMaintNotificationsHandler is propagated to all connections."""
         cluster = self._create_cluster_client(enable_cache=True)
-        # Verify all nodes have the handler
-        for node in cluster.nodes_manager.nodes_cache.values():
-            assert node.redis_connection is not None
-            assert node.redis_connection.connection_pool is not None
-            for conn in (
-                *node.redis_connection.connection_pool._get_in_use_connections(),
-                *node.redis_connection.connection_pool._get_free_connections(),
-            ):
-                assert conn._conn._oss_cluster_maint_notifications_handler is not None
-                self._validate_connection_handlers(
-                    conn._conn, cluster, cluster.maint_notifications_config
-                )
+        try:
+            # Verify all nodes have the handler
+            for node in cluster.nodes_manager.nodes_cache.values():
+                assert node.redis_connection is not None
+                assert node.redis_connection.connection_pool is not None
+                for conn in (
+                    *node.redis_connection.connection_pool._get_in_use_connections(),
+                    *node.redis_connection.connection_pool._get_free_connections(),
+                ):
+                    assert (
+                        conn._conn._oss_cluster_maint_notifications_handler is not None
+                    )
+                    self._validate_connection_handlers(
+                        conn._conn, cluster, cluster.maint_notifications_config
+                    )
+        finally:
+            cluster.close()
 
 
 class TestClusterMaintNotificationsHandlingBase(TestClusterMaintNotificationsBase):
@@ -604,31 +612,33 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
             relaxed_timeout=-1,  # This means the relaxed timeout is Disabled
         )
         cluster = self._create_cluster_client(maint_config=disabled_config)
+        try:
+            # warm up connection pools
+            self._warm_up_connection_pools(cluster, created_connections_count=3)
 
-        # warm up connection pools
-        self._warm_up_connection_pools(cluster, created_connections_count=3)
+            # send a notification to node 1
+            notification = RespTranslator.oss_maint_notification_to_resp(
+                "SMIGRATING 12 123,456,5000-7000"
+            )
+            self.proxy_helper.send_notification(notification)
 
-        # send a notification to node 1
-        notification = RespTranslator.oss_maint_notification_to_resp(
-            "SMIGRATING 12 123,456,5000-7000"
-        )
-        self.proxy_helper.send_notification(notification)
-
-        # validate no timeout is relaxed on any connection
-        self._validate_connections_states(
-            self.cluster,
-            [
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_1, changed_connections_count=0
-                ),
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_2, changed_connections_count=0
-                ),
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_3, changed_connections_count=0
-                ),
-            ],
-        )
+            # validate no timeout is relaxed on any connection
+            self._validate_connections_states(
+                self.cluster,
+                [
+                    ConnectionStateExpectation(
+                        node_port=NODE_PORT_1, changed_connections_count=0
+                    ),
+                    ConnectionStateExpectation(
+                        node_port=NODE_PORT_2, changed_connections_count=0
+                    ),
+                    ConnectionStateExpectation(
+                        node_port=NODE_PORT_3, changed_connections_count=0
+                    ),
+                ],
+            )
+        finally:
+            cluster.close()
 
     def test_receive_smigrated_notification(self):
         """Test receiving an OSS maintenance completed notification."""

--- a/tests/test_asyncio/test_scenario/async_fault_injector_client.py
+++ b/tests/test_asyncio/test_scenario/async_fault_injector_client.py
@@ -110,10 +110,10 @@ class AsyncREFaultInjector(AsyncFaultInjectorClient):
                 response.raise_for_status()
                 return await response.json()
 
-    async def _trigger_action(self, action_request: ActionRequest) -> Dict[str, Any]:
+    async def trigger_action(self, action_request: ActionRequest) -> Dict[str, Any]:
         return await self._make_request("POST", "/action", action_request.to_dict())
 
-    async def _get_action_status(self, action_id: str) -> Dict[str, Any]:
+    async def get_action_status(self, action_id: str) -> Dict[str, Any]:
         return await self._make_request("GET", f"/action/{action_id}")
 
     async def get_operation_result(
@@ -127,7 +127,7 @@ class AsyncREFaultInjector(AsyncFaultInjectorClient):
 
         while loop.time() - start_time < timeout:
             try:
-                status_result = await self._get_action_status(action_id)
+                status_result = await self.get_action_status(action_id)
                 operation_status = status_result.get("status", "unknown")
 
                 if operation_status in TaskStatuses.COMPLETED_STATUSES:
@@ -151,7 +151,7 @@ class AsyncREFaultInjector(AsyncFaultInjectorClient):
         bdb_config: Dict[str, Any],
     ) -> Dict[str, Any]:
         logging.debug(f"Creating database with config: {bdb_config}")
-        result = await self._trigger_action(
+        result = await self.trigger_action(
             ActionRequest(ActionType.CREATE_DATABASE, {"database_config": bdb_config})
         )
         action_id = result.get("action_id")
@@ -172,7 +172,7 @@ class AsyncREFaultInjector(AsyncFaultInjectorClient):
         bdb_id: int,
     ) -> Dict[str, Any]:
         logging.debug(f"Deleting database with id: {bdb_id}")
-        result = await self._trigger_action(
+        result = await self.trigger_action(
             ActionRequest(ActionType.DELETE_DATABASE, {"bdb_id": bdb_id})
         )
         action_id = result.get("action_id")
@@ -198,7 +198,7 @@ class AsyncREFaultInjector(AsyncFaultInjectorClient):
                     else self._current_db_id,
                 },
             )
-            trigger_result = await self._trigger_action(action)
+            trigger_result = await self.trigger_action(action)
             action_id = trigger_result.get("action_id")
             if not action_id:
                 raise ValueError(
@@ -285,7 +285,7 @@ class AsyncREFaultInjector(AsyncFaultInjectorClient):
         logging.debug(f"Executing {action_type.value} with parameters: {parameters}")
 
         try:
-            result = await self._trigger_action(ActionRequest(action_type, parameters))
+            result = await self.trigger_action(ActionRequest(action_type, parameters))
             logging.debug(f"Trigger effect action result: {result}")
             action_id = result.get("action_id")
             if not action_id:

--- a/tests/test_asyncio/test_scenario/async_fault_injector_client.py
+++ b/tests/test_asyncio/test_scenario/async_fault_injector_client.py
@@ -1,0 +1,395 @@
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+import aiohttp
+import pytest
+
+from tests.maint_notifications.proxy_server_helpers import (
+    ProxyInterceptorHelper,
+    SlotsRange,
+)
+from tests.test_scenario.fault_injector_client import (
+    ActionRequest,
+    ActionType,
+    DEFAULT_BDB_ID,
+    MockProxyFaultInjector,
+    SlotMigrateEffects,
+    TaskStatuses,
+    TopologyChangeStandaloneEffects,
+)
+
+
+class AsyncFaultInjectorClient(ABC):
+    """Async counterpart to FaultInjectorClient — all I/O methods are coroutines."""
+
+    @abstractmethod
+    async def get_operation_result(
+        self,
+        action_id: str,
+        timeout: int = 60,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def create_database(
+        self,
+        bdb_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def delete_database(
+        self,
+        bdb_id: int,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def find_database_id_by_name(
+        self,
+        database_name: str,
+        force_cluster_info_refresh: bool = True,
+    ) -> Optional[int]:
+        pass
+
+    @abstractmethod
+    def get_moving_ttl(self) -> int:
+        pass
+
+    @abstractmethod
+    async def get_slot_migrate_triggers(
+        self,
+        effect_name: SlotMigrateEffects,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def trigger_effect(
+        self,
+        endpoint_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: Optional[str] = None,
+        source_node: Optional[str] = None,
+        target_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+    ) -> str:
+        pass
+
+
+class AsyncREFaultInjector(AsyncFaultInjectorClient):
+    """Async fault injector client for Redis Enterprise cluster setup."""
+
+    MOVING_TTL = 15
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self._cluster_nodes_info: Optional[str] = None
+        self._current_db_id: Optional[int] = None
+
+    async def _make_request(
+        self, method: str, path: str, data: Optional[Dict] = None
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        headers = {"Content-Type": "application/json"} if data else {}
+        async with aiohttp.ClientSession() as session:
+            async with session.request(
+                method, url, json=data, headers=headers
+            ) as response:
+                if response.status == 422:
+                    error_body = await response.json()
+                    raise ValueError(f"Validation Error: {error_body}")
+                response.raise_for_status()
+                return await response.json()
+
+    async def _trigger_action(self, action_request: ActionRequest) -> Dict[str, Any]:
+        return await self._make_request("POST", "/action", action_request.to_dict())
+
+    async def _get_action_status(self, action_id: str) -> Dict[str, Any]:
+        return await self._make_request("GET", f"/action/{action_id}")
+
+    async def get_operation_result(
+        self,
+        action_id: str,
+        timeout: int = 60,
+    ) -> Dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
+        check_interval = 0.3
+
+        while loop.time() - start_time < timeout:
+            try:
+                status_result = await self._get_action_status(action_id)
+                operation_status = status_result.get("status", "unknown")
+
+                if operation_status in TaskStatuses.COMPLETED_STATUSES:
+                    logging.debug(
+                        f"Operation {action_id} completed with status: "
+                        f"{operation_status}"
+                    )
+                    if operation_status != TaskStatuses.SUCCESS:
+                        pytest.fail(f"Operation {action_id} failed: {status_result}")
+                    return status_result
+
+                await asyncio.sleep(check_interval)
+            except Exception as e:
+                logging.warning(f"Error checking operation status: {e}")
+                await asyncio.sleep(check_interval)
+
+        pytest.fail(f"Timeout waiting for operation {action_id} after {timeout}s")
+
+    async def create_database(
+        self,
+        bdb_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        logging.debug(f"Creating database with config: {bdb_config}")
+        result = await self._trigger_action(
+            ActionRequest(ActionType.CREATE_DATABASE, {"database_config": bdb_config})
+        )
+        action_id = result.get("action_id")
+        if not action_id:
+            raise Exception(f"Failed to trigger create database action: {result}")
+
+        response = await self.get_operation_result(action_id)
+        logging.debug(f"Create database action result: {response}")
+
+        if response.get("status") != TaskStatuses.SUCCESS:
+            raise Exception(f"Create database action failed: {response}")
+
+        self._current_db_id = response["output"]["bdb_id"]
+        return response["output"]
+
+    async def delete_database(
+        self,
+        bdb_id: int,
+    ) -> Dict[str, Any]:
+        logging.debug(f"Deleting database with id: {bdb_id}")
+        result = await self._trigger_action(
+            ActionRequest(ActionType.DELETE_DATABASE, {"bdb_id": bdb_id})
+        )
+        action_id = result.get("action_id")
+        if not action_id:
+            raise Exception(f"Failed to trigger delete database action: {result}")
+
+        response = await self.get_operation_result(action_id)
+        self._current_db_id = None
+
+        if response.get("status") != TaskStatuses.SUCCESS:
+            raise Exception(f"Delete database action failed: {response}")
+        logging.debug(f"Delete database action result: {response}")
+        return response
+
+    async def _get_cluster_nodes_info(self) -> None:
+        try:
+            action = ActionRequest(
+                ActionType.EXECUTE_RLADMIN_COMMAND,
+                {
+                    "rladmin_command": "status",
+                    "bdb_id": DEFAULT_BDB_ID
+                    if self._current_db_id is None
+                    else self._current_db_id,
+                },
+            )
+            trigger_result = await self._trigger_action(action)
+            action_id = trigger_result.get("action_id")
+            if not action_id:
+                raise ValueError(
+                    f"Failed to trigger get cluster status action: {trigger_result}"
+                )
+
+            response = await self.get_operation_result(action_id)
+
+            if response.get("status") != TaskStatuses.SUCCESS:
+                raise Exception(f"Get cluster status action failed: {response}")
+            self._cluster_nodes_info = response.get("output", {}).get("output", "")
+        except Exception as e:
+            pytest.fail(f"Failed to get cluster nodes info: {e}")
+
+    async def find_database_id_by_name(
+        self,
+        database_name: str,
+        force_cluster_info_refresh: bool = True,
+    ) -> Optional[int]:
+        if self._cluster_nodes_info is None or force_cluster_info_refresh:
+            await self._get_cluster_nodes_info()
+
+        if not self._cluster_nodes_info:
+            raise ValueError("No cluster status info found")
+
+        lines = self._cluster_nodes_info.split("\n")
+        databases_section_started = False
+
+        for line in lines:
+            line = line.strip()
+            if line.startswith("DATABASES:"):
+                databases_section_started = True
+                continue
+            elif databases_section_started and line and not line.startswith("DB:ID"):
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == database_name:
+                    return int(parts[0].replace("db:", ""))
+
+        raise ValueError(f"Database {database_name} not found")
+
+    async def get_slot_migrate_triggers(
+        self,
+        effect_name: SlotMigrateEffects,
+    ) -> Dict[str, Any]:
+        return await self._make_request(
+            "GET", f"/slot-migrate?effect={effect_name.value}&cluster_index=0"
+        )
+
+    async def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        return await self._make_request(
+            "GET",
+            f"/topology-change-standalone?effect={effect_name.value}&cluster_index=0",
+        )
+
+    async def trigger_effect(
+        self,
+        endpoint_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: str,
+        source_node: Optional[str] = None,
+        target_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+    ) -> str:
+        bdb_id = endpoint_config.get("bdb_id")
+        parameters: Dict[str, Any] = {
+            "bdb_id": bdb_id,
+            "cluster_index": 0,
+            "effect": effect_name,
+            "trigger": trigger_name,
+        }
+        if source_node:
+            parameters["source_node"] = source_node
+        if target_node:
+            parameters["target_node"] = target_node
+
+        action_type = (
+            ActionType.SLOT_MIGRATE
+            if isinstance(effect_name, SlotMigrateEffects)
+            else ActionType.TOPOLOGY_CHANGE_STANDALONE
+        )
+        logging.debug(f"Executing {action_type.value} with parameters: {parameters}")
+
+        try:
+            result = await self._trigger_action(ActionRequest(action_type, parameters))
+            logging.debug(f"Trigger effect action result: {result}")
+            action_id = result.get("action_id")
+            if not action_id:
+                raise Exception(f"Failed to trigger slot migrate action: {result}")
+            return action_id
+        except Exception as e:
+            raise Exception(f"Failed to execute slot migrate: {e}")
+
+    def get_moving_ttl(self) -> int:
+        return self.MOVING_TTL
+
+
+class AsyncProxyServerFaultInjector(MockProxyFaultInjector, AsyncFaultInjectorClient):
+    """Async fault injector client for proxy server setup."""
+
+    NODE_PORT_1 = 15379
+    NODE_PORT_2 = 15380
+    NODE_PORT_3 = 15381
+
+    DEFAULT_CLUSTER_SLOTS = [
+        SlotsRange("127.0.0.1", NODE_PORT_1, 0, 8191),
+        SlotsRange("127.0.0.1", NODE_PORT_2, 8192, 16383),
+    ]
+
+    CLUSTER_SLOTS_INTERCEPTOR_NAME = "test_topology"
+    SLEEP_TIME_BETWEEN_START_END_NOTIFICATIONS = 2
+    MOVING_TTL = 4
+
+    def __init__(self, oss_cluster: bool = False):
+        self.oss_cluster = oss_cluster
+        self.proxy_helper = ProxyInterceptorHelper()
+        logging.info(
+            f"Setting up initial cluster slots -> {self.DEFAULT_CLUSTER_SLOTS}"
+        )
+        self.proxy_helper.set_cluster_slots(
+            self.CLUSTER_SLOTS_INTERCEPTOR_NAME, self.DEFAULT_CLUSTER_SLOTS
+        )
+
+    async def get_operation_result(
+        self,
+        action_id: str,
+        timeout: int = 60,
+    ) -> Dict[str, Any]:
+        return {"status": "done"}
+
+    async def create_database(
+        self,
+        bdb_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "bdb_id": 1,
+            "username": "default",
+            "password": "",
+            "tls": False,
+            "raw_endpoints": [
+                {
+                    "addr": ["127.0.0.1"],
+                    "addr_type": "external",
+                    "dns_name": "localhost",
+                    "oss_cluster_api_preferred_endpoint_type": "ip",
+                    "oss_cluster_api_preferred_ip_type": "internal",
+                    "port": 15379,
+                    "proxy_policy": "all-master-shards",
+                    "uid": "1:1",
+                }
+            ],
+            "endpoints": ["redis://127.0.0.1:15379"],
+        }
+
+    async def delete_database(
+        self,
+        bdb_id: int,
+    ) -> Dict[str, Any]:
+        return {}
+
+    async def find_database_id_by_name(
+        self,
+        database_name: str,
+        force_cluster_info_refresh: bool = True,
+    ) -> Optional[int]:
+        return 1
+
+    def get_moving_ttl(self) -> int:
+        return self.MOVING_TTL
+
+    async def get_slot_migrate_triggers(
+        self,
+        effect_name: SlotMigrateEffects,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Not implemented for proxy server")
+
+    async def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Not implemented for proxy server")
+
+    async def trigger_effect(
+        self,
+        endpoint_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: Optional[str] = None,
+        source_node: Optional[str] = None,
+        target_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+    ) -> str:
+        raise NotImplementedError("Not implemented for proxy server")

--- a/tests/test_asyncio/test_scenario/conftest.py
+++ b/tests/test_asyncio/test_scenario/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Optional
+from urllib.parse import urlparse
 
 import pytest
 import pytest_asyncio
@@ -13,11 +14,22 @@ from redis.asyncio.multidb.config import (
 )
 from redis.asyncio.multidb.event import AsyncActiveDatabaseChanged
 from redis.asyncio.retry import Retry
-from redis.backoff import ExponentialBackoff
+from redis.backoff import ExponentialBackoff, ExponentialWithJitterBackoff, NoBackoff
 from redis.event import AsyncEventListenerInterface, EventDispatcher
+from redis.maint_notifications import EndpointType, MaintNotificationsConfig
 from redis.multidb.failure_detector import DEFAULT_MIN_NUM_FAILURES
-from tests.test_scenario.conftest import get_endpoints_config, extract_cluster_fqdn
-from tests.test_scenario.fault_injector_client import REFaultInjector
+from tests.test_scenario.conftest import (
+    CLIENT_TIMEOUT,
+    RELAXED_TIMEOUT,
+    _prepare_ssl_certificates,
+    extract_cluster_fqdn,
+    get_endpoints_config,
+    use_mock_proxy,
+)
+from tests.test_asyncio.test_scenario.async_fault_injector_client import (
+    AsyncProxyServerFaultInjector,
+    AsyncREFaultInjector,
+)
 
 
 class CheckActiveDatabaseChangedListener(AsyncEventListenerInterface):
@@ -30,8 +42,99 @@ class CheckActiveDatabaseChangedListener(AsyncEventListenerInterface):
 
 @pytest.fixture()
 def fault_injector_client():
-    url = os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324")
-    return REFaultInjector(url)
+    if use_mock_proxy():
+        return AsyncProxyServerFaultInjector(oss_cluster=False)
+    else:
+        url = os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324")
+        return AsyncREFaultInjector(url)
+
+
+def _get_async_client_maint_notifications(
+    endpoints_config,
+    protocol: int = 3,
+    enable_maintenance_notifications: bool = True,
+    endpoint_type: Optional[EndpointType] = None,
+    enable_relaxed_timeout: bool = True,
+    enable_proactive_reconnect: bool = True,
+    disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
+    socket_timeout: Optional[float] = None,
+    host_config: Optional[str] = None,
+) -> Redis:
+    """Create async Redis client with maintenance notifications enabled."""
+    username = endpoints_config.get("username")
+    password = endpoints_config.get("password")
+
+    endpoints = endpoints_config.get("endpoints", [])
+    if not endpoints:
+        raise ValueError("No endpoints found in configuration")
+
+    parsed = urlparse(endpoints[0])
+    host = parsed.hostname if host_config is None else host_config
+    port = parsed.port
+
+    if not host:
+        raise ValueError(f"Could not parse host from endpoint URL: {endpoints[0]}")
+
+    if port is None:
+        raise ValueError(f"Could not parse port from endpoint URL: {endpoints[0]}")
+
+    maintenance_config = MaintNotificationsConfig(
+        enabled=enable_maintenance_notifications,
+        proactive_reconnect=enable_proactive_reconnect,
+        relaxed_timeout=RELAXED_TIMEOUT if enable_relaxed_timeout else -1,
+        endpoint_type=endpoint_type,
+    )
+
+    if disable_retries:
+        retry = Retry(NoBackoff(), 0)
+    else:
+        retry = Retry(
+            backoff=ExponentialWithJitterBackoff(base=0.01, cap=1), retries=10
+        )
+
+    tls_enabled = parsed.scheme == "rediss"
+    tls_kwargs = {"ssl": tls_enabled}
+    if tls_enabled:
+        ssl_config = _prepare_ssl_certificates(auth_ssl_client_certs)
+        tls_kwargs.update(ssl_config)
+
+    return Redis(
+        host=host,
+        port=port,
+        socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
+        username=username,
+        password=password,
+        protocol=protocol,
+        maint_notifications_config=maintenance_config,
+        retry=retry,
+        **tls_kwargs,
+    )
+
+
+def get_async_standalone_client_maint_notifications(
+    endpoints_config,
+    protocol: int = 3,
+    enable_maintenance_notifications: bool = True,
+    endpoint_type: Optional[EndpointType] = None,
+    enable_relaxed_timeout: bool = True,
+    enable_proactive_reconnect: bool = True,
+    disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
+    socket_timeout: Optional[float] = None,
+) -> Redis:
+    """Create async Redis standalone client with maintenance notifications enabled."""
+    return _get_async_client_maint_notifications(
+        endpoints_config=endpoints_config,
+        protocol=protocol,
+        enable_maintenance_notifications=enable_maintenance_notifications,
+        endpoint_type=endpoint_type,
+        enable_relaxed_timeout=enable_relaxed_timeout,
+        enable_proactive_reconnect=enable_proactive_reconnect,
+        disable_retries=disable_retries,
+        auth_ssl_client_certs=auth_ssl_client_certs,
+        socket_timeout=socket_timeout,
+    )
 
 
 @pytest_asyncio.fixture()

--- a/tests/test_asyncio/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_asyncio/test_scenario/maint_notifications_helpers.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import pytest
+
+from redis.asyncio import Redis
+from redis.maint_notifications import MaintenanceState
+
+
+class AsyncClientValidations:
+    @staticmethod
+    async def get_default_connection(redis_client: Redis):
+        return await redis_client.connection_pool.get_connection()
+
+    @staticmethod
+    async def release_connection(redis_client: Redis, connection):
+        await redis_client.connection_pool.release(connection)
+
+    @staticmethod
+    async def wait_push_notification(
+        redis_client: Redis,
+        timeout: float = 120,
+        fail_on_timeout: bool = True,
+        connection=None,
+        expected_state: Optional[MaintenanceState] = None,
+    ):
+        """Wait for a push notification to be received."""
+        start_time = time.time()
+        check_interval = 0.2
+        test_conn = (
+            connection
+            if connection
+            else await AsyncClientValidations.get_default_connection(redis_client)
+        )
+        logging.info(
+            f"Waiting for push notification on connection: {test_conn}, "
+            f"peer: {test_conn.getpeername()}"
+        )
+
+        try:
+            if (
+                expected_state is not None
+                and test_conn.maintenance_state == expected_state
+            ):
+                logging.debug(
+                    f"Connection already in expected state {expected_state}, "
+                    f"returning immediately"
+                )
+                return
+
+            while time.time() - start_time < timeout:
+                try:
+                    if await test_conn.can_read():
+                        push_response = await test_conn.read_response(push_request=True)
+                        logging.debug(
+                            f"Push notification received. Response: {push_response}"
+                        )
+                        if test_conn.should_reconnect():
+                            logging.debug("Connection is marked for reconnect")
+                        if (
+                            expected_state is None
+                            or test_conn.maintenance_state == expected_state
+                        ):
+                            return
+                except Exception as e:
+                    logging.error(f"Error reading push notification: {e}")
+                    raise
+                await asyncio.sleep(check_interval)
+            if fail_on_timeout:
+                pytest.fail(
+                    f"Timeout waiting for push notification: "
+                    f"waiting > {time.time() - start_time} seconds."
+                )
+        finally:
+            try:
+                if not connection:
+                    await AsyncClientValidations.release_connection(
+                        redis_client, test_conn
+                    )
+            except Exception as e:
+                logging.error(f"Error releasing connection: {e}")

--- a/tests/test_asyncio/test_scenario/test_active_active.py
+++ b/tests/test_asyncio/test_scenario/test_active_active.py
@@ -29,12 +29,14 @@ async def trigger_network_failure_action(
         parameters={"bdb_id": config["bdb_id"], "delay": 3, "cluster_index": 0},
     )
 
-    result = fault_injector_client.trigger_action(action_request)
-    status_result = fault_injector_client.get_action_status(result["action_id"])
+    result = await fault_injector_client.trigger_action(action_request)
+    status_result = await fault_injector_client.get_action_status(result["action_id"])
 
     while status_result["status"] != "success":
         await asyncio.sleep(0.1)
-        status_result = fault_injector_client.get_action_status(result["action_id"])
+        status_result = await fault_injector_client.get_action_status(
+            result["action_id"]
+        )
         logger.info(
             f"Waiting for action to complete. Status: {status_result['status']}"
         )

--- a/tests/test_asyncio/test_scenario/test_maint_notifications.py
+++ b/tests/test_asyncio/test_scenario/test_maint_notifications.py
@@ -1,0 +1,1197 @@
+"""Tests for Redis Enterprise maintenance push notifications — async standalone client."""
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import pytest
+import pytest_asyncio
+
+from redis.asyncio import Redis
+from redis.maint_notifications import (
+    EndpointType,
+    MaintenanceState,
+)
+from tests.test_asyncio.test_scenario.conftest import (
+    _get_async_client_maint_notifications,
+    get_async_standalone_client_maint_notifications,
+)
+from tests.test_asyncio.test_scenario.maint_notifications_helpers import (
+    AsyncClientValidations,
+)
+from tests.test_scenario.conftest import (
+    CLIENT_TIMEOUT,
+    RELAXED_TIMEOUT,
+    _FAULT_INJECTOR_STANDALONE_CLIENT,
+    use_mock_proxy,
+)
+from tests.test_asyncio.test_scenario.async_fault_injector_client import (
+    AsyncFaultInjectorClient,
+    AsyncProxyServerFaultInjector,
+)
+from tests.test_scenario.fault_injector_client import (
+    SlotMigrateEffects,
+    TopologyChangeStandaloneEffects,
+)
+from tests.test_scenario.maint_notifications_helpers import (
+    generate_params,
+    is_endpoint_configured_correctly,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S:%f",
+)
+
+logging.getLogger("redis.asyncio.maint_notifications").setLevel(logging.DEBUG)
+
+STANDALONE_MAINT_TIMEOUT = 60
+SLOT_SHUFFLE_TIMEOUT = 120
+
+DEFAULT_BIND_TTL = 15
+DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
+
+
+class TestAsyncPushNotificationsBase:
+    async def _get_all_connections_in_pool(self, client: Redis) -> List:
+        connections = []
+        async with client.connection_pool._get_pool_lock():
+            for conn in client.connection_pool._get_free_connections():
+                connections.append(conn)
+            for conn in client.connection_pool._get_in_use_connections():
+                connections.append(conn)
+        return connections
+
+    async def _validate_maintenance_state(
+        self, client: Redis, expected_matching_conns_count: int
+    ):
+        matching_conns_count = 0
+        connections = await self._get_all_connections_in_pool(client)
+
+        for conn in connections:
+            if (
+                conn.is_connected
+                and conn.socket_timeout == RELAXED_TIMEOUT
+                and conn.maintenance_state == MaintenanceState.MAINTENANCE
+            ):
+                matching_conns_count += 1
+        assert matching_conns_count == expected_matching_conns_count
+
+    async def _validate_moving_state(
+        self,
+        client: Redis,
+        configured_endpoint_type: EndpointType,
+        expected_matching_connected_conns_count: int,
+        expected_matching_disconnected_conns_count: int,
+        fault_injector_client: AsyncFaultInjectorClient,
+    ):
+        matching_connected_conns_count = 0
+        matching_disconnected_conns_count = 0
+        # No outer lock here: asyncio.Lock is non-reentrant and
+        # _get_all_connections_in_pool already holds the lock for its snapshot.
+        # Single-threaded event loop guarantees no interleaving after the await.
+        connections = await self._get_all_connections_in_pool(client)
+        for conn in connections:
+            endpoint_configured_correctly = is_endpoint_configured_correctly(
+                conn, configured_endpoint_type, fault_injector_client
+            )
+
+            if (
+                conn.is_connected
+                and conn.socket_timeout == RELAXED_TIMEOUT
+                and conn.maintenance_state == MaintenanceState.MOVING
+                and endpoint_configured_correctly
+            ):
+                matching_connected_conns_count += 1
+            elif (
+                not conn.is_connected
+                and conn.maintenance_state == MaintenanceState.MOVING
+                and conn.socket_timeout == RELAXED_TIMEOUT
+                and endpoint_configured_correctly
+            ):
+                matching_disconnected_conns_count += 1
+
+        assert matching_connected_conns_count == expected_matching_connected_conns_count
+        assert (
+            matching_disconnected_conns_count
+            == expected_matching_disconnected_conns_count
+        )
+
+    async def _validate_default_state(
+        self,
+        client: Redis,
+        expected_matching_conns_count: Union[int, Literal["all"]],
+        configured_timeout: float = CLIENT_TIMEOUT,
+    ):
+        matching_conns_count = 0
+        connections = await self._get_all_connections_in_pool(client)
+        logging.info(f"Validating {len(connections)} connections")
+
+        for conn in connections:
+            if not conn.is_connected:
+                if (
+                    conn.maintenance_state == MaintenanceState.NONE
+                    and conn.socket_timeout == configured_timeout
+                    and conn.host == getattr(conn, "orig_host_address", conn.host)
+                ):
+                    matching_conns_count += 1
+                else:
+                    logging.debug(
+                        f"Connection not matching default state: "
+                        f"maintenance_state={conn.maintenance_state}, "
+                        f"socket_timeout={conn.socket_timeout}, "
+                        f"host={conn.host}, "
+                        f"orig_host_address={getattr(conn, 'orig_host_address', None)}"
+                    )
+            elif (
+                conn.socket_timeout == configured_timeout
+                and conn.maintenance_state == MaintenanceState.NONE
+                and conn.host == getattr(conn, "orig_host_address", conn.host)
+            ):
+                matching_conns_count += 1
+            else:
+                logging.debug(
+                    f"Connection not matching default state: "
+                    f"maintenance_state={conn.maintenance_state}, "
+                    f"socket_timeout={conn.socket_timeout}, "
+                    f"host={conn.host}, "
+                    f"orig_host_address={getattr(conn, 'orig_host_address', None)}"
+                )
+
+        conn_kwargs = client.connection_pool.connection_kwargs
+        client_host = conn_kwargs.get("host", "unknown")
+        client_port = conn_kwargs.get("port", "unknown")
+
+        if expected_matching_conns_count == "all":
+            expected_matching_conns_count = len(connections)
+
+        assert matching_conns_count == expected_matching_conns_count, (
+            f"Default state validation failed. "
+            f"Client: host={client_host}, port={client_port}, "
+            f"configured_timeout={configured_timeout}. "
+            f"Expected {expected_matching_conns_count} matching connections, "
+            f"but found {matching_conns_count} out of {len(connections)} total connections."
+        )
+
+    async def _validate_default_notif_disabled_state(
+        self, client: Redis, expected_matching_conns_count: int
+    ):
+        matching_conns_count = 0
+        connections = await self._get_all_connections_in_pool(client)
+
+        for conn in connections:
+            if not conn.is_connected:
+                if (
+                    conn.maintenance_state == MaintenanceState.NONE
+                    and conn.socket_timeout == CLIENT_TIMEOUT
+                    and not hasattr(conn, "orig_host_address")
+                ):
+                    matching_conns_count += 1
+            elif (
+                conn.socket_timeout == CLIENT_TIMEOUT
+                and conn.maintenance_state == MaintenanceState.NONE
+                and not hasattr(conn, "orig_host_address")
+            ):
+                matching_conns_count += 1
+        assert matching_conns_count == expected_matching_conns_count
+
+    async def delete_prev_db(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        db_name: str,
+    ):
+        try:
+            logging.info(f"Deleting database if exists: {db_name}")
+            existing_db_id = await fault_injector_client.find_database_id_by_name(
+                db_name
+            )
+            if existing_db_id:
+                await fault_injector_client.delete_database(existing_db_id)
+                logging.info(f"Deleted database: {db_name}")
+            else:
+                logging.info(f"Database {db_name} does not exist.")
+        except Exception as e:
+            logging.error(f"Failed to delete database {db_name}: {e}")
+
+    async def create_db(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        bdb_config: Dict[str, Any],
+    ):
+        try:
+            logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
+            cluster_endpoint_config = await fault_injector_client.create_database(
+                bdb_config
+            )
+            return cluster_endpoint_config
+        except Exception as e:
+            pytest.fail(f"Failed to create database: {e}")
+
+    async def _trigger_effect(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        endpoints_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: Optional[str] = None,
+        target_node: Optional[str] = None,
+        empty_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+        timeout: int = SLOT_SHUFFLE_TIMEOUT,
+    ):
+        action_id = await fault_injector_client.trigger_effect(
+            endpoint_config=endpoints_config,
+            effect_name=effect_name,
+            trigger_name=trigger_name,
+            source_node=target_node,
+            target_node=empty_node,
+            skip_end_notification=skip_end_notification,
+        )
+        result = await fault_injector_client.get_operation_result(
+            action_id,
+            timeout=timeout,
+        )
+        logging.debug(f"Action execution result: {result}")
+
+
+class TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase(
+    TestAsyncPushNotificationsBase
+):
+    async def setup_env(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        db_config: Dict[str, Any],
+        endpoint_type: Optional[EndpointType] = None,
+    ):
+        self._fault_injector = fault_injector_client
+        await self.delete_prev_db(fault_injector_client, db_config["name"])
+
+        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        self._bdb_name = db_config["name"]
+
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            else False
+        )
+
+        self._client = get_async_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
+            socket_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+            enable_maintenance_notifications=True,
+            endpoint_type=endpoint_type,
+            auth_ssl_client_certs=auth_ssl_client_certs,
+        )
+        return self._client, db_endpoint_config
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def setup_and_cleanup(self):
+        self.maintenance_ops_tasks = []
+        self._bdb_name = None
+        self._fault_injector = None
+        self._client: Redis | None = None
+
+        yield
+
+        logging.info("Starting cleanup...")
+
+        logging.info("Waiting for maintenance operation tasks to finish...")
+        if self.maintenance_ops_tasks:
+            await asyncio.gather(*self.maintenance_ops_tasks, return_exceptions=True)
+
+        if self._client is not None:
+            await self._client.aclose()
+
+        if self._bdb_name and self._fault_injector:
+            await self.delete_prev_db(self._fault_injector, self._bdb_name)
+
+        logging.info("Cleanup finished")
+
+
+class TestAsyncStandaloneClientPushNotificationsHandlingWithEffectTrigger(
+    TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP],
+        ),
+    )
+    async def test_notification_handling_during_data_movements_no_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        logging.info("Creating one connection in the pool.")
+        conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for opening push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn,
+        )
+
+        logging.info("Validating connection maintenance state...")
+        assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+        assert conn.socket_timeout == RELAXED_TIMEOUT
+
+        logging.info("Waiting for closing push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn,
+        )
+
+        logging.info("Validating connection default state is restored...")
+        assert conn.maintenance_state == MaintenanceState.NONE
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+
+        logging.info("Releasing connection back to the pool...")
+        await client.connection_pool.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    async def test_notification_handling_during_data_movements_with_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        conn = await client.connection_pool.get_connection()
+        await client.connection_pool.release(conn)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        logging.info("Validating connection migrating state...")
+        conn = await client.connection_pool.get_connection()
+        assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+        assert conn.socket_timeout == RELAXED_TIMEOUT
+        await client.connection_pool.release(conn)
+
+        logging.info("Waiting for MIGRATED push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        logging.info("Validating connection states...")
+        conn = await client.connection_pool.get_connection()
+        assert conn.maintenance_state == MaintenanceState.NONE
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+        await client.connection_pool.release(conn)
+
+        logging.info("Waiting for MOVING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        logging.info("Validating connection states...")
+        conn = await client.connection_pool.get_connection()
+        assert conn.maintenance_state == MaintenanceState.MOVING
+        assert conn.socket_timeout == RELAXED_TIMEOUT
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(DEFAULT_BIND_TTL)
+
+        logging.info("Validating connection states...")
+        assert conn.maintenance_state == MaintenanceState.NONE
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+
+        await client.connection_pool.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
+    )
+    async def test_timeout_handling_during_data_movements_with_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
+    ):
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        logging.info("Creating three connections in the pool.")
+        conns = []
+        for _ in range(3):
+            conns.append(await client.connection_pool.get_connection())
+        for conn in conns:
+            await client.connection_pool.release(conn)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=2,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        logging.info("Waiting for MIGRATED push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        logging.info("Validating connection states after MIGRATED ...")
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        logging.info("Waiting for MOVING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        if endpoint_type == EndpointType.NONE:
+            logging.info(
+                "Waiting for moving ttl/2 to expire to validate proactive reconnection"
+            )
+            await asyncio.sleep(fault_injector_client.get_moving_ttl() / 2 + 1)
+
+        logging.info("Validating connections states...")
+        await self._validate_moving_state(
+            client,
+            endpoint_type,
+            expected_matching_connected_conns_count=0,
+            expected_matching_disconnected_conns_count=3,
+            fault_injector_client=fault_injector_client,
+        )
+        conn = await client.connection_pool.get_connection()
+        await self._validate_moving_state(
+            client,
+            endpoint_type,
+            expected_matching_connected_conns_count=1,
+            expected_matching_disconnected_conns_count=2,
+            fault_injector_client=fault_injector_client,
+        )
+        await client.connection_pool.release(conn)
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(DEFAULT_BIND_TTL)
+
+        logging.info("Validating connection states...")
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
+    )
+    async def test_connection_handling_during_data_movements_with_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
+    ):
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing with endpoint type: {endpoint_type}")
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info("Waiting for MIGRATED push notification ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        await client.connection_pool.release(first_conn)
+
+        logging.info("Waiting for MOVING push notifications on random connection ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        if endpoint_type == EndpointType.NONE:
+            logging.info(
+                "Waiting for moving ttl/2 to expire to validate proactive reconnection"
+            )
+            await asyncio.sleep(fault_injector_client.get_moving_ttl() / 2 + 1)
+
+        connections = []
+        for _ in range(3):
+            connections.append(await client.connection_pool.get_connection())
+        for conn in connections:
+            logging.debug(f"Releasing connection {conn}. {conn.maintenance_state}")
+            await client.connection_pool.release(conn)
+
+        logging.info("Validating connections states during MOVING ...")
+        await self._validate_moving_state(
+            client,
+            endpoint_type,
+            expected_matching_connected_conns_count=3,
+            expected_matching_disconnected_conns_count=0,
+            fault_injector_client=fault_injector_client,
+        )
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(fault_injector_client.get_moving_ttl())
+
+        logging.info("Validating connection states after MOVING has expired ...")
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    async def test_new_connections_receive_notifications_no_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for opening push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info(
+            "Creating second connection that should receive the opening notification as well."
+        )
+        second_conn = await client.connection_pool.get_connection()
+        await self._validate_maintenance_state(client, expected_matching_conns_count=2)
+
+        logging.info("Waiting for closing push notifications on both connections ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=second_conn,
+        )
+
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=2,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        await client.connection_pool.release(first_conn)
+        await client.connection_pool.release(second_conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    async def test_old_connection_shutdown_during_moving(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        endpoint_type = EndpointType.EXTERNAL_IP
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        conn = await client.connection_pool.get_connection()
+        await client.connection_pool.release(conn)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info("Waiting for MIGRATED push notification ...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=1,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        moving_event = asyncio.Event()
+        errors = asyncio.Queue()
+
+        async def execute_commands():
+            while not moving_event.is_set():
+                try:
+                    await client.set("key", "value")
+                    await client.get("key")
+                except Exception as e:
+                    await errors.put(
+                        f"Command failed in task {asyncio.current_task().get_name()}: {e}"
+                    )
+                await asyncio.sleep(0.001)
+
+        conn_to_check_moving = await client.connection_pool.get_connection()
+
+        threads_count = 10
+        tasks = [
+            asyncio.create_task(execute_commands(), name=f"cmd_task_{i}")
+            for i in range(threads_count)
+        ]
+
+        logging.info("Waiting for MOVING push notification ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn_to_check_moving,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        logging.info("Setting moving event...")
+        moving_event.set()
+        await client.connection_pool.release(conn_to_check_moving)
+
+        await asyncio.gather(*tasks)
+
+        logging.info("All command tasks finished. Validating connections states...")
+        connections = await self._get_all_connections_in_pool(client)
+        for conn in connections:
+            if conn.is_connected:
+                assert conn.get_resolved_ip() == conn.host
+                assert conn.maintenance_state == MaintenanceState.MOVING
+                assert conn.socket_timeout == RELAXED_TIMEOUT
+                if not isinstance(fault_injector_client, AsyncProxyServerFaultInjector):
+                    assert conn.host != conn.orig_host_address
+                assert not conn.should_reconnect()
+            else:
+                assert conn.maintenance_state == MaintenanceState.MOVING
+                assert conn.socket_timeout == RELAXED_TIMEOUT
+                if not isinstance(fault_injector_client, AsyncProxyServerFaultInjector):
+                    assert conn.host != conn.orig_host_address
+                assert not conn.should_reconnect()
+
+        error_items = []
+        while not errors.empty():
+            error_items.append(errors.get_nowait())
+        assert not error_items, f"Errors occurred in tasks: {error_items}"
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    async def test_new_connections_receive_moving(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        endpoint_type = EndpointType.EXTERNAL_IP
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info("Waiting for MIGRATED push notifications ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        logging.info("Waiting for MOVING push notifications on random connection ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        assert first_conn.is_connected, (
+            "Connection must be active after receiving MOVING notification"
+        )
+        old_address = first_conn.getpeername()
+        logging.info(f"The node address before bind: {old_address}")
+
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            else False
+        )
+
+        logging.info(
+            "Creating new client pointing at old address — "
+            "new connections should receive the moving notification..."
+        )
+        new_client = _get_async_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            endpoint_type=endpoint_type,
+            host_config=old_address,
+            socket_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+            auth_ssl_client_certs=auth_ssl_client_certs,
+        )
+
+        logging.info(
+            "Creating one connection in the new pool that should receive the moving notification."
+        )
+        new_client_conn = await new_client.connection_pool.get_connection()
+
+        logging.info("Validating connections states during MOVING ...")
+        await self._validate_moving_state(
+            new_client,
+            endpoint_type,
+            expected_matching_connected_conns_count=1,
+            expected_matching_disconnected_conns_count=0,
+            fault_injector_client=fault_injector_client,
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        await new_client.connection_pool.release(new_client_conn)
+        await new_client.aclose()
+
+        await client.connection_pool.release(first_conn)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    async def test_disabled_handling_during_migrating_and_moving(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        self._fault_injector = fault_injector_client
+        await self.delete_prev_db(fault_injector_client, db_config["name"])
+        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        self._bdb_name = db_config["name"]
+
+        logging.info("Creating client with disabled notifications.")
+        self._client = client = get_async_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
+            enable_maintenance_notifications=False,
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=first_conn
+        )
+
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=1
+        )
+
+        logging.info(
+            "Creating second connection — expect it not to receive MIGRATING either."
+        )
+        second_conn = await client.connection_pool.get_connection()
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=second_conn
+        )
+
+        logging.info(
+            "Validating connection states after MIGRATING for both connections ..."
+        )
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=2
+        )
+
+        logging.info("Waiting for MIGRATED push notifications on both connections ...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=first_conn
+        )
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=second_conn
+        )
+
+        await client.connection_pool.release(first_conn)
+        await client.connection_pool.release(second_conn)
+
+        logging.info("Waiting for MOVING push notifications on random connection ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=10,
+            fail_on_timeout=False,
+        )
+
+        connections = []
+        for _ in range(3):
+            connections.append(await client.connection_pool.get_connection())
+        for conn in connections:
+            await client.connection_pool.release(conn)
+
+        logging.info("Validating connections states during MOVING ...")
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=3
+        )
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(DEFAULT_BIND_TTL)
+
+        logging.info("Validating connection states after MOVING has expired ...")
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=3
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+
+class TestAsyncStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
+    TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [
+                TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP,
+                TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP,
+                TopologyChangeStandaloneEffects.CONN_DROP,
+                TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
+            ],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
+    )
+    async def test_command_execution_during_maintenance(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
+    ):
+        errors = asyncio.Queue()
+        if isinstance(fault_injector_client, AsyncProxyServerFaultInjector):
+            execution_duration = 20
+        else:
+            execution_duration = 60
+
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        async def execute_commands(duration: int):
+            start = time.time()
+            while time.time() - start < duration:
+                try:
+                    await client.set("key", "value")
+                    await client.get("key")
+                except Exception as e:
+                    logging.error(
+                        f"Error in task {asyncio.current_task().get_name()}: {e}"
+                    )
+                    await errors.put(
+                        f"Command failed in task "
+                        f"{asyncio.current_task().get_name()}: {e}"
+                    )
+                await asyncio.sleep(0.001)
+            logging.debug(f"{asyncio.current_task().get_name()}: task ended")
+
+        tasks = [
+            asyncio.create_task(
+                execute_commands(execution_duration), name=f"cmd_task_{i}"
+            )
+            for i in range(10)
+        ]
+
+        logging.info("Waiting for tasks to start and have a few cycles executed ...")
+        await asyncio.sleep(3)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        await asyncio.gather(*tasks)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=10,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        error_items = []
+        while not errors.empty():
+            error_items.append(errors.get_nowait())
+        assert not error_items, f"Errors occurred in tasks: {error_items}"

--- a/tests/test_asyncio/test_scenario/test_maint_notifications.py
+++ b/tests/test_asyncio/test_scenario/test_maint_notifications.py
@@ -277,7 +277,7 @@ class TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
@@ -953,7 +953,7 @@ class TestAsyncStandaloneClientPushNotificationsHandlingWithEffectTrigger(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 

--- a/tests/test_scenario/conftest.py
+++ b/tests/test_scenario/conftest.py
@@ -425,6 +425,7 @@ def get_cluster_client_maint_notifications(
     disable_retries: bool = False,
     auth_ssl_client_certs: bool = False,
     socket_timeout: Optional[float] = None,
+    socket_connect_timeout: Optional[float] = None,
 ):
     """Create Redis cluster client with maintenance notifications enabled."""
     # Get credentials from the configuration
@@ -476,8 +477,8 @@ def get_cluster_client_maint_notifications(
         port=port,
         socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
         socket_connect_timeout=CLIENT_TIMEOUT
-        if socket_timeout is None
-        else socket_timeout,
+        if socket_connect_timeout is None
+        else socket_connect_timeout,
         username=username,
         password=password,
         protocol=protocol,  # RESP3 required for push notifications

--- a/tests/test_scenario/fault_injector_client.py
+++ b/tests/test_scenario/fault_injector_client.py
@@ -435,7 +435,16 @@ class REFaultInjector(FaultInjectorClient):
         return self.MOVING_TTL
 
 
-class ProxyServerFaultInjector(FaultInjectorClient):
+class MockProxyFaultInjector:
+    """Marker mixin for proxy-server-based fault injectors (sync and async).
+
+    Used to skip endpoint-type validation in tests — the mock proxy doesn't
+    distinguish endpoint types, so any isinstance check against this class
+    means "we're running against a local proxy, skip the check".
+    """
+
+
+class ProxyServerFaultInjector(MockProxyFaultInjector, FaultInjectorClient):
     """Fault injector client for proxy server setup."""
 
     NODE_PORT_1 = 15379

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -7,9 +7,10 @@ from redis import RedisCluster
 
 from redis.client import Redis
 from redis.connection import Connection
-from redis.maint_notifications import MaintenanceState
+from redis.maint_notifications import EndpointType, MaintenanceState
 from tests.test_scenario.fault_injector_client import (
     FaultInjectorClient,
+    MockProxyFaultInjector,
     SlotMigrateEffects,
     TopologyChangeStandaloneEffects,
 )
@@ -252,3 +253,106 @@ class KeyGenerationHelpers:
                 keys.append(KeyGenerationHelpers.generate_key(slot_number, prefix))
 
         return keys
+
+
+def is_endpoint_configured_correctly(
+    conn,
+    configured_endpoint_type: EndpointType,
+    fault_injector_client,
+) -> bool:
+    """Return True if conn's host matches the expected endpoint type.
+
+    Always returns True for mock-proxy injectors — the proxy doesn't
+    distinguish endpoint types so there is nothing to validate.
+    """
+    if isinstance(fault_injector_client, MockProxyFaultInjector):
+        return True
+
+    if configured_endpoint_type == EndpointType.NONE:
+        if conn.host != conn.orig_host_address:
+            logging.debug(
+                f"Endpoint check failed: configured NONE but "
+                f"host={conn.host!r} != orig_host_address={conn.orig_host_address!r}"
+            )
+            return False
+        return True
+
+    if conn.host == conn.orig_host_address:
+        logging.debug(
+            f"Endpoint check failed: expected non-NONE endpoint type but "
+            f"host={conn.host!r} == orig_host_address={conn.orig_host_address!r}"
+        )
+        return False
+    actual_endpoint_type = conn.maint_notifications_config.get_endpoint_type(
+        conn.orig_host_address, conn
+    )
+    if configured_endpoint_type != actual_endpoint_type:
+        logging.debug(
+            f"Endpoint check failed: "
+            f"configured_endpoint_type={configured_endpoint_type!r} != "
+            f"actual_endpoint_type={actual_endpoint_type!r} for host={conn.host!r}"
+        )
+        return False
+    return True
+
+
+def generate_params(
+    fault_injector_client: FaultInjectorClient,
+    effect_names: list[SlotMigrateEffects | TopologyChangeStandaloneEffects],
+    skip_combinations: list[tuple[SlotMigrateEffects, str]] = [],
+    endpoint_types: Optional[list[EndpointType]] = None,
+):
+    """Build parametrize tuples for maint-notification scenario tests.
+
+    Returns a list of (effect_name, trigger, dbconfig, db_name) tuples, or
+    (effect_name, trigger, dbconfig, db_name, endpoint_type) when endpoint_types
+    is provided.
+    """
+    params = []
+    try:
+        logging.info(f"Extracting params for test with effect_names: {effect_names}")
+        for effect_name in effect_names:
+            if isinstance(effect_name, SlotMigrateEffects):
+                triggers_data = ClusterOperations.get_slot_migrate_triggers(
+                    fault_injector_client, effect_name
+                )
+            else:
+                triggers_data = (
+                    ClusterOperations.get_topology_change_standalone_triggers(
+                        fault_injector_client, effect_name
+                    )
+                )
+
+            for trigger_info in triggers_data["triggers"]:
+                trigger = trigger_info["name"]
+                if (effect_name, trigger) in skip_combinations:
+                    continue
+                if trigger == "maintenance_mode":
+                    continue
+                trigger_requirements = trigger_info["requirements"]
+                for requirement in trigger_requirements:
+                    dbconfig = requirement["dbconfig"]
+                    if requirement.get("oss_cluster_api"):
+                        ip_type = requirement["oss_cluster_api"]["ip_type"]
+                        if ip_type == "internal":
+                            continue
+                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
+                    dbconfig["name"] = db_name_pattern
+
+                    if endpoint_types is not None:
+                        for endpoint_type in endpoint_types:
+                            params.append(
+                                (
+                                    effect_name,
+                                    trigger,
+                                    dbconfig,
+                                    db_name_pattern,
+                                    endpoint_type,
+                                )
+                            )
+                    else:
+                        params.append((effect_name, trigger, dbconfig, db_name_pattern))
+    except Exception as e:
+        logging.error(f"Failed to extract params for test: {e}")
+
+    return params

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -1393,6 +1393,7 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
 
         self._bdb_name = db_config["name"]
         socket_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
+        socket_connect_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
 
         auth_ssl_client_certs_config_info = db_config.get(
             "authentication_ssl_client_certs", None
@@ -1409,6 +1410,7 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
             endpoints_config=cluster_endpoint_config,
             disable_retries=True,
             socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
             enable_maintenance_notifications=True,
             auth_ssl_client_certs=auth_ssl_client_certs,
         )

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -38,6 +38,8 @@ from tests.test_scenario.maint_notifications_helpers import (
     ClientValidations,
     ClusterOperations,
     KeyGenerationHelpers,
+    generate_params,
+    is_endpoint_configured_correctly,
 )
 
 logging.basicConfig(
@@ -152,43 +154,6 @@ class TestPushNotificationsBase:
                 matching_conns_count += 1
         assert matching_conns_count == expected_matching_conns_count
 
-    def _is_endpoint_configured_correctly(
-        self,
-        conn,
-        configured_endpoint_type: EndpointType,
-        fault_injector_client: FaultInjectorClient,
-    ) -> bool:
-        if isinstance(fault_injector_client, ProxyServerFaultInjector):
-            return True  # skip endpoint type validation when using proxy server
-
-        if configured_endpoint_type == EndpointType.NONE:
-            if conn.host != conn.orig_host_address:
-                logging.debug(
-                    f"Endpoint check failed: configured NONE but "
-                    f"host={conn.host!r} != orig_host_address={conn.orig_host_address!r}"
-                )
-                return False
-            return True
-
-        # configured_endpoint_type != EndpointType.NONE
-        if conn.host == conn.orig_host_address:
-            logging.debug(
-                f"Endpoint check failed: expected non-NONE endpoint type but "
-                f"host={conn.host!r} == orig_host_address={conn.orig_host_address!r}"
-            )
-            return False
-        actual_endpoint_type = conn.maint_notifications_config.get_endpoint_type(
-            conn.orig_host_address, conn
-        )
-        if configured_endpoint_type != actual_endpoint_type:
-            logging.debug(
-                f"Endpoint check failed: "
-                f"configured_endpoint_type={configured_endpoint_type!r} != "
-                f"actual_endpoint_type={actual_endpoint_type!r} for host={conn.host!r}"
-            )
-            return False
-        return True
-
     def _validate_moving_state(
         self,
         client: Redis,
@@ -203,7 +168,7 @@ class TestPushNotificationsBase:
         with client.connection_pool._lock:
             connections = self._get_all_connections_in_pool(client)
             for conn in connections:
-                endpoint_configured_correctly = self._is_endpoint_configured_correctly(
+                endpoint_configured_correctly = is_endpoint_configured_correctly(
                     conn, configured_endpoint_type, fault_injector_client
                 )
 
@@ -312,67 +277,6 @@ class TestPushNotificationsBase:
         assert matching_conns_count == expected_matching_conns_count
 
 
-def generate_params(
-    fault_injector_client: FaultInjectorClient,
-    effect_names: list[SlotMigrateEffects | TopologyChangeStandaloneEffects],
-    skip_combinations: list[tuple[SlotMigrateEffects, str]] = [],
-    endpoint_types: Optional[list[EndpointType]] = None,
-):
-    # params should produce list of tuples: (effect_name, trigger_name, bdb_config, bdb_name)
-    # when endpoint_types is provided, each tuple is expanded to include an endpoint_type,
-    # producing: (effect_name, trigger_name, bdb_config, bdb_name, endpoint_type)
-    params = []
-    try:
-        logging.info(f"Extracting params for test with effect_names: {effect_names}")
-        for effect_name in effect_names:
-            if isinstance(effect_name, SlotMigrateEffects):
-                triggers_data = ClusterOperations.get_slot_migrate_triggers(
-                    fault_injector_client, effect_name
-                )
-            else:
-                triggers_data = (
-                    ClusterOperations.get_topology_change_standalone_triggers(
-                        fault_injector_client, effect_name
-                    )
-                )
-
-            for trigger_info in triggers_data["triggers"]:
-                trigger = trigger_info["name"]
-                if (effect_name, trigger) in skip_combinations:
-                    continue
-                if trigger == "maintenance_mode":
-                    continue
-                trigger_requirements = trigger_info["requirements"]
-                for requirement in trigger_requirements:
-                    dbconfig = requirement["dbconfig"]
-                    if requirement.get("oss_cluster_api"):
-                        ip_type = requirement["oss_cluster_api"]["ip_type"]
-                        if ip_type == "internal":
-                            continue
-                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
-                    dbconfig["name"] = (
-                        db_name_pattern  # this will ensure dbs will be deleted
-                    )
-
-                    if endpoint_types is not None:
-                        for endpoint_type in endpoint_types:
-                            params.append(
-                                (
-                                    effect_name,
-                                    trigger,
-                                    dbconfig,
-                                    db_name_pattern,
-                                    endpoint_type,
-                                )
-                            )
-                    else:
-                        params.append((effect_name, trigger, dbconfig, db_name_pattern))
-    except Exception as e:
-        logging.error(f"Failed to extract params for test: {e}")
-
-    return params
-
-
 class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
     TestPushNotificationsBase
 ):
@@ -396,21 +300,19 @@ class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
-        standalone_client_maint_notifications = (
-            get_standalone_client_maint_notifications(
-                endpoints_config=db_endpoint_config,
-                disable_retries=True,
-                socket_timeout=socket_timeout,
-                enable_maintenance_notifications=True,
-                endpoint_type=endpoint_type,
-                auth_ssl_client_certs=auth_ssl_client_certs,
-            )
+        self._client = get_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
+            socket_timeout=socket_timeout,
+            enable_maintenance_notifications=True,
+            endpoint_type=endpoint_type,
+            auth_ssl_client_certs=auth_ssl_client_certs,
         )
-        return standalone_client_maint_notifications, db_endpoint_config
+        return self._client, db_endpoint_config
 
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(
@@ -418,18 +320,23 @@ class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
     ):
         self.maintenance_ops_threads = []
         self._bdb_name = None
+        self._client = None
 
         # Yield control to the test
         yield
 
         # Cleanup code - this will run even if the test fails
         logging.info("Starting cleanup...")
-        if self._bdb_name:
-            self.delete_prev_db(_FAULT_INJECTOR_STANDALONE_CLIENT, self._bdb_name)
+
+        if self._client is not None:
+            self._client.close()
 
         logging.info("Waiting for maintenance operations threads to finish...")
         for thread in self.maintenance_ops_threads:
             thread.join()
+
+        if self._bdb_name:
+            self.delete_prev_db(_FAULT_INJECTOR_STANDALONE_CLIENT, self._bdb_name)
 
         logging.info("Cleanup finished")
 
@@ -1199,7 +1106,7 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
@@ -1260,7 +1167,8 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
         self._bdb_name = db_config["name"]
 
         logging.info("Creating client with disabled notifications.")
-        client = get_standalone_client_maint_notifications(
+        # self._client for teardown cleanup; local `client` used in the rest of this method.
+        self._client = client = get_standalone_client_maint_notifications(
             endpoints_config=db_endpoint_config,
             disable_retries=True,
             enable_maintenance_notifications=False,
@@ -1493,18 +1401,18 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
-        cluster_client_maint_notifications = get_cluster_client_maint_notifications(
+        self._client = get_cluster_client_maint_notifications(
             endpoints_config=cluster_endpoint_config,
             disable_retries=True,
             socket_timeout=socket_timeout,
             enable_maintenance_notifications=True,
             auth_ssl_client_certs=auth_ssl_client_certs,
         )
-        return cluster_client_maint_notifications, cluster_endpoint_config
+        return self._client, cluster_endpoint_config
 
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(
@@ -1512,18 +1420,23 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
     ):
         self.maintenance_ops_threads = []
         self._bdb_name = None
+        self._client = None
 
         # Yield control to the test
         yield
 
         # Cleanup code - this will run even if the test fails
         logging.info("Starting cleanup...")
-        if self._bdb_name:
-            self.delete_prev_db(_FAULT_INJECTOR_CLIENT_OSS_API, self._bdb_name)
+
+        if self._client is not None:
+            self._client.close()
 
         logging.info("Waiting for maintenance operations threads to finish...")
         for thread in self.maintenance_ops_threads:
             thread.join()
+
+        if self._bdb_name:
+            self.delete_prev_db(_FAULT_INJECTOR_CLIENT_OSS_API, self._bdb_name)
 
         logging.info("Cleanup finished")
 


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The deadline-based scheduling change affects async maintenance MOVING/reconnect timing in production; the rest is test-only but is a large new integration surface.
> 
> **Overview**
> This PR adds **async scenario coverage** for Redis Enterprise **standalone maintenance push notifications** (MIGRATING/MIGRATED/MOVING, endpoint types, proactive reconnect, disabled notifications, and concurrent command execution), wired through new **async fault-injector clients** (`aiohttp` for RE, mock proxy when enabled) and async pytest fixtures/helpers.
> 
> **Production behavior change:** `AsyncMaintNotificationsPoolHandler` now schedules delayed work from an **absolute loop deadline** at `create_task` time instead of sleeping the full delay when the task starts, so event-loop lag does not push proactive reconnect / MOVING cleanup later than intended.
> 
> **Test infrastructure:** Shared `generate_params` and `is_endpoint_configured_correctly` (with `MockProxyFaultInjector`), separate `socket_connect_timeout` for cluster maint clients, more reliable teardown (`close`/`aclose`, `cluster.close()` in maint tests), and sync active-active tests updated to `await` async fault-injector calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec8fd8f36138fc0f7b18f5e41ab7fa86ad766598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->