### PR TITLE
docs: add hash_examples to examples.rst toctree

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,3 +15,4 @@ Examples
    examples/timeseries_examples
    examples/redis-stream-example
    examples/opentelemetry_api_examples
+   examples/hash_examples


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only toctree entry with no runtime or API impact.
> 
> **Overview**
> Adds **`examples/hash_examples`** to the Sphinx **Examples** toctree in `docs/examples.rst` so the hash examples page is included in the built documentation navigation alongside the other example sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b416c87a75b4b9211a6e6b2723dd6fa259bf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->