### PR TITLE
fix: detect stale connection via MSG_PEEK in hiredis (#4128)

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -35,6 +35,7 @@ def _socket_can_read(sock, timeout: float) -> bool:
     # timeout=0 must be a non-blocking readiness check only; both branches
     # below are non-destructive and have no FD_SETSIZE limit (select.select
     # raises ValueError for fds >= 1024).
+    socket_readable = False
     if _HAS_POLL:
         # Prefer poll() over selectors.DefaultSelector: epoll/kqueue selectors
         # allocate a file descriptor per check and so fail with EMFILE under
@@ -46,10 +47,38 @@ def _socket_can_read(sock, timeout: float) -> bool:
         # POLLNVAL are always reported regardless of the registered mask, so
         # closed or errored sockets still count as readable, like select().
         poll_timeout = None if timeout is None else timeout * 1000
-        return bool(poller.poll(poll_timeout))
-    with selectors.DefaultSelector() as selector:
-        selector.register(sock, selectors.EVENT_READ)
-        return bool(selector.select(timeout))
+        if poller.poll(poll_timeout):
+            socket_readable = True
+    else:
+        with selectors.DefaultSelector() as selector:
+            selector.register(sock, selectors.EVENT_READ)
+            if selector.select(timeout):
+                socket_readable = True
+
+    # On a stale (half-closed) connection poll()/select() reports the
+    # socket as readable because a FIN/EOF is pending, even though there
+    # is no application data.  Peek at the socket without consuming data
+    # to distinguish a real response from a stale EOF -- the same thing
+    # the pure-Python SocketBuffer parser does (it calls recv() and
+    # checks for b"").
+    # Only applies to non-SSL plain sockets.
+    if timeout == 0 and hasattr(sock, "gettimeout") and not hasattr(sock, "pending"):
+        old_timeout = sock.gettimeout()
+        try:
+            sock.setblocking(False)
+            try:
+                data = sock.recv(1, socket.MSG_PEEK)
+                # b"" means EOF -- the peer has closed the connection.
+                if not data:
+                    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+                return True
+            except BlockingIOError:
+                return False
+        finally:
+            sock.settimeout(old_timeout)
+    if socket_readable:
+        return True
+    return False
 
 
 class _HiredisReaderArgs(TypedDict, total=False):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -221,6 +221,43 @@ def test_hiredis_socket_can_read_under_fd_exhaustion():
         peer.close()
 
 
+@pytest.mark.skipif(
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
+)
+def test_hiredis_socket_can_read_detects_closed_connection_via_peek():
+    """When poll() misses a half-closed EOF, MSG_PEEK recv still catches it."""
+    reader, writer = socket.socketpair()
+    try:
+        writer.sendall(b"x")
+        writer.close()
+        # drain the data so the socket has nothing to read — only EOF remains
+        reader.recv(1)
+
+        # Simulate poll() missing the EOF by returning an empty list.
+        empty_poller = Mock()
+        empty_poller.poll.return_value = []
+        with patch("redis._parsers.hiredis.select.poll", return_value=empty_poller):
+            with pytest.raises(redis.exceptions.ConnectionError):
+                _socket_can_read(reader, timeout=0)
+    finally:
+        reader.close()
+
+
+def test_hiredis_socket_can_read_detects_stale_eof_when_poll_reports_readable():
+    """When poll() reports readable due to EOF (stale connection), MSG_PEEK
+    should detect the lack of real data and raise ConnectionError (#4128)."""
+    reader, writer = socket.socketpair()
+    try:
+        writer.close()
+        # The peer is closed. poll() reports the reader as readable (EOF),
+        # but there is no application data — this is the stale-pooled-
+        # connection scenario from issue #4128.
+        with pytest.raises(redis.exceptions.ConnectionError):
+            _socket_can_read(reader, timeout=0)
+    finally:
+        reader.close()
+
+
 def test_hiredis_can_read_does_not_decide_disable_decoding():
     raw = b"\xe2\x98\x83"
     parser = make_hiredis_parser(


### PR DESCRIPTION
Fixes #4128

## Problem

When / reports a stale (half-closed) socket as readable due to EOF/POLLHUP,  returned  without checking whether actual data was present. This caused the hiredis  to report the connection had data, but the subsequent  →  returned 0 bytes, raising  instead of allowing the pool to detect and recycle the stale connection.

## Fix

After / says the socket is readable, use a non-destructive   to distinguish real application data from a stale EOF on plain (non-SSL) sockets with . If the peek returns , raise  immediately — the same approach the pure-Python  parser uses.

This fixes the root cause at the  level, benefiting all callers rather than patching individual call sites.

## Testing

- All existing  tests pass (mock-based tests correctly skip MSG_PEEK since mock sockets lack /)
- New test  verifies that a socket with EOF (peer closed, no data) raises 
- All checks passed! passes on both changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection readiness logic on every hiredis non-blocking check for plain sockets; behavior is scoped to timeout=0 and non-SSL, but it affects pooled connection validation paths.
> 
> **Overview**
> Fixes **#4128** by tightening hiredis `_socket_can_read` so a non-blocking readiness check does not treat a half-closed socket as having data when only EOF is pending.
> 
> After `poll()` / `select()` reports readability, **`timeout=0`** on plain (non-SSL) sockets now uses a non-destructive **`MSG_PEEK`** `recv`: empty peek raises **`ConnectionError`** (server closed), matching the pure-Python socket parser behavior and letting the pool recycle stale connections instead of failing later on zero-byte reads.
> 
> Tests cover EOF when poll reports readable and when poll is mocked to miss EOF while peek still catches it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165baed83fffbff82ad0a81c5393af7966747343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->