### PR TITLE
fix: expose command_stack property on ClusterPipeline

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3420,7 +3420,6 @@ class ClusterPipeline(RedisCluster):
         **kwargs,
     ):
         """ """
-        self.command_stack = []
         self.nodes_manager = nodes_manager
         self.commands_parser = commands_parser
         self.refresh_table_asap = False
@@ -3492,6 +3491,14 @@ class ClusterPipeline(RedisCluster):
             self._event_dispatcher = EventDispatcher()
         else:
             self._event_dispatcher = event_dispatcher
+
+    @property
+    def command_stack(self):
+        return self._execution_strategy.command_queue
+
+    @command_stack.setter
+    def command_stack(self, queue):
+        self._execution_strategy.command_queue = queue
 
     def __repr__(self):
         """ """

--- a/tests/test_cluster_transaction.py
+++ b/tests/test_cluster_transaction.py
@@ -417,6 +417,34 @@ class TestClusterTransaction:
 
 
 @pytest.mark.onlycluster
+class TestClusterPipelineCommandStack:
+    def test_pipeline_command_stack(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            pipe.set("foo", "value1")
+            pipe.set("baz", "value2")
+
+            assert len(pipe.command_stack) == 2
+            assert pipe.command_stack[0].args == ("SET", "foo", "value1")
+            assert pipe.command_stack[1].args == ("SET", "baz", "value2")
+
+    def test_transaction_command_stack(self, r):
+        with r.pipeline(transaction=True) as pipe:
+            pipe.set("foo", "value1")
+            pipe.set("baz", "value2")
+
+            assert len(pipe.command_stack) == 2
+            assert pipe.command_stack[0].args == ("SET", "foo", "value1")
+            assert pipe.command_stack[1].args == ("SET", "baz", "value2")
+
+    def test_command_stack_empty_after_execute(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            pipe.set("foo", "value1")
+            pipe.execute()
+
+            assert not pipe.command_stack
+
+
+@pytest.mark.onlycluster
 class TestClusterTransactionMetricsRecording:
     """
     Integration tests that verify metrics are properly recorded


### PR DESCRIPTION
## Problem

Fixes #3703

After PR #3611 added execution strategies,  is always  because commands are now stored in  instead. This breaks tracing libraries (like Datadog) and other tools that read  to inspect pipeline commands.

## Solution

This is a minimal, focused fix:

1. **Removed** the redundant  initialization from 
2. **Added** a  property that delegates to 
3. **Added** a setter for backward compatibility with code that might assign to 

## Tests

Added  class with three tests:
-  - verifies commands are visible in non-transaction mode
-  - verifies commands are visible in transaction mode  
-  - verifies command_stack is cleared after execution

## Related

- Issue #3703
- Reference fix: https://github.com/mathewlee11/redis-py/pull/1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small backward-compatibility shim with no change to execution paths; new tests cover the exposed queue behavior.
> 
> **Overview**
> **Fixes broken `command_stack` on cluster pipelines** after commands were moved into `_execution_strategy.command_queue` (#3611), which left the old attribute always empty and broke tracers that read it (e.g. Datadog, #3703).
> 
> `ClusterPipeline` no longer initializes a separate `command_stack` list. **`command_stack` is now a property** that reads and writes `_execution_strategy.command_queue`, so inspection, length, and reset/discard behavior stay aligned with the real queued `PipelineCommand` objects in both pipeline and transaction modes.
> 
> Adds **`TestClusterPipelineCommandStack`** integration tests for non-transaction and transaction pipelines, including that the stack clears after `execute()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e87f9e1ac11c834d7e5375c83bd00dd112fdef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->