### PR TITLE
fix: filter None nodes in _determine_nodes during topology changes (#3835)

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -824,16 +824,22 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         else:
             nodes = policy_callback()
 
-        # Filter out None nodes that can occur during cluster topology
-        # changes (e.g. scale-down, failover) where in-memory slot/node
-        # caches become temporarily inconsistent.
-        if nodes:
-            nodes = [n for n in nodes if n is not None]
+        # None entries can appear during topology changes when the
+        # in-memory slot/node cache is temporarily inconsistent. Silently
+        # dropping them is unsafe for multi-node / broadcast commands
+        # (partial success with no error). Mark the cluster for reinit and
+        # raise a retryable error so execute_command retries cleanly.
+        if nodes and any(n is None for n in nodes):
+            self._initialize = True
+            raise ClusterDownError(
+                "Cluster node mapping returned None during a topology "
+                "change; reinitialized topology for retry"
+            )
 
         if command.lower() == "ft.aggregate":
             self._aggregate_nodes = nodes
 
-        return nodes
+        return nodes or []
 
     async def _determine_slot(self, command: str, *args: Any) -> int:
         if self.command_flags.get(command) == SLOT_ID:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -824,6 +824,12 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         else:
             nodes = policy_callback()
 
+        # Filter out None nodes that can occur during cluster topology
+        # changes (e.g. scale-down, failover) where in-memory slot/node
+        # caches become temporarily inconsistent.
+        if nodes:
+            nodes = [n for n in nodes if n is not None]
+
         if command.lower() == "ft.aggregate":
             self._aggregate_nodes = nodes
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1347,16 +1347,22 @@ class RedisCluster(
         else:
             nodes = policy_callback()
 
-        # Filter out None nodes that can occur during cluster topology
-        # changes (e.g. scale-down, failover) where in-memory slot/node
-        # caches become temporarily inconsistent.
-        if nodes:
-            nodes = [n for n in nodes if n is not None]
+        # None entries can appear during topology changes when the
+        # in-memory slot/node cache is temporarily inconsistent. Silently
+        # dropping them is unsafe for multi-node / broadcast commands
+        # (partial success with no error). Reinitialize and raise a
+        # retryable error so execute_command retries on a fresh view.
+        if nodes and any(n is None for n in nodes):
+            self.nodes_manager.initialize()
+            raise ClusterDownError(
+                "Cluster node mapping returned None during a topology "
+                "change; reinitialized topology for retry"
+            )
 
         if args[0].lower() == "ft.aggregate":
             self._aggregate_nodes = nodes
 
-        return nodes
+        return nodes or []
 
     def _should_reinitialized(self):
         # To reinitialize the cluster on every MOVED error,
@@ -4364,16 +4370,19 @@ class PipelineStrategy(AbstractStrategy):
         else:
             nodes = policy_callback()
 
-        # Filter out None nodes that can occur during cluster topology
-        # changes (e.g. scale-down, failover) where in-memory slot/node
-        # caches become temporarily inconsistent.
-        if nodes:
-            nodes = [n for n in nodes if n is not None]
+        # See RedisCluster._determine_nodes: do not silently drop None
+        # targets (unsafe for multi-node / broadcast commands).
+        if nodes and any(n is None for n in nodes):
+            self._pipe.nodes_manager.initialize()
+            raise ClusterDownError(
+                "Cluster node mapping returned None during a topology "
+                "change; reinitialized topology for retry"
+            )
 
         if args[0].lower() == "ft.aggregate":
             self._aggregate_nodes = nodes
 
-        return nodes
+        return nodes or []
 
     def multi(self):
         raise RedisClusterException(

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1347,6 +1347,12 @@ class RedisCluster(
         else:
             nodes = policy_callback()
 
+        # Filter out None nodes that can occur during cluster topology
+        # changes (e.g. scale-down, failover) where in-memory slot/node
+        # caches become temporarily inconsistent.
+        if nodes:
+            nodes = [n for n in nodes if n is not None]
+
         if args[0].lower() == "ft.aggregate":
             self._aggregate_nodes = nodes
 
@@ -4357,6 +4363,12 @@ class PipelineStrategy(AbstractStrategy):
             nodes = policy_callback(args[0])
         else:
             nodes = policy_callback()
+
+        # Filter out None nodes that can occur during cluster topology
+        # changes (e.g. scale-down, failover) where in-memory slot/node
+        # caches become temporarily inconsistent.
+        if nodes:
+            nodes = [n for n in nodes if n is not None]
 
         if args[0].lower() == "ft.aggregate":
             self._aggregate_nodes = nodes

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1108,11 +1108,11 @@ class TestRedisClusterObj:
         assert n_used > 1
 
     @pytest.mark.onlycluster
-    async def test_determine_nodes_filters_none_nodes(self):
+    async def test_determine_nodes_rejects_none_nodes(self):
         """
-        Test that _determine_nodes filters out None values from the node list.
-        This can occur during cluster topology changes (scale-down, failover)
-        where in-memory slot/node caches become temporarily inconsistent.
+        None entries must not be silently filtered (unsafe for multi-node
+        commands). Async path marks the client for reinitialization and raises
+        ClusterDownError so execute_command retries on a fresh topology.
         """
         from redis._parsers.commands import RequestPolicy
 
@@ -1121,29 +1121,28 @@ class TestRedisClusterObj:
         assert len(primaries) > 0
         valid_node = primaries[0]
 
-        # PING maps to DEFAULT_NODE policy via command_flags.
-        # Simulate a transient None from get_default_node during topology change.
         original_callback = r._policies_callback_mapping[
             RequestPolicy.DEFAULT_NODE
         ]
         r._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
             lambda: [None, valid_node, None]
         )
+        r._initialize = False
         try:
-            nodes = await r._determine_nodes(
-                "PING", request_policy=RequestPolicy.DEFAULT_NODE
-            )
-            assert nodes == [valid_node]
-            assert None not in nodes
+            with pytest.raises(ClusterDownError, match="node mapping returned None"):
+                await r._determine_nodes(
+                    "PING", request_policy=RequestPolicy.DEFAULT_NODE
+                )
+            assert r._initialize is True
         finally:
             r._policies_callback_mapping[
                 RequestPolicy.DEFAULT_NODE
             ] = original_callback
 
     @pytest.mark.onlycluster
-    async def test_determine_nodes_returns_empty_when_all_none(self):
+    async def test_determine_nodes_rejects_all_none_nodes(self):
         """
-        Test that _determine_nodes returns an empty list when all nodes are None.
+        An all-None node list is also a stale-topology signal.
         """
         from redis._parsers.commands import RequestPolicy
 
@@ -1155,11 +1154,13 @@ class TestRedisClusterObj:
         r._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
             lambda: [None, None]
         )
+        r._initialize = False
         try:
-            nodes = await r._determine_nodes(
-                "PING", request_policy=RequestPolicy.DEFAULT_NODE
-            )
-            assert nodes == []
+            with pytest.raises(ClusterDownError, match="node mapping returned None"):
+                await r._determine_nodes(
+                    "PING", request_policy=RequestPolicy.DEFAULT_NODE
+                )
+            assert r._initialize is True
         finally:
             r._policies_callback_mapping[
                 RequestPolicy.DEFAULT_NODE

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1107,6 +1107,64 @@ class TestRedisClusterObj:
         n_used = sum((1 if p.n_connections else 0) for p in proxies)
         assert n_used > 1
 
+    @pytest.mark.onlycluster
+    async def test_determine_nodes_filters_none_nodes(self):
+        """
+        Test that _determine_nodes filters out None values from the node list.
+        This can occur during cluster topology changes (scale-down, failover)
+        where in-memory slot/node caches become temporarily inconsistent.
+        """
+        from redis._parsers.commands import RequestPolicy
+
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        primaries = r.get_primaries()
+        assert len(primaries) > 0
+        valid_node = primaries[0]
+
+        # PING maps to DEFAULT_NODE policy via command_flags.
+        # Simulate a transient None from get_default_node during topology change.
+        original_callback = r._policies_callback_mapping[
+            RequestPolicy.DEFAULT_NODE
+        ]
+        r._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
+            lambda: [None, valid_node, None]
+        )
+        try:
+            nodes = await r._determine_nodes(
+                "PING", request_policy=RequestPolicy.DEFAULT_NODE
+            )
+            assert nodes == [valid_node]
+            assert None not in nodes
+        finally:
+            r._policies_callback_mapping[
+                RequestPolicy.DEFAULT_NODE
+            ] = original_callback
+
+    @pytest.mark.onlycluster
+    async def test_determine_nodes_returns_empty_when_all_none(self):
+        """
+        Test that _determine_nodes returns an empty list when all nodes are None.
+        """
+        from redis._parsers.commands import RequestPolicy
+
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+
+        original_callback = r._policies_callback_mapping[
+            RequestPolicy.DEFAULT_NODE
+        ]
+        r._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
+            lambda: [None, None]
+        )
+        try:
+            nodes = await r._determine_nodes(
+                "PING", request_policy=RequestPolicy.DEFAULT_NODE
+            )
+            assert nodes == []
+        finally:
+            r._policies_callback_mapping[
+                RequestPolicy.DEFAULT_NODE
+            ] = original_callback
+
 
 @pytest.mark.onlycluster
 class TestClusterRedisCommands:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1095,6 +1095,62 @@ class TestRedisClusterObj:
         n_used = sum((1 if p.n_connections else 0) for p in proxies)
         assert n_used > 1
 
+    def test_determine_nodes_filters_none_nodes(self):
+        """
+        Test that _determine_nodes filters out None values from the node list.
+        This can occur during cluster topology changes (scale-down, failover)
+        where in-memory slot/node caches become temporarily inconsistent.
+        """
+        from redis._parsers.commands import RequestPolicy
+
+        cluster = get_mocked_redis_client(host=default_host, port=default_port)
+        primaries = cluster.get_primaries()
+        assert len(primaries) > 0
+        valid_node = primaries[0]
+
+        # PING maps to DEFAULT_NODE policy via command_flags.
+        # Simulate a transient None from get_default_node during topology change.
+        original_callback = cluster._policies_callback_mapping[
+            RequestPolicy.DEFAULT_NODE
+        ]
+        cluster._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
+            lambda: [None, valid_node, None]
+        )
+        try:
+            nodes = cluster._determine_nodes(
+                "PING", request_policy=RequestPolicy.DEFAULT_NODE
+            )
+            assert nodes == [valid_node]
+            assert None not in nodes
+        finally:
+            cluster._policies_callback_mapping[
+                RequestPolicy.DEFAULT_NODE
+            ] = original_callback
+
+    def test_determine_nodes_returns_empty_when_all_none(self):
+        """
+        Test that _determine_nodes returns an empty list when all nodes are None.
+        """
+        from redis._parsers.commands import RequestPolicy
+
+        cluster = get_mocked_redis_client(host=default_host, port=default_port)
+
+        original_callback = cluster._policies_callback_mapping[
+            RequestPolicy.DEFAULT_NODE
+        ]
+        cluster._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
+            lambda: [None, None]
+        )
+        try:
+            nodes = cluster._determine_nodes(
+                "PING", request_policy=RequestPolicy.DEFAULT_NODE
+            )
+            assert nodes == []
+        finally:
+            cluster._policies_callback_mapping[
+                RequestPolicy.DEFAULT_NODE
+            ] = original_callback
+
 
 @pytest.mark.onlycluster
 class TestClusterRedisCommands:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1095,11 +1095,12 @@ class TestRedisClusterObj:
         n_used = sum((1 if p.n_connections else 0) for p in proxies)
         assert n_used > 1
 
