### PR TITLE
fix: detect closed pooled connection without consuming pending push data (RESP3 + hiredis) (#4128)

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -70,6 +70,10 @@ def _socket_is_closed(sock) -> bool:
     # close instead, and _POLLRDHUP is 0 there.
     if not _HAS_POLL:
         return False
+    # Decrypted TLS bytes buffered above the OS socket layer must be processed
+    # before the connection can be treated as closed, like kernel-level data.
+    if hasattr(sock, "pending") and sock.pending():
+        return False
     poller = select.poll()
     poller.register(sock, select.POLLIN | _POLLRDHUP)
     events = poller.poll(0)
@@ -77,7 +81,25 @@ def _socket_is_closed(sock) -> bool:
         return False
     _, revents = events[0]
     closed_flags = select.POLLHUP | select.POLLERR | select.POLLNVAL | _POLLRDHUP
-    return bool(revents & closed_flags)
+    if not (revents & closed_flags):
+        return False
+    # POLLHUP/POLLRDHUP can be reported while unread data is still buffered
+    # (the peer sent data, then closed). That data may carry cache
+    # invalidations that must be processed before the connection is dropped,
+    # so confirm with a non-destructive MSG_PEEK and report closed only once
+    # the buffer is drained.
+    try:
+        return sock.recv(1, socket.MSG_PEEK) == b""
+    except NONBLOCKING_EXCEPTIONS:
+        # Transient would-block: data may still arrive, keep the connection.
+        return False
+    except ValueError:
+        # SSL sockets do not support recv() flags; their buffered plaintext is
+        # covered by the pending() check above, so rely on the poll flags.
+        return True
+    except OSError:
+        # The socket is errored (POLLERR/POLLNVAL); nothing left to read.
+        return True
 
 
 class _HiredisReaderArgs(TypedDict, total=False):

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -27,6 +27,10 @@ NOT_ENOUGH_DATA = object()
 # select.poll() is unavailable on Windows; fall back to selectors there.
 _HAS_POLL = hasattr(select, "poll")
 
+# POLLRDHUP (Linux) reports a peer half-close (FIN) that POLLHUP does not cover.
+# It is absent on macOS/Windows, where 0 turns the masks that use it into no-ops.
+_POLLRDHUP = getattr(select, "POLLRDHUP", 0)
+
 
 def _socket_can_read(sock, timeout: float) -> bool:
     # SSL sockets can have decrypted bytes buffered above the OS socket layer.
@@ -55,19 +59,25 @@ def _socket_can_read(sock, timeout: float) -> bool:
 def _socket_is_closed(sock) -> bool:
     # A server-closed socket reads as ready (it yields EOF), so readiness alone
     # cannot tell it apart from a socket holding pending data. poll() can:
-    # POLLHUP/POLLERR/POLLNVAL flag a closed/errored socket while a live socket
+    # POLLHUP/POLLERR/POLLNVAL/POLLRDHUP flag a closed socket while a live socket
     # with buffered data reports POLLIN only. Polling is non-destructive, so any
     # pending push messages are left intact. Without poll() the two states are
     # indistinguishable here, so report not-closed.
+    #
+    # POLLRDHUP must be in the register mask or poll() won't report it: on Linux
+    # a graceful peer close (FIN) reports POLLIN|POLLRDHUP and never POLLHUP, so
+    # without it a closed connection is missed. macOS/Windows set POLLHUP on
+    # close instead, and _POLLRDHUP is 0 there.
     if not _HAS_POLL:
         return False
     poller = select.poll()
-    poller.register(sock, select.POLLIN)
+    poller.register(sock, select.POLLIN | _POLLRDHUP)
     events = poller.poll(0)
     if not events:
         return False
     _, revents = events[0]
-    return bool(revents & (select.POLLHUP | select.POLLERR | select.POLLNVAL))
+    closed_flags = select.POLLHUP | select.POLLERR | select.POLLNVAL | _POLLRDHUP
+    return bool(revents & closed_flags)
 
 
 class _HiredisReaderArgs(TypedDict, total=False):

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -52,6 +52,24 @@ def _socket_can_read(sock, timeout: float) -> bool:
         return bool(selector.select(timeout))
 
 
+def _socket_is_closed(sock) -> bool:
+    # A server-closed socket reads as ready (it yields EOF), so readiness alone
+    # cannot tell it apart from a socket holding pending data. poll() can:
+    # POLLHUP/POLLERR/POLLNVAL flag a closed/errored socket while a live socket
+    # with buffered data reports POLLIN only. Polling is non-destructive, so any
+    # pending push messages are left intact. Without poll() the two states are
+    # indistinguishable here, so report not-closed.
+    if not _HAS_POLL:
+        return False
+    poller = select.poll()
+    poller.register(sock, select.POLLIN)
+    events = poller.poll(0)
+    if not events:
+        return False
+    _, revents = events[0]
+    return bool(revents & (select.POLLHUP | select.POLLERR | select.POLLNVAL))
+
+
 class _HiredisReaderArgs(TypedDict, total=False):
     protocolError: Callable[[str], Exception]
     replyError: Callable[[str], Exception]
@@ -119,7 +137,17 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 
         if self._reader.has_data():
             return True
-        return _socket_can_read(self._sock, timeout)
+        if not _socket_can_read(self._sock, timeout):
+            return False
+        # the socket reports readable but the reader has no buffered data. a
+        # server-closed socket also reads as ready (it yields EOF), so tell the
+        # two apart with a non-destructive poll: a peer-closed socket must not be
+        # reused, while a readable-but-open socket may just hold a pending push.
+        # this mirrors how the pure-Python parser (recv -> b"") and the async
+        # parser (StreamReader.at_eof()) already signal a closed connection.
+        if _socket_is_closed(self._sock):
+            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
+        return True
 
     def read_from_socket(self, timeout=SENTINEL, raise_on_timeout=True):
         sock = self._sock

--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -58,16 +58,10 @@ def _socket_can_read(sock, timeout: float) -> bool:
 
 def _socket_is_closed(sock) -> bool:
     # A server-closed socket reads as ready (it yields EOF), so readiness alone
-    # cannot tell it apart from a socket holding pending data. poll() can:
-    # POLLHUP/POLLERR/POLLNVAL/POLLRDHUP flag a closed socket while a live socket
-    # with buffered data reports POLLIN only. Polling is non-destructive, so any
-    # pending push messages are left intact. Without poll() the two states are
-    # indistinguishable here, so report not-closed.
-    #
-    # POLLRDHUP must be in the register mask or poll() won't report it: on Linux
-    # a graceful peer close (FIN) reports POLLIN|POLLRDHUP and never POLLHUP, so
-    # without it a closed connection is missed. macOS/Windows set POLLHUP on
-    # close instead, and _POLLRDHUP is 0 there.
+    # cannot tell it apart from a socket holding pending data, and both checks
+    # here are non-destructive so pending push messages (e.g. cache
+    # invalidations) are left intact to be processed. Without poll() the two
+    # states are indistinguishable, so report not-closed.
     if not _HAS_POLL:
         return False
     # Decrypted TLS bytes buffered above the OS socket layer must be processed
@@ -80,14 +74,11 @@ def _socket_is_closed(sock) -> bool:
     if not events:
         return False
     _, revents = events[0]
-    closed_flags = select.POLLHUP | select.POLLERR | select.POLLNVAL | _POLLRDHUP
-    if not (revents & closed_flags):
-        return False
-    # POLLHUP/POLLRDHUP can be reported while unread data is still buffered
-    # (the peer sent data, then closed). That data may carry cache
-    # invalidations that must be processed before the connection is dropped,
-    # so confirm with a non-destructive MSG_PEEK and report closed only once
-    # the buffer is drained.
+    # A readable socket holds either data or EOF, and the poll flags alone
+    # cannot always tell which: POLLHUP/POLLRDHUP can be reported while unread
+    # data is still buffered (the peer sent data, then closed), and a drained
+    # closed socket reports plain POLLIN where POLLRDHUP is unavailable
+    # (PyPy). A non-destructive MSG_PEEK settles it: EOF peeks as b"".
     try:
         return sock.recv(1, socket.MSG_PEEK) == b""
     except NONBLOCKING_EXCEPTIONS:
@@ -95,8 +86,12 @@ def _socket_is_closed(sock) -> bool:
         return False
     except ValueError:
         # SSL sockets do not support recv() flags; their buffered plaintext is
-        # covered by the pending() check above, so rely on the poll flags.
-        return True
+        # covered by the pending() check above, so fall back to the poll
+        # flags. POLLRDHUP must be in the register mask or poll() won't
+        # report it: on Linux a graceful FIN reports POLLIN|POLLRDHUP and
+        # never POLLHUP. macOS/Windows set POLLHUP instead (_POLLRDHUP is 0).
+        closed_flags = select.POLLHUP | select.POLLERR | select.POLLNVAL | _POLLRDHUP
+        return bool(revents & closed_flags)
     except OSError:
         # The socket is errored (POLLERR/POLLNVAL); nothing left to read.
         return True

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,6 +6,7 @@ import selectors
 import socket
 import ssl
 import threading
+import time
 import types
 from errno import ECONNREFUSED, EWOULDBLOCK
 from typing import Any
@@ -260,6 +261,31 @@ def test_socket_is_closed_detects_peer_close():
         alive.close()
         peer.close()
         closed.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(select, "POLLRDHUP"),
+    reason="POLLRDHUP is Linux-specific; graceful FIN reports POLLHUP elsewhere",
+)
+def test_socket_is_closed_detects_tcp_peer_half_close():
+    # on Linux a graceful peer close (FIN) reports POLLIN|POLLRDHUP and never
+    # POLLHUP, so _socket_is_closed() must register and check POLLRDHUP. a real
+    # TCP socket pair is required: the kernel (not a mock) produces the event,
+    # and AF_UNIX socketpairs set POLLHUP on close and would hide the gap. this
+    # fails on POLLHUP-only code.
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    client = socket.create_connection(listener.getsockname())
+    server, _ = listener.accept()
+    try:
+        assert _socket_is_closed(client) is False
+        server.close()  # graceful FIN
+        time.sleep(0.1)
+        assert _socket_is_closed(client) is True
+    finally:
+        client.close()
+        listener.close()
 
 
 def test_socket_is_closed_without_poll_reports_not_closed(monkeypatch):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -312,15 +312,13 @@ def test_socket_is_closed_detects_peer_close():
 
 
 @pytest.mark.skipif(
-    not hasattr(select, "POLLRDHUP"),
-    reason="POLLRDHUP is Linux-specific; graceful FIN reports POLLHUP elsewhere",
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
 )
 def test_socket_is_closed_detects_tcp_peer_half_close():
     # on Linux a graceful peer close (FIN) reports POLLIN|POLLRDHUP and never
