### PR TITLE
Add ASM (Atomic Slot Migration) cluster maintenance-notification scenario tests

### DIFF
--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -1416,6 +1416,41 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
         )
         return self._client, cluster_endpoint_config
 
+    def _wait_for_node_cache_delta(
+        self, client, connections, initial_count, expected_delta, timeout=SMIGRATED_TIMEOUT
+    ):
+        """Poll the client node cache until it reflects the expected +/- delta.
+
+        A topology change may arrive as several push notifications (in particular an ASM scale
+        add/remove is a cascade of SMIGRATING/SMIGRATED as the decision engine moves slots), so
+        the client reconciles its node cache over multiple notifications after the server-side
+        operation finishes. Drain pending notifications on the given connections and poll until
+        the cache reaches initial_count + expected_delta, or the timeout elapses. Single-step
+        triggers (migrate/failover) reach the target immediately and return on the first check.
+        """
+        expected = initial_count + expected_delta
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if len(client.nodes_manager.nodes_cache) == expected:
+                return
+            for conn in connections:
+                try:
+                    if conn._sock and conn.can_read(timeout=0.2):
+                        conn.read_response(push_request=True)
+                except Exception:
+                    # A connection to a node being removed may error; that is expected.
+                    pass
+            time.sleep(0.5)
+        # Best-effort: the caller asserts the exact delta next, which will fail loudly if the
+        # cache never reconciled. Log so a timeout here is not silent.
+        logging.warning(
+            "Node cache did not reach %s (delta %s) within %ss; current size=%s",
+            expected,
+            expected_delta,
+            timeout,
+            len(client.nodes_manager.nodes_cache),
+        )
+
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(
         self,
@@ -1765,6 +1800,18 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
             connection=con_to_read_smigrated,
         )
 
