### PR TITLE
fix: handle empty/None responses in FT.INFO parsers

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -876,10 +876,9 @@ class SearchCommands:
         if not res:
             return {}
         info = self._to_string_recursive(res)
-        # If the response is already a list (RESP2 format from cluster),
-        # it's already in legacy format - return as-is.
         if isinstance(info, list):
-            return info
+            it = map(str_if_bytes, info)
+            info = dict(zip(it, it))
         attrs = info.get("attributes")
         if isinstance(attrs, list):
             info["attributes"] = [

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -256,6 +256,8 @@ class SearchCommands:
     # ---- RESP2 legacy parsers ----
 
     def _parse_info(self, res, **kwargs):
+        if not res:
+            return {}
         it = map(str_if_bytes, res)
         return dict(zip(it, it))
 
@@ -388,6 +390,8 @@ class SearchCommands:
         """Parse FT.INFO into the unified shape with ``attributes`` as a
         list of dicts so RESP2 output matches RESP3 output.
         """
+        if not res:
+            return {}
         it = map(str_if_bytes, res)
         info = dict(zip(it, it))
         if "attributes" in info and isinstance(info["attributes"], list):
@@ -869,7 +873,13 @@ class SearchCommands:
         """Parse RESP3 FT.INFO into the legacy RESP2 flat shape so
         ``legacy_responses=True`` on a RESP3 wire matches RESP2 output.
         """
+        if not res:
+            return {}
         info = self._to_string_recursive(res)
+        # If the response is already a list (RESP2 format from cluster),
+        # it's already in legacy format - return as-is.
+        if isinstance(info, list):
+            return info
         attrs = info.get("attributes")
         if isinstance(attrs, list):
             info["attributes"] = [

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -253,3 +253,62 @@ class TestParseSpellcheckResp3:
         s = _make_search()
         # ``_parse_spellcheck`` short-circuits on ``res == 0``.
         assert s._parse_spellcheck_resp3(0) == {}
+
+
+@pytest.mark.fixed_client
+class TestParseInfoEmptyResults:
+    """Regression tests for FT.INFO parsers handling empty/None responses.
+
+    When a search query returns empty results or the index doesn't exist,
+    the FT.INFO response may be empty or None. These tests verify that all
+    info parsers handle these cases gracefully without raising exceptions.
+    """
+
+    def test_parse_info_empty_list(self):
+        """_parse_info returns empty dict for empty list."""
+        s = _make_search()
+        assert s._parse_info([]) == {}
+
+    def test_parse_info_none(self):
+        """_parse_info returns empty dict for None."""
+        s = _make_search()
+        assert s._parse_info(None) == {}
+
+    def test_parse_info_unified_empty_list(self):
+        """_parse_info_unified returns empty dict for empty list."""
+        s = _make_search()
+        assert s._parse_info_unified([]) == {}
+
+    def test_parse_info_unified_none(self):
+        """_parse_info_unified returns empty dict for None."""
+        s = _make_search()
+        assert s._parse_info_unified(None) == {}
+
+    def test_parse_info_resp3_to_legacy_none(self):
+        """_parse_info_resp3_to_legacy returns empty dict for None."""
+        s = _make_search()
+        assert s._parse_info_resp3_to_legacy(None) == {}
+
+    def test_parse_info_resp3_to_legacy_empty_dict(self):
+        """_parse_info_resp3_to_legacy returns empty dict for empty dict."""
+        s = _make_search()
+        assert s._parse_info_resp3_to_legacy({}) == {}
+
+    def test_parse_info_resp3_to_legacy_list_response(self):
+        """_parse_info_resp3_to_legacy returns list as-is for RESP2 format.
+
+        When using RedisCluster, FT.INFO may return a flat RESP2-style list
+        even though the default protocol version is RESP3.
+        """
+        s = _make_search()
+        res = [
+            "index_name", "myIndex",
+            "num_docs", "100",
+            "attributes", [
+                ["identifier", "name", "attribute", "name", "type", "TEXT"],
+            ],
+        ]
+        out = s._parse_info_resp3_to_legacy(res)
+        assert isinstance(out, list)
+        assert out[0] == "index_name"
+        assert out[1] == "myIndex"

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -295,7 +295,7 @@ class TestParseInfoEmptyResults:
         assert s._parse_info_resp3_to_legacy({}) == {}
 
     def test_parse_info_resp3_to_legacy_list_response(self):
-        """_parse_info_resp3_to_legacy returns list as-is for RESP2 format.
+        """_parse_info_resp3_to_legacy converts flat list to dict for RESP2 format.
 
         When using RedisCluster, FT.INFO may return a flat RESP2-style list
         even though the default protocol version is RESP3.
@@ -309,6 +309,6 @@ class TestParseInfoEmptyResults:
             ],
         ]
         out = s._parse_info_resp3_to_legacy(res)
-        assert isinstance(out, list)
-        assert out[0] == "index_name"
-        assert out[1] == "myIndex"
+        assert isinstance(out, dict)
+        assert out["index_name"] == "myIndex"
+        assert out["num_docs"] == "100"


### PR DESCRIPTION
## Summary

Fixes crash when FT.INFO returns empty or None responses (e.g., when the index doesn't exist or query returns no results).

## Changes

- `_parse_info`: Add guard for None/empty response, return `{}`
- `_parse_info_unified`: Add guard for None/empty response, return `{}`
- `_parse_info_resp3_to_legacy`: Add guard for None/empty response, return `{}; also handle list responses from RESP2 cluster connections

## Root Cause

When FT.INFO returns empty results (`[]`, `{}`, or `None`), the parsers would crash:
- `_parse_info(None)` -> TypeError: 'NoneType' object is not iterable
- `_parse_info_unified(None)` -> TypeError: 'NoneType' object is not iterable
- `_parse_info_resp3_to_legacy([])` -> AttributeError: 'list' object has no attribute 'get'
- `_parse_info_resp3_to_legacy(None)` -> AttributeError: 'NoneType' object has no attribute 'get'

## Regression Tests

Added `TestParseInfoEmptyResults` test class with 7 tests covering all info parsers with empty list, None, empty dict, and list responses.

Fixes #4121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive parsing only in RediSearch FT.INFO callbacks; behaviour change is returning `{}` instead of raising on edge-case server responses.
> 
> **Overview**
> Prevents crashes when **`FT.INFO`** returns **`None`**, an empty list/dict, or unexpected wire shapes by short-circuiting to **`{}`** in **`_parse_info`**, **`_parse_info_unified`**, and **`_parse_info_resp3_to_legacy`**.
> 
> **`_parse_info_resp3_to_legacy`** also treats a flat RESP2-style **list** (e.g. from **RedisCluster** on a RESP3 connection) as alternating key/value pairs before normalising attributes, instead of calling **`.get`** on a list.
> 
> Adds **`TestParseInfoEmptyResults`** regression tests for empty/None inputs and list-shaped legacy responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcfd8a57cd0563a7dae2493c47d0d61e529b7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->