### PR TITLE
fix: retry on asyncio heap corruption in read_response (#3748)

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -122,6 +122,8 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         return _socket_can_read(self._sock, timeout)
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
+        if not self._reader:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         sock = self._sock
         custom_timeout = timeout is not SENTINEL
         try:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -777,44 +777,60 @@ class AbstractConnection:
         else:
             read_timeout = timeout if timeout is not None else self.socket_timeout
         host_error = self._host_error()
-        try:
-            if read_timeout is not None and self.protocol in ["3", 3]:
-                async with async_timeout(read_timeout):
+
+        # Retry loop to handle RuntimeError from asyncio's internal heap
+        # corruption when rapid timeout context creation/destruction occurs.
+        # See: https://github.com/python/cpython/issues/127200 and
+        # https://github.com/redis/redis-py/issues/3748
+        _max_heap_retries = 3
+        for _heap_retry in range(_max_heap_retries):
+            try:
+                if read_timeout is not None and self.protocol in ["3", 3]:
+                    async with async_timeout(read_timeout):
+                        response = await self._parser.read_response(
+                            disable_decoding=disable_decoding,
+                            push_request=push_request,
+                        )
+                elif read_timeout is not None:
+                    async with async_timeout(read_timeout):
+                        response = await self._parser.read_response(
+                            disable_decoding=disable_decoding
+                        )
+                elif self.protocol in ["3", 3]:
                     response = await self._parser.read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
+                        disable_decoding=disable_decoding,
+                        push_request=push_request,
                     )
-            elif read_timeout is not None:
-                async with async_timeout(read_timeout):
+                else:
                     response = await self._parser.read_response(
                         disable_decoding=disable_decoding
                     )
-            elif self.protocol in ["3", 3]:
-                response = await self._parser.read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                break
+            except RuntimeError as e:
+                if "list changed size during iteration" in str(e):
+                    if _heap_retry < _max_heap_retries - 1:
+                        continue
+                raise
+            except asyncio.TimeoutError:
+                if timeout is not None:
+                    return None
+                if disconnect_on_error:
+                    await self.disconnect(nowait=True)
+                raise TimeoutError(f"Timeout reading from {host_error}")
+            except OSError as e:
+                if disconnect_on_error:
+                    await self.disconnect(nowait=True)
+                raise ConnectionError(
+                    f"Error while reading from {host_error} : {e.args}"
                 )
-            else:
-                response = await self._parser.read_response(
-                    disable_decoding=disable_decoding
-                )
-        except asyncio.TimeoutError:
-            if timeout is not None:
-                # user requested timeout, return None. Operation can be retried
-                return None
-            # it was a self.socket_timeout error.
-            if disconnect_on_error:
-                await self.disconnect(nowait=True)
-            raise TimeoutError(f"Timeout reading from {host_error}")
-        except OSError as e:
-            if disconnect_on_error:
-                await self.disconnect(nowait=True)
-            raise ConnectionError(f"Error while reading from {host_error} : {e.args}")
-        except BaseException:
-            # Also by default close in case of BaseException.  A lot of code
-            # relies on this behaviour when doing Command/Response pairs.
-            # See #1128.
-            if disconnect_on_error:
-                await self.disconnect(nowait=True)
-            raise
+            except BaseException:
+                if disconnect_on_error:
+                    await self.disconnect(nowait=True)
+                raise
+        else:
+            raise RuntimeError(
+                "Failed to read response after retries due to asyncio heap corruption"
+            )
 
         if self.health_check_interval:
             next_time = asyncio.get_running_loop().time() + self.health_check_interval

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -857,3 +857,72 @@ async def test_disconnect_no_current_task_calls_close(request):
             mock_on_disconnect.assert_called_once()
 
     assert not conn.is_connected
