### PR TITLE
Fix ClusterPipeline.command_stack to reflect queued commands

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3420,7 +3420,6 @@ class ClusterPipeline(RedisCluster):
         **kwargs,
     ):
         """ """
-        self.command_stack = []
         self.nodes_manager = nodes_manager
         self.commands_parser = commands_parser
         self.refresh_table_asap = False
@@ -3492,6 +3491,10 @@ class ClusterPipeline(RedisCluster):
             self._event_dispatcher = EventDispatcher()
         else:
             self._event_dispatcher = event_dispatcher
+
+    @property
+    def command_stack(self):
+        return self._execution_strategy.command_queue
 
     def __repr__(self):
         """ """

--- a/tests/test_cluster_transaction.py
+++ b/tests/test_cluster_transaction.py
@@ -9,7 +9,7 @@ import redis
 from redis import CrossSlotTransactionError, ConnectionPool, RedisClusterException
 from redis.backoff import NoBackoff
 from redis.client import Redis
-from redis.cluster import PRIMARY, ClusterNode, RedisCluster
+from redis.cluster import PRIMARY, ClusterNode, PipelineCommand, RedisCluster
 from redis.observability import recorder
 from redis.observability.config import OTelConfig, MetricGroup
 from redis.observability.metrics import RedisMetricsCollector
@@ -804,3 +804,29 @@ class TestClusterTransactionMetricsRecording:
         assert "server.address" in attrs
         assert "server.port" in attrs
         assert "db.namespace" in attrs
+
+    @pytest.mark.onlycluster
+    def test_pipeline_command_stack(self, r):
+        """Test that command_stack reflects queued commands in transactional pipeline."""
+        with r.pipeline(transaction=True) as tx:
+            assert len(tx.command_stack) == 0
+
+            tx.set("{foo}bar", "value1")
+            tx.set("{foo}baz", "value2")
+
+            assert len(tx.command_stack) == 2
+            assert tx.command_stack[0].args == ("SET", "{foo}bar", "value1")
+            assert tx.command_stack[1].args == ("SET", "{foo}baz", "value2")
+
+    @pytest.mark.onlycluster
+    def test_pipeline_command_stack_non_transactional(self, r):
+        """Test that command_stack reflects queued commands in non-transactional pipeline."""
+        with r.pipeline(transaction=False) as tx:
+            assert len(tx.command_stack) == 0
+
+            tx.set("{foo}bar", "value1")
+            tx.set("{foo}baz", "value2")
+
+            assert len(tx.command_stack) == 2
+            assert tx.command_stack[0].args == ("SET", "{foo}bar", "value1")
+            assert tx.command_stack[1].args == ("SET", "{foo}baz", "value2")


### PR DESCRIPTION
## Description

This PR fixes issue #3703 where `self.command_stack` was always `[]` in `ClusterPipeline` even when commands were queued.

### Root Cause

After the changes in PR #3611 which added execution strategies, commands in `ClusterPipeline` are stored in `self._execution_strategy.command_queue` instead of `self.command_stack`. However, `self.command_stack` was still initialized as an empty list in `__init__` and never updated.

This caused tracing libraries (e.g. Datadog) that inspect `command_stack` to report empty command lists, breaking observability.

### Fix

Convert `command_stack` from an instance attribute to a property that delegates to `self._execution_strategy.command_queue`.

### Changes

- **redis/cluster.py**: Remove `self.command_stack = []` from `__init__`, add `command_stack` property
- **tests/test_cluster_transaction.py**: Add tests verifying `command_stack` reflects queued commands in both transactional and non-transactional pipelines

### Testing

- Added unit tests verifying `command_stack` correctly reflects queued commands
- Verified the fix works for both transactional and non-transactional pipelines
- Existing tests continue to pass

Closes #3703

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small backward-compatible API fix delegating to existing queue storage; covered by new cluster pipeline tests.
> 
> **Overview**
> Fixes **ClusterPipeline** observability where `command_stack` stayed empty after queued commands were moved to execution strategies.
> 
> **`command_stack`** is no longer an unused `[]` on init; it is a **property** that returns **`self._execution_strategy.command_queue`**, so tracing integrations that read `command_stack` see the same queued **`PipelineCommand`** entries as transactional and non-transactional pipelines.
> 
> Cluster transaction tests assert stack length and **`args`** for both pipeline modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5603b32e9da48fac1a750f853a883fd74704ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->