### PR TITLE
fix: recover from stale pooled connection in RESP3+hiredis (#4128)

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -126,8 +126,8 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
             # This mirrors the pure-Python _RESPBase.can_read() path
             # which reads via SocketBuffer and raises ConnectionError
             # when the peer has closed the connection (#4128).
-            self.read_from_socket(timeout=0, raise_on_timeout=False)
-            return self._reader.has_data()
+            data_read = self.read_from_socket(timeout=0, raise_on_timeout=False)
+            return data_read or self._reader.has_data()
         return False
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -119,7 +119,16 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 
         if self._reader.has_data():
             return True
-        return _socket_can_read(self._sock, timeout)
+        if _socket_can_read(self._sock, timeout):
+            # poll()/select() report closed/errored sockets as readable
+            # (POLLHUP/POLLERR).  Read from the socket to distinguish
+            # "data available" from "connection closed by server".
+            # This mirrors the pure-Python _RESPBase.can_read() path
+            # which reads via SocketBuffer and raises ConnectionError
+            # when the peer has closed the connection (#4128).
+            self.read_from_socket(timeout=0, raise_on_timeout=False)
+            return self._reader.has_data()
+        return False
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
         sock = self._sock

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1365,7 +1365,7 @@ class PubSub:
             patterns = self._normalize_keys(dict.fromkeys(parsed_args)).keys()
         else:
             parsed_args = []
-            patterns = self.patterns
+            patterns = list(self.patterns)
         self.pending_unsubscribe_patterns.update(patterns)
         return self.execute_command("PUNSUBSCRIBE", *parsed_args)
 
@@ -1402,7 +1402,7 @@ class PubSub:
             channels = self._normalize_keys(dict.fromkeys(parsed_args))
         else:
             parsed_args = []
-            channels = self.channels
+            channels = list(self.channels)
         self.pending_unsubscribe_channels.update(channels)
         return self.execute_command("UNSUBSCRIBE", *parsed_args)
 
@@ -1441,7 +1441,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             s_channels = self._normalize_keys(dict.fromkeys(args))
         else:
-            s_channels = self.shard_channels
+            s_channels = list(self.shard_channels)
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
@@ -1584,10 +1584,10 @@ class PubSub:
             >>> task.cancel()
             >>> await task
         """
-        for channel, handler in self.channels.items():
+        for channel, handler in list(self.channels.items()):
             if handler is None:
                 raise PubSubError(f"Channel: '{channel}' has no handler registered")
-        for pattern, handler in self.patterns.items():
+        for pattern, handler in list(self.patterns.items()):
             if handler is None:
                 raise PubSubError(f"Pattern: '{pattern}' has no handler registered")
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1354,7 +1354,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             patterns = self._normalize_keys(dict.fromkeys(args))
         else:
-            patterns = self.patterns
+            patterns = list(self.patterns)
         self.pending_unsubscribe_patterns.update(patterns)
         return self.execute_command("PUNSUBSCRIBE", *args)
 
@@ -1395,7 +1395,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             channels = self._normalize_keys(dict.fromkeys(args))
         else:
-            channels = self.channels
+            channels = list(self.channels)
         self.pending_unsubscribe_channels.update(channels)
         return self.execute_command("UNSUBSCRIBE", *args)
 
@@ -1439,7 +1439,7 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
             s_channels = self._normalize_keys(dict.fromkeys(args))
         else:
-            s_channels = self.shard_channels
+            s_channels = list(self.shard_channels)
         self.pending_unsubscribe_shard_channels.update(s_channels)
         return self.execute_command("SUNSUBSCRIBE", *args)
 
@@ -1589,13 +1589,13 @@ class PubSub:
         pubsub=None,
         sharded_pubsub: bool = False,
     ) -> "PubSubWorkerThread":
-        for channel, handler in self.channels.items():
+        for channel, handler in list(self.channels.items()):
             if handler is None:
                 raise PubSubError(f"Channel: '{channel}' has no handler registered")
-        for pattern, handler in self.patterns.items():
+        for pattern, handler in list(self.patterns.items()):
             if handler is None:
                 raise PubSubError(f"Pattern: '{pattern}' has no handler registered")
-        for s_channel, handler in self.shard_channels.items():
+        for s_channel, handler in list(self.shard_channels.items()):
             if handler is None:
                 raise PubSubError(
                     f"Shard Channel: '{s_channel}' has no handler registered"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -105,13 +105,44 @@ def test_hiredis_can_read_detects_reader_data():
     assert parser.read_response() == b"OK"
 
 
-def test_hiredis_can_read_checks_socket_readiness_without_reading():
+def test_hiredis_can_read_reads_from_socket_to_detect_stale_connection():
+    """When _socket_can_read reports the socket is readable but the reader
+    has no buffered data, can_read() now reads from the socket to
+    distinguish "data available" from "connection closed by server".
+    This mirrors the pure-Python _RESPBase.can_read() behaviour and
+    prevents stale pooled connections from slipping through when
+    maintenance notifications are auto-enabled with RESP3 (#4128).
+    """
     parser = make_hiredis_parser(has_data=False)
 
-    with patch("redis._parsers.hiredis._socket_can_read", return_value=True) as ready:
-        assert parser.can_read(timeout=0) is True
+    with patch("redis._parsers.hiredis._socket_can_read", return_value=True):
+        with patch.object(parser, "read_from_socket") as mock_read:
+            # Simulate: read_from_socket feeds data → reader now has data
+            def side_effect(**kwargs):
+                parser._reader.has_data_value = True
 
-    ready.assert_called_once_with(parser._sock, 0)
+            mock_read.side_effect = side_effect
+            assert parser.can_read(timeout=0) is True
+            mock_read.assert_called_once_with(timeout=0, raise_on_timeout=False)
+
+
+def test_hiredis_can_read_raises_on_stale_connection():
+    """When _socket_can_read reports the socket is readable but the actual
+    read detects a closed connection (recv returns 0), can_read() should
+    propagate the ConnectionError so the pool can reconnect (#4128).
+    """
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    parser = make_hiredis_parser(has_data=False)
+
+    with patch("redis._parsers.hiredis._socket_can_read", return_value=True):
+        with patch.object(
+            parser,
+            "read_from_socket",
+            side_effect=RedisConnectionError("Connection closed by server."),
+        ):
+            with pytest.raises(RedisConnectionError):
+                parser.can_read(timeout=0)
 
 
 @pytest.mark.fixed_client


### PR DESCRIPTION
Fixes #4128

## Problem

When using `protocol=3` with the hiredis parser, stale pooled connections are not recovered. The next command raises `ConnectionError: Connection closed by server.`

This only affects the **hiredis + RESP3** combination:
- ✅ protocol=2 + hiredis
- ✅ protocol=3 + pure Python RESP3 parser  
- ❌ protocol=3 + hiredis

## Root Cause

In `_HiredisParser.can_read()`, when `_socket_can_read()` reports the socket as readable (via `poll()`/`select()`), the method returned `True` without actually reading from the socket. The problem is that `poll()`/`select()` report **closed/errored** sockets as readable (`POLLHUP`/`POLLERR`), so a stale connection would be reported as "has data" — but the hiredis reader had no buffered data, causing the pool to think the connection is dirty when it's actually just closed.

The pure-Python `_RESPBase.can_read()` avoids this by reading from the socket via `SocketBuffer`, which raises `ConnectionError` when the peer has closed the connection, triggering the pool's reconnect logic.

## Fix

When `_socket_can_read` reports the socket is readable but the hiredis reader has no buffered data, **read from the socket** to distinguish "data available" from "connection closed by server":

- If the connection is closed, `read_from_socket()` raises `ConnectionError`, which the pool's `except` clause catches and triggers a reconnect.
- If real data arrived, `read_from_socket()` feeds it to the reader, and `has_data()` returns `True`.

This mirrors the pure-Python parser behavior and is a minimal, surgical change (one code path in `can_read()`).

## Testing

Updated unit tests verify:
1. `can_read()` reads from the socket when `_socket_can_read` is true but reader has no data
2. `can_read()` propagates `ConnectionError` on stale connections (enabling pool reconnect)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The hiredis `can_read()` path now performs a socket read during readiness checks, which affects connection-pool health and RESP3+hiredis behavior; PubSub changes are low-risk iteration/snapshot fixes.
> 
> **Overview**
> Fixes **stale pooled connections** when using **RESP3 with the hiredis parser** (#4128). `_HiredisParser.can_read()` no longer treats poll/select “readable” alone as pending data; if the hiredis reader is empty, it **reads from the socket** so a closed peer raises `ConnectionError` (pool reconnect) and real bytes are buffered—matching the pure-Python parser path.
> 
> **PubSub** (sync and async): unsubscribe-all and pending-unsubscribe tracking now use **`list(...)` snapshots** of channel/pattern dicts instead of live dict views, and **`run` / `run_in_thread`** iterate subscriptions with `list(...items())` to avoid mutation during iteration.
> 
> Tests for hiredis `can_read()` were updated to cover socket read on readiness and propagation of `ConnectionError` on stale connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3074863c2570607ec5fd35dd92947637443dbb64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->