### PR TITLE
Remove stale "connection" arg from get_resolved_ip docstring

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -658,9 +658,6 @@ class MaintNotificationsAbstractConnection:
         First tries to get the actual IP from the socket (most accurate),
         then falls back to DNS resolution if needed.
 
-        Args:
-            connection: The connection object to extract the IP from
-
         Returns:
             str: The resolved IP address, or None if it cannot be determined
         """


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change? (doc-only, no behavior change)
- [x] Is the new or changed code fully tested? (n/a - docstring-only)
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

`AbstractConnection.get_resolved_ip` takes no arguments (it operates on `self`), but its docstring documents a `connection` parameter left over from an earlier signature. This removes the stale `Args:` block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **`get_resolved_ip`** docstring on **`MaintNotificationsAbstractConnection`** so it matches the real API: the method only uses **`self`** (socket peer name, then DNS on **`host`**/**`port`**).
> 
> Removes the leftover **`Args:`** block that documented a **`connection`** parameter from an older signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee3a8e9253009caf7681ebfa2e057c6b4c332049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->