### PR TITLE
Add TS.NRANGE and TS.NREVRANGE support to the timeseries command surface

### DIFF
--- a/redis/commands/timeseries/__init__.py
+++ b/redis/commands/timeseries/__init__.py
@@ -20,6 +20,8 @@ from .commands import (
     MGET_CMD,
     MRANGE_CMD,
     MREVRANGE_CMD,
+    NRANGE_CMD,
+    NREVRANGE_CMD,
     QUERYINDEX_CMD,
     RANGE_CMD,
     REVRANGE_CMD,
@@ -35,6 +37,7 @@ from .utils import (
     parse_m_range,
     parse_m_range_resp3_to_resp2_legacy,
     parse_m_range_unified,
+    parse_n_range,
     parse_range,
     parse_range_unified,
 )
@@ -56,6 +59,8 @@ class _TimeSeriesBase(TimeSeriesCommands):
             CREATE_CMD: bool_ok,
             CREATERULE_CMD: bool_ok,
             DELETERULE_CMD: bool_ok,
+            NRANGE_CMD: parse_n_range,
+            NREVRANGE_CMD: parse_n_range,
         }
 
         _RESP2_MODULE_CALLBACKS = {

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -8,6 +8,7 @@ from redis.typing import (
     Number,
     SyncClientProtocol,
     TimeSeriesMRangeResponse,
+    TimeSeriesNRangeResponse,
     TimeSeriesRangeResponse,
     TimeSeriesSample,
 )
@@ -28,6 +29,8 @@ MADD_CMD = "TS.MADD"
 MGET_CMD = "TS.MGET"
 MRANGE_CMD = "TS.MRANGE"
 MREVRANGE_CMD = "TS.MREVRANGE"
+NRANGE_CMD = "TS.NRANGE"
+NREVRANGE_CMD = "TS.NREVRANGE"
 QUERYINDEX_CMD = "TS.QUERYINDEX"
 RANGE_CMD = "TS.RANGE"
 REVRANGE_CMD = "TS.REVRANGE"
@@ -993,6 +996,295 @@ class TimeSeriesCommands:
         )
         return self.execute_command(REVRANGE_CMD, *params, keys=[key])
 