-    # POLLHUP, so _socket_is_closed() must register and check POLLRDHUP. a real
-    # TCP socket pair is required: the kernel (not a mock) produces the event,
-    # and AF_UNIX socketpairs set POLLHUP on close and would hide the gap. this
-    # fails on POLLHUP-only code.
+    # POLLHUP, so a POLLHUP-only flags check misses it. a real TCP socket pair
+    # is required: the kernel (not a mock) produces the event, and AF_UNIX
+    # socketpairs set POLLHUP on close and would hide the gap.
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.bind(("127.0.0.1", 0))
     listener.listen(1)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -135,6 +135,54 @@ def test_hiredis_can_read_raises_on_peer_closed_socket():
             parser.can_read(timeout=0)
 
 
+@pytest.mark.skipif(not HIREDIS_AVAILABLE, reason="hiredis is not installed")
+@pytest.mark.skipif(
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
+)
+def test_hiredis_can_read_consumes_pending_push_before_reporting_closed():
+    # a peer that sends push data and then closes reports the closed poll flags
+    # while the data is still buffered. can_read() must keep reporting readable
+    # so pending messages (e.g. cache invalidations) get processed, and only
+    # raise once the buffer is drained, matching the pure-Python parser which
+    # consumes buffered data before raising.
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    client = socket.create_connection(listener.getsockname())
+    server, _ = listener.accept()
+
+    parser = _HiredisParser(socket_read_size=65536)
+    connection = mock.Mock()
+    connection._sock = client
+    connection.socket_timeout = None
+    connection.encoder.encoding_errors = "strict"
+    connection.encoder.decode_responses = False
+    parser.on_connect(connection)
+    try:
+        server.sendall(b">3\r\n$7\r\nmessage\r\n$2\r\nch\r\n$5\r\nhello\r\n")
+        server.close()  # graceful FIN with the push message still buffered
+        time.sleep(0.1)
+
+        assert parser.can_read(timeout=0) is True
+        assert parser.read_response(push_request=True) == [b"message", b"ch", b"hello"]
+        with pytest.raises(redis.ConnectionError):
+            parser.can_read(timeout=0)
+    finally:
+        parser.on_disconnect()
+        client.close()
+        listener.close()
+
+
+def test_socket_is_closed_reports_not_closed_with_pending_ssl_data():
+    # SSL sockets buffer decrypted bytes above the OS socket layer; those must
+    # be processed before the connection can be treated as closed, like
+    # kernel-level pending data.
+    sock = Mock(spec=["pending", "fileno"])
+    sock.pending.return_value = 10
+
+    assert _socket_is_closed(sock) is False
+
+
 @pytest.mark.fixed_client
 @pytest.mark.skipif(
     not hasattr(select, "poll"), reason="select.poll not available on this platform"
@@ -282,6 +330,34 @@ def test_socket_is_closed_detects_tcp_peer_half_close():
         assert _socket_is_closed(client) is False
         server.close()  # graceful FIN
         time.sleep(0.1)
+        assert _socket_is_closed(client) is True
+    finally:
+        client.close()
+        listener.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
+)
+def test_socket_is_closed_defers_close_until_pending_data_is_read():
+    # a peer that sends data and then closes reports the closed poll flags
+    # while unread bytes remain (POLLIN|POLLHUP on macOS, POLLIN|POLLRDHUP on
+    # Linux). that data may carry cache invalidations that must be processed
+    # before the connection is dropped, so _socket_is_closed() must report
+    # not-closed until the buffer is drained, without consuming anything.
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    client = socket.create_connection(listener.getsockname())
+    server, _ = listener.accept()
+    try:
+        server.sendall(b"pending invalidation")
+        server.close()  # graceful FIN with data still buffered
+        time.sleep(0.1)
+
+        assert _socket_is_closed(client) is False
+        # the MSG_PEEK confirmation must not consume the pending data
+        assert client.recv(65536) == b"pending invalidation"
         assert _socket_is_closed(client) is True
     finally:
         client.close()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,7 +16,7 @@ import pytest
 import redis
 from redis import ConnectionPool, Redis
 from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
