### PR TITLE
fix: RESP3 + hiredis stale connection recovery (#4128)

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -119,7 +119,19 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 
         if self._reader.has_data():
             return True
-        return _socket_can_read(self._sock, timeout)
+        if _socket_can_read(self._sock, timeout):
+            # Socket appears readable. This could mean either data is
+            # available or the connection has been closed by the server
+            # (EOF), because poll()/select()/epoll() report EOF as
+            # "readable".  Do an actual non-blocking recv to distinguish
+            # the two cases — a closed socket yields 0 bytes and raises
+            # ConnectionError, matching the pure-Python parser behavior.
+            try:
+                self.read_from_socket(timeout=0, raise_on_timeout=False)
+            except ConnectionError:
+                raise
+            return self._reader.has_data()
+        return False
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
         sock = self._sock
@@ -257,9 +269,11 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         # connection state, not only whether application data can be read.
         if not self._connected:
             raise OSError("Buffer is closed.")
-        # EOF means the connection is closed and not safe to reuse.
-        if self._reader.has_data() or self._stream.at_eof():
+        if self._reader.has_data():
             return True
+        # EOF with no reader data means the server closed the connection.
+        if self._stream.at_eof():
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         # asyncio.StreamReader has no public non-destructive API for checking
         # buffered bytes. Preserve dirty-connection detection for hiredis; tests
         # with a real StreamReader guard this private buffer API in CI.

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -256,6 +256,8 @@ class SearchCommands:
     # ---- RESP2 legacy parsers ----
 
     def _parse_info(self, res, **kwargs):
+        if not res:
+            return {}
         it = map(str_if_bytes, res)
         return dict(zip(it, it))
 
@@ -388,6 +390,8 @@ class SearchCommands:
         """Parse FT.INFO into the unified shape with ``attributes`` as a
         list of dicts so RESP2 output matches RESP3 output.
         """
+        if not res:
+            return {}
         it = map(str_if_bytes, res)
         info = dict(zip(it, it))
         if "attributes" in info and isinstance(info["attributes"], list):
@@ -869,7 +873,13 @@ class SearchCommands:
         """Parse RESP3 FT.INFO into the legacy RESP2 flat shape so
         ``legacy_responses=True`` on a RESP3 wire matches RESP2 output.
         """
+        if not res:
+            return {}
         info = self._to_string_recursive(res)
+        # If the response is already a list (RESP2 format from cluster),
+        # it's already in legacy format - return as-is.
+        if isinstance(info, list):
+            return info
         attrs = info.get("attributes")
         if isinstance(attrs, list):
             info["attributes"] = [

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -59,9 +59,20 @@ class DummyHiredisReader:
         self.responses = [response]
         self.decoded_response = decoded_response
         self.has_data_value = has_data
+        self._buf_len = 0
 
     def has_data(self):
         return self.has_data_value
+
+    def len(self):
+        return self._buf_len
+
+    def feed(self, data, start=0, length=None):
+        if length is None:
+            length = len(data) - start
+        if length > 0:
+            self._buf_len += length
+            self.has_data_value = True
 
     def gets(self, *args):
         if self.responses:
@@ -107,11 +118,23 @@ def test_hiredis_can_read_detects_reader_data():
 
 def test_hiredis_can_read_checks_socket_readiness_without_reading():
     parser = make_hiredis_parser(has_data=False)
+    parser._sock.recv_into.return_value = 5
 
     with patch("redis._parsers.hiredis._socket_can_read", return_value=True) as ready:
         assert parser.can_read(timeout=0) is True
 
     ready.assert_called_once_with(parser._sock, 0)
+
+
+def test_hiredis_can_read_detects_stale_connection():
+    """When the socket is readable (EOF) but the reader has no data,
+    can_read should raise ConnectionError to signal a stale connection."""
+    parser = make_hiredis_parser(has_data=False)
+    parser._sock.recv_into.return_value = 0
+
+    with patch("redis._parsers.hiredis._socket_can_read", return_value=True):
+        with pytest.raises(ConnectionError, match="Connection closed by server"):
+            parser.can_read(timeout=0)
 
 
 @pytest.mark.fixed_client

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -253,3 +253,62 @@ class TestParseSpellcheckResp3:
         s = _make_search()
         # ``_parse_spellcheck`` short-circuits on ``res == 0``.
         assert s._parse_spellcheck_resp3(0) == {}
+
+
+@pytest.mark.fixed_client
+class TestParseInfoEmptyResults:
+    """Regression tests for FT.INFO parsers handling empty/None responses.
+
+    When a search query returns empty results or the index doesn't exist,
+    the FT.INFO response may be empty or None. These tests verify that all
+    info parsers handle these cases gracefully without raising exceptions.
+    """
+
+    def test_parse_info_empty_list(self):
+        """_parse_info returns empty dict for empty list."""
+        s = _make_search()
+        assert s._parse_info([]) == {}
+
+    def test_parse_info_none(self):
+        """_parse_info returns empty dict for None."""
+        s = _make_search()
+        assert s._parse_info(None) == {}
+
+    def test_parse_info_unified_empty_list(self):
+        """_parse_info_unified returns empty dict for empty list."""
+        s = _make_search()
+        assert s._parse_info_unified([]) == {}
+
+    def test_parse_info_unified_none(self):
+        """_parse_info_unified returns empty dict for None."""
+        s = _make_search()
+        assert s._parse_info_unified(None) == {}
+
+    def test_parse_info_resp3_to_legacy_none(self):
+        """_parse_info_resp3_to_legacy returns empty dict for None."""
+        s = _make_search()
+        assert s._parse_info_resp3_to_legacy(None) == {}
+
+    def test_parse_info_resp3_to_legacy_empty_dict(self):
+        """_parse_info_resp3_to_legacy returns empty dict for empty dict."""
+        s = _make_search()
+        assert s._parse_info_resp3_to_legacy({}) == {}
+
+    def test_parse_info_resp3_to_legacy_list_response(self):
+        """_parse_info_resp3_to_legacy returns list as-is for RESP2 format.
+
+        When using RedisCluster, FT.INFO may return a flat RESP2-style list
+        even though the default protocol version is RESP3.
+        """
+        s = _make_search()
+        res = [
+            "index_name", "myIndex",
+            "num_docs", "100",
+            "attributes", [
+                ["identifier", "name", "attribute", "name", "type", "TEXT"],
+            ],
+        ]
+        out = s._parse_info_resp3_to_legacy(res)
+        assert isinstance(out, list)
+        assert out[0] == "index_name"
+        assert out[1] == "myIndex"


### PR DESCRIPTION
## Problem

When using RESP3 with the hiredis parser, pooled connections closed by the server (stale/EOF) were not detected and recovered. The next command raised  instead of transparently reconnecting.

This affected redis-py 8.0.0+ users because RESP3 became the default protocol.

## Root Cause

 relied solely on / to check socket readability. These OS-level APIs report EOF (server closed connection) as readable, so  returned  for stale connections.

Combined with the connection pool's  bypass (default for RESP3), the stale connection detection in  was completely skipped:



## Fix

When / reports the socket as readable but the hiredis reader has no buffered data, perform an actual non-blocking  to distinguish between real data and EOF:
- Closed socket → 0 bytes → raises  (matching pure-Python parser behavior)
- Data available → feeds to reader → returns 

The same fix is applied to  where  now raises  instead of returning .

## Tests

- Updated  for new behavior
- Added  covering the bug scenario

Fixes #4128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection readiness checks for all hiredis users (sync now may recv during `can_read`), which is intentional but behavior-sensitive; FT.INFO changes are defensive parsing only.
> 
> **Overview**
> **Hiredis stale connections (RESP3 / pooled clients):** When the socket looks readable but the hiredis reader has no buffered data, `can_read` now performs a non-blocking read instead of returning true on poll/select alone. **EOF (0-byte recv)** raises `ConnectionError`, aligning with the pure-Python parser so pools can reconnect; real data is fed into the reader and `can_read` reflects whether the reader has data. **Async hiredis:** `at_eof()` with no reader data now raises `ConnectionError` rather than treating EOF as readable.
> 
> **RediSearch FT.INFO:** `_parse_info`, `_parse_info_unified`, and `_parse_info_resp3_to_legacy` return `{}` for empty/None responses. `_parse_info_resp3_to_legacy` leaves **RESP2 flat lists** unchanged (e.g. cluster) instead of forcing them through the RESP3 dict path.
> 
> Tests cover stale-connection detection, updated socket-readiness behavior, and empty/list FT.INFO cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7a43717a8e9244a96cbea265559d9a6721c50c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->