### PR TITLE
fix: check _reader is not None in _HiredisParser.read_from_socket()

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -122,6 +122,8 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         return _socket_can_read(self._sock, timeout)
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
+        if not self._reader:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         sock = self._sock
         custom_timeout = timeout is not SENTINEL
         try:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -294,6 +294,17 @@ def test_hiredis_read_response_timeout_zero_maps_would_block_to_timeout():
         parser.read_response(timeout=0)
 
 
+def test_hiredis_read_from_socket_raises_when_reader_is_none():
+    """Regression: read_from_socket must raise ConnectionError if _reader is
+    None (e.g. on_disconnect was called by another thread).  Previously this
+    produced AttributeError: 'NoneType' object has no attribute 'feed'."""
+    parser = make_hiredis_parser()
+    parser._reader = None  # simulate on_disconnect clearing the reader
+
+    with pytest.raises(ConnectionError, match="Connection closed by server"):
+        parser.read_from_socket()
+
+
 def test_socket_buffer_timeout_zero_maps_would_block_to_timeout():
     sock = Mock()
     sock.recv.side_effect = BlockingIOError(


### PR DESCRIPTION
## Problem

Fixes #4003: When using redis-py with the hiredis parser and connection pooling in a multi-threaded environment,  can become  when the socket is closed by another thread, causing:



## Root Cause

The race condition occurs in :

1. Thread A enters  and is about to call 
2. Thread B calls  which sets 
3. Thread A executes  → AttributeError

## Fix

Added a guard at the top of  to check if  is None:



This is consistent with the existing checks in  (line 117) and  (line 175).

## Test

Added  to verify the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive check aligned with existing parser disconnect handling; behavior change only affects the erroneous race path.
> 
> **Overview**
> Fixes a **multi-threaded race** on pooled hiredis connections where one thread can call `on_disconnect()` (setting `_reader` to `None`) while another is inside `_HiredisParser.read_from_socket()`, which previously led to **`AttributeError`** on `_reader.feed()`.
> 
> **`read_from_socket`** now raises **`ConnectionError`** with the same “connection closed” message used elsewhere when `_reader` is missing, matching existing checks in **`can_read`** and **`read_response`**.
> 
> Adds **`test_hiredis_read_from_socket_raises_when_reader_is_none`** to lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539975e025a62ada5ba13058adc7134ab1ea172c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->