### PR TITLE
Fix AttributeError on concurrent disconnect in hiredis parser (#2967)

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -114,23 +114,28 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
     def can_read(self, timeout: float = 0) -> bool:
         # TODO: Rename this API; it detects pending data or dirty/closed
         # connection state, not only whether application data can be read.
-        if not self._reader:
+        reader = self._reader
+        sock = self._sock
+        if not reader or sock is None:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
-        if self._reader.has_data():
+        if reader.has_data():
             return True
-        return _socket_can_read(self._sock, timeout)
+        return _socket_can_read(sock, timeout)
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
         sock = self._sock
+        reader = self._reader
+        if sock is None or reader is None:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         custom_timeout = timeout is not SENTINEL
         try:
             if custom_timeout:
                 sock.settimeout(timeout)
-            bufflen = self._sock.recv_into(self._buffer)
+            bufflen = sock.recv_into(self._buffer)
             if bufflen == 0:
                 raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
-            self._reader.feed(self._buffer, 0, bufflen)
+            reader.feed(self._buffer, 0, bufflen)
             # data was read from the socket and added to the buffer.
             # return True to indicate that data was read.
             return True
@@ -160,20 +165,24 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
         push_request=False,
         timeout: Union[float, object] = SENTINEL,
     ):
-        if not self._reader:
+        reader = self._reader
+        if not reader:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
 
         if disable_decoding:
-            response = self._reader.gets(False)
+            response = reader.gets(False)
         else:
-            response = self._reader.gets()
+            response = reader.gets()
 
         while response is NOT_ENOUGH_DATA:
             self.read_from_socket(timeout=timeout)
+            reader = self._reader
+            if not reader:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
             if disable_decoding:
-                response = self._reader.gets(False)
+                response = reader.gets(False)
             else:
-                response = self._reader.gets()
+                response = reader.gets()
         # if the response is a ConnectionError or the response is a list and
         # the first item is a ConnectionError, raise it as something bad
         # happened
@@ -269,7 +278,10 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         buffer = await self._stream.read(self._read_size)
         if not buffer or not isinstance(buffer, bytes):
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
-        self._reader.feed(buffer)
+        reader = self._reader
+        if reader is None:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        reader.feed(buffer)
         # data was read from the socket and added to the buffer.
         # return True to indicate that data was read.
         return True
@@ -283,17 +295,24 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         if not self._connected:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR) from None
 
+        reader = self._reader
+        if not reader:
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+
         if disable_decoding:
-            response = self._reader.gets(False)
+            response = reader.gets(False)
         else:
-            response = self._reader.gets()
+            response = reader.gets()
 
         while response is NOT_ENOUGH_DATA:
             await self.read_from_socket()
+            reader = self._reader
+            if not reader:
+                raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
             if disable_decoding:
-                response = self._reader.gets(False)
+                response = reader.gets(False)
             else:
-                response = self._reader.gets()
+                response = reader.gets()
 
         # if the response is a ConnectionError or the response is a list and
         # the first item is a ConnectionError, raise it as something bad

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -356,6 +356,62 @@ def test_redis_client_default_driver_info():
     client.close()
 
 
+def test_hiredis_read_from_socket_handles_concurrent_disconnect():
+    """Regression test for #2967: read_from_socket should raise ConnectionError
+    (not AttributeError) when another thread disconnects the connection."""
+    parser = make_hiredis_parser()
+
+    # Simulate concurrent disconnect: _reader and _sock set to None
+    # (as happens when another thread calls connection.disconnect())
+    parser._reader = None
+
+    with pytest.raises(ConnectionError):
+        parser.read_from_socket()
+
+
+def test_hiredis_read_from_socket_handles_sock_becoming_none():
+    """Regression test for #2967: read_from_socket should raise ConnectionError
+    when _sock becomes None."""
+    parser = make_hiredis_parser()
+
+    parser._sock = None
+
+    with pytest.raises(ConnectionError):
+        parser.read_from_socket()
+
+
+def test_hiredis_read_response_handles_reader_becoming_none():
+    """Regression test for #2967: read_response should raise ConnectionError
+    when _reader becomes None (simulating concurrent disconnect)."""
+    parser = make_hiredis_parser()
+
+    # _reader is None — another thread already disconnected
+    parser._reader = None
+
+    with pytest.raises(ConnectionError):
+        parser.read_response()
+
+
+def test_hiredis_can_read_handles_concurrent_disconnect():
+    """Regression test for #2967: can_read should raise ConnectionError
+    when _sock or _reader becomes None."""
+    parser = make_hiredis_parser(has_data=False)
+    parser._sock = None
+
+    with pytest.raises(ConnectionError):
+        parser.can_read(timeout=0)
+
+
+def test_hiredis_can_read_handles_reader_becoming_none():
+    """Regression test for #2967: can_read should raise ConnectionError
+    when _reader becomes None."""
+    parser = make_hiredis_parser(has_data=False)
+    parser._reader = None
+
+    with pytest.raises(ConnectionError):
+        parser.can_read(timeout=0)
+
+
 @pytest.mark.fixed_client
 class TestConnection:
     def test_disconnect(self):


### PR DESCRIPTION
## Problem

When multiple threads share a `Redis` client and one thread calls `close()` (e.g. via `with redis:` context manager), `connection_pool.disconnect()` sets `_reader` and `_sock` to `None` on all connections — including those actively in use by other threads. Those threads then crash with:

```
AttributeError: 'NoneType' object has no attribute 'feed'
```

This is a regression introduced in 5.0.1 with the addition of `auto_close_connection_pool` in `Redis.close()`, and is still reproducible on latest code (confirmed by maintainers).

## Root Cause

In `_HiredisParser.read_from_socket()`, `self._reader` and `self._sock` are accessed directly without null checks. When another thread calls `disconnect()` concurrently, these become `None` mid-operation.

Additionally, `read_from_socket()` captured `sock = self._sock` but then used `self._sock.recv_into()` instead of the local `sock` variable, widening the race window.

## Fix

Capture local references to `self._reader` and `self._sock` at the start of each method and check for `None` before use. This converts the unhelpful `AttributeError` into a proper `ConnectionError` with the standard `SERVER_CLOSED_CONNECTION_ERROR` message.

Applied to:
- `_HiredisParser.can_read()`
- `_HiredisParser.read_from_socket()`
- `_HiredisParser.read_response()` (re-checks after `read_from_socket()` in the loop)
- `_AsyncHiredisParser.read_from_socket()`
- `_AsyncHiredisParser.read_response()`

## Tests

5 new regression tests verify that `ConnectionError` (not `AttributeError`) is raised when `_reader` or `_sock` is `None`.

Fixes #2967

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted defensive checks on the hiredis read path; behavior unchanged when connections stay connected, with clearer errors on races.
> 
> **Overview**
> Fixes a **thread-safety race** when one thread closes a shared `Redis` client while another is reading: `disconnect()` clears `_reader` and `_sock`, which previously caused **`AttributeError`** (e.g. on `feed`) instead of a proper closed-connection error.
> 
> The **hiredis** sync and async parsers now **snapshot** `_reader` / `_sock` (and use the local socket for `recv_into`), **guard** against `None` at entry and **after** socket reads in `read_response` loops, and raise **`ConnectionError`** with `SERVER_CLOSED_CONNECTION_ERROR` when the connection was torn down mid-operation. Coverage spans `can_read`, `read_from_socket`, and `read_response`.
> 
> **Five regression tests** assert `ConnectionError` when `_reader` or `_sock` is `None`, simulating concurrent disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6dfed6fcb0ddfccf0cdeb5f3c942c4d865cc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->