### PR TITLE
fix: convert recursive RESP parsing to iterative to avoid RecursionError

### DIFF
--- a/redis/_parsers/resp2.py
+++ b/redis/_parsers/resp2.py
@@ -53,6 +53,7 @@ class _RESP2Parser(_RESPBase):
                 # inside a pipeline response. the connection's read_response()
                 # and/or the pipeline's execute() will raise this error if
                 # necessary, so just return the exception instance here.
+                response = error
             # single value
             elif byte == b"+":
                 pass
@@ -136,6 +137,7 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
                 # inside a pipeline response. the connection's read_response()
                 # and/or the pipeline's execute() will raise this error if
                 # necessary, so just return the exception instance here.
+                response = error
             # single value
             elif byte == b"+":
                 pass

--- a/redis/_parsers/resp2.py
+++ b/redis/_parsers/resp2.py
@@ -29,46 +29,66 @@ class _RESP2Parser(_RESPBase):
     def _read_response(
         self, disable_decoding=False, timeout: Union[float, object] = SENTINEL
     ):
-        raw = self._buffer.readline(timeout=timeout)
-        if not raw:
-            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        # Iterative stack-based parsing to avoid RecursionError on deeply nested arrays.
+        # Each stack entry: (remaining_count, results_list)
+        stack = []
+        response = None
 
-        byte, response = raw[:1], raw[1:]
+        while True:
+            raw = self._buffer.readline(timeout=timeout)
+            if not raw:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
-        # server returned an error
-        if byte == b"-":
-            response = response.decode("utf-8", errors="replace")
-            error = self.parse_error(response)
-            # if the error is a ConnectionError, raise immediately so the user
-            # is notified
-            if isinstance(error, ConnectionError):
-                raise error
-            # otherwise, we're dealing with a ResponseError that might belong
-            # inside a pipeline response. the connection's read_response()
-            # and/or the pipeline's execute() will raise this error if
-            # necessary, so just return the exception instance here.
-            return error
-        # single value
-        elif byte == b"+":
-            pass
-        # int value
-        elif byte == b":":
-            return int(response)
-        # bulk response
-        elif byte == b"$" and response == b"-1":
-            return None
-        elif byte == b"$":
-            response = self._buffer.read(int(response), timeout=timeout)
-        # multi-bulk response
-        elif byte == b"*" and response == b"-1":
-            return None
-        elif byte == b"*":
-            response = [
-                self._read_response(disable_decoding=disable_decoding, timeout=timeout)
-                for i in range(int(response))
-            ]
-        else:
-            raise InvalidResponse(f"Protocol Error: {raw!r}")
+            byte, response = raw[:1], raw[1:]
+
+            # server returned an error
+            if byte == b"-":
+                response = response.decode("utf-8", errors="replace")
+                error = self.parse_error(response)
+                # if the error is a ConnectionError, raise immediately so the user
+                # is notified
+                if isinstance(error, ConnectionError):
+                    raise error
+                # otherwise, we're dealing with a ResponseError that might belong
+                # inside a pipeline response. the connection's read_response()
+                # and/or the pipeline's execute() will raise this error if
+                # necessary, so just return the exception instance here.
+            # single value
+            elif byte == b"+":
+                pass
+            # int value
+            elif byte == b":":
+                response = int(response)
+            # bulk response
+            elif byte == b"$" and response == b"-1":
+                response = None
+            elif byte == b"$":
+                response = self._buffer.read(int(response), timeout=timeout)
+            # multi-bulk response
+            elif byte == b"*" and response == b"-1":
+                response = None
+            elif byte == b"*":
+                count = int(response)
+                if count == 0:
+                    response = []
+                else:
+                    stack.append((count, []))
+                    continue
+            else:
+                raise InvalidResponse(f"Protocol Error: {raw!r}")
+
+            while stack:
+                remaining, results = stack[-1]
+                results.append(response)
+                remaining -= 1
+                if remaining > 0:
+                    stack[-1] = (remaining, results)
+                    break
+                else:
+                    stack.pop()
+                    response = results
+            else:
+                break
 
         if disable_decoding is False:
             response = self.encoder.decode(response)