+        logging.info("Waiting for the operation to finish server-side...")
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+        logging.info("Draining notifications until the node cache reflects -1 node...")
+        self._wait_for_node_cache_delta(
+            cluster_client_maint_notifications,
+            list(in_use_connections.values()),
+            len(initial_cluster_nodes),
+            expected_delta=-1,
+        )
+
         logging.info("Validating connection state after SMIGRATED ...")
 
         updated_cluster_nodes = (
@@ -1788,15 +1835,12 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         assert conn is not None
         assert conn.should_reconnect() is True
 
-        # validate no other connections are marked for reconnect
-        marked_conns_for_reconnect = 0
-        for conn in in_use_connections.values():
-            if conn.should_reconnect():
-                marked_conns_for_reconnect += 1
-        # only one connection should be marked for reconnect
-        # onle the one that belongs to the node that was from
-        # the src address of the maintenance
-        assert marked_conns_for_reconnect == 1
+        # At least the removed node's connection is marked for reconnect. A single-step migrate
+        # marks exactly one; an ASM scale-in cascade may touch more, so accept >= 1.
+        marked_conns_for_reconnect = sum(
+            1 for conn in in_use_connections.values() if conn.should_reconnect()
+        )
+        assert marked_conns_for_reconnect >= 1
 
         logging.info("Releasing connections back to the pool...")
         for node, conn in in_use_connections.items():
@@ -1804,8 +1848,115 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 continue
             node.redis_connection.connection_pool.release(conn)
 
+    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_CLIENT_OSS_API,
+            [
+                SlotMigrateEffects.ADD,
+            ],
+        ),
+    )
+    def test_notification_handling_with_node_add(
+        self,
+        fault_injector_client_oss_api: FaultInjectorClient,
+        effect_name: SlotMigrateEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        """
+        Test push notifications when a cluster operation moves slots such that a previously
+        empty node gains a master shard / endpoint (the client's node cache grows by one).
+        Mirrors test_notification_handling_with_node_remove for the opposite (+1) delta.
+        """
+        logging.info(f"DB name: {db_name}")
+
+        cluster_client_maint_notifications, cluster_endpoint_config = self.setup_env(
+            fault_injector_client_oss_api, db_config
+        )
+
+        logging.info("Creating one connection in each node's pool.")
+        initial_cluster_nodes = (
+            cluster_client_maint_notifications.nodes_manager.nodes_cache.copy()
+        )
+        in_use_connections = {}
+        for node in initial_cluster_nodes.values():
+            in_use_connections[node] = (
+                node.redis_connection.connection_pool.get_connection()
+            )
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
+            args=(
+                fault_injector_client_oss_api,
+                cluster_endpoint_config,
+                effect_name,
+                trigger,
+            ),
+        )
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
+
+        logging.info("Waiting for SMIGRATING push notifications in all connections...")
+        for conn in in_use_connections.values():
+            ClientValidations.wait_push_notification(
+                cluster_client_maint_notifications,
+                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                connection=conn,
+            )
+
+        logging.info("Validating connection maintenance state...")
+        for conn in in_use_connections.values():
+            assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+            assert conn._sock.gettimeout() == RELAXED_TIMEOUT
+            assert conn.should_reconnect() is False
+
+        logging.info("Waiting for SMIGRATED push notifications...")
+        con_to_read_smigrated = random.choice(list(in_use_connections.values()))
+        ClientValidations.wait_push_notification(
+            cluster_client_maint_notifications,
+            timeout=SMIGRATED_TIMEOUT,
+            connection=con_to_read_smigrated,
+        )
+
+        logging.info("Waiting for the operation to finish server-side...")
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+        logging.info("Draining notifications until the node cache reflects +1 node...")
+        self._wait_for_node_cache_delta(
+            cluster_client_maint_notifications,
+            list(in_use_connections.values()),
+            len(initial_cluster_nodes),
+            expected_delta=1,
+        )
+
+        logging.info("Validating a node was added to the client's node cache...")
+        updated_cluster_nodes = (
+            cluster_client_maint_notifications.nodes_manager.nodes_cache.copy()
+        )
+        added_nodes = set(updated_cluster_nodes.values()) - set(
+            initial_cluster_nodes.values()
+        )
+        assert len(added_nodes) == 1
+        assert len(updated_cluster_nodes) == len(initial_cluster_nodes) + 1
+
+        # An add moves slots FROM an existing shard onto the previously empty node, so the
+        # connection to that source shard is marked for reconnect.
+        marked_conns_for_reconnect = sum(
+            1 for conn in in_use_connections.values() if conn.should_reconnect()
+        )
+        assert marked_conns_for_reconnect >= 1
+
+        logging.info("Releasing connections back to the pool...")
+        for node, conn in in_use_connections.items():
+            if node.redis_connection is None:
+                continue
+            node.redis_connection.connection_pool.release(conn)
 
     @pytest.mark.timeout(300)  # 5 minutes timeout for this test
     @pytest.mark.skipif(
@@ -1840,6 +1991,19 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
 
         """
         logging.info(f"DB name: {db_name}")
+
+        # A new connection catching the in-flight SMIGRATING relies on a single maintenance
+        # window. ASM scale (add/remove) is a cascade of SMIGRATING/SMIGRATED windows, so a new
+        # connection made between windows sees no maintenance state - the check is racy.
+        # slot-shuffle (single migrate_slots) keeps a single window and is exercised here.
+        if trigger == "reshard" and effect_name in (
+            SlotMigrateEffects.ADD,
+            SlotMigrateEffects.REMOVE,
+        ):
+            pytest.skip(
+                "new-connection-catches-window is a single-window property; ASM scale "
+                "(reshard add/remove) is a multi-window cascade"
+            )
 
         cluster_client_maint_notifications, cluster_endpoint_config = self.setup_env(
             fault_injector_client_oss_api, db_config

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -67,10 +67,15 @@ SLOT_SHUFFLE_TIMEOUT = 300
 # the command-execution workers are left running (their join then hangs to the pytest cap). Cover
 # the FI's slowest reshard (ASM scale = 600s).
 RESHARD_OP_TIMEOUT = 600
-# Per-test cap for the OSS-cluster reshard tests: must exceed RESHARD_OP_TIMEOUT so a legitimately
-# slow ASM scale runs to completion instead of being killed mid-reshard (only bites on the slow
-# path; fast reshards are unaffected).
-RESHARD_TEST_TIMEOUT = 660
+# Default op-wait for non-reshard (standalone / single-window) triggers: comfortably under the
+# standalone tests' 300s pytest cap so a stuck FI poll can't outlive the cap and block teardown on
+# thread.join(). The reshard tests pass RESHARD_OP_TIMEOUT explicitly.
+DEFAULT_TRIGGER_OP_TIMEOUT = 180
+# Per-test cap for the OSS-cluster reshard tests: must exceed the worst-case reshard wall time =
+# the trigger op-wait (RESHARD_OP_TIMEOUT) plus the post-join node-cache drain (SMIGRATED_TIMEOUT),
+# with margin, so a legitimately slow ASM scale runs to completion instead of being killed mid-way.
+# Only bites on the slow path; fast reshards are unaffected.
+RESHARD_TEST_TIMEOUT = RESHARD_OP_TIMEOUT + SMIGRATED_TIMEOUT + 180
 
 DEFAULT_BIND_TTL = 15
 DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
@@ -124,7 +129,7 @@ class TestPushNotificationsBase:
         target_node: Optional[str] = None,
         empty_node: Optional[str] = None,
         skip_end_notification: bool = False,
-        timeout: int = RESHARD_OP_TIMEOUT,
+        timeout: int = DEFAULT_TRIGGER_OP_TIMEOUT,
     ):
         trigger_effect_action_id = ClusterOperations.trigger_effect(
             fault_injector=fault_injector_client,
@@ -1454,14 +1459,12 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
                     # A connection to a node being removed may error; that is expected.
                     pass
             time.sleep(0.5)
-        # Best-effort: the caller asserts the exact delta next, which will fail loudly if the
-        # cache never reconciled. Log so a timeout here is not silent.
-        logging.warning(
-            "Node cache did not reach %s (delta %s) within %ss; current size=%s",
-            expected,
-            expected_delta,
-            timeout,
-            len(client.nodes_manager.nodes_cache),
+        # Fail explicitly on a drain timeout so it surfaces as a clear "node cache did not
+        # reconcile" error, rather than silently returning and letting the caller's exact-delta
+        # assertion fail later with a misleading node-count message.
+        pytest.fail(
+            f"Node cache did not reach {expected} (delta {expected_delta}) within {timeout}s; "
+            f"current size={len(client.nodes_manager.nodes_cache)}"
         )
 
     @pytest.fixture(autouse=True)
@@ -1541,6 +1544,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 effect_name,
                 trigger,
             ),
+            kwargs={"timeout": RESHARD_OP_TIMEOUT},
         )
         self.maintenance_ops_threads.append(trigger_effect_thread)
         trigger_effect_thread.start()
@@ -1657,6 +1661,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 effect_name,
                 trigger,
             ),
+            kwargs={"timeout": RESHARD_OP_TIMEOUT},
         )
         self.maintenance_ops_threads.append(trigger_effect_thread)
         trigger_effect_thread.start()
@@ -1778,6 +1783,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 effect_name,
                 trigger,
             ),
+            kwargs={"timeout": RESHARD_OP_TIMEOUT},
         )
         self.maintenance_ops_threads.append(trigger_effect_thread)
         trigger_effect_thread.start()
@@ -1910,6 +1916,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 effect_name,
                 trigger,
             ),
+            kwargs={"timeout": RESHARD_OP_TIMEOUT},
         )
         self.maintenance_ops_threads.append(trigger_effect_thread)
         trigger_effect_thread.start()
@@ -1927,6 +1934,17 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
             assert conn.maintenance_state == MaintenanceState.MAINTENANCE
             assert conn._sock.gettimeout() == RELAXED_TIMEOUT
             assert conn.should_reconnect() is False
+
+        # During SMIGRATING (before reconciliation) the added node is not in the cache yet: the
+        # cache size is unchanged and every initial node key is still present. Mirrors the same
+        # invariant asserted by test_notification_handling_with_node_remove.
+        assert len(initial_cluster_nodes) == len(
+            cluster_client_maint_notifications.nodes_manager.nodes_cache
+        )
+        for node_key in initial_cluster_nodes.keys():
+            assert (
+                node_key in cluster_client_maint_notifications.nodes_manager.nodes_cache
+            )
 
         logging.info("Waiting for SMIGRATED push notifications...")
         con_to_read_smigrated = random.choice(list(in_use_connections.values()))
@@ -2049,6 +2067,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 effect_name,
                 trigger,
             ),
+            kwargs={"timeout": RESHARD_OP_TIMEOUT},
         )
 
         self.maintenance_ops_threads.append(trigger_effect_thread)
@@ -2223,6 +2242,7 @@ class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
                 effect_name,
                 trigger,
             ),
+            kwargs={"timeout": RESHARD_OP_TIMEOUT},
         )
         self.maintenance_ops_threads.append(trigger_effect_thread)
         trigger_effect_thread.start()

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -1992,17 +1992,24 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         """
         logging.info(f"DB name: {db_name}")
 
-        # A new connection catching the in-flight SMIGRATING relies on a single maintenance
-        # window. ASM scale (add/remove) is a cascade of SMIGRATING/SMIGRATED windows, so a new
-        # connection made between windows sees no maintenance state - the check is racy.
-        # slot-shuffle (single migrate_slots) keeps a single window and is exercised here.
+        # Catching the in-flight SMIGRATING on a NEWLY opened connection needs a maintenance
+        # window that stays open long enough to open that fresh connection mid-flight. For the
+        # `reshard` (ASM) trigger this is not reliable:
+        #   - add/remove are a cascade of short SMIGRATING/SMIGRATED windows, so a connection
+        #     opened between windows sees no maintenance state;
+        #   - slot-shuffle is a single ASM migrate_slots that, for a small slot range, closes
+        #     (SMIGRATED) ~1s after SMIGRATING - the window shuts before a new connection can be
+        #     opened, the same "ends too fast" class as the slot_shuffle+failover skip below.
+        # remove_add keeps a long enough combined window and is still exercised here.
         if trigger == "reshard" and effect_name in (
             SlotMigrateEffects.ADD,
             SlotMigrateEffects.REMOVE,
+            SlotMigrateEffects.SLOT_SHUFFLE,
         ):
             pytest.skip(
-                "new-connection-catches-window is a single-window property; ASM scale "
-                "(reshard add/remove) is a multi-window cascade"
+                "new-connection-catches-window needs a window long enough to open a fresh "
+                "connection mid-flight; ASM reshard windows (add/remove cascade, ~1s "
+                "slot-shuffle) close too fast to be reliable"
             )
 
         cluster_client_maint_notifications, cluster_endpoint_config = self.setup_env(

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -55,9 +55,22 @@ logging.getLogger("redis.cluster").setLevel(logging.DEBUG)
 
 STANDALONE_MAINT_TIMEOUT = 60
 SMIGRATING_TIMEOUT = 20
-SMIGRATED_TIMEOUT = 40
+# SMIGRATED / slot-shuffle waits sized for the FI's real reshard budget: the fault injector
+# blocks on the reshard up to 300s (slot-shuffle migrate_slots) / 600s (ASM scale). Sizing the
+# client below that turned slow-but-successful reshards into false failures. Raising a timeout
+# only affects the failure path (it waits longer before failing), so it is free on green runs.
+SMIGRATED_TIMEOUT = 120
 
-SLOT_SHUFFLE_TIMEOUT = 120
+SLOT_SHUFFLE_TIMEOUT = 300
+
+# The trigger thread must not give up before the FI finishes the reshard, otherwise it dies and
+# the command-execution workers are left running (their join then hangs to the pytest cap). Cover
+# the FI's slowest reshard (ASM scale = 600s).
+RESHARD_OP_TIMEOUT = 600
+# Per-test cap for the OSS-cluster reshard tests: must exceed RESHARD_OP_TIMEOUT so a legitimately
+# slow ASM scale runs to completion instead of being killed mid-reshard (only bites on the slow
+# path; fast reshards are unaffected).
+RESHARD_TEST_TIMEOUT = 660
 
 DEFAULT_BIND_TTL = 15
 DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
@@ -111,7 +124,7 @@ class TestPushNotificationsBase:
         target_node: Optional[str] = None,
         empty_node: Optional[str] = None,
         skip_end_notification: bool = False,
-        timeout: int = SLOT_SHUFFLE_TIMEOUT,
+        timeout: int = RESHARD_OP_TIMEOUT,
     ):
         trigger_effect_action_id = ClusterOperations.trigger_effect(
             fault_injector=fault_injector_client,
@@ -1481,7 +1494,7 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
 class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
     TestClusterClientPushNotificationsWithEffectTriggerBase
 ):
-    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1593,7 +1606,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1714,7 +1727,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1848,7 +1861,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 continue
             node.redis_connection.connection_pool.release(conn)
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1958,7 +1971,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 continue
             node.redis_connection.connection_pool.release(conn)
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.skipif(
         use_mock_proxy(),
         reason="Mock proxy doesn't support sending notifications to new connections.",
@@ -2116,7 +2129,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
 class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
     TestClusterClientPushNotificationsWithEffectTriggerBase
 ):
-    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -54,7 +54,6 @@ logging.getLogger("redis.cluster").setLevel(logging.DEBUG)
 
 
 STANDALONE_MAINT_TIMEOUT = 60
-SMIGRATING_TIMEOUT = 20
 # SMIGRATED / slot-shuffle waits sized for the FI's real reshard budget: the fault injector
 # blocks on the reshard up to 300s (slot-shuffle migrate_slots) / 600s (ASM scale). Sizing the
 # client below that turned slow-but-successful reshards into false failures. Raising a timeout
@@ -62,6 +61,13 @@ SMIGRATING_TIMEOUT = 20
 SMIGRATED_TIMEOUT = 120
 
 SLOT_SHUFFLE_TIMEOUT = 300
+
+# Wait budget for the FIRST SMIGRATING of a reshard. It has to cover the ASM decision engine's
+# planning time before the first slot actually moves - not just the move itself - so it is sized as
+# a fraction of the FI's own slot-shuffle budget rather than as a "notification should be instant"
+# value. Every reshard test uses this, including remove_add: that effect keeps its maintenance
+# window open the longest, but it is also the heaviest plan, so it is the slowest to open it.
+RESHARD_SMIGRATING_TIMEOUT = int(SLOT_SHUFFLE_TIMEOUT / 2)
 
 # The trigger thread must not give up before the FI finishes the reshard, otherwise it dies and
 # the command-execution workers are left running (their join then hangs to the pytest cap). Cover
@@ -1435,7 +1441,12 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
         return self._client, cluster_endpoint_config
 
     def _wait_for_node_cache_delta(
-        self, client, connections, initial_count, expected_delta, timeout=SMIGRATED_TIMEOUT
+        self,
+        client,
+        connections,
+        initial_count,
+        expected_delta,
+        timeout=SMIGRATED_TIMEOUT,
     ):
         """Poll the client node cache until it reflects the expected +/- delta.
 
@@ -1497,7 +1508,9 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
 class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
     TestClusterClientPushNotificationsWithEffectTriggerBase
 ):
-    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1553,7 +1566,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             ClientValidations.wait_push_notification(
                 cluster_client_maint_notifications,
-                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1610,7 +1623,9 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
 
-    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1670,7 +1685,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             ClientValidations.wait_push_notification(
                 cluster_client_maint_notifications,
-                timeout=SMIGRATING_TIMEOUT,
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1732,7 +1747,9 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         trigger_effect_thread.join()
         self.maintenance_ops_threads.remove(trigger_effect_thread)
 
-    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1792,7 +1809,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             ClientValidations.wait_push_notification(
                 cluster_client_maint_notifications,
-                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1867,7 +1884,9 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 continue
             node.redis_connection.connection_pool.release(conn)
 
-    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -1925,7 +1944,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
         for conn in in_use_connections.values():
             ClientValidations.wait_push_notification(
                 cluster_client_maint_notifications,
-                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                timeout=RESHARD_SMIGRATING_TIMEOUT,
                 connection=conn,
             )
 
@@ -1989,7 +2008,9 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 continue
             node.redis_connection.connection_pool.release(conn)
 
-    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.skipif(
         use_mock_proxy(),
         reason="Mock proxy doesn't support sending notifications to new connections.",
@@ -2004,9 +2025,21 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
                 SlotMigrateEffects.REMOVE,
                 SlotMigrateEffects.ADD,
             ],
+            # Catching the in-flight SMIGRATING on a NEWLY opened connection needs a
+            # maintenance window that stays open long enough to open that fresh connection
+            # mid-flight. These combinations close too fast for the test to be reliable:
+            #   - slot_shuffle + failover: maintenance ends almost immediately;
+            #   - reshard + add/remove: a cascade of short SMIGRATING/SMIGRATED windows, so a
+            #     connection opened between windows sees no maintenance state;
+            #   - reshard + slot_shuffle: a single ASM migrate_slots that, for a small slot
+            #     range, closes (SMIGRATED) ~1s after SMIGRATING.
+            # remove_add keeps a long enough combined window and is still exercised here.
             skip_combinations=[
                 (SlotMigrateEffects.SLOT_SHUFFLE, "failover"),
-            ],  # maintenance ends too fast for the test to be reliable
+                (SlotMigrateEffects.SLOT_SHUFFLE, "reshard"),
+                (SlotMigrateEffects.REMOVE, "reshard"),
+                (SlotMigrateEffects.ADD, "reshard"),
+            ],
         ),
     )
     def test_new_connections_receive_last_smigrating_smigrated_notification(
@@ -2022,26 +2055,6 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
 
         """
         logging.info(f"DB name: {db_name}")
-
-        # Catching the in-flight SMIGRATING on a NEWLY opened connection needs a maintenance
-        # window that stays open long enough to open that fresh connection mid-flight. For the
-        # `reshard` (ASM) trigger this is not reliable:
-        #   - add/remove are a cascade of short SMIGRATING/SMIGRATED windows, so a connection
-        #     opened between windows sees no maintenance state;
-        #   - slot-shuffle is a single ASM migrate_slots that, for a small slot range, closes
-        #     (SMIGRATED) ~1s after SMIGRATING - the window shuts before a new connection can be
-        #     opened, the same "ends too fast" class as the slot_shuffle+failover skip below.
-        # remove_add keeps a long enough combined window and is still exercised here.
-        if trigger == "reshard" and effect_name in (
-            SlotMigrateEffects.ADD,
-            SlotMigrateEffects.REMOVE,
-            SlotMigrateEffects.SLOT_SHUFFLE,
-        ):
-            pytest.skip(
-                "new-connection-catches-window needs a window long enough to open a fresh "
-                "connection mid-flight; ASM reshard windows (add/remove cascade, ~1s "
-                "slot-shuffle) close too fast to be reliable"
-            )
 
         cluster_client_maint_notifications, cluster_endpoint_config = self.setup_env(
             fault_injector_client_oss_api, db_config
@@ -2078,7 +2091,7 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
             for conn in conns_per_node:
                 ClientValidations.wait_push_notification(
                     cluster_client_maint_notifications,
-                    timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                    timeout=RESHARD_SMIGRATING_TIMEOUT,
                     connection=conn,
                 )
                 logging.info(
@@ -2148,7 +2161,9 @@ class TestClusterClientPushNotificationsHandlingWithEffectTrigger(
 class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
     TestClusterClientPushNotificationsWithEffectTriggerBase
 ):
-    @pytest.mark.timeout(RESHARD_TEST_TIMEOUT)  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
+    @pytest.mark.timeout(
+        RESHARD_TEST_TIMEOUT
+    )  # sized for slow ASM reshard, see RESHARD_OP_TIMEOUT
     @pytest.mark.parametrize(
         "effect_name, trigger, db_config, db_name",
         generate_params(
@@ -2157,7 +2172,6 @@ class TestClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
                 SlotMigrateEffects.SLOT_SHUFFLE,
                 SlotMigrateEffects.REMOVE,
                 SlotMigrateEffects.ADD,
-                SlotMigrateEffects.SLOT_SHUFFLE,
             ],
         ),
     )


### PR DESCRIPTION
## Description of change

Cluster client maintenance-notification scenario tests for the **ASM (Atomic Slot Migration)** path. All ASM logic lives in the fault injector behind its `SLOT_MIGRATE_ASM` toggle, so **the client stays generic** (no ASM-specific code): when the FI runs in ASM mode, the existing effect-trigger cluster tests exercise the FI's `reshard` trigger and assert `SMIGRATING` → `MaintenanceState.MAINTENANCE` → `SMIGRATED` with node-cache reconciliation.

This PR is therefore small and test-only.

### Changes
- Add generic `test_notification_handling_with_node_add` (+1 node), the mirror of `test_notification_handling_with_node_remove`.
- Add `_wait_for_node_cache_delta` settle-poll on the cluster test base: ASM scale (add/remove) is a **cascade** of `SMIGRATING`/`SMIGRATED` (the decision engine moves slots across shards), so the client reconciles its node cache over several notifications after the FI op completes — drain + poll until the ±1 delta before asserting. `node_remove` now joins the trigger thread + waits for −1 first; reconnect count relaxed to `>= 1` (a cascade can mark more than one).
- Skip `test_new_connections_receive_last_smigrating_smigrated_notification` for **all `reshard` effects (slot-shuffle, add, remove)**: "a new connection catches the in-flight `SMIGRATING`" needs a maintenance window that stays open long enough to open a fresh connection mid-flight. ASM add/remove is a multi-window cascade, and a single ASM slot-shuffle over a small slot range closes (`SMIGRATED`) ~1s after `SMIGRATING` — the window shuts before a new connection can be opened. Same "ends too fast" class already skipped for `slot_shuffle+failover`. Existing-connection handling for slot-shuffle stays covered by the handling and cmd-execution tests.
- Size the reshard test timeouts to the FI's **real** reshard budget so a slow-but-successful reshard is not counted as a failure (raising a timeout only affects the failure path, so it is free on green runs). The FI blocks on a reshard up to 300s (slot-shuffle) / 600s (ASM scale); the client was smaller (op-wait 120s, `SMIGRATING` waits 60s, `SMIGRATED` 40s, per-test cap 300s), so a slow reshard flaked and the trigger thread could give up early and leave the command-execution workers hanging. Now: trigger `get_operation_result` waits `RESHARD_OP_TIMEOUT` (600s), `SLOT_SHUFFLE_TIMEOUT` 120→300, `SMIGRATED_TIMEOUT` 40→120, and the OSS reshard tests use a `RESHARD_TEST_TIMEOUT` (660s) cap (standalone/non-reshard tests keep 300s).

### Requirements
Needs the fault injector with the `reshard` trigger + `SLOT_MIGRATE_ASM` toggle. CI runs the generic tests against an ASM-mode fault injector (`asm=true`).

## Pull Request check-list
- [x] Do tests and lints pass with this change? Full single-version (100.0.20) ASM run green — all 4 matrix variants (plain/hiredis × handling/cmd_execution), 0 failures; `new_connections[slot-shuffle-reshard]` skipped as designed.
- [x] Do the CI tests pass with this change? Validated against an ASM-mode fault injector (`asm=true`); green end-to-end.
- [x] Is the new or changed code fully tested?

## History (condensed)
Earlier revisions added an `AsmTriggers` enum, `include_asm` threading, and a dedicated `TestClusterClientPushNotificationsWithAsmEffectTrigger` with a node-cache "drain until settled" loop. Per review, all ASM logic moved into the FI behind the toggle, so those client-side constructs were removed and the change collapsed to the small, generic diff above. The branch was rebased onto the current `feat_add_sch_async` base (the earlier huge diff was stale-base divergence, not real change). Follow-up commits then made the generic tests robust to real ASM reshard latency (new-connection skip + FI-budget timeouts) after live ASM CI runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in scenario maintenance-notification coverage; no production client or runtime behavior changes.
> 
> **Overview**
> Makes cluster maintenance-notification scenario tests reliable under **ASM (Atomic Slot Migration)** reshards by aligning waits with the fault injector’s real budgets and by settling the client node cache after multi-notification cascades.
> 
> **Timeouts** are raised and split by role: `SMIGRATED_TIMEOUT` / `SLOT_SHUFFLE_TIMEOUT`, `RESHARD_SMIGRATING_TIMEOUT`, `RESHARD_OP_TIMEOUT` (600s) for reshard trigger threads, `DEFAULT_TRIGGER_OP_TIMEOUT` (180s) for non-reshard `_trigger_effect`, and `RESHARD_TEST_TIMEOUT` (~900s) pytest caps on OSS reshard tests. Reshard tests pass `timeout=RESHARD_OP_TIMEOUT` into the trigger thread so it does not exit before slow ASM scale completes.
> 
> Adds **`_wait_for_node_cache_delta`** to drain push notifications and poll until `nodes_manager.nodes_cache` reaches the expected ±1 change. **`test_notification_handling_with_node_remove`** joins the FI thread first, then drains for −1; reconnect assertions relax to **`>= 1`** for ASM cascades. New mirror test **`test_notification_handling_with_node_add`** asserts +1 after the same flow.
> 
> **`test_new_connections_receive_last_smigrating_smigrated_notification`** expands `skip_combinations` for `reshard` with add/remove/slot_shuffle (short or multi-window maintenance). Command-execution param list drops a duplicate `SLOT_SHUFFLE` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ee811208acbd731ef5f18f630d01da675af483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



