### PR TITLE
Fix blocking commands timeout when blocking_timeout exceeds socket_timeout

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -874,12 +874,16 @@ class Redis(
         self, connection: Connection, command_name: Union[str, bytes], **options
     ):
         """Parses a response from the Redis server"""
+        # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
+        # This ensures the socket timeout is long enough to wait for the
+        # blocking command's timeout
+        blocking_timeout = options.pop("_blocking_timeout", SENTINEL)
         try:
             if NEVER_DECODE in options:
                 response = await connection.read_response(disable_decoding=True)
                 options.pop(NEVER_DECODE)
             else:
-                response = await connection.read_response()
+                response = await connection.read_response(timeout=blocking_timeout)
         except ResponseError:
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -877,7 +877,12 @@ class Redis(
         # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
         # This ensures the socket timeout is long enough to wait for the
         # blocking command's timeout
-        blocking_timeout = options.pop("_blocking_timeout", SENTINEL)
+        blocking_timeout = options.pop("_blocking_timeout", None)
+        # When the Redis server is told to block indefinitely (timeout=0),
+        # the client must also wait indefinitely rather than issuing a
+        # zero-second socket read.
+        if blocking_timeout == 0:
+            blocking_timeout = None
         try:
             if NEVER_DECODE in options:
                 response = await connection.read_response(disable_decoding=True)

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -877,12 +877,15 @@ class Redis(
         # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
         # This ensures the socket timeout is long enough to wait for the
         # blocking command's timeout
+        # Default None means "no blocking override" so read_response falls
+        # back to connection.socket_timeout. This differs from the sync client,
+        # where the default is SENTINEL and timeout=None means block forever.
         blocking_timeout = options.pop("_blocking_timeout", None)
-        # When the Redis server is told to block indefinitely (timeout=0),
-        # the client must also wait indefinitely rather than issuing a
-        # zero-second socket read.
+        # Redis timeout=0 means block indefinitely on the server. Async
+        # Connection.read_response treats timeout=None as "use socket_timeout"
+        # and timeout=math.inf as "block with no timeout", so map 0 -> inf.
         if blocking_timeout == 0:
-            blocking_timeout = None
+            blocking_timeout = math.inf
         try:
             if NEVER_DECODE in options:
                 response = await connection.read_response(disable_decoding=True)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1661,6 +1661,11 @@ class ClusterNode:
         # This ensures the socket timeout is long enough to wait for the
         # blocking command's timeout
         blocking_timeout = kwargs.pop("_blocking_timeout", None)
+        # When the Redis server is told to block indefinitely (timeout=0),
+        # the client must also wait indefinitely rather than issuing a
+        # zero-second socket read.
+        if blocking_timeout == 0:
+            blocking_timeout = None
         try:
             if NEVER_DECODE in kwargs:
                 response = await connection.read_response(disable_decoding=True)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import logging
+import math
 import random
 import socket
 import threading
@@ -1660,12 +1661,15 @@ class ClusterNode:
         # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
         # This ensures the socket timeout is long enough to wait for the
         # blocking command's timeout
+        # Default None means "no blocking override" so read_response falls
+        # back to connection.socket_timeout. This differs from the sync client,
+        # where the default is SENTINEL and timeout=None means block forever.
         blocking_timeout = kwargs.pop("_blocking_timeout", None)
-        # When the Redis server is told to block indefinitely (timeout=0),
-        # the client must also wait indefinitely rather than issuing a
-        # zero-second socket read.
+        # Redis timeout=0 means block indefinitely on the server. Async
+        # Connection.read_response treats timeout=None as "use socket_timeout"
+        # and timeout=math.inf as "block with no timeout", so map 0 -> inf.
         if blocking_timeout == 0:
-            blocking_timeout = None
+            blocking_timeout = math.inf
         try:
             if NEVER_DECODE in kwargs:
                 response = await connection.read_response(disable_decoding=True)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1657,12 +1657,16 @@ class ClusterNode:
     async def parse_response(
         self, connection: Connection, command: str, **kwargs: Any
     ) -> Any:
+        # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
+        # This ensures the socket timeout is long enough to wait for the
+        # blocking command's timeout
+        blocking_timeout = kwargs.pop("_blocking_timeout", None)
         try:
             if NEVER_DECODE in kwargs:
                 response = await connection.read_response(disable_decoding=True)
                 kwargs.pop(NEVER_DECODE)
             else:
-                response = await connection.read_response()
+                response = await connection.read_response(timeout=blocking_timeout)
         except ResponseError:
             if EMPTY_RESPONSE in kwargs:
                 return kwargs[EMPTY_RESPONSE]

--- a/redis/client.py
+++ b/redis/client.py
@@ -860,6 +860,11 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         # This ensures the socket timeout is long enough to wait for the
         # blocking command's timeout
         blocking_timeout = options.pop("_blocking_timeout", SENTINEL)
+        # When the Redis server is told to block indefinitely (timeout=0),
+        # the client must also wait indefinitely rather than issuing a
+        # zero-second socket read.
+        if blocking_timeout == 0:
+            blocking_timeout = None
         try:
             if NEVER_DECODE in options:
                 response = connection.read_response(disable_decoding=True)

--- a/redis/client.py
+++ b/redis/client.py
@@ -859,6 +859,9 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
         # This ensures the socket timeout is long enough to wait for the
         # blocking command's timeout
+        # Default SENTINEL means "no blocking override" so read_response uses
+        # the configured socket_timeout. Unlike async, timeout=None here means
+        # block forever (settimeout(None)), so Redis timeout=0 maps to None.
         blocking_timeout = options.pop("_blocking_timeout", SENTINEL)
         # When the Redis server is told to block indefinitely (timeout=0),
         # the client must also wait indefinitely rather than issuing a

--- a/redis/client.py
+++ b/redis/client.py
@@ -856,12 +856,16 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
 
     def parse_response(self, connection, command_name, **options):
         """Parses a response from the Redis server"""
+        # Extract blocking timeout for blocking commands (BLPOP, BRPOP, etc.)
+        # This ensures the socket timeout is long enough to wait for the
+        # blocking command's timeout
+        blocking_timeout = options.pop("_blocking_timeout", SENTINEL)
         try:
             if NEVER_DECODE in options:
                 response = connection.read_response(disable_decoding=True)
                 options.pop(NEVER_DECODE)
             else:
-                response = connection.read_response()
+                response = connection.read_response(timeout=blocking_timeout)
         except ResponseError:
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3603,7 +3603,9 @@ class BasicKeyCommands(CommandsProtocol):
         For more information, see https://redis.io/commands/blmove
         """
         params = [first_list, second_list, src, dest, timeout]
-        return self.execute_command("BLMOVE", *params)
+        return self.execute_command(
+            "BLMOVE", *params, _blocking_timeout=timeout
+        )
 
     @overload
     def mget(
@@ -4717,7 +4719,9 @@ class ListCommands(CommandsProtocol):
             timeout = 0
         keys = list_or_args(keys, None)
         keys.append(timeout)
-        return self.execute_command("BLPOP", *keys)
+        return self.execute_command(
+            "BLPOP", *keys, _blocking_timeout=timeout
+        )
 
     @overload
     def brpop(
@@ -4748,7 +4752,9 @@ class ListCommands(CommandsProtocol):
             timeout = 0
         keys = list_or_args(keys, None)
         keys.append(timeout)
-        return self.execute_command("BRPOP", *keys)
+        return self.execute_command(
+            "BRPOP", *keys, _blocking_timeout=timeout
+        )
 
     @overload
     def brpoplpush(
@@ -4775,7 +4781,9 @@ class ListCommands(CommandsProtocol):
         """
         if timeout is None:
             timeout = 0
-        return self.execute_command("BRPOPLPUSH", src, dst, timeout)
+        return self.execute_command(
+            "BRPOPLPUSH", src, dst, timeout, _blocking_timeout=timeout
+        )
 
     @overload
     def blmpop(
@@ -4816,7 +4824,9 @@ class ListCommands(CommandsProtocol):
         """
         cmd_args = [timeout, numkeys, *args, direction, "COUNT", count]
 
-        return self.execute_command("BLMPOP", *cmd_args)
+        return self.execute_command(
+            "BLMPOP", *cmd_args, _blocking_timeout=timeout
+        )
 
     @overload
     def lmpop(

--- a/tests/test_asyncio/test_blocking_timeout.py
+++ b/tests/test_asyncio/test_blocking_timeout.py
@@ -1,0 +1,55 @@
+"""Unit tests for async blocking-command timeout mapping.
+
+These do not require a live Redis server.
+"""
+
+import math
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import redis.asyncio as redis
+
+
+@pytest.mark.asyncio
+async def test_async_parse_response_maps_zero_blocking_timeout_to_math_inf():
+    """Redis timeout=0 must block indefinitely on async reads.
+
+    Async Connection.read_response treats:
+      - None as \"use socket_timeout\"
+      - math.inf as \"no timeout\"
+    so parse_response must map _blocking_timeout=0 to math.inf, not None.
+    """
+    conn = MagicMock()
+    conn.read_response = AsyncMock(return_value=None)
+
+    client = redis.Redis(connection_pool=MagicMock())
+    result = await client.parse_response(conn, "BLPOP", _blocking_timeout=0)
+
+    assert result is None
+    conn.read_response.assert_awaited_once_with(timeout=math.inf)
+
+
+@pytest.mark.asyncio
+async def test_async_parse_response_forwards_positive_blocking_timeout():
+    conn = MagicMock()
+    conn.read_response = AsyncMock(return_value=None)
+
+    client = redis.Redis(connection_pool=MagicMock())
+    await client.parse_response(conn, "BLPOP", _blocking_timeout=5)
+
+    conn.read_response.assert_awaited_once_with(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_async_parse_response_without_blocking_timeout_uses_default():
+    conn = MagicMock()
+    conn.read_response = AsyncMock(return_value=b"OK")
+
+    client = redis.Redis(connection_pool=MagicMock())
+    # Use a command without a response callback so the raw value is returned.
+    result = await client.parse_response(conn, "CUSTOMCMD")
+
+    assert result == b"OK"
+    # No override: default None -> read_response falls back to socket_timeout.
+    conn.read_response.assert_awaited_once_with(timeout=None)


### PR DESCRIPTION
## Problem

Blocking commands like `BRPOP`, `BLPOP`, `BRPOPLPUSH`, `BLMOVE`, and `BLMPOP` fail with `TimeoutError` when the command's blocking timeout exceeds the client's `socket_timeout`.

**Issue:** #2807

## Root Cause

Blocking commands send the timeout to the Redis server but do not pass it to the connection's `read_response()` method. The parser already supports custom timeouts via the `timeout` parameter, but it wasn't being used for blocking commands.

For example, with `socket_timeout=4` and `brpop('key', timeout=8)`:
1. Client sends `BRPOP key 8` to server
2. Client waits for response with 4-second socket timeout
3. Socket times out after 4 seconds, before the server can respond (after 8 seconds)

## Fix

This fix:
- Adds `_blocking_timeout` option to all blocking list commands
- Modifies `parse_response()` in sync, async, and cluster clients to extract `_blocking_timeout` and pass it to `connection.read_response()`
- The socket buffer temporarily uses the blocking timeout for the read operation, preventing premature socket timeouts

## Changes

- `redis/commands/core.py`: Added `_blocking_timeout` parameter to `blpop`, `brpop`, `brpoplpush`, `blmove`, `blmpop`
- `redis/client.py`: Modified `parse_response()` to extract and pass `_blocking_timeout`
- `redis/asyncio/client.py`: Same change for async client
- `redis/asyncio/cluster.py`: Same change for async cluster client

## Testing

Verified with unit tests that:
1. Blocking commands pass `_blocking_timeout` correctly
2. `parse_response()` correctly extracts and passes timeout to `connection.read_response()`
3. Non-blocking commands use default SENTINEL timeout (no behavior change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command execution and socket read timeouts across sync/async/cluster clients; behavior change is targeted to blocking commands but incorrect timeout mapping could affect long-blocking or indefinite waits.
> 
> **Overview**
> Fixes premature `TimeoutError` on blocking list commands when the Redis wait time is longer than the client `socket_timeout`.
> 
> Blocking commands (`BLPOP`, `BRPOP`, `BRPOPLPUSH`, `BLMOVE`, `BLMPOP`) now pass an internal `_blocking_timeout` through `execute_command`, and **sync**, **async**, and **async cluster** `parse_response()` forward it to `connection.read_response(timeout=…)` so the read waits at least as long as the server block. **Redis `timeout=0` (block forever)** is mapped to `None` on sync reads and `math.inf` on async reads to match each stack’s timeout semantics.
> 
> Adds offline async unit tests for `parse_response` timeout forwarding and the zero-timeout mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3007415948a315662e2b52fb4323b8e932a338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->