### PR TITLE
fix: extend socket_timeout for blocking commands to prevent premature timeouts

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -773,12 +773,85 @@ class Redis(
         """
         await self.aclose(close_connection_pool)
 
+    _BLOCKING_COMMANDS_TIMEOUT_AT_END = frozenset(
+        ["BRPOP", "BLPOP", "BZPOPMIN", "BZPOPMAX"]
+    )
+
+    def _get_blocking_timeout(self, command_name, args):
+        """Extract blocking timeout (seconds) from a blocking command's args.
+        Returns None for non-blocking commands or when no timeout is present."""
+        cmd = command_name.upper() if isinstance(command_name, str) else command_name
+
+        if cmd in self._BLOCKING_COMMANDS_TIMEOUT_AT_END:
+            if args:
+                try:
+                    return float(args[-1])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd == "BRPOPLPUSH":
+            # BRPOPLPUSH src dst timeout
+            if len(args) >= 3:
+                try:
+                    return float(args[2])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd == "BLMOVE":
+            # BLMOVE src dst LEFT|RIGHT LEFT|RIGHT timeout
+            if len(args) >= 5:
+                try:
+                    return float(args[4])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd == "BZMPOP":
+            # BZMPOP timeout numkeys key [key ...] LEFT|RIGHT [COUNT count]
+            if args:
+                try:
+                    return float(args[0])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd in ("XREAD", "XREADGROUP"):
+            # XREAD [COUNT count] [BLOCK milliseconds] STREAMS ...
+            # XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] ...
+            for i, arg in enumerate(args):
+                arg_str = (
+                    arg.upper() if isinstance(arg, bytes) else str(arg).upper()
+                )
+                if arg_str == "BLOCK":
+                    if i + 1 < len(args):
+                        try:
+                            return float(args[i + 1]) / 1000.0
+                        except (ValueError, TypeError):
+                            return None
+            return None
+
+        return None
+
     async def _send_command_parse_response(self, conn, command_name, *args, **options):
         """
         Send a command and parse the response
         """
-        await conn.send_command(*args)
-        return await self.parse_response(conn, command_name, **options)
+        blocking_timeout = self._get_blocking_timeout(command_name, args)
+        orig_socket_timeout = None
+        if blocking_timeout and blocking_timeout > 0:
+            orig_socket_timeout = conn.socket_timeout
+            required_timeout = blocking_timeout + 1
+            if orig_socket_timeout is None or required_timeout > orig_socket_timeout:
+                conn.socket_timeout = required_timeout
+
+        try:
+            await conn.send_command(*args)
+            return await self.parse_response(conn, command_name, **options)
+        finally:
+            if orig_socket_timeout is not None:
+                conn.socket_timeout = orig_socket_timeout
 
     async def _close_connection(
         self,

--- a/redis/client.py
+++ b/redis/client.py
@@ -756,12 +756,85 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         if self.auto_close_connection_pool:
             self.connection_pool.disconnect()
 
+    _BLOCKING_COMMANDS_TIMEOUT_AT_END = frozenset(
+        ["BRPOP", "BLPOP", "BZPOPMIN", "BZPOPMAX"]
+    )
+
+    def _get_blocking_timeout(self, command_name, args):
+        """Extract blocking timeout (seconds) from a blocking command's args.
+        Returns None for non-blocking commands or when no timeout is present."""
+        cmd = command_name.upper() if isinstance(command_name, str) else command_name
+
+        if cmd in self._BLOCKING_COMMANDS_TIMEOUT_AT_END:
+            if args:
+                try:
+                    return float(args[-1])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd == "BRPOPLPUSH":
+            # BRPOPLPUSH src dst timeout
+            if len(args) >= 3:
+                try:
+                    return float(args[2])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd == "BLMOVE":
+            # BLMOVE src dst LEFT|RIGHT LEFT|RIGHT timeout
+            if len(args) >= 5:
+                try:
+                    return float(args[4])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd == "BZMPOP":
+            # BZMPOP timeout numkeys key [key ...] LEFT|RIGHT [COUNT count]
+            if args:
+                try:
+                    return float(args[0])
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        if cmd in ("XREAD", "XREADGROUP"):
+            # XREAD [COUNT count] [BLOCK milliseconds] STREAMS ...
+            # XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] ...
+            for i, arg in enumerate(args):
+                arg_str = (
+                    arg.upper() if isinstance(arg, bytes) else str(arg).upper()
+                )
+                if arg_str == "BLOCK":
+                    if i + 1 < len(args):
+                        try:
+                            return float(args[i + 1]) / 1000.0
+                        except (ValueError, TypeError):
+                            return None
+            return None
+
+        return None
+
     def _send_command_parse_response(self, conn, command_name, *args, **options):
         """
         Send a command and parse the response
         """
-        conn.send_command(*args, **options)
-        return self.parse_response(conn, command_name, **options)
+        blocking_timeout = self._get_blocking_timeout(command_name, args)
+        orig_socket_timeout = None
+        if blocking_timeout and blocking_timeout > 0:
+            orig_socket_timeout = conn.socket_timeout
+            required_timeout = blocking_timeout + 1
+            if orig_socket_timeout is None or required_timeout > orig_socket_timeout:
+                conn.socket_timeout = required_timeout
+
+        try:
+            conn.send_command(*args, **options)
+            return self.parse_response(conn, command_name, **options)
+        finally:
+            if orig_socket_timeout is not None:
+                conn.socket_timeout = orig_socket_timeout
 
     def _close_connection(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -513,3 +513,126 @@ class TestRedisClientMetricsRecording:
             assert "error.type" in error_attrs
 
         recorder.reset_collector()
+
+
+class TestBlockingCommandTimeout:
+    """Tests for blocking command socket timeout adjustment."""
+
+    def test_get_blocking_timeout_brpop(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("BRPOP", ["mykey", 8]) == 8.0
+        assert client._get_blocking_timeout("BRPOP", ["mykey", 0]) == 0.0
+        assert client._get_blocking_timeout("BRPOP", ["mykey"]) is None
+        assert client._get_blocking_timeout("BRPOP", []) is None
+
+    def test_get_blocking_timeout_blpop(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("BLPOP", ["mykey", 10]) == 10.0
+
+    def test_get_blocking_timeout_bzpopmin(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("BZPOPMIN", ["mykey", 5]) == 5.0
+
+    def test_get_blocking_timeout_bzpopmax(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("BZPOPMAX", ["mykey", 3]) == 3.0
+
+    def test_get_blocking_timeout_brpoplpush(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("BRPOPLPUSH", ["src", "dst", 7]) == 7.0
+        assert client._get_blocking_timeout("BRPOPLPUSH", ["src", "dst"]) is None
+
+    def test_get_blocking_timeout_blmove(self):
+        client = redis.Redis()
+        assert (
+            client._get_blocking_timeout("BLMOVE", ["src", "dst", "LEFT", "RIGHT", 6])
+            == 6.0
+        )
+        assert (
+            client._get_blocking_timeout("BLMOVE", ["src", "dst", "LEFT", "RIGHT"])
+            is None
+        )
+
+    def test_get_blocking_timeout_bzmpop(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("BZMPOP", [4, 1, "mykey", "LEFT"]) == 4.0
+
+    def test_get_blocking_timeout_xread_block(self):
+        client = redis.Redis()
+        assert (
+            client._get_blocking_timeout(
+                "XREAD", ["COUNT", 10, "BLOCK", 5000, "STREAMS", "mystream", "0"]
+            )
+            == 5.0
+        )
+        assert (
+            client._get_blocking_timeout(
+                "XREAD", ["COUNT", 10, "STREAMS", "mystream", "0"]
+            )
+            is None
+        )
+
+    def test_get_blocking_timeout_xreadgroup_block(self):
+        client = redis.Redis()
+        assert (
+            client._get_blocking_timeout(
+                "XREADGROUP",
+                ["GROUP", "mygroup", "consumer1", "BLOCK", 3000, "STREAMS", "mystream", ">"],
+            )
+            == 3.0
+        )
+
+    def test_get_blocking_timeout_non_blocking(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("GET", ["mykey"]) is None
+        assert client._get_blocking_timeout("SET", ["mykey", "value"]) is None
+        assert client._get_blocking_timeout("LPUSH", ["mykey", "value"]) is None
+
+    def test_get_blocking_timeout_case_insensitive(self):
+        client = redis.Redis()
+        assert client._get_blocking_timeout("brpop", ["mykey", 8]) == 8.0
+        assert client._get_blocking_timeout("BrPop", ["mykey", 8]) == 8.0
+
+    def test_send_command_extends_socket_timeout_for_blocking(self):
+        client = redis.Redis(socket_timeout=4)
+        conn = mock.MagicMock()
+        conn.socket_timeout = 4
+        conn.send_command = mock.MagicMock()
+        client.parse_response = mock.MagicMock(return_value=b"OK")
+
+        client._send_command_parse_response(conn, "BRPOP", "mykey", 8)
+
+        assert conn.socket_timeout == 4
+
+    def test_send_command_does_not_reduce_socket_timeout(self):
+        client = redis.Redis(socket_timeout=30)
+        conn = mock.MagicMock()
+        conn.socket_timeout = 30
+        conn.send_command = mock.MagicMock()
+        client.parse_response = mock.MagicMock(return_value=b"OK")
+
+        client._send_command_parse_response(conn, "BRPOP", "mykey", 8)
+
+        assert conn.socket_timeout == 30
+
+    def test_send_command_restores_socket_timeout_on_error(self):
+        client = redis.Redis(socket_timeout=4)
+        conn = mock.MagicMock()
+        conn.socket_timeout = 4
+        conn.send_command = mock.MagicMock(side_effect=Exception("fail"))
+
+        with pytest.raises(Exception, match="fail"):
+            client._send_command_parse_response(conn, "BRPOP", "mykey", 8)
+
+        assert conn.socket_timeout == 4
+
+    def test_send_command_no_change_for_non_blocking(self):
+        client = redis.Redis(socket_timeout=4)
+        conn = mock.MagicMock()
+        conn.socket_timeout = 4
+        conn.send_command = mock.MagicMock()
+        client.parse_response = mock.MagicMock(return_value=b"OK")
+
+        client._send_command_parse_response(conn, "GET", "mykey")
+
+        assert conn.socket_timeout == 4


### PR DESCRIPTION
## Description

Fixes #2807

Blocking commands (BRPOP, BLPOP, BRPOPLPUSH, BLMOVE, BZPOPMIN, BZPOPMAX, BZMPOP, XREAD/XREADGROUP with BLOCK) specify their own timeout at the Redis protocol level. When the command timeout exceeds the client's `socket_timeout`, the socket layer raises `TimeoutError` before the blocking command can complete.

### Problem

```python
r = redis.Redis(socket_timeout=4)
r.brpop('my_key', timeout=8)  # Raises TimeoutError after 4 seconds
```

The `socket_timeout` is a low-level socket setting that should not prevent application-level blocking timeouts from being honored.

### Solution

This fix detects blocking commands in `_send_command_parse_response` and temporarily extends the connection's `socket_timeout` to cover the command's blocking duration (plus a 1-second buffer). The original timeout is restored after the command completes, even if an exception occurs.

### Changes

- **`redis/client.py`**: Added `_get_blocking_timeout()` method and socket timeout adjustment in `_send_command_parse_response()`
- **`redis/asyncio/client.py`**: Same fix for the async client
- **`tests/test_client.py`**: Added `TestBlockingCommandTimeout` test class with 15 tests covering all blocking commands

### Commands Fixed

| Command | Timeout Location |
|---------|-----------------|
| BRPOP, BLPOP, BZPOPMIN, BZPOPMAX | Last argument (seconds) |
| BRPOPLPUSH | 3rd argument (seconds) |
| BLMOVE | 5th argument (seconds) |
| BZMPOP | 1st argument (seconds) |
| XREAD, XREADGROUP | After BLOCK keyword (milliseconds, converted to seconds) |

### Testing

All 25 tests in `tests/test_client.py` pass, including 15 new tests specifically for the blocking timeout fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared command-send path by mutating per-connection `socket_timeout`, which could affect pooled connections if restore failed; behavior is narrow, guarded, and covered by new tests.
> 
> **Overview**
> Fixes premature `TimeoutError` when a blocking command’s Redis-level wait is longer than the client’s `socket_timeout` (e.g. `brpop(..., timeout=8)` with `socket_timeout=4`).
> 
> **Sync and async** `Redis` clients now parse the block duration for commands like `BRPOP`/`BLPOP`, `BRPOPLPUSH`, `BLMOVE`, `BZMPOP`, and `XREAD`/`XREADGROUP` with `BLOCK`. In `_send_command_parse_response`, the connection’s `socket_timeout` is **temporarily** raised to that duration plus one second (only if needed), then **restored** in a `finally` block—including on errors. Non-blocking commands and timeouts of `0` are unchanged.
> 
> Adds `TestBlockingCommandTimeout` in `tests/test_client.py` for parsing and socket-timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd5e17266f9f0a64c2387b00f663190236d6fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->