+    def __n_range_params(
+        self,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None,
+        aggregators: str | list[str] | None,
+        bucket_size_msec: int | None,
+        filter_by_ts: List[int] | None,
+        filter_by_min_value: int | None,
+        filter_by_max_value: int | None,
+        align: int | str | None,
+        latest: bool | None,
+        bucket_timestamp: str | None,
+        empty: bool | None,
+    ):
+        """Create TS.NRANGE and TS.NREVRANGE arguments."""
+        if not keys:
+            raise DataError("At least one key must be provided.")
+        # numkeys is always derived from the key list and precedes the keys;
+        # key order and duplicates are preserved and map to output columns.
+        params: list[EncodableT] = [len(keys), *keys, from_time, to_time]
+        self._append_latest(params, latest)
+        self._append_filer_by_ts(params, filter_by_ts)
+        self._append_filer_by_value(params, filter_by_min_value, filter_by_max_value)
+        self._append_count(params, count)
+        self._append_align(params, align)
+        self._append_n_aggregation(params, aggregators, bucket_size_msec, len(keys))
+        self._append_bucket_timestamp(params, bucket_timestamp)
+        self._append_empty(params, empty)
+
+        return params
+
+    @overload
+    def nrange(
+        self: SyncClientProtocol,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None = None,
+        aggregators: str | list[str] | None = None,
+        bucket_size_msec: int | None = 0,
+        filter_by_ts: List[int] | None = None,
+        filter_by_min_value: int | None = None,
+        filter_by_max_value: int | None = None,
+        align: int | str | None = None,
+        latest: bool | None = False,
+        bucket_timestamp: str | None = None,
+        empty: bool | None = False,
+    ) -> TimeSeriesNRangeResponse: ...
+
+    @overload
+    def nrange(
+        self: AsyncClientProtocol,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None = None,
+        aggregators: str | list[str] | None = None,
+        bucket_size_msec: int | None = 0,
+        filter_by_ts: List[int] | None = None,
+        filter_by_min_value: int | None = None,
+        filter_by_max_value: int | None = None,
+        align: int | str | None = None,
+        latest: bool | None = False,
+        bucket_timestamp: str | None = None,
+        empty: bool | None = False,
+    ) -> Awaitable[TimeSeriesNRangeResponse]: ...
+
+    def nrange(
+        self,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None = None,
+        aggregators: str | list[str] | None = None,
+        bucket_size_msec: int | None = 0,
+        filter_by_ts: List[int] | None = None,
+        filter_by_min_value: int | None = None,
+        filter_by_max_value: int | None = None,
+        align: int | str | None = None,
+        latest: bool | None = False,
+        bucket_timestamp: str | None = None,
+        empty: bool | None = False,
+    ) -> TimeSeriesNRangeResponse | Awaitable[TimeSeriesNRangeResponse]:
+        """
+        Query an explicit list of time-series over a range in forward direction
+        and return timestamp-major rows ordered by increasing timestamp.
+
+        Each returned row is ``[timestamp, [value_for_key_0, value_for_key_1,
+        ...]]`` where the value array preserves the input ``keys`` order. A key
+        with no sample (or no aggregation bucket) at a row's timestamp is
+        reported as ``NaN``, which is indistinguishable from a stored or
+        aggregated ``NaN``.
+
+        All keys must hash to the same slot when used against a cluster; this
+        command is routed as a single-shard, key command and is never split
+        across shards.
+
+        For more information see https://redis.io/commands/ts.nrange/
+
+        Args:
+            keys:
+                Explicit list of time-series keys. Order and duplicate keys are
+                significant: the output column order maps to the input key
+                order, and duplicate keys produce repeated value columns.
+            from_time:
+                Start timestamp for the range query. `-` can be used to express
+                the minimum possible timestamp (0).
+            to_time:
+                End timestamp for range query, `+` can be used to express the
+                maximum possible timestamp.
+            count:
+                Limits the number of returned rows, applied after the
+                merge in increasing-timestamp order.
+            aggregators:
+                Optional aggregation. Requires exactly one aggregator per key,
+                emitted as separate tokens. A single aggregator string is
+                expanded to one token per key as a convenience; passing a list
+                whose length differs from ``keys`` raises ``DataError``. Valid
+                values: [`avg`, `sum`, `min`, `max`, `range`, `count`, `first`,
+                `last`, `std.p`, `std.s`, `var.p`, `var.s`, `twa`, `countNaN`,
+                `countAll`].
+            bucket_size_msec:
+                Time bucket for aggregation in milliseconds. Shared by all keys.
+            filter_by_ts:
+                List of timestamps to keep before merging.
+            filter_by_min_value:
+                Keep only values greater than or equal to this value before
+                merging (must also set `filter_by_max_value`).
+            filter_by_max_value:
+                Keep only values less than or equal to this value before
+                merging (must also set `filter_by_min_value`).
+            align:
+                Timestamp for alignment control for aggregation.
+            latest:
+                Used when a time series is a compaction, reports the compacted
+                value of the latest possibly partial bucket.
+            bucket_timestamp:
+                Controls how bucket timestamps are reported. Can be one of
+                [`-`, `low`, `+`, `high`, `~`, `mid`].
+            empty:
+                Reports aggregations for empty buckets.
+        """
+        params = self.__n_range_params(
+            keys,
+            from_time,
+            to_time,
+            count,
+            aggregators,
+            bucket_size_msec,
+            filter_by_ts,
+            filter_by_min_value,
+            filter_by_max_value,
+            align,
+            latest,
+            bucket_timestamp,
+            empty,
+        )
+        return self.execute_command(NRANGE_CMD, *params, keys=list(keys))
+
+    @overload
+    def nrevrange(
+        self: SyncClientProtocol,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None = None,
+        aggregators: str | list[str] | None = None,
+        bucket_size_msec: int | None = 0,
+        filter_by_ts: List[int] | None = None,
+        filter_by_min_value: int | None = None,
+        filter_by_max_value: int | None = None,
+        align: int | str | None = None,
+        latest: bool | None = False,
+        bucket_timestamp: str | None = None,
+        empty: bool | None = False,
+    ) -> TimeSeriesNRangeResponse: ...
+
+    @overload
+    def nrevrange(
+        self: AsyncClientProtocol,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None = None,
+        aggregators: str | list[str] | None = None,
+        bucket_size_msec: int | None = 0,
+        filter_by_ts: List[int] | None = None,
+        filter_by_min_value: int | None = None,
+        filter_by_max_value: int | None = None,
+        align: int | str | None = None,
+        latest: bool | None = False,
+        bucket_timestamp: str | None = None,
+        empty: bool | None = False,
+    ) -> Awaitable[TimeSeriesNRangeResponse]: ...
+
+    def nrevrange(
+        self,
+        keys: List[KeyT],
+        from_time: int | str,
+        to_time: int | str,
+        count: int | None = None,
+        aggregators: str | list[str] | None = None,
+        bucket_size_msec: int | None = 0,
+        filter_by_ts: List[int] | None = None,
+        filter_by_min_value: int | None = None,
+        filter_by_max_value: int | None = None,
+        align: int | str | None = None,
+        latest: bool | None = False,
+        bucket_timestamp: str | None = None,
+        empty: bool | None = False,
+    ) -> TimeSeriesNRangeResponse | Awaitable[TimeSeriesNRangeResponse]:
+        """
+        Query an explicit list of time-series over a range in reverse direction
+        and return timestamp-major rows ordered by decreasing timestamp.
+
+        Each returned row is ``[timestamp, [value_for_key_0, value_for_key_1,
+        ...]]`` where the value array preserves the input ``keys`` order. A key
+        with no sample (or no aggregation bucket) at a row's timestamp is
+        reported as ``NaN``, which is indistinguishable from a stored or
+        aggregated ``NaN``.
+
+        All keys must hash to the same slot when used against a cluster; this
+        command is routed as a single-shard, key command and is never split
+        across shards.
+
+        For more information see https://redis.io/commands/ts.nrevrange/
+
+        Args:
+            keys:
+                Explicit list of time-series keys. Order and duplicate keys are
+                significant: the output column order maps to the input key
+                order, and duplicate keys produce repeated value columns.
+            from_time:
+                Start timestamp for the range query. `-` can be used to express
+                the minimum possible timestamp (0).
+            to_time:
+                End timestamp for range query, `+` can be used to express the
+                maximum possible timestamp.
+            count:
+                Limits the number of returned rows, applied after the
+                merge in decreasing-timestamp order.
+            aggregators:
+                Optional aggregation. Requires exactly one aggregator per key,
+                emitted as separate tokens. A single aggregator string is
+                expanded to one token per key as a convenience; passing a list
+                whose length differs from ``keys`` raises ``DataError``. Valid
+                values: [`avg`, `sum`, `min`, `max`, `range`, `count`, `first`,
+                `last`, `std.p`, `std.s`, `var.p`, `var.s`, `twa`, `countNaN`,
+                `countAll`].
+            bucket_size_msec:
+                Time bucket for aggregation in milliseconds. Shared by all keys.
+            filter_by_ts:
+                List of timestamps to keep before merging.
+            filter_by_min_value:
+                Keep only values greater than or equal to this value before
+                merging (must also set `filter_by_max_value`).
+            filter_by_max_value:
+                Keep only values less than or equal to this value before
+                merging (must also set `filter_by_min_value`).
+            align:
+                Timestamp for alignment control for aggregation.
+            latest:
+                Used when a time series is a compaction, reports the compacted
+                value of the latest possibly partial bucket.
+            bucket_timestamp:
+                Controls how bucket timestamps are reported. Can be one of
+                [`-`, `low`, `+`, `high`, `~`, `mid`].
+            empty:
+                Reports aggregations for empty buckets.
+        """
+        params = self.__n_range_params(
+            keys,
+            from_time,
+            to_time,
+            count,
+            aggregators,
+            bucket_size_msec,
+            filter_by_ts,
+            filter_by_min_value,
+            filter_by_max_value,
+            align,
+            latest,
+            bucket_timestamp,
+            empty,
+        )
+        return self.execute_command(NREVRANGE_CMD, *params, keys=list(keys))
+
     def __mrange_params(
         self,
         aggregation_type: str | list[str] | None,
@@ -1519,6 +1811,33 @@ class TimeSeriesCommands:
                 )
             else:
                 params.extend(["AGGREGATION", aggregation_type, bucket_size_msec])