@@ -94,45 +114,64 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
     async def _read_response(
         self, disable_decoding: bool = False
     ) -> Union[EncodableT, ResponseError, None]:
-        raw = await self._readline()
-        response: Any
-        byte, response = raw[:1], raw[1:]
+        # Iterative stack-based parsing to avoid RecursionError on deeply nested arrays.
+        # Each stack entry: (remaining_count, results_list)
+        stack = []
+        response: Any = None
 
-        # server returned an error
-        if byte == b"-":
-            response = response.decode("utf-8", errors="replace")
-            error = self.parse_error(response)
-            # if the error is a ConnectionError, raise immediately so the user
-            # is notified
-            if isinstance(error, ConnectionError):
-                self._clear()  # Successful parse
-                raise error
-            # otherwise, we're dealing with a ResponseError that might belong
-            # inside a pipeline response. the connection's read_response()
-            # and/or the pipeline's execute() will raise this error if
-            # necessary, so just return the exception instance here.
-            return error
-        # single value
-        elif byte == b"+":
-            pass
-        # int value
-        elif byte == b":":
-            return int(response)
-        # bulk response
-        elif byte == b"$" and response == b"-1":
-            return None
-        elif byte == b"$":
-            response = await self._read(int(response))
-        # multi-bulk response
-        elif byte == b"*" and response == b"-1":
-            return None
-        elif byte == b"*":
-            response = [
-                (await self._read_response(disable_decoding))
-                for _ in range(int(response))  # noqa
-            ]
-        else:
-            raise InvalidResponse(f"Protocol Error: {raw!r}")
+        while True:
+            raw = await self._readline()
+            byte, response = raw[:1], raw[1:]
+
+            # server returned an error
+            if byte == b"-":
+                response = response.decode("utf-8", errors="replace")
+                error = self.parse_error(response)
+                # if the error is a ConnectionError, raise immediately so the user
+                # is notified
+                if isinstance(error, ConnectionError):
+                    self._clear()  # Successful parse
+                    raise error
+                # otherwise, we're dealing with a ResponseError that might belong
+                # inside a pipeline response. the connection's read_response()
+                # and/or the pipeline's execute() will raise this error if
+                # necessary, so just return the exception instance here.
+            # single value
+            elif byte == b"+":
+                pass
+            # int value
+            elif byte == b":":
+                response = int(response)
+            # bulk response
+            elif byte == b"$" and response == b"-1":
+                response = None
+            elif byte == b"$":
+                response = await self._read(int(response))
+            # multi-bulk response
+            elif byte == b"*" and response == b"-1":
+                response = None
+            elif byte == b"*":
+                count = int(response)
+                if count == 0:
+                    response = []
+                else:
+                    stack.append((count, []))
+                    continue
+            else:
+                raise InvalidResponse(f"Protocol Error: {raw!r}")
+
+            while stack:
+                remaining, results = stack[-1]
+                results.append(response)
+                remaining -= 1
+                if remaining > 0:
+                    stack[-1] = (remaining, results)
+                    break
+                else:
+                    stack.pop()
+                    response = results
+            else:
+                break
 
         if disable_decoding is False:
             response = self.encoder.decode(response)

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -90,6 +90,7 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
                 # inside a pipeline response. the connection's read_response()
                 # and/or the pipeline's execute() will raise this error if
                 # necessary, so just return the exception instance here.
+                response = error
             # single value
             elif byte == b"+":
                 pass
@@ -145,6 +146,9 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
                 count = int(response)
                 if count == 0:
                     response = self.handle_push_response([])
+                    if push_request:
+                        return response
+                    continue
                 else:
                     stack.append(('push', count, [], None))
                     continue
@@ -251,6 +255,7 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
                 # inside a pipeline response. the connection's read_response()
                 # and/or the pipeline's execute() will raise this error if
                 # necessary, so just return the exception instance here.