-from redis._parsers.hiredis import NOT_ENOUGH_DATA, _socket_can_read
+from redis._parsers.hiredis import NOT_ENOUGH_DATA, _socket_can_read, _socket_is_closed
 from redis._parsers.socket import SocketBuffer
 from redis.backoff import NoBackoff
 from redis.cache import (
@@ -105,13 +105,33 @@ def test_hiredis_can_read_detects_reader_data():
     assert parser.read_response() == b"OK"
 
 
-def test_hiredis_can_read_checks_socket_readiness_without_reading():
+def test_hiredis_can_read_returns_true_for_readable_open_socket():
+    # socket readable, reader empty, and not closed -> pending data/push, so
+    # can_read() reports readable without consuming anything.
     parser = make_hiredis_parser(has_data=False)
 
-    with patch("redis._parsers.hiredis._socket_can_read", return_value=True) as ready:
+    with (
+        patch("redis._parsers.hiredis._socket_can_read", return_value=True) as ready,
+        patch("redis._parsers.hiredis._socket_is_closed", return_value=False) as closed,
+    ):
         assert parser.can_read(timeout=0) is True
 
     ready.assert_called_once_with(parser._sock, 0)
+    closed.assert_called_once_with(parser._sock)
+
+
+def test_hiredis_can_read_raises_on_peer_closed_socket():
+    # regression for #4128: a peer-closed socket reads as ready but the reader
+    # has no buffered data. can_read() must raise ConnectionError so the pool
+    # recycles it, matching the pure-Python and async parsers.
+    parser = make_hiredis_parser(has_data=False)
+
+    with (
+        patch("redis._parsers.hiredis._socket_can_read", return_value=True),
+        patch("redis._parsers.hiredis._socket_is_closed", return_value=True),
+    ):
+        with pytest.raises(redis.ConnectionError):
+            parser.can_read(timeout=0)
 
 
 @pytest.mark.fixed_client
@@ -219,6 +239,39 @@ def test_hiredis_socket_can_read_under_fd_exhaustion():
         writable.close()
         empty_sock.close()
         peer.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(select, "poll"), reason="select.poll not available on this platform"
+)
+def test_socket_is_closed_detects_peer_close():
+    # a peer-closed socket reads as ready (it yields EOF), so readiness alone
+    # cannot tell it apart from a socket holding pending data; _socket_is_closed()
+    # distinguishes them via POLLHUP without consuming data.
+    alive, peer = socket.socketpair()
+    closed, closing_peer = socket.socketpair()
+    try:
+        peer.sendall(b"pending push data")
+        closing_peer.close()
+
+        assert _socket_is_closed(alive) is False
+        assert _socket_is_closed(closed) is True
+    finally:
+        alive.close()
+        peer.close()
+        closed.close()
+
+
+def test_socket_is_closed_without_poll_reports_not_closed(monkeypatch):
+    # without select.poll (e.g. Windows) closed and has-data states are
+    # indistinguishable here, so we conservatively report not-closed.
+    monkeypatch.setattr("redis._parsers.hiredis._HAS_POLL", False)
+    closed, closing_peer = socket.socketpair()
+    try:
+        closing_peer.close()
+        assert _socket_is_closed(closed) is False
+    finally:
+        closed.close()
 
 
 def test_hiredis_can_read_does_not_decide_disable_decoding():