+
+
+async def test_read_response_retries_on_heap_corruption():
+    """
+    Regression test for issue #3748:
+    Python's asyncio event loop can raise RuntimeError("list changed size
+    during iteration") when rapid timeout scheduling occurs (e.g. PubSub
+    with small timeouts). The read_response method should retry the operation
+    when this specific error occurs.
+    """
+    conn = Connection(socket_timeout=5.0)
+    conn._connected = True
+
+    call_count = 0
+    expected_response = b"+OK\r\n"
+
+    async def mock_read_response(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise RuntimeError(
+                "list changed size during iteration"
+            )
+        return expected_response
+
+    mock_parser = mock.MagicMock()
+    mock_parser.read_response = mock_read_response
+    conn._parser = mock_parser
+
+    response = await conn.read_response()
+    assert response == expected_response
+    assert call_count == 3
+
+
+async def test_read_response_raises_after_max_heap_retries():
+    """
+    Verify that RuntimeError is raised after all retries are exhausted
+    when the heap corruption error persists.
+    """
+    conn = Connection(socket_timeout=5.0)
+    conn._connected = True
+
+    async def mock_read_response_always_fails(*args, **kwargs):
+        raise RuntimeError("list changed size during iteration")
+
+    mock_parser = mock.MagicMock()
+    mock_parser.read_response = mock_read_response_always_fails
+    conn._parser = mock_parser
+
+    with pytest.raises(RuntimeError, match="list changed size during iteration"):
+        await conn.read_response()
+
+
+async def test_read_response_does_not_retry_other_runtime_errors():
+    """
+    Verify that other RuntimeError messages are not caught by the retry logic.
+    """
+    conn = Connection(socket_timeout=5.0)
+    conn._connected = True
+
+    async def mock_read_response_other_error(*args, **kwargs):
+        raise RuntimeError("some other error")
+
+    mock_parser = mock.MagicMock()
+    mock_parser.read_response = mock_read_response_other_error
+    conn._parser = mock_parser
+
+    with pytest.raises(RuntimeError, match="some other error"):
+        await conn.read_response()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -294,6 +294,17 @@ def test_hiredis_read_response_timeout_zero_maps_would_block_to_timeout():
         parser.read_response(timeout=0)
 
 
+def test_hiredis_read_from_socket_raises_when_reader_is_none():
+    """Regression: read_from_socket must raise ConnectionError if _reader is
+    None (e.g. on_disconnect was called by another thread).  Previously this
+    produced AttributeError: 'NoneType' object has no attribute 'feed'."""
+    parser = make_hiredis_parser()
+    parser._reader = None  # simulate on_disconnect clearing the reader
+
+    with pytest.raises(ConnectionError, match="Connection closed by server"):
+        parser.read_from_socket()
+
+
 def test_socket_buffer_timeout_zero_maps_would_block_to_timeout():
     sock = Mock()
     sock.recv.side_effect = BlockingIOError(


### PR DESCRIPTION
## Description

This PR fixes #3748 by adding retry logic for a known Python asyncio bug where the event loop's internal heap of scheduled callbacks can be corrupted during iteration.

### Root Cause

Python's asyncio event loop can raise  when:
- Rapid timeout context creation/destruction occurs (e.g., PubSub with small timeouts like )
- Multiple concurrent tasks are scheduling callbacks on the event loop

This is a known Python issue: https://github.com/python/cpython/issues/127200

### Fix

Added a retry loop (up to 3 attempts) in  that specifically catches this error. The retry:
- Only catches  with the specific message about list size change
- Does NOT retry other  messages
- Preserves all existing error handling for , , etc.

### Tests

Added 3 test cases:
1.  - Verifies retry succeeds after transient failures
2.  - Verifies error is raised after all retries exhausted
3.  - Verifies only the specific error is retried

### Related Issues
- Fixes #3748
- Related to CPython issue https://github.com/python/cpython/issues/127200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async read path and retry semantics; behavior change is narrow but affects all timed reads under load.
> 
> **Overview**
> Fixes intermittent **PubSub / short-timeout** failures where asyncio raises `RuntimeError("list changed size during iteration")` during rapid `async_timeout` use (CPython [#127200](https://github.com/python/cpython/issues/127200), redis-py [#3748](https://github.com/redis/redis-py/issues/3748)).
> 
> **Async `Connection.read_response`** now retries the timed parser read up to **3 times** when that specific message appears; other `RuntimeError`s, timeouts, `OSError`, and disconnect-on-error behavior are unchanged. If every attempt hits the corruption error, the original `RuntimeError` is re-raised (or a final message after the loop).
> 
> **Sync hiredis `read_from_socket`** now matches `can_read` by raising **`ConnectionError`** when `_reader` is `None` after disconnect, instead of failing on `feed`.
> 
> Tests cover retry success, exhausted retries, non-matching `RuntimeError`, and the hiredis disconnect race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3ce62ca14e53bb9793d8e72bcf12ad09fc5729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->