-    def test_determine_nodes_filters_none_nodes(self):
+    def test_determine_nodes_rejects_none_nodes(self):
         """
-        Test that _determine_nodes filters out None values from the node list.
-        This can occur during cluster topology changes (scale-down, failover)
-        where in-memory slot/node caches become temporarily inconsistent.
+        None entries in the determined node list (stale topology) must not be
+        silently filtered — that risks partial success on multi-node commands.
+        _determine_nodes should reinitialize and raise ClusterDownError so the
+        execute_command retry loop can re-resolve targets.
         """
         from redis._parsers.commands import RequestPolicy
 
@@ -1108,28 +1109,28 @@ class TestRedisClusterObj:
         assert len(primaries) > 0
         valid_node = primaries[0]
 
-        # PING maps to DEFAULT_NODE policy via command_flags.
-        # Simulate a transient None from get_default_node during topology change.
         original_callback = cluster._policies_callback_mapping[
             RequestPolicy.DEFAULT_NODE
         ]
         cluster._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
             lambda: [None, valid_node, None]
         )
-        try:
-            nodes = cluster._determine_nodes(
-                "PING", request_policy=RequestPolicy.DEFAULT_NODE
-            )
-            assert nodes == [valid_node]
-            assert None not in nodes
-        finally:
-            cluster._policies_callback_mapping[
-                RequestPolicy.DEFAULT_NODE
-            ] = original_callback
+        with patch.object(cluster.nodes_manager, "initialize") as init:
+            try:
+                with pytest.raises(ClusterDownError, match="node mapping returned None"):
+                    cluster._determine_nodes(
+                        "PING", request_policy=RequestPolicy.DEFAULT_NODE
+                    )
+                init.assert_called_once()
+            finally:
+                cluster._policies_callback_mapping[
+                    RequestPolicy.DEFAULT_NODE
+                ] = original_callback
 