+                response = error
             # single value
             elif byte == b"+":
                 pass
@@ -306,6 +311,9 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
                 count = int(response)
                 if count == 0:
                     response = await self.handle_push_response([])
+                    if push_request:
+                        return response
+                    continue
                 else:
                     stack.append(('push', count, [], None))
                     continue

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -62,100 +62,130 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
         push_request=False,
         timeout: Union[float, object] = SENTINEL,
     ):
-        raw = self._buffer.readline(timeout=timeout)
-        if not raw:
-            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        # Iterative stack-based parsing to avoid RecursionError on deeply nested aggregates.
+        # Each stack entry: (type, remaining_count, container, pending_key)
+        # type is one of: 'array', 'set', 'map', 'push'
+        # pending_key is used only for maps to store the key until we read the value
+        stack = []
+        response = None
 
-        byte, response = raw[:1], raw[1:]
+        while True:
+            raw = self._buffer.readline(timeout=timeout)
+            if not raw:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
-        # server returned an error
-        if byte in (b"-", b"!"):
-            if byte == b"!":
+            byte, response = raw[:1], raw[1:]
+
+            # server returned an error
+            if byte in (b"-", b"!"):
+                if byte == b"!":
+                    response = self._buffer.read(int(response), timeout=timeout)
+                response = response.decode("utf-8", errors="replace")
+                error = self.parse_error(response)
+                # if the error is a ConnectionError, raise immediately so the user
+                # is notified
+                if isinstance(error, ConnectionError):
+                    raise error
+                # otherwise, we're dealing with a ResponseError that might belong
+                # inside a pipeline response. the connection's read_response()
+                # and/or the pipeline's execute() will raise this error if
+                # necessary, so just return the exception instance here.
+            # single value
+            elif byte == b"+":
+                pass
+            # null value
+            elif byte == b"_":
+                response = None
+            # int and big int values
+            elif byte in (b":", b"("):
+                response = int(response)
+            # double value
+            elif byte == b",":
+                response = float(response)
+            # bool value
+            elif byte == b"#":
+                response = response == b"t"
+            # bulk response
+            elif byte == b"$":
                 response = self._buffer.read(int(response), timeout=timeout)