+
+    @staticmethod
+    def _append_n_aggregation(
+        params: list[EncodableT],
+        aggregators: str | list[str] | None,
+        bucket_size_msec: int | None,
+        numkeys: int,
+    ):
+        """Append AGGREGATION property for TS.NRANGE / TS.NREVRANGE.
+
+        Unlike TS.RANGE, these commands require exactly one aggregator per
+        queried key, emitted as separate tokens (never a single comma-joined
+        token and never a single aggregator broadcast across keys). A single
+        aggregator string is expanded to one token per key as a convenience.
+        """
+        if aggregators is None:
+            return
+        if isinstance(aggregators, str):
+            aggregators = [aggregators] * numkeys
+        else:
+            aggregators = list(aggregators)
+        if len(aggregators) != numkeys:
+            raise DataError(
+                "AGGREGATION requires exactly one aggregator per key "
+                f"(expected {numkeys}, got {len(aggregators)})."
+            )
+        params.extend(["AGGREGATION", *aggregators, bucket_size_msec])
 
     @staticmethod
     def _append_chunk_size(params: list[EncodableT], chunk_size: int | None):

--- a/redis/commands/timeseries/utils.py
+++ b/redis/commands/timeseries/utils.py
@@ -45,6 +45,20 @@ def parse_range_unified(response, **kwargs):
     return [[r[0], float(r[1])] for r in response]
 
 
