### PR TITLE
fix(hiredis): raise ConnectionError instead of AttributeError on concurrent disconnect

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -123,14 +123,21 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
         sock = self._sock
+        reader = self._reader
+        # Another thread may disconnect this connection while we are here (e.g.
+        # a shared client closed via `with redis:`); on_disconnect() sets both
+        # _sock and _reader to None. Bind them locally and fail with a
+        # descriptive, retryable ConnectionError instead of an AttributeError.
+        if sock is None or reader is None:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         custom_timeout = timeout is not SENTINEL
         try:
             if custom_timeout:
                 sock.settimeout(timeout)
-            bufflen = self._sock.recv_into(self._buffer)
+            bufflen = sock.recv_into(self._buffer)
             if bufflen == 0:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            self._reader.feed(self._buffer, 0, bufflen)
+            reader.feed(self._buffer, 0, bufflen)
             # data was read from the socket and added to the buffer.
             # return True to indicate that data was read.
             return True
@@ -160,20 +167,24 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         push_request=False,
         timeout: Union[float, object] = SENTINEL,
     ):
-        if not self._reader:
+        # Bind the reader locally so a concurrent disconnect that clears
+        # self._reader can't turn a later .gets() into an AttributeError;
+        # re-checking the attribute each time would still race.
+        reader = self._reader
+        if reader is None:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
         if disable_decoding:
-            response = self._reader.gets(False)
+            response = reader.gets(False)
         else:
-            response = self._reader.gets()
+            response = reader.gets()
 
         while response is NOT_ENOUGH_DATA:
             self.read_from_socket(timeout=timeout)
             if disable_decoding:
-                response = self._reader.gets(False)
+                response = reader.gets(False)
             else:
-                response = self._reader.gets()
+                response = reader.gets()
         # if the response is a ConnectionError or the response is a list and
         # the first item is a ConnectionError, raise it as something bad
         # happened

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -294,6 +294,38 @@ def test_hiredis_read_response_timeout_zero_maps_would_block_to_timeout():
         parser.read_response(timeout=0)
 
 
+@pytest.mark.parametrize("cleared_attr", ["_reader", "_sock"])
+def test_hiredis_read_from_socket_raises_connection_error_when_disconnected(
+    cleared_attr,
+):
+    # regression for #4003: another thread may disconnect the connection while
+    # we are reading (e.g. a shared client closed via `with redis:`), which sets
+    # _sock and _reader to None. read_from_socket() must raise a descriptive,
+    # retryable ConnectionError rather than an AttributeError.
+    parser = make_hiredis_parser()
+    parser._sock.recv_into.return_value = 10
+    setattr(parser, cleared_attr, None)
+
+    with pytest.raises(ConnectionError, match="Connection closed by server"):
+        parser.read_from_socket()
+
+
+def test_hiredis_read_response_uses_local_reader_if_disconnected_mid_read():
+    # regression for #4003: if _reader is cleared by a concurrent disconnect
+    # after read_from_socket() returns, the in-flight read must still complete
+    # via the locally bound reader instead of raising AttributeError on .gets().
+    parser = make_hiredis_parser()
+    parser._reader.responses = [NOT_ENOUGH_DATA, b"OK"]
+
+    def fake_read_from_socket(*args, **kwargs):
+        parser._reader = None  # simulate on_disconnect() from another thread
+        return True
+
+    parser.read_from_socket = fake_read_from_socket
+
+    assert parser.read_response() == b"OK"
+
+
 def test_socket_buffer_timeout_zero_maps_would_block_to_timeout():
     sock = Mock()
     sock.recv.side_effect = BlockingIOError(


### PR DESCRIPTION
### Description of change

Fixes #4003.

When a Redis client is shared across threads with per-operation `with redis:` blocks, the sync hiredis parser can crash with `AttributeError: 'NoneType' object has no attribute 'feed'` (also `recv_into`/`gets`). `with redis:` disconnects on exit, and `_HiredisParser.on_disconnect()` sets `self._sock` and `self._reader` to `None`; a read in flight on another thread then hits the `None`. Since it's an `AttributeError` and not a `ConnectionError`, the retry/reconnect path never catches it and it surfaces to the caller.

**Changes** (`redis/_parsers/hiredis.py`):
- `read_from_socket`: bind `self._sock`/`self._reader` to locals, raise a `ConnectionError` if either is `None`, and use the locals consistently (also fixes an existing `self._sock` re-read).
- `read_response`: bind `self._reader` to a local and read through it, so a disconnect during `read_from_socket()` can't turn a later `.gets()` into an `AttributeError`.
- `tests/test_connection.py`: regression tests for the `None`-socket / `None`-reader cases and the `read_response` race.

**Notes:**
- Binding to a local also closes the race. Re-checking the attribute each time would still be a TOCTOU race.
- Sync hiredis only: the async parser's `on_disconnect()` doesn't null `_reader`/`_stream`, so it isn't affected.
- This doesn't make sharing one connection across threads safe (still unsupported); it just turns the crash into a proper, retryable error.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? -NA
- [x] Is there an example added to the examples folder (if applicable)? -NA

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow sync hiredis parser change with targeted error-mapping and regression tests; no auth or API surface changes.
> 
> **Overview**
> Fixes **#4003**: when another thread disconnects a shared sync client (e.g. exiting `with redis:`) while a read is in flight, `on_disconnect()` clears `_sock` and `_reader`, which used to surface as `AttributeError` on `recv_into`, `feed`, or `gets()`—bypassing retry/reconnect logic.
> 
> In **`redis/_parsers/hiredis.py`**, `read_from_socket` now snapshots `_sock` and `_reader` locally, raises **`ConnectionError`** if either is already `None`, and uses those locals for I/O. **`read_response`** snapshots `_reader` once and parses through it so a disconnect during `read_from_socket()` does not break subsequent `.gets()` calls.
> 
> Adds regression tests in **`tests/test_connection.py`** for disconnected socket/reader at read start and for completing a read after `_reader` is cleared mid-loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70cb39dfc2cf56e6c4cbce916d426ab83be923d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->