### PR TITLE
Fix timeout writing to socket after health check (#3741)

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -750,7 +750,7 @@ class MaintNotificationsAbstractConnection:
     def update_parser_timeout(self, timeout: Optional[float] = None):
         parser = self._get_parser()
         if parser and parser._buffer:
-            if isinstance(parser, _RESP3Parser) and timeout:
+            if isinstance(parser, (_RESP2Parser, _RESP3Parser)) and timeout:
                 parser._buffer.socket_timeout = timeout
             elif isinstance(parser, _HiredisParser):
                 parser._socket_timeout = timeout
@@ -1310,8 +1310,18 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         try:
             if isinstance(command, str):
                 command = [command]
+            # Re-assert the socket timeout before writing. The health check
+            # (above) may have triggered a disconnect/reconnect cycle, and
+            # concurrent operations (e.g. can_read from another thread) or
+            # maintenance-notification timeout changes can leave the socket
+            # with a stale timeout.  Guarding here ensures the write uses
+            # the configured socket_timeout regardless of what happened
+            # during the health check.
+            sock = self._sock
+            if sock.gettimeout() != self.socket_timeout:
+                sock.settimeout(self.socket_timeout)
             for item in command:
-                self._sock.sendall(item)
+                sock.sendall(item)
         except socket.timeout:
             self.disconnect()
             raise TimeoutError("Timeout writing to socket")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1508,4 +1508,128 @@ class TestBlockingConnectionPoolGetConnectionCount:
         assert idle_count == 2
         assert used_count == 0
 
-        pool.disconnect()
+
+class TestSendPackedCommandTimeoutReassertion:
+    """Tests that send_packed_command re-asserts socket timeout after health check."""
+
+    def test_send_packed_command_reasserts_timeout_after_health_check(self):
+        """
+        Verify that send_packed_command resets the socket timeout to the
+        configured socket_timeout before calling sendall, even when the
+        health check leaves the socket with a different timeout.
+
+        Regression test for https://github.com/redis/redis-py/issues/3741
+        """
+        conn = Connection(socket_timeout=5.0, health_check_interval=0)
+        conn._sock = mock.Mock()
+        conn._sock.gettimeout.return_value = 1.0  # stale timeout
+        conn.connect = mock.Mock()  # prevent real connect
+
+        # send_packed_command expects a list of byte chunks, not raw bytes.
+        # (raw bytes would be iterated byte-by-byte.)
+        packed = [b"*1\r\n$4\r\nPING\r\n"]
+        conn.send_packed_command(packed)
+
+        # The timeout should have been re-asserted to 5.0 before sendall
+        conn._sock.settimeout.assert_called_with(5.0)
+        conn._sock.sendall.assert_called_once_with(packed[0])
+
+    def test_send_packed_command_does_not_call_settimeout_when_already_correct(self):
+        """
+        When the socket already has the correct timeout, settimeout should
+        not be called unnecessarily.
+        """
+        conn = Connection(socket_timeout=5.0, health_check_interval=0)
+        conn._sock = mock.Mock()
+        conn._sock.gettimeout.return_value = 5.0  # correct timeout
+        conn.connect = mock.Mock()
+
+        packed = [b"*1\r\n$4\r\nPING\r\n"]
+        conn.send_packed_command(packed)
+
+        # settimeout should NOT have been called since timeout was already correct
+        conn._sock.settimeout.assert_not_called()
+        conn._sock.sendall.assert_called_once_with(packed[0])
+
+    def test_send_packed_command_reasserts_timeout_after_health_check_ping(self):
+        """
+        When health_check_interval > 0 and a health check runs, the socket
+        timeout should still be re-asserted before the actual command sendall.
+        """
+        conn = Connection(socket_timeout=5.0, health_check_interval=1)
+        conn._sock = mock.Mock()
+        conn._sock.gettimeout.return_value = 2.0  # stale timeout
+        conn.connect = mock.Mock()
+
+        # Mock the health check to avoid real PING/PONG
+        conn.check_health = mock.Mock()
+        # After check_health returns, gettimeout still returns stale value
+        conn._sock.gettimeout.return_value = 2.0
+
+        packed = [b"*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"]
+        conn.send_packed_command(packed)
+
+        # check_health was called
+        conn.check_health.assert_called_once()
+        # The timeout was re-asserted to 5.0 before sendall
+        conn._sock.settimeout.assert_called_with(5.0)
+        conn._sock.sendall.assert_called_once_with(packed[0])
+
+
+class TestUpdateParserTimeoutResp2:
+    """Tests that update_parser_timeout correctly handles _RESP2Parser."""
+
+    def test_update_parser_timeout_updates_resp2_buffer(self):
+        """
+        Verify that update_parser_timeout updates SocketBuffer.socket_timeout
+        for _RESP2Parser connections.
+
+        Regression test for https://github.com/redis/redis-py/issues/3741
+        """
+        conn = Connection(socket_timeout=5.0, parser_class=_RESP2Parser)
+        # Manually set up the parser state without connecting
+        parser = _RESP2Parser(conn._socket_read_size)
+        mock_sock = mock.Mock()
+        parser._sock = mock_sock
+        parser._buffer = SocketBuffer(mock_sock, conn._socket_read_size, 5.0)
+        parser.encoder = conn.encoder
+        conn._parser = parser
+
+        # Verify initial timeout
+        assert parser._buffer.socket_timeout == 5.0
+
+        # Update the timeout
+        conn.update_parser_timeout(10.0)
+
+        # The SocketBuffer's timeout should be updated
+        assert parser._buffer.socket_timeout == 10.0
+
+    def test_update_parser_timeout_handles_resp3_parser(self):
+        """
+        Verify that update_parser_timeout still works for _RESP3Parser.
+        """
+        conn = Connection(socket_timeout=5.0, parser_class=_RESP3Parser)
+        parser = _RESP3Parser(conn._socket_read_size)
+        mock_sock = mock.Mock()
+        parser._sock = mock_sock
+        parser._buffer = SocketBuffer(mock_sock, conn._socket_read_size, 5.0)
+        parser.encoder = conn.encoder
+        conn._parser = parser
+
+        assert parser._buffer.socket_timeout == 5.0
+        conn.update_parser_timeout(10.0)
+        assert parser._buffer.socket_timeout == 10.0
+
+    def test_update_parser_timeout_handles_hiredis_parser(self):
+        """
+        Verify that update_parser_timeout still works for _HiredisParser.
+        """
+        if not HIREDIS_AVAILABLE:
+            pytest.skip("Hiredis not available")
+        conn = Connection(socket_timeout=5.0, parser_class=_HiredisParser)
+        parser = make_hiredis_parser()
+        parser._socket_timeout = 5.0
+        conn._parser = parser
+
+        conn.update_parser_timeout(10.0)
+        assert parser._socket_timeout == 10.0


### PR DESCRIPTION
## Problem

Users report intermittent `TimeoutError: Timeout writing to socket` when using redis-py with both `socket_timeout` and `health_check_interval` configured. The error occurs even though the operation should complete within the configured timeout.

## Root Cause

Two related issues:

### 1. Socket timeout not re-asserted after health check

In `send_packed_command()`, the health check runs before the `sendall` loop. When the health check triggers a disconnect/reconnect cycle (via `_send_ping` failure → `_ping_failed` → `disconnect` → retry → reconnect), the new socket gets the correct timeout from `_connect()`. However, the code did not explicitly re-assert the socket timeout before `sendall()` after `check_health()` returned. If any concurrent operation (e.g., `can_read()` from another thread) or maintenance notification handler modified the socket timeout between the health check completing and `sendall` executing, the write would use a stale timeout value.

### 2. `update_parser_timeout` didn't handle `_RESP2Parser`

The `update_parser_timeout()` method updated `SocketBuffer.socket_timeout` for `_RESP3Parser` and `_HiredisParser`, but **not** for `_RESP2Parser`. When the connection timeout was changed (e.g., via maintenance notifications), `_RESP2Parser`'s `SocketBuffer` retained the old timeout snapshot. If `_read_from_socket` was later called with a custom timeout, its `finally` block would restore the stale snapshot instead of the current timeout.

## Fix

1. **Re-assert socket timeout in `send_packed_command`**: After `check_health()` returns, explicitly check and reset the socket timeout to `self.socket_timeout` before the `sendall` loop. This is a defensive measure that ensures correctness regardless of what happened during the health check.

2. **Fix `update_parser_timeout` for `_RESP2Parser`**: Add `_RESP2Parser` to the `isinstance` check alongside `_RESP3Parser` so that `SocketBuffer.socket_timeout` is properly updated.

## Tests

- 3 tests verifying socket timeout re-assertion after health check
- 3 tests verifying `update_parser_timeout` handles all parser types (RESP2, RESP3, Hiredis)

Closes #3741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for every command write and parser timeout propagation; changes are defensive and well-tested but affect connection I/O behavior under health checks and RESP2 parsing.
> 
> **Overview**
> Fixes intermittent **`TimeoutError: Timeout writing to socket`** when **`socket_timeout`** and **`health_check_interval`** are both set.
> 
> **`send_packed_command`** now resets the socket to **`self.socket_timeout`** before **`sendall`** if **`gettimeout()`** differs—covering stale values left by health-check reconnects, concurrent **`can_read`**, or maintenance-notification timeout tweaks.
> 
> **`update_parser_timeout`** also updates **`SocketBuffer.socket_timeout`** for **`_RESP2Parser`**, not only RESP3/Hiredis, so parser read paths restore the current timeout instead of an old snapshot.
> 
> Regression tests cover write-path timeout re-assertion (with and without health check) and parser timeout updates for RESP2, RESP3, and Hiredis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bde3546e989fb0417e083f3dfb906029b6a17cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->