-            response = response.decode("utf-8", errors="replace")
-            error = self.parse_error(response)
-            # if the error is a ConnectionError, raise immediately so the user
-            # is notified
-            if isinstance(error, ConnectionError):
-                raise error
-            # otherwise, we're dealing with a ResponseError that might belong
-            # inside a pipeline response. the connection's read_response()
-            # and/or the pipeline's execute() will raise this error if
-            # necessary, so just return the exception instance here.
-            return error
-        # single value
-        elif byte == b"+":
-            pass
-        # null value
-        elif byte == b"_":
-            return None
-        # int and big int values
-        elif byte in (b":", b"("):
-            return int(response)
-        # double value
-        elif byte == b",":
-            return float(response)
-        # bool value
-        elif byte == b"#":
-            return response == b"t"
-        # bulk response
-        elif byte == b"$":
-            response = self._buffer.read(int(response), timeout=timeout)
-        # verbatim string response
-        elif byte == b"=":
-            response = self._buffer.read(int(response), timeout=timeout)[4:]
-        # array response
-        elif byte == b"*":
-            response = [
-                self._read_response(disable_decoding=disable_decoding, timeout=timeout)
-                for _ in range(int(response))
-            ]
-        # set response
-        elif byte == b"~":
-            # redis can return unhashable types (like dict) in a set,
-            # so we return sets as list, all the time, for predictability
-            response = [
-                self._read_response(disable_decoding=disable_decoding, timeout=timeout)
-                for _ in range(int(response))
-            ]
-        # map response
-        elif byte == b"%":
-            # We cannot use a dict-comprehension to parse stream.
-            # Evaluation order of key:val expression in dict comprehension only
-            # became defined to be left-right in version 3.8
-            resp_dict = {}
-            for _ in range(int(response)):
-                key = self._read_response(
-                    disable_decoding=disable_decoding, timeout=timeout
-                )
-                resp_dict[key] = self._read_response(
-                    disable_decoding=disable_decoding,
-                    push_request=push_request,
-                    timeout=timeout,
-                )
-            response = resp_dict
-        # push response
-        elif byte == b">":
-            response = [
-                self._read_response(
-                    disable_decoding=disable_decoding,
-                    push_request=push_request,
-                    timeout=timeout,
-                )
-                for _ in range(int(response))
-            ]
-            response = self.handle_push_response(response)
+            # verbatim string response
+            elif byte == b"=":
+                response = self._buffer.read(int(response), timeout=timeout)[4:]
+            # array response
+            elif byte == b"*":
+                count = int(response)
+                if count == 0:
+                    response = []
+                else:
+                    stack.append(('array', count, [], None))
+                    continue
+            # set response
+            elif byte == b"~":
+                # redis can return unhashable types (like dict) in a set,
+                # so we return sets as list, all the time, for predictability
+                count = int(response)
+                if count == 0:
+                    response = []
+                else:
+                    stack.append(('set', count, [], None))
+                    continue
+            # map response
+            elif byte == b"%":
+                count = int(response)
+                if count == 0:
+                    response = {}
+                else:
+                    # We cannot use a dict-comprehension to parse stream.
+                    # Evaluation order of key:val expression in dict comprehension only
+                    # became defined to be left-right in version 3.8
+                    stack.append(('map', count, {}, None))
+                    continue
+            # push response
+            elif byte == b">":
+                count = int(response)
+                if count == 0:
+                    response = self.handle_push_response([])
+                else:
+                    stack.append(('push', count, [], None))
+                    continue
+            else:
+                raise InvalidResponse(f"Protocol Error: {raw!r}")
 
-            # if this is a push request return the push response
-            if push_request:
-                return response
-
-            return self._read_response(
-                disable_decoding=disable_decoding,
-                push_request=push_request,
-            )
-        else:
-            raise InvalidResponse(f"Protocol Error: {raw!r}")
+            while stack:
+                frame_type, remaining, container, pending_key = stack[-1]
+                if frame_type == 'map':
+                    if pending_key is None:
+                        # This is a key - store it and continue reading value
+                        stack[-1] = (frame_type, remaining, container, response)
+                        break
+                    else:
+                        # This is a value - store key-value pair
+                        container[pending_key] = response
+                        remaining -= 1
+                        if remaining > 0:
+                            stack[-1] = (frame_type, remaining, container, None)
+                            break
+                        else:
+                            stack.pop()
+                            response = container
+                            continue
+                else:
+                    container.append(response)
+                    remaining -= 1
+                    if remaining > 0:
+                        stack[-1] = (frame_type, remaining, container, None)
+                        break
+                    else:
+                        stack.pop()
+                        if frame_type == 'push':
+                            response = self.handle_push_response(container)
+                            if push_request:
+                                return response
+                            continue
+                        response = container
+                        continue
+            else:
+                break
 
         if isinstance(response, bytes) and disable_decoding is False:
             response = self.encoder.decode(response)
@@ -194,95 +224,129 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
     ) -> Union[EncodableT, ResponseError, None]:
         if not self._stream or not self.encoder:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-        raw = await self._readline()
-        response: Any
-        byte, response = raw[:1], raw[1:]
 
-        # if byte not in (b"-", b"+", b":", b"$", b"*"):
-        #     raise InvalidResponse(f"Protocol Error: {raw!r}")
+        # Iterative stack-based parsing to avoid RecursionError on deeply nested aggregates.
+        # Each stack entry: (type, remaining_count, container, pending_key)
+        # type is one of: 'array', 'set', 'map', 'push'
+        # pending_key is used only for maps to store the key until we read the value
+        stack = []
+        response: Any = None
 
