### PR TITLE
doc(connection): remove stale  arg from get_resolved_ip docstring

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -658,9 +658,6 @@ class MaintNotificationsAbstractConnection:
         First tries to get the actual IP from the socket (most accurate),
         then falls back to DNS resolution if needed.
 
-        Args:
-            connection: The connection object to extract the IP from
-
         Returns:
             str: The resolved IP address, or None if it cannot be determined
         """


### PR DESCRIPTION
## Description

`get_resolved_ip()` takes no arguments (it operates on `self`), but its docstring documented a `connection` parameter left over from an earlier signature.

This removes the stale `Args:` block to match the actual API.

## Changes

- **File**: `redis/connection.py`
- **What**: Removed the `Args: connection` block from `get_resolved_ip()` docstring
- **Risk**: Documentation only, no runtime or API impact

Fixes #4164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a docstring; no runtime or public signature changes.
> 
> **Overview**
> Fixes misleading API docs for **`MaintNotificationsAbstractConnection.get_resolved_ip()`** in `redis/connection.py`.
> 
> The method is instance-only (`self`); the docstring still listed an **`Args: connection`** block from an old signature. That block is removed so the doc matches how callers use it (e.g. **`extract_connection_details()`**, maintenance notification logging, and endpoint-type resolution).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d90860b31dae975fbd78ab1a4cdb71ee350ba24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->