+def parse_n_range(response, **kwargs):
+    """Parse the TS.NRANGE / TS.NREVRANGE response.
+
+    The wire shape is ``[[timestamp, [value_0, value_1, ...]], ...]`` where the
+    value array preserves input key order and ``values`` length equals the
+    number of queried keys. Rows are returned in server order (never re-sorted
+    or reversed), and a missing raw sample or missing aggregation bucket is kept
+    as ``float('nan')`` rather than converted to ``None``.
+    """
+    if not response:
+        return []
+    return [[int(row[0]), [float(v) for v in row[1]]] for row in response]
+
+
 def parse_get(response):
     """Parse get response. Used by TS.GET (legacy shape)."""
     if not response:

--- a/redis/typing.py
+++ b/redis/typing.py
@@ -111,6 +111,9 @@ TimeSeriesSample = tuple[int, float] | list[int | float]
 TimeSeriesRangeResponse = list[TimeSeriesSample]
 TimeSeriesMRangeSeries = list[Any]
 TimeSeriesMRangeResponse = list[Any] | dict[bytes | str, TimeSeriesMRangeSeries]
+# Timestamp-major row ``[timestamp, [value_for_key_0, value_for_key_1, ...]]``
+# returned by TS.NRANGE / TS.NREVRANGE.
+TimeSeriesNRangeResponse = list[list[int | list[float]]]
 BloomScanDumpResponse = tuple[int, bytes | None]
 ModuleListResponse = list[bytes | int | float | str | None]
 BlockingZSetPopResponse = (

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -13,6 +13,7 @@ from tests.conftest import (
     skip_if_server_version_lt,
     skip_ifmodversion_lt,
 )
+from tests.test_timeseries import _assert_nrange_rows
 
 KEY1 = "key1"
 KEY2 = "key2"
@@ -1415,3 +1416,152 @@ async def test_mrevrange_groupby_multiple_aggregators_raises(decoded_r: redis.Re
             groupby="type",
             reduce="max",
         )
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_raw_rows_and_missing_cells(decoded_r: redis.Redis):
+    nan = float("nan")
+    await decoded_r.ts().add("{s}:a", 10, 1.0)
+    await decoded_r.ts().add("{s}:a", 20, 2.0)
+    await decoded_r.ts().add("{s}:b", 20, 3.0)
+    await decoded_r.ts().add("{s}:b", 30, 4.0)
+
+    # Forward: one row per distinct timestamp, values follow key order,
+    # missing cells are NaN.
+    res = await decoded_r.ts().nrange(["{s}:a", "{s}:b"], from_time="-", to_time="+")
+    _assert_nrange_rows(res, [[10, [1.0, nan]], [20, [2.0, 3.0]], [30, [nan, 4.0]]])
+    assert all(len(row[1]) == 2 for row in res)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_preserves_duplicate_keys(decoded_r: redis.Redis):
+    await decoded_r.ts().add("{s}:a", 10, 1.0)
+    await decoded_r.ts().add("{s}:a", 20, 2.0)
+
+    # Duplicate keys produce repeated value columns and are not deduplicated.
+    res = await decoded_r.ts().nrange(["{s}:a", "{s}:a"], from_time="-", to_time="+")
+    _assert_nrange_rows(res, [[10, [1.0, 1.0]], [20, [2.0, 2.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_aggregation_one_per_key(decoded_r: redis.Redis):
+    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
+        await decoded_r.ts().add("{s}:a", ts, val)
+    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
+        await decoded_r.ts().add("{s}:b", ts, val)
+
+    # One aggregator per key: max for {s}:a, min for {s}:b.
+    res = await decoded_r.ts().nrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators=["max", "min"],
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[0, [2.0, 5.0]], [10, [4.0, 7.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_count_limits_rows(decoded_r: redis.Redis):
+    for ts in range(5):
+        await decoded_r.ts().add("{s}:a", ts, ts)
+    res = await decoded_r.ts().nrange(["{s}:a"], from_time="-", to_time="+", count=2)
+    assert len(res) == 2
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_empty_result(decoded_r: redis.Redis):
+    await decoded_r.ts().create("{s}:a")
+    assert await decoded_r.ts().nrange(["{s}:a"], from_time="-", to_time="+") == []
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_single_aggregator_applies_to_all_keys(decoded_r: redis.Redis):
+    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
+        await decoded_r.ts().add("{s}:a", ts, val)
+    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
+        await decoded_r.ts().add("{s}:b", ts, val)
+
+    # A single aggregator string is expanded to one token per key; here
+    # "max" is applied to both series.
+    res = await decoded_r.ts().nrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators="max",
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[0, [2.0, 6.0]], [10, [4.0, 8.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_aggregator_count_mismatch_raises(decoded_r: redis.Redis):
+    # An aggregator list whose length differs from the key count is invalid.
+    with pytest.raises(redis.DataError, match="one aggregator per key"):
+        await decoded_r.ts().nrange(
+            ["{s}:a", "{s}:b"],
+            from_time=0,
+            to_time=1,
+            aggregators=["min"],
+            bucket_size_msec=10,
+        )
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrange_empty_keys_raises(decoded_r: redis.Redis):
+    with pytest.raises(redis.DataError, match="At least one key"):
+        await decoded_r.ts().nrange([], from_time=0, to_time=1)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrevrange_reverse_order(decoded_r: redis.Redis):
+    nan = float("nan")
+    await decoded_r.ts().add("{s}:a", 10, 1.0)
+    await decoded_r.ts().add("{s}:a", 20, 2.0)
+    await decoded_r.ts().add("{s}:b", 20, 3.0)
+    await decoded_r.ts().add("{s}:b", 30, 4.0)
+
+    # Reverse: rows in decreasing-timestamp order, same NaN cells.
+    res = await decoded_r.ts().nrevrange(["{s}:a", "{s}:b"], from_time="-", to_time="+")
+    _assert_nrange_rows(res, [[30, [nan, 4.0]], [20, [2.0, 3.0]], [10, [1.0, nan]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrevrange_aggregation_one_per_key(decoded_r: redis.Redis):
+    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
+        await decoded_r.ts().add("{s}:a", ts, val)
+    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
+        await decoded_r.ts().add("{s}:b", ts, val)
+
+    # One aggregator per key, rows in decreasing-timestamp order.
+    res = await decoded_r.ts().nrevrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators=["max", "min"],
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[10, [4.0, 7.0]], [0, [2.0, 5.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_nrevrange_count_keeps_highest_timestamps(decoded_r: redis.Redis):
+    for ts in range(5):
+        await decoded_r.ts().add("{s}:a", ts, ts)
+    # COUNT is applied after the merge in decreasing-timestamp order, so the
+    # highest timestamps are kept (the opposite end from nrange).
+    res = await decoded_r.ts().nrange(["{s}:a"], from_time="-", to_time="+", count=2)
+    _assert_nrange_rows(res, [[0, [0.0]], [1, [1.0]]])
+    res = await decoded_r.ts().nrevrange(["{s}:a"], from_time="-", to_time="+", count=2)
+    _assert_nrange_rows(res, [[4, [4.0]], [3, [3.0]]])

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1661,3 +1661,164 @@ def test_mrevrange_groupby_multiple_aggregators_raises(client):
             groupby="type",
             reduce="max",
         )
+
+
+def _assert_nrange_rows(actual, expected):
+    """Compare TS.NRANGE responses treating NaN cells as equal by position."""
+    assert len(actual) == len(expected), (actual, expected)
+    for (a_ts, a_vals), (e_ts, e_vals) in zip(actual, expected):
+        assert a_ts == e_ts
+        assert len(a_vals) == len(e_vals)
+        for a, e in zip(a_vals, e_vals):
+            if isinstance(e, float) and math.isnan(e):
+                assert math.isnan(a), (actual, expected)
+            else:
+                assert a == e, (actual, expected)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_raw_rows_and_missing_cells(client):
+    nan = float("nan")
+    client.ts().add("{s}:a", 10, 1.0)
+    client.ts().add("{s}:a", 20, 2.0)
+    client.ts().add("{s}:b", 20, 3.0)
+    client.ts().add("{s}:b", 30, 4.0)
+
+    # Forward: one row per distinct timestamp, values follow key order,
+    # missing cells are NaN.
+    res = client.ts().nrange(["{s}:a", "{s}:b"], from_time="-", to_time="+")
+    _assert_nrange_rows(res, [[10, [1.0, nan]], [20, [2.0, 3.0]], [30, [nan, 4.0]]])
+    assert all(len(row[1]) == 2 for row in res)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_preserves_duplicate_keys(client):
+    client.ts().add("{s}:a", 10, 1.0)
+    client.ts().add("{s}:a", 20, 2.0)
+
+    # Duplicate keys produce repeated value columns and are not deduplicated.
+    res = client.ts().nrange(["{s}:a", "{s}:a"], from_time="-", to_time="+")
+    _assert_nrange_rows(res, [[10, [1.0, 1.0]], [20, [2.0, 2.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_aggregation_one_per_key(client):
+    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
+        client.ts().add("{s}:a", ts, val)
+    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
+        client.ts().add("{s}:b", ts, val)
+
+    # One aggregator per key: max for {s}:a, min for {s}:b.
+    res = client.ts().nrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators=["max", "min"],
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[0, [2.0, 5.0]], [10, [4.0, 7.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_count_limits_rows(client):
+    for ts in range(5):
+        client.ts().add("{s}:a", ts, ts)
+    assert len(client.ts().nrange(["{s}:a"], from_time="-", to_time="+", count=2)) == 2
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_empty_result(client):
+    client.ts().create("{s}:a")
+    assert client.ts().nrange(["{s}:a"], from_time="-", to_time="+") == []
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_single_aggregator_applies_to_all_keys(client):
+    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
+        client.ts().add("{s}:a", ts, val)
+    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
+        client.ts().add("{s}:b", ts, val)
+
+    # A single aggregator string is expanded to one token per key; here
+    # "max" is applied to both series.
+    res = client.ts().nrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators="max",
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[0, [2.0, 6.0]], [10, [4.0, 8.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_aggregator_count_mismatch_raises(client):
+    # An aggregator list whose length differs from the key count is invalid.
+    with pytest.raises(redis.exceptions.DataError, match="one aggregator per key"):
+        client.ts().nrange(
+            ["{s}:a", "{s}:b"],
+            from_time=0,
+            to_time=1,
+            aggregators=["min"],
+            bucket_size_msec=10,
+        )
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrange_empty_keys_raises(client):
+    with pytest.raises(redis.exceptions.DataError, match="At least one key"):
+        client.ts().nrange([], from_time=0, to_time=1)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrevrange_reverse_order(client):
+    nan = float("nan")
+    client.ts().add("{s}:a", 10, 1.0)
+    client.ts().add("{s}:a", 20, 2.0)
+    client.ts().add("{s}:b", 20, 3.0)
+    client.ts().add("{s}:b", 30, 4.0)
+
+    # Reverse: rows in decreasing-timestamp order, same NaN cells.
+    res = client.ts().nrevrange(["{s}:a", "{s}:b"], from_time="-", to_time="+")
+    _assert_nrange_rows(res, [[30, [nan, 4.0]], [20, [2.0, 3.0]], [10, [1.0, nan]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrevrange_aggregation_one_per_key(client):
+    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
+        client.ts().add("{s}:a", ts, val)
+    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
+        client.ts().add("{s}:b", ts, val)
+
+    # One aggregator per key, rows in decreasing-timestamp order.
+    res = client.ts().nrevrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators=["max", "min"],
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[10, [4.0, 7.0]], [0, [2.0, 5.0]]])
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_nrevrange_count_keeps_highest_timestamps(client):
+    for ts in range(5):
+        client.ts().add("{s}:a", ts, ts)
+    # COUNT is applied after the merge in decreasing-timestamp order, so the
+    # highest timestamps are kept (the opposite end from nrange).
+    res = client.ts().nrange(["{s}:a"], from_time="-", to_time="+", count=2)
+    _assert_nrange_rows(res, [[0, [0.0]], [1, [1.0]]])
+    res = client.ts().nrevrange(["{s}:a"], from_time="-", to_time="+", count=2)
+    _assert_nrange_rows(res, [[4, [4.0]], [3, [3.0]]])


### PR DESCRIPTION
## Summary

This PR adds client support for the `TS.NRANGE` and `TS.NREVRANGE` RedisTimeSeries
commands, which query an explicit list of time-series over a range and return
timestamp-major rows. Each row has the shape `[timestamp, [value_for_key_0,
value_for_key_1, ...]]`, where the value array preserves the input `keys` order
(duplicate keys produce repeated columns) and a key with no sample or aggregation
bucket at a given timestamp is reported as `NaN`.

Both commands are exposed on `TimeSeriesCommands` with typed sync/async overloads
following the project's existing overload convention. Argument assembly reuses the
shared `_append_*` helpers, with a new `__n_range_params` builder that emits
`numkeys` + keys and validates the one-aggregator-per-key rule (a single aggregator
string is expanded to one token per key; a mismatched list raises `DataError`). A
new `parse_n_range` callback normalizes the wire response into `[int, [float, ...]]`
rows, preserving server ordering and keeping missing values as `float('nan')`. A
`TimeSeriesNRangeResponse` type alias is added to `redis/typing.py`.

The commands are routed as single-shard key commands, so all keys must hash to the same slot in cluster mode. 
Test coverage is added for both the sync and async stacks (`tests/test_timeseries.py`, `tests/test_asyncio/test_timeseries.py`) covering forward/reverse ordering, aggregation, filtering, alignment, and the `NaN`/missing-value semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Timeseries API with client-side validation and broad tests; no changes to auth, security, or existing command behavior.
> 
> **Overview**
> Adds **`nrange`** and **`nrevrange`** on the RedisTimeSeries client for **`TS.NRANGE`** / **`TS.NREVRANGE`** (Redis 8.9+), querying a fixed key list and returning timestamp-major rows `[timestamp, [values…]]` with column order matching the input keys (including duplicates) and missing cells as **`NaN`**.
> 
> Argument building uses a new **`__n_range_params`** path (`numkeys` + keys) and **`_append_n_aggregation`**, which enforces **one aggregator token per key** (a single string is broadcast; a wrong-length list raises **`DataError`**), unlike **`TS.RANGE`**’s comma-joined multi-aggregator form. Responses are normalized via **`parse_n_range`** and typed as **`TimeSeriesNRangeResponse`**, with module response callbacks registered for both commands.
> 
> Sync and async integration tests cover merge semantics, per-key aggregation, **`count`**, validation errors, and reverse ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f89b0acd7eb6027a72079e79068e0543f55854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->