### PR TITLE
fix(connection): fail fast on unrecoverable connect errors (#4026)

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import errno
 import inspect
 import math
 import socket
@@ -344,6 +345,25 @@ class AbstractConnection:
         """
         self._parser = parser_class(socket_read_size=self._socket_read_size)
 
+    # OS-level errno values for which reconnecting can never succeed, so
+    # there is no point spending the retry/backoff budget on them.
+    _UNRETRYABLE_CONNECT_ERRNOS = frozenset({errno.ENOENT})
+
+    @classmethod
+    def _is_retryable_connect_error(cls, error: BaseException) -> bool:
+        """Whether a failed connection attempt is worth retrying.
+
+        Returns ``False`` for definitively unrecoverable socket errors (e.g. a
+        Unix socket path that does not exist, ``ENOENT``) so that ``connect()``
+        fails fast instead of backing off for every retry. Transient errors
+        such as ``ECONNREFUSED`` during server startup stay retryable.
+        """
+        cause = error.__cause__
+        return not (
+            isinstance(cause, OSError)
+            and cause.errno in cls._UNRETRYABLE_CONNECT_ERRNOS
+        )
+
     async def connect(self):
         """Connects to the Redis server if not already connected"""
         # try once the socket connect with the handshake, retry the whole
@@ -355,6 +375,7 @@ class AbstractConnection:
             lambda error, failure_count: self.disconnect(
                 error=error, failure_count=failure_count
             ),
+            is_retryable=self._is_retryable_connect_error,
             with_failure_count=True,
         )
 
@@ -395,17 +416,19 @@ class AbstractConnection:
             )
             raise e
         except OSError as e:
-            e = ConnectionError(self._error_message(e))
+            conn_error = ConnectionError(self._error_message(e))
             await record_error_count(
                 server_address=getattr(self, "host", None),
                 server_port=getattr(self, "port", None),
                 network_peer_address=getattr(self, "host", None),
                 network_peer_port=getattr(self, "port", None),
-                error_type=e,
+                error_type=conn_error,
                 retry_attempts=actual_retry_attempts,
                 is_internal=False,
             )
-            raise e
+            # Preserve the original OSError (with its errno) as the cause so
+            # the retry policy can tell unrecoverable failures apart.
+            raise conn_error from e
         except Exception as exc:
             raise ConnectionError(exc) from exc
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1,4 +1,5 @@
 import copy
+import errno
 import os
 import socket
 import sys
@@ -1000,6 +1001,25 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
     def _get_parser(self) -> Union[_HiredisParser, _RESP3Parser, _RESP2Parser]:
         return self._parser
 
+    # OS-level errno values for which reconnecting can never succeed, so
+    # there is no point spending the retry/backoff budget on them.
+    _UNRETRYABLE_CONNECT_ERRNOS = frozenset({errno.ENOENT})
+
+    @classmethod
+    def _is_retryable_connect_error(cls, error: BaseException) -> bool:
+        """Whether a failed connection attempt is worth retrying.
+
+        Returns ``False`` for definitively unrecoverable socket errors (e.g. a
+        Unix socket path that does not exist, ``ENOENT``) so that ``connect()``
+        fails fast instead of backing off for every retry. Transient errors
+        such as ``ECONNREFUSED`` during server startup stay retryable.
+        """
+        cause = error.__cause__
+        return not (
+            isinstance(cause, OSError)
+            and cause.errno in cls._UNRETRYABLE_CONNECT_ERRNOS
+        )
+
     def connect(self):
         "Connects to the Redis server if not already connected"
         # try once the socket connect with the handshake, retry the whole
@@ -1009,6 +1029,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 check_health=True, retry_socket_connect=False
             ),
             lambda error: self.disconnect(error),
+            is_retryable=self._is_retryable_connect_error,
         )
 
     def connect_check_health(
@@ -1044,16 +1065,18 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             )
             raise e
         except OSError as e:
-            e = ConnectionError(self._error_message(e))
+            conn_error = ConnectionError(self._error_message(e))
             record_error_count(
                 server_address=getattr(self, "host", None),
                 server_port=getattr(self, "port", None),
                 network_peer_address=getattr(self, "host", None),
                 network_peer_port=getattr(self, "port", None),
-                error_type=e,
+                error_type=conn_error,
                 retry_attempts=actual_retry_attempts[0],
             )
-            raise e
+            # Preserve the original OSError (with its errno) as the cause so
+            # the retry policy can tell unrecoverable failures apart.
+            raise conn_error from e
 
         self._sock = sock
         try:

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -3,7 +3,7 @@ import socket
 import ssl
 import types
 from unittest import mock
-from errno import ECONNREFUSED
+from errno import ECONNREFUSED, ENOENT
 from unittest.mock import patch
 
 import pytest
@@ -409,6 +409,37 @@ async def test_connect_timeout_error_without_retry():
     with pytest.raises(TimeoutError, match="Timeout connecting to server"):
         await conn.connect()
     assert conn._connect.call_count == 1
+
+
+@pytest.mark.fixed_client
+async def test_connect_without_retry_on_unrecoverable_oserror():
+    """A connect error that can never succeed on retry (e.g. a missing Unix
+    socket path, ENOENT) fails fast instead of consuming the retry budget."""
+    conn = Connection(retry=Retry(NoBackoff(), 3))
+    conn._connect = mock.AsyncMock()
+    conn._connect.side_effect = OSError(ENOENT, "No such file or directory")
+
+    with pytest.raises(ConnectionError) as excinfo:
+        await conn.connect()
+    # no retries: _connect is called exactly once
+    assert conn._connect.call_count == 1
+    # the original OSError is preserved as the cause for classification
+    assert isinstance(excinfo.value.__cause__, OSError)
+    assert excinfo.value.__cause__.errno == ENOENT
+
+
+@pytest.mark.fixed_client
+async def test_connect_retries_on_transient_oserror():
+    """A transient socket error such as ECONNREFUSED (server not up yet)
+    stays retryable, so the whole connect flow is retried as before."""
+    conn = Connection(retry=Retry(NoBackoff(), 2))
+    conn._connect = mock.AsyncMock()
+    conn._connect.side_effect = OSError(ECONNREFUSED, "Connection refused")
+
+    with pytest.raises(ConnectionError):
+        await conn.connect()
+    # 2 retries --> 3 attempts
+    assert conn._connect.call_count == 3
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,7 +7,7 @@ import socket
 import ssl
 import threading
 import types
-from errno import ECONNREFUSED, EWOULDBLOCK
+from errno import ECONNREFUSED, ENOENT, EWOULDBLOCK
 from typing import Any
 from unittest import mock
 from unittest.mock import call, patch, MagicMock, Mock
@@ -500,6 +500,35 @@ class TestConnection:
         with pytest.raises(TimeoutError, match="Timeout connecting to server"):
             conn.connect()
         assert conn._connect.call_count == 1
+        self.clear(conn)
+
+    def test_connect_without_retry_on_unrecoverable_oserror(self):
+        """A connect error that can never succeed on retry (e.g. a missing Unix
+        socket path, ENOENT) fails fast instead of consuming the retry budget."""
+        conn = Connection(retry=Retry(NoBackoff(), 3))
+        conn._connect = mock.Mock()
+        conn._connect.side_effect = OSError(ENOENT, "No such file or directory")
+
+        with pytest.raises(ConnectionError) as excinfo:
+            conn.connect()
+        # no retries: _connect is called exactly once
+        assert conn._connect.call_count == 1
+        # the original OSError is preserved as the cause for classification
+        assert isinstance(excinfo.value.__cause__, OSError)
+        assert excinfo.value.__cause__.errno == ENOENT
+        self.clear(conn)
+
+    def test_connect_retries_on_transient_oserror(self):
+        """A transient socket error such as ECONNREFUSED (server not up yet)
+        stays retryable, so the whole connect flow is retried as before."""
+        conn = Connection(retry=Retry(NoBackoff(), 2))
+        conn._connect = mock.Mock()
+        conn._connect.side_effect = OSError(ECONNREFUSED, "Connection refused")
+
+        with pytest.raises(ConnectionError):
+            conn.connect()
+        # 2 retries --> 3 attempts
+        assert conn._connect.call_count == 3
         self.clear(conn)
 
 


### PR DESCRIPTION
## Summary

Addresses the narrow, separable problem I raised in #4026: **definitively-unrecoverable connection errors are retried with full backoff.** The intentional handshake-phase retry behavior (clarified by @petyaslavova in that thread) is left completely untouched.

Since 7.1.0, `Connection.connect()` wraps the entire connect + handshake in the retry policy. During socket establishment every `OSError` is re-wrapped into a generic `ConnectionError`; because the policy's supported errors include `ConnectionError`, these are retried up to `DEFAULT_RETRY_COUNT` (10) times with exponential backoff — even for errors that can never succeed on retry, e.g. a Unix-domain-socket `ENOENT` (the socket path simply doesn't exist). The wrap also discarded the original `errno`, so nothing downstream could distinguish a permanent failure from a transient one.

Net effect: `Redis(unix_socket_path=..., socket_connect_timeout=2)` against a missing socket spends seconds sleeping/retrying, and the common "try UDS, fall back to TCP" pattern becomes very slow.

## Change

Uses the existing `is_retryable` hook in `Retry.call_with_retry` that `connect()` simply wasn't passing:

1. **Preserve the original error** — the `OSError` → `ConnectionError` wrap now uses `raise ... from e`, so the original `errno` survives for classification.
2. **Pass an `is_retryable` predicate** from `connect()` that returns `False` for a conservative set of unrecoverable socket errnos (currently just `ENOENT`). Those fail fast; transient errors such as `ECONNREFUSED` during server startup keep retrying exactly as before.

Applied to **both** the sync (`redis/connection.py`) and async (`redis/asyncio/connection.py`) stacks.

## Tests

- `test_connect_without_retry_on_unrecoverable_oserror` (sync + async): `ENOENT` → single attempt, original `OSError` preserved as `__cause__`.
- `test_connect_retries_on_transient_oserror` (sync + async): `ECONNREFUSED` → still retried (3 attempts with `retries=2`).

## Open questions (carried over from #4026)

Kept deliberately conservative — happy to adjust to your preference:

1. **Scope of "unrecoverable":** just `ENOENT` for now — should it also include `EACCES` / `EAFNOSUPPORT` / `EPROTONOSUPPORT`?
2. **`socket_connect_timeout` as a total-time cap:** left out of scope here (a broader change carrying a deadline across retries); could be a follow-up.
3. **Default vs opt-in:** implemented as the default; happy to gate behind a flag if preferred.

Refs #4026.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow connect-path retry behavior change with conservative errno list and tests; handshake retry logic is unchanged.
> 
> **Overview**
> **Connect failures that cannot succeed on retry (e.g. missing Unix socket, `ENOENT`) now fail immediately** instead of burning the default retry count and exponential backoff.
> 
> Sync and async `Connection.connect()` pass **`is_retryable=self._is_retryable_connect_error`** into the existing `Retry.call_with_retry` hook. The predicate treats errors as non-retryable when the raised `ConnectionError` chains an `OSError` whose `errno` is in `_UNRETRYABLE_CONNECT_ERRNOS` (currently **`ENOENT` only**). **`ECONNREFUSED` and other transient errors keep retrying** as before.
> 
> **`OSError` handling during connect** now uses `raise ConnectionError(...) from e` so the original errno is available on `__cause__` for that classification. Tests cover one-shot failure on `ENOENT` and full retries on `ECONNREFUSED`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3459a64fe9262b3b96a48fff4deda3945ec52b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->