### PR TITLE
feat: add MAXCOUNT/MAXSIZE support to XREAD and XREADGROUP

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -7639,6 +7639,8 @@ class StreamCommands(CommandsProtocol):
         streams: Dict[KeyT, StreamIdT],
         count: int | None = None,
         block: int | None = None,
+        max_count: int | None = None,
+        max_size: int | None = None,
     ) -> XReadResponse: ...
 
     @overload
@@ -7647,6 +7649,8 @@ class StreamCommands(CommandsProtocol):
         streams: Dict[KeyT, StreamIdT],
         count: int | None = None,
         block: int | None = None,
+        max_count: int | None = None,
+        max_size: int | None = None,
     ) -> Awaitable[XReadResponse]: ...
 
     def xread(
@@ -7654,6 +7658,8 @@ class StreamCommands(CommandsProtocol):
         streams: Dict[KeyT, StreamIdT],
         count: int | None = None,
         block: int | None = None,
+        max_count: int | None = None,
+        max_size: int | None = None,
     ) -> XReadResponse | Awaitable[XReadResponse]:
         """
         Block and monitor multiple streams for new data.
@@ -7661,10 +7667,23 @@ class StreamCommands(CommandsProtocol):
         streams: a dict of stream names to stream IDs, where
                    IDs indicate the last ID already seen.
 
-        count: if set, only return this many items, beginning with the
-               earliest available.
+        count: if set, only return this many items per stream, beginning with
+               the earliest available.
 
         block: number of milliseconds to wait, if nothing already present.
+
+        max_count: if set, cap the total number of entries returned across all
+                   streams combined. Unlike ``count`` (a per-stream limit),
+                   this is a cumulative cap over the whole reply. Must be a
+                   positive integer and, when ``count`` is also set, must be
+                   greater than or equal to ``count``. Requires Redis >= 8.10.0.
+
+        max_size: if set, a soft cap on the total server reply size in bytes
+                  across all streams combined. Measured server-side including
+                  protocol overhead, so it is not an exact application-payload
+                  size guarantee; a single available entry larger than the cap
+                  may still be returned. Must be a positive integer. Requires
+                  Redis >= 8.10.0.
 
         For more information, see https://redis.io/commands/xread
         """
@@ -7679,6 +7698,20 @@ class StreamCommands(CommandsProtocol):
                 raise DataError("XREAD count must be a positive integer")
             pieces.append(b"COUNT")
             pieces.append(str(count))
+        if max_count is not None:
+            if not isinstance(max_count, int) or max_count < 1:
+                raise DataError("XREAD max_count must be a positive integer")
+            if count is not None and max_count < count:
+                raise DataError(
+                    "XREAD max_count must be greater than or equal to count"
+                )
+            pieces.append(b"MAXCOUNT")
+            pieces.append(str(max_count))
+        if max_size is not None:
+            if not isinstance(max_size, int) or max_size < 1:
+                raise DataError("XREAD max_size must be a positive integer")
+            pieces.append(b"MAXSIZE")
+            pieces.append(str(max_size))
         if not isinstance(streams, dict) or len(streams) == 0:
             raise DataError("XREAD streams must be a non empty dict")
         pieces.append(b"STREAMS")
@@ -7711,6 +7744,8 @@ class StreamCommands(CommandsProtocol):
         block: int | None = None,
         noack: bool = False,
         claim_min_idle_time: int | None = None,
+        max_count: int | None = None,
+        max_size: int | None = None,
     ) -> XReadGroupResponse: ...
 
     @overload
@@ -7723,6 +7758,8 @@ class StreamCommands(CommandsProtocol):
         block: int | None = None,
         noack: bool = False,
         claim_min_idle_time: int | None = None,
