### PR TITLE
test(search): add multi-language RediSearch coverage, re-enable search module pipeline tests, add 8.10 to CI matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.8.0'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.8:8.8.0
+    8.10:custom-28445327071-debian
 
 jobs:
   dependency-audit:
@@ -80,7 +80,7 @@ jobs:
       max-parallel: 30
       fail-fast: false
       matrix:
-        redis-version: ['${{ needs.redis_version.outputs.CURRENT }}', '8.6.3', '8.4.3', '8.2.6', '8.0.6' ,'7.4.9', '7.2.14']
+        redis-version: ['8.10', '${{ needs.redis_version.outputs.CURRENT }}', '8.6.3', '8.4.3', '8.2.6', '8.0.6' ,'7.4.9', '7.2.14']
         python-version: ['3.10', '3.14']
         parser-backend: ['plain']
         event-loop: ['asyncio']

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -57,6 +57,40 @@ TITLES_CSV = os.path.abspath(
 )
 
 
+def _assert_search_result(client, result, expected_doc_ids):
+    """
+    Make sure the result of a search is as expected, taking into account the
+    RESP version being used.
+    """
+    if expects_resp2_shape(client) or expects_unified_shape(client):
+        assert set([doc.id for doc in result.docs]) == set(expected_doc_ids)
+    elif expects_resp3_shape(client):
+        assert set([doc["id"] for doc in result["results"]]) == set(expected_doc_ids)
+
+
+def _search_total(client, result):
+    """
+    Return the number of matched documents in a search result, taking into
+    account the RESP version being used.
+    """
+    if expects_resp2_shape(client) or expects_unified_shape(client):
+        return result.total
+    return result["total_results"]
+
+
+# Languages RediSearch analyses with a Snowball stemmer.  For each case the
+# document stores ``doc_word`` (inside ``text``) and the query uses a different
+# surface form that shares the same stem in that language but NOT in English --
+# so a match proves the language stemmer is applied rather than a literal match.
+NON_ENGLISH_STEMMING_CASES = [
+    # (language, text, query, doc_word)
+    ("german", "Die Kinder spielen im Garten", "Kind", "Kinder"),
+    ("french", "Les chevaux courent vite", "cheval", "chevaux"),
+    ("spanish", "Nosotros hablamos mucho", "hablar", "hablamos"),
+    ("greek", "Οι άνθρωποι περπατούν", "άνθρωπος", "άνθρωποι"),
+]
+
+
 class AsyncSearchTestsBase:
     @pytest_asyncio.fixture()
     async def decoded_r(self, create_redis, stack_url):
@@ -1196,6 +1230,138 @@ class TestBaseSearchFunctionality(AsyncSearchTestsBase):
         )
 
 