### PR DESCRIPTION
### Description of change

Fixes #4128.

With `redis[hiredis]` installed and `protocol=3` (the default since 8.0.0), a
pooled connection closed by the server is not recovered, and the next command
raises `ConnectionError: Connection closed by server.` instead of transparently
reconnecting. The issue matrix isolates it to protocol=3 + hiredis; protocol=2 +
hiredis and protocol=3 + pure-Python RESP3 both recover.

The root cause is that the hiredis parser could not tell a server-closed socket
apart from one holding pending data. A closed socket reads as ready (it yields
EOF), so `can_read()` reported it readable, the pool handed it back, and the next
command failed. The pure-Python parser already signals this by `recv()` returning
`b""`, and the async hiredis parser by `StreamReader.at_eof()` — the sync hiredis
parser had no equivalent, so the three parsers were out of line.

The fix adds a non-destructive `_socket_is_closed()` helper and calls it from
`_HiredisParser.can_read()`: when the socket reports readable but the reader has
no buffered data, it distinguishes a pending push from a peer-closed socket and
raises `ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)` on close. The existing
pool-checkout guard in `ConnectionPool.get_connection()` catches that error and
triggers its disconnect-and-reconnect path, so a readable-but-open connection
under client-side caching or maintenance notifications still keeps its pending
push, while a genuinely closed one is recycled. This keeps the change contained
to the parser and avoids expanding the public connection interface.