+        max_count: int | None = None,
+        max_size: int | None = None,
     ) -> Awaitable[XReadGroupResponse]: ...
 
     def xreadgroup(
@@ -7734,6 +7771,8 @@ class StreamCommands(CommandsProtocol):
         block: int | None = None,
         noack: bool = False,
         claim_min_idle_time: int | None = None,
+        max_count: int | None = None,
+        max_size: int | None = None,
     ) -> XReadGroupResponse | Awaitable[XReadGroupResponse]:
         """
         Read from a stream via a consumer group.
@@ -7745,14 +7784,27 @@ class StreamCommands(CommandsProtocol):
         streams: a dict of stream names to stream IDs, where
                IDs indicate the last ID already seen.
 
-        count: if set, only return this many items, beginning with the
-               earliest available.
+        count: if set, only return this many items per stream, beginning with
+               the earliest available.
 
         block: number of milliseconds to wait, if nothing already present.
         noack: do not add messages to the PEL
 
         claim_min_idle_time: accepts an integer type and represents a
                              time interval in milliseconds
+
+        max_count: if set, cap the total number of entries returned across all
+                   streams combined. Unlike ``count`` (a per-stream limit),
+                   this is a cumulative cap over the whole reply. Must be a
+                   positive integer and, when ``count`` is also set, must be
+                   greater than or equal to ``count``. Requires Redis 8.10.0.
+
+        max_size: if set, a soft cap on the total server reply size in bytes
+                  across all streams combined. Measured server-side including
+                  protocol overhead, so it is not an exact application-payload
+                  size guarantee; a single available entry larger than the cap
+                  may still be returned. Must be a positive integer. Requires
+                  Redis 8.10.0.
 
         For more information, see https://redis.io/commands/xreadgroup
         """
@@ -7763,6 +7815,20 @@ class StreamCommands(CommandsProtocol):
                 raise DataError("XREADGROUP count must be a positive integer")
             pieces.append(b"COUNT")
             pieces.append(str(count))
+        if max_count is not None:
+            if not isinstance(max_count, int) or max_count < 1:
+                raise DataError("XREADGROUP max_count must be a positive integer")
+            if count is not None and max_count < count:
+                raise DataError(
+                    "XREADGROUP max_count must be greater than or equal to count"
+                )
+            pieces.append(b"MAXCOUNT")
+            pieces.append(str(max_count))
+        if max_size is not None:
+            if not isinstance(max_size, int) or max_size < 1:
+                raise DataError("XREADGROUP max_size must be a positive integer")
+            pieces.append(b"MAXSIZE")
+            pieces.append(str(max_size))
         if block is not None:
             if not isinstance(block, int) or block < 0:
                 raise DataError("XREADGROUP block must be a non-negative integer")

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -5304,6 +5304,112 @@ class TestRedisCommands:
             {strem_name: expected_entries},
         )
 
+    def _total_stream_entries(self, r, response):
+        """Count entries across all streams regardless of response shape."""
+        shape = expected_response_shape(r)
+        if shape == "legacy_resp2":
+            return sum(len(item[1]) for item in response)
+        elif shape == "legacy_resp3":
+            return sum(len(entries[0]) for entries in response.values())
+        else:
+            return sum(len(entries) for entries in response.values())
+
+    async def test_xread_max_count_max_size_validation(self, r: redis.Redis):
+        with pytest.raises(DataError):
+            await r.xread(streams={"stream": 0}, max_count=0)
+        with pytest.raises(DataError):
+            await r.xread(streams={"stream": 0}, max_count=-1)
+        with pytest.raises(DataError):
+            await r.xread(streams={"stream": 0}, max_size=0)
+        # max_count must be >= count when both are provided
+        with pytest.raises(DataError):
+            await r.xread(streams={"stream": 0}, count=5, max_count=3)
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_xread_with_max_count(self, r: redis.Redis):
+        stream = "stream"
+        for i in range(5):
+            await r.xadd(stream, {"f": i})
+
+        # max_count caps the total number of returned entries
+        res = await r.xread(streams={stream: 0}, max_count=2)
+        assert self._total_stream_entries(r, res) == 2
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_xread_with_max_size(self, r: redis.Redis):
+        stream = "stream"
+        await r.xadd(stream, {"f": "v"})
+
+        # a generous soft cap returns the available entry
+        res = await r.xread(streams={stream: 0}, max_size=65536)
+        assert self._total_stream_entries(r, res) == 1
+
+        # max_size is a soft cap: a single available entry that exceeds the cap
+        # is still returned rather than suppressed
+        res = await r.xread(streams={stream: 0}, max_size=1)
+        assert self._total_stream_entries(r, res) == 1
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_xread_max_count_cumulative_across_streams(self, r: redis.Redis):
+        stream_1 = "stream1:{maxcount}"
+        stream_2 = "stream2:{maxcount}"
+        for i in range(3):
+            await r.xadd(stream_1, {"f": i})
+        for i in range(3):
+            await r.xadd(stream_2, {"f": i})
+
+        # count is per-stream (up to 3 each), max_count caps the cumulative
+        # reply; streams are served in caller order, so stream_1 contributes 3
+        # and stream_2 contributes 1
+        res = await r.xread(streams={stream_1: 0, stream_2: 0}, count=3, max_count=4)
+        assert self._total_stream_entries(r, res) == 4
+
+    async def test_xreadgroup_max_count_max_size_validation(self, r: redis.Redis):
+        with pytest.raises(DataError):
+            await r.xreadgroup("g", "c", streams={"stream": ">"}, max_count=0)
+        with pytest.raises(DataError):
+            await r.xreadgroup("g", "c", streams={"stream": ">"}, max_size=-1)
+        with pytest.raises(DataError):
+            await r.xreadgroup("g", "c", streams={"stream": ">"}, count=5, max_count=3)
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_xreadgroup_with_max_count(self, r: redis.Redis):
+        stream = "stream"
+        group = "group"
+        consumer = "consumer"
+        for i in range(5):
+            await r.xadd(stream, {"f": i})
+        await r.xgroup_create(stream, group, 0)
+
+        # max_count caps the total number of returned entries
+        res = await r.xreadgroup(group, consumer, streams={stream: ">"}, max_count=2)
+        assert self._total_stream_entries(r, res) == 2
+        await r.xgroup_destroy(stream, group)
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_xreadgroup_max_count_cumulative_across_streams(self, r: redis.Redis):
+        stream_1 = "stream1:{grpmaxcount}"
+        stream_2 = "stream2:{grpmaxcount}"
+        group = "group"
+        consumer = "consumer"
+        for i in range(3):
+            await r.xadd(stream_1, {"f": i})
+        for i in range(3):
+            await r.xadd(stream_2, {"f": i})
+        await r.xgroup_create(stream_1, group, 0)
+        await r.xgroup_create(stream_2, group, 0)
+
+        res = await r.xreadgroup(
+            group,
+            consumer,
+            streams={stream_1: ">", stream_2: ">"},
+            count=3,
+            max_count=4,
+        )
+        assert self._total_stream_entries(r, res) == 4
+        await r.xgroup_destroy(stream_1, group)
+        await r.xgroup_destroy(stream_2, group)
+
     @skip_if_server_version_lt("5.0.0")
     async def test_xreadgroup(self, r: redis.Redis):
         stream = "stream"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7125,6 +7125,112 @@ class TestRedisCommands:
         # xread starting at the last message returns an empty list
         assert_resp_response(r, r.xread(streams={stream: m2}), [], {})
 