-    def test_determine_nodes_returns_empty_when_all_none(self):
+    def test_determine_nodes_rejects_all_none_nodes(self):
         """
-        Test that _determine_nodes returns an empty list when all nodes are None.
+        An all-None node list is also a stale-topology signal: reinitialize and
+        raise ClusterDownError rather than returning [] (which would not retry).
         """
         from redis._parsers.commands import RequestPolicy
 
@@ -1141,15 +1142,17 @@ class TestRedisClusterObj:
         cluster._policies_callback_mapping[RequestPolicy.DEFAULT_NODE] = (
             lambda: [None, None]
         )
-        try:
-            nodes = cluster._determine_nodes(
-                "PING", request_policy=RequestPolicy.DEFAULT_NODE
-            )
-            assert nodes == []
-        finally:
-            cluster._policies_callback_mapping[
-                RequestPolicy.DEFAULT_NODE
-            ] = original_callback
+        with patch.object(cluster.nodes_manager, "initialize") as init:
+            try:
+                with pytest.raises(ClusterDownError, match="node mapping returned None"):
+                    cluster._determine_nodes(
+                        "PING", request_policy=RequestPolicy.DEFAULT_NODE
+                    )
+                init.assert_called_once()
+            finally:
+                cluster._policies_callback_mapping[
+                    RequestPolicy.DEFAULT_NODE
+                ] = original_callback
 
 
 @pytest.mark.onlycluster