-        # server returned an error
-        if byte in (b"-", b"!"):
-            if byte == b"!":
+        while True:
+            raw = await self._readline()
+            byte, response = raw[:1], raw[1:]
+
+            # server returned an error
+            if byte in (b"-", b"!"):
+                if byte == b"!":
+                    response = await self._read(int(response))
+                response = response.decode("utf-8", errors="replace")
+                error = self.parse_error(response)
+                # if the error is a ConnectionError, raise immediately so the user
+                # is notified
+                if isinstance(error, ConnectionError):
+                    self._clear()  # Successful parse
+                    raise error
+                # otherwise, we're dealing with a ResponseError that might belong
+                # inside a pipeline response. the connection's read_response()
+                # and/or the pipeline's execute() will raise this error if
+                # necessary, so just return the exception instance here.
+            # single value
+            elif byte == b"+":
+                pass
+            # null value
+            elif byte == b"_":
+                response = None
+            # int and big int values
+            elif byte in (b":", b"("):
+                response = int(response)
+            # double value
+            elif byte == b",":
+                response = float(response)
+            # bool value
+            elif byte == b"#":
+                response = response == b"t"
+            # bulk response
+            elif byte == b"$":
                 response = await self._read(int(response))
-            response = response.decode("utf-8", errors="replace")
-            error = self.parse_error(response)
-            # if the error is a ConnectionError, raise immediately so the user
-            # is notified
-            if isinstance(error, ConnectionError):
-                self._clear()  # Successful parse
-                raise error
-            # otherwise, we're dealing with a ResponseError that might belong
-            # inside a pipeline response. the connection's read_response()
-            # and/or the pipeline's execute() will raise this error if
-            # necessary, so just return the exception instance here.
-            return error
-        # single value
-        elif byte == b"+":
-            pass
-        # null value
-        elif byte == b"_":
-            return None
-        # int and big int values
-        elif byte in (b":", b"("):
-            return int(response)
-        # double value
-        elif byte == b",":
-            return float(response)
-        # bool value
-        elif byte == b"#":
-            return response == b"t"
-        # bulk response
-        elif byte == b"$":
-            response = await self._read(int(response))
-        # verbatim string response
-        elif byte == b"=":
-            response = (await self._read(int(response)))[4:]
-        # array response
-        elif byte == b"*":
-            response = [
-                (await self._read_response(disable_decoding=disable_decoding))
-                for _ in range(int(response))
-            ]
-        # set response
-        elif byte == b"~":
-            # redis can return unhashable types (like dict) in a set,
-            # so we always convert to a list, to have predictable return types
-            response = [
-                (await self._read_response(disable_decoding=disable_decoding))
-                for _ in range(int(response))
-            ]
-        # map response
-        elif byte == b"%":
-            # We cannot use a dict-comprehension to parse stream.
-            # Evaluation order of key:val expression in dict comprehension only
-            # became defined to be left-right in version 3.8
-            resp_dict = {}
-            for _ in range(int(response)):
-                key = await self._read_response(disable_decoding=disable_decoding)
-                resp_dict[key] = await self._read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
-                )
-            response = resp_dict
-        # push response
-        elif byte == b">":
-            response = [
-                (
-                    await self._read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
-                    )
-                )
-                for _ in range(int(response))
-            ]
-            response = await self.handle_push_response(response)
-            if not push_request:
-                return await self._read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
-                )
+            # verbatim string response
+            elif byte == b"=":
+                response = (await self._read(int(response)))[4:]
+            # array response
+            elif byte == b"*":
+                count = int(response)
+                if count == 0:
+                    response = []
+                else:
+                    stack.append(('array', count, [], None))
+                    continue
+            # set response
+            elif byte == b"~":
+                # redis can return unhashable types (like dict) in a set,
+                # so we always convert to a list, to have predictable return types
+                count = int(response)
+                if count == 0:
+                    response = []
+                else:
+                    stack.append(('set', count, [], None))
+                    continue
+            # map response
+            elif byte == b"%":
+                count = int(response)
+                if count == 0:
+                    response = {}
+                else:
+                    # We cannot use a dict-comprehension to parse stream.
+                    # Evaluation order of key:val expression in dict comprehension only
+                    # became defined to be left-right in version 3.8
+                    stack.append(('map', count, {}, None))
+                    continue
+            # push response
+            elif byte == b">":
+                count = int(response)
+                if count == 0:
+                    response = await self.handle_push_response([])
+                else:
+                    stack.append(('push', count, [], None))
+                    continue
             else:
-                return response
-        else:
-            raise InvalidResponse(f"Protocol Error: {raw!r}")
+                raise InvalidResponse(f"Protocol Error: {raw!r}")
+
+            while stack:
+                frame_type, remaining, container, pending_key = stack[-1]
+                if frame_type == 'map':
+                    if pending_key is None:
+                        # This is a key - store it and continue reading value
+                        stack[-1] = (frame_type, remaining, container, response)
+                        break
+                    else:
+                        # This is a value - store key-value pair
+                        container[pending_key] = response
+                        remaining -= 1
+                        if remaining > 0:
+                            stack[-1] = (frame_type, remaining, container, None)
+                            break
+                        else:
+                            stack.pop()
+                            response = container
+                            continue
+                else:
+                    container.append(response)
+                    remaining -= 1
+                    if remaining > 0:
+                        stack[-1] = (frame_type, remaining, container, None)
+                        break
+                    else:
+                        stack.pop()
+                        if frame_type == 'push':
+                            response = await self.handle_push_response(container)
+                            if push_request:
+                                return response
+                            continue
+                        response = container
+                        continue
+            else:
+                break
 
         if isinstance(response, bytes) and disable_decoding is False:
             response = self.encoder.decode(response)

--- a/tests/test_parsers/test_resp_recursion.py
+++ b/tests/test_parsers/test_resp_recursion.py
@@ -1,0 +1,144 @@
+import sys
+
+import pytest
+
+from redis._parsers.resp2 import _RESP2Parser, _AsyncRESP2Parser
+from redis._parsers.resp3 import _RESP3Parser, _AsyncRESP3Parser
+from redis._parsers.socket import SocketBuffer
+
+
+class FakeSocket:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def recv(self, n: int) -> bytes:
+        if not self.payload:
+            return b""
+        chunk = self.payload[:n]
+        self.payload = self.payload[n:]
+        return chunk
+
+    def settimeout(self, _timeout: float) -> None:
+        pass
+
+
+def make_resp2_parser(payload: bytes) -> _RESP2Parser:
+    parser = _RESP2Parser(socket_read_size=65536)
+    parser._buffer = SocketBuffer(
+        FakeSocket(payload), socket_read_size=65536, socket_timeout=5
+    )
+    return parser
+
+
+def make_resp3_parser(payload: bytes) -> _RESP3Parser:
+    parser = _RESP3Parser(socket_read_size=65536)
+    parser._buffer = SocketBuffer(
+        FakeSocket(payload), socket_read_size=65536, socket_timeout=5
+    )
+    return parser
+
+
+class TestRESP2DeepNesting:
+    def test_nested_arrays_below_limit(self):
+        depth = 100
+        payload = (b"*1\r\n" * depth) + b"+OK\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        expected = b"OK"
+        for _ in range(depth):
+            expected = [expected]
+        assert result == expected
+
+    def test_nested_arrays_above_default_limit(self):
+        depth = sys.getrecursionlimit() + 200
+        payload = (b"*1\r\n" * depth) + b"+OK\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        expected = b"OK"
+        for _ in range(depth):
+            expected = [expected]
+        assert result == expected
+
+    def test_empty_arrays(self):
+        payload = b"*0\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result == []
+
+    def test_null_array(self):
+        payload = b"*-1\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result is None
+
+    def test_multiple_elements_nested(self):
+        payload = b"*2\r\n*2\r\n+OK\r\n+OK\r\n+OK\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result == [[b"OK", b"OK"], b"OK"]
+
+    def test_deeply_nested_multiple_elements(self):
+        depth = 500
+        payload = (b"*1\r\n" * depth) + b"*2\r\n+OK\r\n+OK\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        expected = [b"OK", b"OK"]
+        for _ in range(depth):
+            expected = [expected]
+        assert result == expected
+
+    def test_mixed_types_nested(self):
+        payload = b"*3\r\n+OK\r\n:42\r\n$5\r\nhello\r\n"
+        parser = make_resp2_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result == [b"OK", 42, b"hello"]
+
+
+class TestRESP3DeepNesting:
+    def test_nested_arrays(self):
+        depth = sys.getrecursionlimit() + 200
+        payload = (b"*1\r\n" * depth) + b"+OK\r\n"
+        parser = make_resp3_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        expected = b"OK"
+        for _ in range(depth):
+            expected = [expected]
+        assert result == expected
+
+    def test_nested_sets(self):
+        depth = 200
+        payload = (b"~1\r\n" * depth) + b"+OK\r\n"
+        parser = make_resp3_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        expected = b"OK"
+        for _ in range(depth):
+            expected = [expected]
+        assert result == expected
+
+    def test_nested_maps(self):
+        depth = 200
+        payload = (b"%1\r\n+key\r\n" * depth) + b"+value\r\n"
+        parser = make_resp3_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        expected = b"value"
+        for _ in range(depth):
+            expected = {b"key": expected}
+        assert result == expected
+
+    def test_mixed_nested_aggregates(self):
+        payload = b"*1\r\n~1\r\n%1\r\n+key\r\n+value\r\n"
+        parser = make_resp3_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result == [[{b"key": b"value"}]]
+
+    def test_empty_set(self):
+        payload = b"~0\r\n"
+        parser = make_resp3_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result == []
+
+    def test_empty_map(self):
+        payload = b"%0\r\n"
+        parser = make_resp3_parser(payload)
+        result = parser._read_response(disable_decoding=True)
+        assert result == {}