+    def _total_stream_entries(self, r, response):
+        """Count entries across all streams regardless of response shape."""
+        shape = expected_response_shape(r)
+        if shape == "legacy_resp2":
+            return sum(len(item[1]) for item in response)
+        elif shape == "legacy_resp3":
+            return sum(len(entries[0]) for entries in response.values())
+        else:
+            return sum(len(entries) for entries in response.values())
+
+    def test_xread_max_count_max_size_validation(self, r):
+        with pytest.raises(DataError):
+            r.xread(streams={"stream": 0}, max_count=0)
+        with pytest.raises(DataError):
+            r.xread(streams={"stream": 0}, max_count=-1)
+        with pytest.raises(DataError):
+            r.xread(streams={"stream": 0}, max_size=0)
+        # max_count must be >= count when both are provided
+        with pytest.raises(DataError):
+            r.xread(streams={"stream": 0}, count=5, max_count=3)
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_xread_with_max_count(self, r):
+        stream = "stream"
+        for i in range(5):
+            r.xadd(stream, {"f": i})
+
+        # max_count caps the total number of returned entries
+        res = r.xread(streams={stream: 0}, max_count=2)
+        assert self._total_stream_entries(r, res) == 2
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_xread_with_max_size(self, r):
+        stream = "stream"
+        r.xadd(stream, {"f": "v"})
+
+        # a generous soft cap returns the available entry
+        res = r.xread(streams={stream: 0}, max_size=65536)
+        assert self._total_stream_entries(r, res) == 1
+
+        # max_size is a soft cap: a single available entry that exceeds the cap
+        # is still returned rather than suppressed
+        res = r.xread(streams={stream: 0}, max_size=1)
+        assert self._total_stream_entries(r, res) == 1
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_xread_max_count_cumulative_across_streams(self, r):
+        stream_1 = "stream1:{maxcount}"
+        stream_2 = "stream2:{maxcount}"
+        for i in range(3):
+            r.xadd(stream_1, {"f": i})
+        for i in range(3):
+            r.xadd(stream_2, {"f": i})
+
+        # count is per-stream (up to 3 each), max_count caps the cumulative
+        # reply; streams are served in caller order, so stream_1 contributes 3
+        # and stream_2 contributes 1
+        res = r.xread(streams={stream_1: 0, stream_2: 0}, count=3, max_count=4)
+        assert self._total_stream_entries(r, res) == 4
+
+    def test_xreadgroup_max_count_max_size_validation(self, r):
+        with pytest.raises(DataError):
+            r.xreadgroup("g", "c", streams={"stream": ">"}, max_count=0)
+        with pytest.raises(DataError):
+            r.xreadgroup("g", "c", streams={"stream": ">"}, max_size=-1)
+        with pytest.raises(DataError):
+            r.xreadgroup("g", "c", streams={"stream": ">"}, count=5, max_count=3)
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_xreadgroup_with_max_count(self, r):
+        stream = "stream"
+        group = "group"
+        consumer = "consumer"
+        for i in range(5):
+            r.xadd(stream, {"f": i})
+        r.xgroup_create(stream, group, 0)
+
+        # max_count caps the total number of returned entries
+        res = r.xreadgroup(group, consumer, streams={stream: ">"}, max_count=2)
+        assert self._total_stream_entries(r, res) == 2
+        r.xgroup_destroy(stream, group)
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_xreadgroup_max_count_cumulative_across_streams(self, r):
+        stream_1 = "stream1:{grpmaxcount}"
+        stream_2 = "stream2:{grpmaxcount}"
+        group = "group"
+        consumer = "consumer"
+        for i in range(3):
+            r.xadd(stream_1, {"f": i})
+        for i in range(3):
+            r.xadd(stream_2, {"f": i})
+        r.xgroup_create(stream_1, group, 0)
+        r.xgroup_create(stream_2, group, 0)
+
+        res = r.xreadgroup(
+            group,
+            consumer,
+            streams={stream_1: ">", stream_2: ">"},
+            count=3,
+            max_count=4,
+        )
+        assert self._total_stream_entries(r, res) == 4
+        r.xgroup_destroy(stream_1, group)
+        r.xgroup_destroy(stream_2, group)
+
     @skip_if_server_version_lt("5.0.0")
     def test_xreadgroup(self, r):
         stream = "stream"