### PR DESCRIPTION
## Problem

During cluster topology changes (scale-down, failover, node replacement), `_determine_nodes()` can return a list containing `None` values when in-memory slot/node caches become temporarily inconsistent.

The existing check `if not target_nodes` only catches empty lists — `[None]` is truthy, so it leaks through to `node.name` and causes:

```
AttributeError: 'NoneType' object has no attribute 'name'
```

This was reported in #3835, where GCP Memorystore cluster maintenance triggered the error during a create-before-destroy node replacement process.

## Fix

Add `None` filtering in `_determine_nodes()` after the policy callbacks return, for all three implementations:

- `redis/asyncio/cluster.py` — async `RedisCluster._determine_nodes()`
- `redis/cluster.py` — sync `RedisCluster._determine_nodes()` 
- `redis/cluster.py` — sync `ClusterPipeline._determine_nodes()`

The filter is placed before any downstream code accesses the node list, so callers (both `execute_command` and pipeline `_execute`) are protected without needing individual changes.

## Tests

Added 4 unit tests (2 sync + 2 async) that verify:

1. `test_determine_nodes_filters_none_nodes` — mixed None/valid nodes are filtered to only valid nodes
2. `test_determine_nodes_returns_empty_when_all_none` — all-None list results in empty list (which callers handle with `RedisClusterException`)

Fixes #3835

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cluster command routing and retry behavior during topology changes; mis-handling could affect multi-node commands, though the change aligns with existing ClusterDownError retry semantics.
> 
> **Overview**
> Fixes **#3835** where transient `None` values in node lists during maintenance could cause `AttributeError` on `node.name`, or—if filtered—**silent partial execution** on multi-node commands.
> 
> **`_determine_nodes`** in async `RedisCluster`, sync `RedisCluster`, and sync `ClusterPipeline` now detects any `None` in the policy callback result, **triggers topology refresh** (`nodes_manager.initialize()` or `_initialize = True` on async), and raises **`ClusterDownError`** so `execute_command`’s existing **`ERRORS_ALLOW_RETRY`** path retries with a fresh slot map. Return value is normalized with **`nodes or []`** when the list is empty but valid.
> 
> **Tests** (sync + async) assert mixed or all-`None` lists raise `ClusterDownError` and that reinit is signaled (`initialize` called / `_initialize` set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025cce3732a8f0816b9e0a24403d3d8e18c238f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->