### PR DESCRIPTION
## Fix: Convert recursive RESP parsing to iterative to avoid RecursionError

### Problem
The pure-Python RESP parser used recursive parsing for nested aggregate replies. A malicious Redis server, compromised Redis proxy, or an on-path actor that can inject RESP replies could send sufficiently deep nested aggregates and trigger , causing client-side denial of service.

### Solution
This fix converts the recursive parsing in both RESP2 and RESP3 parsers (including async variants) to use iterative stack-based parsing. The approach handles all RESP3 aggregate types: arrays, sets, maps, and push responses.

### Changes
- : Converted  and  from recursive to iterative
- : Converted  and  from recursive to iterative
- : Added tests for deeply nested RESP replies

### Testing
All existing parser tests pass, plus new tests that verify:
- Deeply nested arrays (depth > Python recursion limit)
- Nested sets and maps (RESP3)
- Mixed nested aggregate types
- Empty arrays, sets, and maps
- Null arrays

Fixes redis/redis-py#4116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core wire-protocol parsing on every Redis read; behavior should be equivalent but regressions in push/map edge cases would affect all connections using the pure-Python parsers.
> 
> **Overview**
> Replaces **recursive** aggregate parsing in the sync/async **RESP2** and **RESP3** `_read_response` paths with **iterative stack-based** loops so deeply nested arrays (and RESP3 sets, maps, and push frames) no longer blow the Python recursion limit—addressing client-side **DoS** from malicious or injected wire data.
> 
> RESP2 uses a simple `(remaining_count, results_list)` stack for `*` multi-bulks; RESP3 extends that with typed frames (`array`, `set`, `map`, `push`) and a **pending key** slot for map key/value pairs, preserving prior behavior for empty aggregates, null arrays, push handling, and `ResponseError` instances inside pipelines.
> 
> Adds **`tests/test_parsers/test_resp_recursion.py`** with fake-socket fixtures exercising nesting beyond `sys.getrecursionlimit()`, mixed types, and empty/null aggregates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf1af7a25bfdbfb9e2c2888b1afbab0f9e4d0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->