### PR DESCRIPTION

## Change summary

This pull request adds support for the `MAXCOUNT` and `MAXSIZE` modifiers to the
`XREAD` and `XREADGROUP` stream commands, exposed as two new optional keyword
arguments — `max_count` and `max_size` — on `StreamCommands.xread` and
`StreamCommands.xreadgroup` in `redis/commands/core.py`. Redis 8.10 extends these
commands with cumulative reply limits: whereas `count` is a *per-stream* limit,
`max_count` caps the total number of entries returned across all streams
combined, and `max_size` applies a soft cap on the total server reply size in
bytes across all streams.

The new parameters are appended to the command as `MAXCOUNT <n>` / `MAXSIZE <n>`
after the existing `COUNT` handling and before the `STREAMS` keyword. Input is
validated client-side consistent with the existing `count` checks: both must be
positive integers (otherwise `DataError` is raised), and when `count` is also
supplied, `max_count` must be greater than or equal to `count`. The docstrings
are updated to clarify that `count` is per-stream, to document the new
cumulative semantics, and to note that `max_size` is a *soft* cap measured
server-side (including protocol overhead), so a single available entry larger
than the cap may still be returned.

The changes are additive and fully backward compatible: both new arguments
default to `None`, so existing callers and command output are unchanged, and no
public signature, return type, or error semantics are altered. Sync/async parity
is preserved within the single `core.py` mixin — the shared implementation and
its sync/`Awaitable` `@overload` declarations were both extended, and the test
mirrors under `tests/` and `tests/test_asyncio/` were updated together.

## Test coverage

New tests were added to both `tests/test_commands.py` and
`tests/test_asyncio/test_commands.py`. A shared `_total_stream_entries` helper
counts returned entries across the RESP2/legacy-RESP3/unified response shapes so
assertions hold under all protocol/`legacy_responses` combinations. Validation
tests assert `DataError` for non-positive `max_count`/`max_size` and for
`max_count < count`; these run unconditionally since validation is client-side.

Behavioral tests (guarded by `skip_if_server_version_lt("8.9.0")`) cover
`max_count` capping the total entries, `max_size` returning a single entry under
both a generous cap and a sub-entry-size soft cap, and the cumulative-across-
streams behavior for both `xread` and `xreadgroup` (per-stream `count=3` with
`max_count=4` yields 4 total, served in caller order).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 311ed70642d7748dbe4e177ed9b959495fd1c2c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->