Closure is decided by a non-destructive `MSG_PEEK` whenever the socket polls
readable (EOF peeks as `b""` on every runtime), which settles cases the poll
flags alone cannot: `POLLHUP`/`POLLRDHUP` can be reported while unread data is
still buffered, and a drained closed socket reports plain `POLLIN` where
`POLLRDHUP` is unavailable (PyPy). Pending data — including RESP3 push messages
such as cache invalidations — is therefore fully processed before the connection
is treated as closed, matching the pure-Python parser. `POLLRDHUP` is registered
on Linux (guarded with `getattr(select, "POLLRDHUP", 0)`, so macOS/Windows keep
relying on `POLLHUP`) to cover graceful peer half-close, and TLS sockets fall back
to poll flags since their buffered plaintext is covered by the `pending()` check.

This is sync-only by design: the async pool's `can_read()` already detects EOF
via `StreamReader.at_eof()`, so the async stack recovers without changes. New
tests use real TCP socket pairs (an `AF_UNIX` socketpair sets `POLLHUP` on close
and would hide the Linux FIN path) to cover peer close, Linux half-close,
deferring closure until buffered push data is drained, the no-`poll()` fallback,
and the pending-SSL-data case.

### Changes

- Add `_socket_is_closed()` to `redis/_parsers/hiredis.py`: a non-destructive
  `poll()` + `MSG_PEEK` check that reports whether a readable socket is
  peer-closed, with `POLLRDHUP` handling for Linux graceful FIN and a `pending()`
  guard for buffered TLS plaintext.
- Have `_HiredisParser.can_read()` raise `ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)`
  when the socket is readable, the reader has no buffered data, and the socket is
  closed — bringing the sync hiredis parser in line with the pure-Python and
  async parsers.
- Add regression tests in `tests/test_connection.py` covering peer close, Linux
  TCP half-close, pending-push-before-close, the no-`poll()` fallback, and
  pending SSL data.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? - NA
- [x] Is there an example added to the examples folder (if applicable)? - NA

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection lifecycle on every hiredis readiness check (poll/peek/SSL paths); behavior is platform-dependent where poll is absent, but covered by extensive tests and aligned with other parsers.
> 
> **Overview**
> Fixes **#4128** for the sync **hiredis** parser when RESP3 leaves the socket readable with no hiredis buffer (server FIN vs pending push).
> 
> Adds **`_socket_is_closed()`**, a non-destructive check using **`select.poll()`** (with **`POLLRDHUP`** on Linux), optional **`MSG_PEEK`**, and SSL **`pending()`** handling so buffered push/invalidation bytes are not treated as closed. Without **`poll()`** (e.g. Windows), it conservatively reports not closed.
> 
> **`_HiredisParser.can_read()`** now raises **`ConnectionError`** when the socket is ready but empty and the peer has closed—matching pure-Python/async behavior so pools can recycle stale connections—while still returning **`True`** for readable open sockets with pending data.
> 
> Tests cover peer close, TCP half-close, data-then-close, SSL pending, and integration with **`can_read()`** / push reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d41593d3795080cdfc090ed56c19d9ab4ea3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->