### PR TITLE
docs: add hash examples notebook

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,3 +15,4 @@ Examples
    examples/timeseries_examples
    examples/redis-stream-example
    examples/opentelemetry_api_examples
+   examples/hash_examples

--- a/docs/examples/hash_examples.ipynb
+++ b/docs/examples/hash_examples.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Redis Hash Examples\n",
+    "\n",
+    "This notebook demonstrates how to work with Redis Hashes using redis-py.\n",
+    "Hashes are maps between string fields and string values, making them perfect\n",
+    "for representing objects (e.g., a user profile)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis\n",
+    "\n",
+    "r = redis.Redis(host='localhost', port=6379, decode_responses=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set and get a single field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hset('user:1', 'name', 'Alice')\n",
+    "print(r.hget('user:1', 'name'))  # Alice"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set multiple fields at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hset('user:1', mapping={\n",
+    "    'name': 'Alice',\n",
+    "    'age': '30',\n",
+    "    'email': 'alice@example.com'\n",
+    "})\n",
+    "print(r.hgetall('user:1'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check if a field exists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(r.hexists('user:1', 'email'))   # True\n",
+    "print(r.hexists('user:1', 'phone'))   # False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get all fields and values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(r.hkeys('user:1'))    # ['name', 'age', 'email']\n",
+    "print(r.hvals('user:1'))    # ['Alice', '30', 'alice@example.com']\n",
+    "print(r.hlen('user:1'))     # 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Increment a numeric field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hset('user:1', 'age', '30')\n",
+    "r.hincrby('user:1', 'age', 1)\n",
+    "print(r.hget('user:1', 'age'))  # 31"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hdel('user:1', 'email')\n",
+    "print(r.hgetall('user:1'))  # email is gone"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.delete('user:1')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Relates to #1744

Added a new `hash_examples.ipynb` notebook to `docs/examples/` covering
the most common Redis Hash operations:
- hset / hget (single and multiple fields)
- hgetall, hkeys, hvals, hlen
- hexists
- hincrby
- hdel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no library or runtime behavior impact.
> 
> **Overview**
> Adds **Redis Hash** documentation alongside the other example notebooks by introducing `hash_examples.ipynb` and wiring it into the Examples toctree.
> 
> The notebook walks through common hash operations with redis-py (`hset`/`hget`, `mapping`, `hgetall`, `hkeys`/`hvals`/`hlen`, `hexists`, `hincrby`, `hdel`) using a `user:1` profile example, plus a final `delete` cleanup step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adfa6471d692e21010c92fd148b335d8741ab4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->