### PR TITLE
fix: iterate over list copy in PubSub (#3748)

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1365,7 +1365,7 @@ class PubSub:
             patterns = self._normalize_keys(dict.fromkeys(parsed_args)).keys()
         else:
             parsed_args = []
-            patterns = self.patterns
+            patterns = list(self.patterns)
         self.pending_unsubscribe_patterns.update(patterns)
         return self.execute_command("PUNSUBSCRIBE", *parsed_args)
 
@@ -1402,7 +1402,7 @@ class PubSub:
             channels = self._normalize_keys(dict.fromkeys(parsed_args))
         else:
             parsed_args = []
-            channels = self.channels
+            channels = list(self.channels)
         self.pending_unsubscribe_channels.update(channels)
         return self.execute_command("UNSUBSCRIBE", *parsed_args)
 
@@ -1441,7 +1441,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             s_channels = self._normalize_keys(dict.fromkeys(args))
         else:
-            s_channels = self.shard_channels
+            s_channels = list(self.shard_channels)
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
@@ -1584,10 +1584,10 @@ class PubSub:
             >>> task.cancel()
             >>> await task
         """
-        for channel, handler in self.channels.items():
+        for channel, handler in list(self.channels.items()):
             if handler is None:
                 raise PubSubError(f"Channel: '{channel}' has no handler registered")
-        for pattern, handler in self.patterns.items():
+        for pattern, handler in list(self.patterns.items()):
             if handler is None:
                 raise PubSubError(f"Pattern: '{pattern}' has no handler registered")
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1354,7 +1354,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             patterns = self._normalize_keys(dict.fromkeys(args))
         else:
-            patterns = self.patterns
+            patterns = list(self.patterns)
         self.pending_unsubscribe_patterns.update(patterns)
         return self.execute_command("PUNSUBSCRIBE", *args)
 
@@ -1395,7 +1395,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             channels = self._normalize_keys(dict.fromkeys(args))
         else:
-            channels = self.channels
+            channels = list(self.channels)
         self.pending_unsubscribe_channels.update(channels)
         return self.execute_command("UNSUBSCRIBE", *args)
 
@@ -1439,7 +1439,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             s_channels = self._normalize_keys(dict.fromkeys(args))
         else:
-            s_channels = self.shard_channels
+            s_channels = list(self.shard_channels)
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
@@ -1589,13 +1589,13 @@ class PubSub:
         pubsub=None,
         sharded_pubsub: bool = False,
     ) -> "PubSubWorkerThread":
-        for channel, handler in self.channels.items():
+        for channel, handler in list(self.channels.items()):
             if handler is None:
                 raise PubSubError(f"Channel: '{channel}' has no handler registered")
-        for pattern, handler in self.patterns.items():
+        for pattern, handler in list(self.patterns.items()):
             if handler is None:
                 raise PubSubError(f"Pattern: '{pattern}' has no handler registered")
-        for s_channel, handler in self.shard_channels.items():
+        for s_channel, handler in list(self.shard_channels.items()):
             if handler is None:
                 raise PubSubError(
                     f"Shard Channel: '{s_channel}' has no handler registered"


### PR DESCRIPTION
Fixes #3748

## Problem

When using asyncio PubSub, a  can occur when iterating over , , or  while they are concurrently modified by another coroutine/task (e.g., via , , or  processing unsubscribe responses).

## Fix

Iterate over snapshot copies () of the dict items/keys in all PubSub methods that iterate over these mutable collections:

- **** (async) / **** (sync):  → , same for  and 
- ****:  → 
- ****:  → 
- ****:  → 

This is a minimal, safe fix that prevents the  without introducing locks or changing the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized PubSub concurrency fix with no behavior change beyond avoiding iteration crashes under concurrent unsubscribe.
> 
> **Overview**
> Fixes **#3748** by avoiding **RuntimeError** when PubSub subscription state (`channels`, `patterns`, `shard_channels`) changes while another coroutine or task is iterating it.
> 
> In **sync and async** `PubSub`, bulk unsubscribe paths now use **`list(...)`** snapshots of those dicts (or their keys) before updating `pending_unsubscribe_*` sets. **`run`** / **`run_in_thread`** validation loops now iterate **`list(...items())`** instead of live dict views.
> 
> No API or locking changes—only copy-at-iteration so concurrent unsubscribe/message handling cannot mutate a collection mid-loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2270d7961b02db97caf6db63910f6ae139d472d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->