+class TestSearchLanguages(AsyncSearchTestsBase):
+    """Functional coverage for indexing and searching text in languages other
+    than English: Snowball stemming for several languages, query-time language
+    selection, the Chinese (friso) tokenizer and per-document ``LANGUAGE_FIELD``
+    routing."""
+
+    @pytest.mark.redismod
+    @pytest.mark.parametrize(
+        "language, text, query, doc_word",
+        NON_ENGLISH_STEMMING_CASES,
+    )
+    async def test_search_non_english_stemming(
+        self, decoded_r: redis.Redis, language, text, query, doc_word
+    ):
+        """A query for a different inflection of ``doc_word`` matches when the
+        document is indexed with its own language stemmer, but not when the same
+        text is indexed as English -- proving the language setting is what drives
+        the stem match."""
+        # Index the document under its own language.
+        lang_def = IndexDefinition(prefix=["lang:"], language=language)
+        await decoded_r.ft("idx_lang").create_index(
+            (TextField("txt"),), definition=lang_def
+        )
+        await decoded_r.hset("lang:1", mapping={"txt": text})
+
+        # Index the same text as English as a negative control.
+        en_def = IndexDefinition(prefix=["en:"], language="english")
+        await decoded_r.ft("idx_en").create_index(
+            (TextField("txt"),), definition=en_def
+        )
+        await decoded_r.hset("en:1", mapping={"txt": text})
+
+        await self.waitForIndex(decoded_r, "idx_lang")
+        await self.waitForIndex(decoded_r, "idx_en")
+
+        # Same query in both cases -- only the index language differs.
+        q = Query(query).language(language).no_content()
+        assert _search_total(decoded_r, await decoded_r.ft("idx_lang").search(q)) == 1
+        assert _search_total(decoded_r, await decoded_r.ft("idx_en").search(q)) == 0
+
+    @pytest.mark.redismod
+    @skip_if_server_version_lt("8.9.0")
+    async def test_search_stemming_indonesian(self, decoded_r: redis.Redis):
+        """The Indonesian stemmer reduces "membaca" to its root "baca", so a
+        query for the stem matches the indexed document.  The Indonesian
+        stemmer is only available on newer server versions."""
+        definition = IndexDefinition(prefix=["doc:"], language="indonesian")
+        await decoded_r.ft("idx_id").create_index(
+            (TextField("content"),), definition=definition
+        )
+        await decoded_r.hset(
+            "doc:1", mapping={"content": "mereka membaca buku di perpustakaan"}
+        )
+        await self.waitForIndex(decoded_r, "idx_id")
+
+        q = Query("baca").language("indonesian").no_content()
+        assert _search_total(decoded_r, await decoded_r.ft("idx_id").search(q)) == 1
+
+    @pytest.mark.redismod
+    async def test_search_query_language(self, decoded_r: redis.Redis):
+        """``Query.language()`` controls how the *query* is stemmed.  The German
+        stemmer reduces "Kindern" to "kind" (matching the indexed document's
+        stem), while English analysis leaves it as "kindern" (no match).  The
+        query word is deliberately absent from the document text so the match
+        can only come from stemming, not from the indexed raw term."""
+        definition = IndexDefinition(prefix=["doc:"], language="german")
+        await decoded_r.ft().create_index((TextField("txt"),), definition=definition)
+        await decoded_r.hset("doc:1", mapping={"txt": "Die Kinder spielen im Garten"})
+        await self.waitForIndex(decoded_r, "idx")
+
+        matched = await decoded_r.ft().search(
+            Query("Kindern").language("german").no_content()
+        )
+        assert _search_total(decoded_r, matched) == 1
+
+        missed = await decoded_r.ft().search(
+            Query("Kindern").language("english").no_content()
+        )
+        assert _search_total(decoded_r, missed) == 0
+
+    @pytest.mark.redismod
+    async def test_search_chinese_tokenization(self, decoded_r: redis.Redis):
+        """Chinese text has no whitespace word boundaries; only the ``chinese``
+        tokenizer (friso) segments it into terms so an inner term can be
+        matched.  Indexed as English the text stays a single token."""
+        text = "我喜欢编程"  # "I like programming"
+        term = "编程"  # "programming"
+
+        cn_def = IndexDefinition(prefix=["cn:"], language="chinese")
+        await decoded_r.ft("idx_cn").create_index(
+            (TextField("txt"),), definition=cn_def
+        )
+        await decoded_r.hset("cn:1", mapping={"txt": text})
+
+        en_def = IndexDefinition(prefix=["en:"], language="english")
+        await decoded_r.ft("idx_en").create_index(
+            (TextField("txt"),), definition=en_def
+        )
+        await decoded_r.hset("en:1", mapping={"txt": text})
+
+        await self.waitForIndex(decoded_r, "idx_cn")
+        await self.waitForIndex(decoded_r, "idx_en")
+
+        cn_res = await decoded_r.ft("idx_cn").search(
+            Query(term).language("chinese").no_content()
+        )
+        assert _search_total(decoded_r, cn_res) == 1
+
+        en_res = await decoded_r.ft("idx_en").search(Query(term).no_content())
+        assert _search_total(decoded_r, en_res) == 0
+
+    @pytest.mark.redismod
+    async def test_search_language_field(self, decoded_r: redis.Redis):
+        """``LANGUAGE_FIELD`` selects the stemmer per document from a document
+        field, so the German document's "Kinder" is stemmed to "kind" while the
+        English document is analysed with the English stemmer."""
+        definition = IndexDefinition(prefix=["doc:"], language_field="__lang")
+        await decoded_r.ft().create_index((TextField("txt"),), definition=definition)
+        await decoded_r.hset(
+            "doc:de", mapping={"txt": "Die Kinder spielen", "__lang": "german"}
+        )
+        await decoded_r.hset(
+            "doc:en", mapping={"txt": "the children play", "__lang": "english"}
+        )
+        await self.waitForIndex(decoded_r, "idx")
+
+        # "Kind" only reaches the German document, whose "Kinder" stems to "kind".
+        res = await decoded_r.ft().search(Query("Kind").language("german").no_content())
+        assert _search_total(decoded_r, res) == 1
+        _assert_search_result(decoded_r, res, ["doc:de"])
+
+
 class TestScorers(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
@@ -1885,7 +2051,6 @@ class TestAggregations(AsyncSearchTestsBase):
 class TestPipeline(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @skip_if_redis_enterprise()
-    @skip_if_server_version_gte("8.7.0")  # Deactivate temporarily
     async def test_search_commands_in_pipeline(self, decoded_r: redis.Redis):
         p = await decoded_r.ft().pipeline()
         p.create_index((TextField("txt"),))
@@ -1923,7 +2088,6 @@ class TestPipeline(AsyncSearchTestsBase):
 
     @pytest.mark.redismod
     @skip_if_server_version_lt("8.3.224")
-    @skip_if_server_version_gte("8.7.0")  # Deactivate temporarily
     async def test_hybrid_search_query_with_pipeline(self, decoded_r: redis.Redis):
         p = decoded_r.ft().pipeline()
         p.create_index(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -85,6 +85,10 @@ class TestCache:
         ]
         # change key in redis (cause invalidation)
         r2.set("foo", "barbar")
+
+        # Add a small delay to allow invalidation to be processed
+        time.sleep(0.1)
+
         # Retrieves a new value from server and cache it
         assert r.get("foo") in [b"barbar", "barbar"]
         # Make sure that new value was cached
@@ -151,6 +155,10 @@ class TestCache:
         ]
         # change key in redis (cause invalidation)
         r2.hset(hash_key, field_1, "barbar")
+
+        # Add a small delay to allow invalidation to be processed
+        time.sleep(0.1)
+
         # Retrieves a new value from server and cache it
         assert r.hget(hash_key, field_1) in [b"barbar", "barbar"]
         # Make sure that new value was cached

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,6 +77,29 @@ def _assert_search_result(client, result, expected_doc_ids):
         assert set([doc["id"] for doc in result["results"]]) == set(expected_doc_ids)
 
 
+def _search_total(client, result):
+    """
+    Return the number of matched documents in a search result, taking into
+    account the RESP version being used.
+    """
+    if expects_resp2_shape(client) or expects_unified_shape(client):
+        return result.total
+    return result["total_results"]
+
+
+# Languages RediSearch analyses with a Snowball stemmer.  For each case the
+# document stores ``doc_word`` (inside ``text``) and the query uses a different
+# surface form that shares the same stem in that language but NOT in English --
+# so a match proves the language stemmer is applied rather than a literal match.
+NON_ENGLISH_STEMMING_CASES = [
+    # (language, text, query, doc_word)
+    ("german", "Die Kinder spielen im Garten", "Kind", "Kinder"),
+    ("french", "Les chevaux courent vite", "cheval", "chevaux"),
+    ("spanish", "Nosotros hablamos mucho", "hablar", "hablamos"),
+    ("greek", "Οι άνθρωποι περπατούν", "άνθρωπος", "άνθρωποι"),
+]
+
+
 class SearchTestsBase:
     @staticmethod
     def waitForIndex(env, idx, timeout=None):
@@ -1782,6 +1805,116 @@ class TestBaseSearchFunctionality(SearchTestsBase):
         assert len(client.info("search")) > 0
 
 
+class TestSearchLanguages(SearchTestsBase):
+    """Functional coverage for indexing and searching text in languages other
+    than English: Snowball stemming for several languages, query-time language
+    selection, the Chinese (friso) tokenizer and per-document ``LANGUAGE_FIELD``
+    routing."""
+
+    @pytest.mark.redismod
+    @pytest.mark.parametrize(
+        "language, text, query, doc_word",
+        NON_ENGLISH_STEMMING_CASES,
+    )
+    def test_search_non_english_stemming(self, client, language, text, query, doc_word):
+        """A query for a different inflection of ``doc_word`` matches when the
+        document is indexed with its own language stemmer, but not when the same
+        text is indexed as English -- proving the language setting is what drives
+        the stem match."""
+        # Index the document under its own language.
+        lang_def = IndexDefinition(prefix=["lang:"], language=language)
+        client.ft("idx_lang").create_index((TextField("txt"),), definition=lang_def)
+        client.hset("lang:1", mapping={"txt": text})
+
+        # Index the same text as English as a negative control.
+        en_def = IndexDefinition(prefix=["en:"], language="english")
+        client.ft("idx_en").create_index((TextField("txt"),), definition=en_def)
+        client.hset("en:1", mapping={"txt": text})
+
+        self.waitForIndex(client, "idx_lang")
+        self.waitForIndex(client, "idx_en")
+
+        # Same query in both cases -- only the index language differs.
+        q = Query(query).language(language).no_content()
+        assert _search_total(client, client.ft("idx_lang").search(q)) == 1
+        assert _search_total(client, client.ft("idx_en").search(q)) == 0
+
+    @pytest.mark.redismod
+    @skip_if_server_version_lt("8.9.0")
+    def test_search_stemming_indonesian(self, client):
+        """The Indonesian stemmer reduces "membaca" to its root "baca", so a
+        query for the stem matches the indexed document.  The Indonesian
+        stemmer is only available on newer server versions."""
+        definition = IndexDefinition(prefix=["doc:"], language="indonesian")
+        client.ft("idx_id").create_index((TextField("content"),), definition=definition)
+        client.hset("doc:1", mapping={"content": "mereka membaca buku di perpustakaan"})
+        self.waitForIndex(client, "idx_id")
+
+        q = Query("baca").language("indonesian").no_content()
+        assert _search_total(client, client.ft("idx_id").search(q)) == 1
+
+    @pytest.mark.redismod
+    def test_search_query_language(self, client):
+        """``Query.language()`` controls how the *query* is stemmed.  The German
+        stemmer reduces "Kindern" to "kind" (matching the indexed document's
+        stem), while English analysis leaves it as "kindern" (no match).  The
+        query word is deliberately absent from the document text so the match
+        can only come from stemming, not from the indexed raw term."""
+        definition = IndexDefinition(prefix=["doc:"], language="german")
+        client.ft().create_index((TextField("txt"),), definition=definition)
+        client.hset("doc:1", mapping={"txt": "Die Kinder spielen im Garten"})
+        self.waitForIndex(client, "idx")
+
+        matched = client.ft().search(Query("Kindern").language("german").no_content())
+        assert _search_total(client, matched) == 1
+
+        missed = client.ft().search(Query("Kindern").language("english").no_content())
+        assert _search_total(client, missed) == 0
+
+    @pytest.mark.redismod
+    def test_search_chinese_tokenization(self, client):
+        """Chinese text has no whitespace word boundaries; only the ``chinese``
+        tokenizer (friso) segments it into terms so an inner term can be
+        matched.  Indexed as English the text stays a single token."""
+        text = "我喜欢编程"  # "I like programming"
+        term = "编程"  # "programming"
+
+        cn_def = IndexDefinition(prefix=["cn:"], language="chinese")
+        client.ft("idx_cn").create_index((TextField("txt"),), definition=cn_def)
+        client.hset("cn:1", mapping={"txt": text})
+
+        en_def = IndexDefinition(prefix=["en:"], language="english")
+        client.ft("idx_en").create_index((TextField("txt"),), definition=en_def)
+        client.hset("en:1", mapping={"txt": text})
+
+        self.waitForIndex(client, "idx_cn")
+        self.waitForIndex(client, "idx_en")
+
+        cn_res = client.ft("idx_cn").search(
+            Query(term).language("chinese").no_content()
+        )
+        assert _search_total(client, cn_res) == 1
+
+        en_res = client.ft("idx_en").search(Query(term).no_content())
+        assert _search_total(client, en_res) == 0
+
+    @pytest.mark.redismod
+    def test_search_language_field(self, client):
+        """``LANGUAGE_FIELD`` selects the stemmer per document from a document
+        field, so the German document's "Kinder" is stemmed to "kind" while the
+        English document is analysed with the English stemmer."""
+        definition = IndexDefinition(prefix=["doc:"], language_field="__lang")
+        client.ft().create_index((TextField("txt"),), definition=definition)
+        client.hset("doc:de", mapping={"txt": "Die Kinder spielen", "__lang": "german"})
+        client.hset("doc:en", mapping={"txt": "the children play", "__lang": "english"})
+        self.waitForIndex(client, "idx")
+
+        # "Kind" only reaches the German document, whose "Kinder" stems to "kind".
+        res = client.ft().search(Query("Kind").language("german").no_content())
+        assert _search_total(client, res) == 1
+        _assert_search_result(client, res, ["doc:de"])
+
+
 class TestScorers(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
@@ -3045,7 +3178,6 @@ class TestDifferentFieldTypesSearch(SearchTestsBase):
 class TestPipeline(SearchTestsBase):
     @pytest.mark.redismod
     @skip_if_redis_enterprise()
-    @skip_if_server_version_gte("8.7.0")  # Deactivate temporarily
     def test_search_commands_in_pipeline(self, client):
         p = client.ft().pipeline()
         p.create_index((TextField("txt"),))
@@ -3083,7 +3215,6 @@ class TestPipeline(SearchTestsBase):
 
     @pytest.mark.redismod
     @skip_if_server_version_lt("8.4.0")
-    @skip_if_server_version_gte("8.7.0")  # Deactivate temporarily
     def test_hybrid_search_query_with_pipeline(self, client):
         p = client.ft().pipeline()
         p.create_index(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5580,14 +5580,26 @@ class TestHybridSearch(SearchTestsBase):
             },
         ]
 
+        # The query only sorts by @price, so the order of rows sharing the same
+        # price (e.g. the two price=15 and the two price=16 groups) is not
+        # deterministic. Validate the price sort separately, then compare the
+        # groups order-independently by their unique (item_type, price) key.
+        def _row_key(row):
+            return (row["price"], row["item_type"])
+
+        def _assert_hybrid_results(results, warnings):
+            assert len(results) == 4
+            prices = [row["price"] for row in results]
+            assert prices == sorted(prices)
+            assert sorted(results, key=_row_key) == sorted(
+                expected_results, key=_row_key
+            )
+            assert warnings == []
+
         if expects_resp2_shape(client) or expects_unified_shape(client):
-            assert len(res.results) == 4
-            assert res.results == expected_results
-            assert res.warnings == []
+            _assert_hybrid_results(res.results, res.warnings)
         elif expects_resp3_shape(client):
-            assert len(res["results"]) == 4
-            assert res["results"] == expected_results
-            assert res["warnings"] == []
+            _assert_hybrid_results(res["results"], res["warnings"])
 
         postprocessing_config = HybridPostProcessingConfig()
         postprocessing_config.load("@color", "@price", "@size", "@item_type")


### PR DESCRIPTION
## Description

This PR adds functional test coverage for indexing and querying non-English
text in RediSearch. 
A new `TestSearchLanguages` class (mirrored across the sync `tests/test_search.py` and async `tests/test_asyncio/test_search.py` suites) exercises the language-aware analysis paths that were previously untested from the Python client.

The stemming tests are written so that a pass can only come from the language analyzer, not from a literal term match: each document stores one surface form of a word and the query uses a different inflection that shares the same stem
only in the target language. 
Coverage includes Snowball stemming for German, French, Spanish and Greek (each with an English-indexed negative control), Indonesian stemming (gated on server ≥ 8.9.0), query-time language selection via `Query.language()`, Chinese (friso) tokenization versus English single-token behavior, and per-document stemmer routing via `LANGUAGE_FIELD`. A small RESP-version-aware `_search_total()` helper (and `_assert_search_result()` on the async side) keeps the assertions valid across RESP2, RESP3 and unified response shapes.

The PR also re-enables `test_search_commands_in_pipeline` and `test_hybrid_search_query_with_pipeline` by removing the temporary `@skip_if_server_version_gte("8.7.0")` markers that had deactivated them, and adds an 8.10 entry to the CI integration matrix so the new multi-language analyzers (including the Indonesian stemmer) are exercised on a server build
that provides them.

No library/runtime code is modified — the change is limited to tests and CI
configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI workflow changes only; no production client or server behavior is modified.
> 
> **Overview**
> Adds **RediSearch multi-language integration tests** in sync and async `test_search` via new `TestSearchLanguages`, with RESP-aware `_search_total()` / `_assert_search_result()` helpers. Coverage includes Snowball stemming (German, French, Spanish, Greek with English controls), Indonesian (≥8.9), `Query.language()`, Chinese tokenization, and `LANGUAGE_FIELD` per-document routing.
> 
> **Re-enables** `test_search_commands_in_pipeline` and `test_hybrid_search_query_with_pipeline` by dropping temporary `@skip_if_server_version_gte("8.7.0")` skips. **CI** maps Redis **8.10** to a custom image and runs it in the integration matrix. **Stabilizes** cache invalidation tests with a short `time.sleep` after cross-client writes, and relaxes a hybrid group-by assertion to compare rows order-independently when `@price` ties.
> 
> No library/runtime code changes—tests and workflow only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a64fae190eb04be99233c2e0c7890f6929caf9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->