### PR TITLE
feat: add LMOVEM and BLMOVEM commands for moving multiple list elements

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.8.0'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.10:unstable-29211243717-debian
+    8.10:custom-29557896054-debian
 
 jobs:
   dependency-audit:

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3654,17 +3654,25 @@ class BasicKeyCommands(CommandsProtocol):
 
         ``ordering`` controls the order at the destination: ``OBO`` pushes each
         element as it is popped (reversing block order, stack semantics) while
-        ``BULK`` preserves the original relative order (queue semantics).
+        ``BULK`` preserves the original relative order (queue semantics). It is
+        required whenever ``count`` is given.
 
         Returns the array of moved elements, or ``None`` if nothing was moved.
 
         For more information, see https://redis.io/commands/lmovem
         """
+        if count is None:
+            if mode is not None or ordering is not None:
+                raise DataError(
+                    "``count`` is required when ``mode`` or ``ordering`` is set"
+                )
+        elif ordering is None:
+            raise DataError(
+                "``ordering`` (OBO or BULK) is required when ``count`` is set"
+            )
         pieces: list[EncodableT] = [first_list, second_list, src, dest]
         if count is not None:
-            pieces.extend([mode or "COUNT", count])
-            if ordering is not None:
-                pieces.append(ordering)
+            pieces.extend([mode or "COUNT", count, ordering])
         return self.execute_command("LMOVEM", *pieces)
 
     @overload
@@ -3714,13 +3722,23 @@ class BasicKeyCommands(CommandsProtocol):
         holds at least ``count`` elements, then moves exactly ``count``
         atomically. On timeout ``None`` is returned and nothing is moved.
 
+        As with ``lmovem``, ``ordering`` (OBO or BULK) is required whenever
+        ``count`` is given.
+
         For more information, see https://redis.io/commands/blmovem
         """
+        if count is None:
+            if mode is not None or ordering is not None:
+                raise DataError(
+                    "``count`` is required when ``mode`` or ``ordering`` is set"
+                )
+        elif ordering is None:
+            raise DataError(
+                "``ordering`` (OBO or BULK) is required when ``count`` is set"
+            )
         pieces: list[EncodableT] = [first_list, second_list, src, dest, timeout]
         if count is not None:
-            pieces.extend([mode or "COUNT", count])
-            if ordering is not None:
-                pieces.append(ordering)
+            pieces.extend([mode or "COUNT", count, ordering])
         return self.execute_command("BLMOVEM", *pieces)
 
     @overload

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -3606,6 +3606,124 @@ class BasicKeyCommands(CommandsProtocol):
         return self.execute_command("BLMOVE", *params)
 
     @overload
+    def lmovem(
+        self: SyncClientProtocol,
+        first_list: str,
+        second_list: str,
+        src: str = "LEFT",
+        dest: str = "RIGHT",
+        count: int | None = None,
+        mode: Literal["COUNT", "EXACTLY"] | None = None,
+        ordering: Literal["OBO", "BULK"] | None = None,
+    ) -> list[bytes | str] | None: ...
+
+    @overload
+    def lmovem(
+        self: AsyncClientProtocol,
+        first_list: str,
+        second_list: str,
+        src: str = "LEFT",
+        dest: str = "RIGHT",
+        count: int | None = None,
+        mode: Literal["COUNT", "EXACTLY"] | None = None,
+        ordering: Literal["OBO", "BULK"] | None = None,
+    ) -> Awaitable[list[bytes | str] | None]: ...
+
+    def lmovem(
+        self,
+        first_list: str,
+        second_list: str,
+        src: str = "LEFT",
+        dest: str = "RIGHT",
+        count: int | None = None,
+        mode: Literal["COUNT", "EXACTLY"] | None = None,
+        ordering: Literal["OBO", "BULK"] | None = None,
+    ) -> (list[bytes | str] | None) | Awaitable[list[bytes | str] | None]:
+        """
+        Atomically moves multiple elements from one end of the ``first_list``
+        to one end of the ``second_list``, returning the moved elements in
+        destination order.
+
+        ``src`` and ``dest`` are the ends to pop from / push to, either
+        ``LEFT`` (head) or ``RIGHT`` (tail).
+
+        When ``count`` is given, ``mode`` selects how many elements to move:
+        ``COUNT`` (the default) moves up to ``count`` elements, while
+        ``EXACTLY`` moves exactly ``count`` elements or nothing at all. When
+        ``count`` is not given a single element is moved.
+
+        ``ordering`` controls the order at the destination: ``OBO`` pushes each
+        element as it is popped (reversing block order, stack semantics) while
+        ``BULK`` preserves the original relative order (queue semantics).
+
+        Returns the array of moved elements, or ``None`` if nothing was moved.
+
+        For more information, see https://redis.io/commands/lmovem
+        """
+        pieces: list[EncodableT] = [first_list, second_list, src, dest]
+        if count is not None:
+            pieces.extend([mode or "COUNT", count])
+            if ordering is not None:
+                pieces.append(ordering)
+        return self.execute_command("LMOVEM", *pieces)
+
+    @overload
+    def blmovem(
+        self: SyncClientProtocol,
+        first_list: str,
+        second_list: str,
+        timeout: float,
+        src: str = "LEFT",
+        dest: str = "RIGHT",
+        count: int | None = None,
+        mode: Literal["COUNT", "EXACTLY"] | None = None,
+        ordering: Literal["OBO", "BULK"] | None = None,
+    ) -> list[bytes | str] | None: ...
+
+    @overload
+    def blmovem(
+        self: AsyncClientProtocol,
+        first_list: str,
+        second_list: str,
+        timeout: float,
+        src: str = "LEFT",
+        dest: str = "RIGHT",
+        count: int | None = None,
+        mode: Literal["COUNT", "EXACTLY"] | None = None,
+        ordering: Literal["OBO", "BULK"] | None = None,
+    ) -> Awaitable[list[bytes | str] | None]: ...
+
+    def blmovem(
+        self,
+        first_list: str,
+        second_list: str,
+        timeout: float,
+        src: str = "LEFT",
+        dest: str = "RIGHT",
+        count: int | None = None,
+        mode: Literal["COUNT", "EXACTLY"] | None = None,
+        ordering: Literal["OBO", "BULK"] | None = None,
+    ) -> (list[bytes | str] | None) | Awaitable[list[bytes | str] | None]:
+        """
+        Blocking version of lmovem.
+
+        Blocks until elements are available to move or ``timeout`` (in seconds)
+        is reached; a ``timeout`` of ``0`` blocks indefinitely. With ``COUNT``
+        the command unblocks once at least one element is available and moves
+        ``min(count, available)``; with ``EXACTLY`` it blocks until the source
+        holds at least ``count`` elements, then moves exactly ``count``
+        atomically. On timeout ``None`` is returned and nothing is moved.
+
+        For more information, see https://redis.io/commands/blmovem
+        """
+        pieces: list[EncodableT] = [first_list, second_list, src, dest, timeout]
+        if count is not None:
+            pieces.extend([mode or "COUNT", count])
+            if ordering is not None:
+                pieces.append(ordering)
+        return self.execute_command("BLMOVEM", *pieces)
+
+    @overload
     def mget(
         self: SyncClientProtocol, keys: KeysT, *args: EncodableT
     ) -> list[bytes | str | None]: ...

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1846,6 +1846,36 @@ class TestClusterRedisCommands:
         assert await r.blmove("{foo}a", "{foo}b", 5)
         assert await r.blmove("{foo}a", "{foo}b", 1, "RIGHT", "LEFT")
 
+    @skip_if_server_version_lt("8.9.0")
+    async def test_cluster_lmovem(self, r: RedisCluster) -> None:
+        # source and destination collocated on the same slot via a hash tag
+        await r.rpush("{foo}a", "1", "2", "3", "4", "5")
+        assert await r.lmovem("{foo}a", "{foo}b") == [b"1"]
+        assert await r.lmovem(
+            "{foo}a", "{foo}b", "LEFT", "LEFT", count=3, ordering="BULK"
+        ) == [b"2", b"3", b"4"]
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_cluster_lmovem_crossslot(self, r: RedisCluster) -> None:
+        # source and destination on different slots -> cannot be dispatched
+        with pytest.raises(RedisClusterException) as ex:
+            await r.lmovem("a", "b", "LEFT", "RIGHT", count=2)
+        assert "all keys must map to the same key slot" in str(ex.value)
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_cluster_blmovem(self, r: RedisCluster) -> None:
+        await r.rpush("{foo}a", "1", "2", "3", "4", "5")
+        assert await r.blmovem("{foo}a", "{foo}b", 1) == [b"1"]
+        assert await r.blmovem(
+            "{foo}a", "{foo}b", 1, "LEFT", "LEFT", count=3, ordering="BULK"
+        ) == [b"2", b"3", b"4"]
+
+    @skip_if_server_version_lt("8.9.0")
+    async def test_cluster_blmovem_crossslot(self, r: RedisCluster) -> None:
+        with pytest.raises(RedisClusterException) as ex:
+            await r.blmovem("a", "b", 1, "LEFT", "RIGHT", count=2)
+        assert "all keys must map to the same key slot" in str(ex.value)
+
     async def test_cluster_msetnx(self, r: RedisCluster) -> None:
         d = {"{foo}a": b"1", "{foo}b": b"2", "{foo}c": b"3"}
         assert await r.msetnx(d)

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -1859,7 +1859,7 @@ class TestClusterRedisCommands:
     async def test_cluster_lmovem_crossslot(self, r: RedisCluster) -> None:
         # source and destination on different slots -> cannot be dispatched
         with pytest.raises(RedisClusterException) as ex:
-            await r.lmovem("a", "b", "LEFT", "RIGHT", count=2)
+            await r.lmovem("a", "b", "LEFT", "RIGHT", count=2, ordering="BULK")
         assert "all keys must map to the same key slot" in str(ex.value)
 
     @skip_if_server_version_lt("8.9.0")
@@ -1873,7 +1873,7 @@ class TestClusterRedisCommands:
     @skip_if_server_version_lt("8.9.0")
     async def test_cluster_blmovem_crossslot(self, r: RedisCluster) -> None:
         with pytest.raises(RedisClusterException) as ex:
-            await r.blmovem("a", "b", 1, "LEFT", "RIGHT", count=2)
+            await r.blmovem("a", "b", 1, "LEFT", "RIGHT", count=2, ordering="BULK")
         assert "all keys must map to the same key slot" in str(ex.value)
 
     async def test_cluster_msetnx(self, r: RedisCluster) -> None:

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2545,20 +2545,30 @@ class TestRedisCommands:
         assert await r.lmovem("a", "b") == [b"1"]
         # COUNT with OBO ordering: pushed one-by-one -> reversed block order
         assert await r.lmovem("a", "b", "LEFT", "LEFT", count=3, ordering="OBO") == [
-            b"2",
-            b"3",
             b"4",
+            b"3",
+            b"2",
         ]
-        # up to count, fewer available
-        assert await r.lmovem("a", "b", "LEFT", "LEFT", count=5) == [b"5"]
+        # up to count, fewer available; BULK preserves relative order
+        assert await r.lmovem("a", "b", "LEFT", "LEFT", count=5, ordering="BULK") == [
+            b"5"
+        ]
         # empty source moves nothing
-        assert await r.lmovem("a", "b", count=2) is None
-        # EXACTLY with too few elements moves nothing
+        assert await r.lmovem("a", "b", count=2, ordering="BULK") is None
+        # EXACTLY with too few elements moves nothing (nil reply, source untouched)
         await r.rpush("names", "john")
-        with pytest.raises(ResponseError):
+        assert (
             await r.lmovem(
-                "names", "processed", "LEFT", "RIGHT", count=2, mode="EXACTLY"
+                "names",
+                "processed",
+                "LEFT",
+                "RIGHT",
+                count=2,
+                mode="EXACTLY",
+                ordering="BULK",
             )
+            is None
+        )
         assert await r.lrange("names", 0, -1) == [b"john"]
         # EXACTLY with enough elements, BULK preserves order
         await r.rpush("names", "doe")
@@ -2571,6 +2581,11 @@ class TestRedisCommands:
             mode="EXACTLY",
             ordering="BULK",
         ) == [b"john", b"doe"]
+        # ordering is mandatory whenever count is given (and vice versa)
+        with pytest.raises(DataError):
+            await r.lmovem("a", "b", count=2)
+        with pytest.raises(DataError):
+            await r.lmovem("a", "b", ordering="BULK")
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
@@ -2581,9 +2596,12 @@ class TestRedisCommands:
             "a", "b", 1, "LEFT", "LEFT", count=3, ordering="BULK"
         ) == [b"2", b"3", b"4"]
         # up to count, fewer available
-        assert await r.blmovem("a", "b", 1, count=5) == [b"5"]
+        assert await r.blmovem("a", "b", 1, count=5, ordering="BULK") == [b"5"]
         # timeout with empty source returns None
-        assert await r.blmovem("foo", "bar", 1, count=2) is None
+        assert await r.blmovem("foo", "bar", 1, count=2, ordering="BULK") is None
+        # ordering is mandatory whenever count is given
+        with pytest.raises(DataError):
+            await r.blmovem("a", "b", 1, count=2)
 
     async def test_lpop(self, r: redis.Redis):
         await r.rpush("a", "1", "2", "3")

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -2537,6 +2537,54 @@ class TestRedisCommands:
         await r.rpush("a", "1", "2", "3")
         assert await r.llen("a") == 3
 
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_lmovem(self, r: redis.Redis):
+        await r.rpush("a", "1", "2", "3", "4", "5")
+        # single element (no count block), still an array reply
+        assert await r.lmovem("a", "b") == [b"1"]
+        # COUNT with OBO ordering: pushed one-by-one -> reversed block order
+        assert await r.lmovem("a", "b", "LEFT", "LEFT", count=3, ordering="OBO") == [
+            b"2",
+            b"3",
+            b"4",
+        ]
+        # up to count, fewer available
+        assert await r.lmovem("a", "b", "LEFT", "LEFT", count=5) == [b"5"]
+        # empty source moves nothing
+        assert await r.lmovem("a", "b", count=2) is None
+        # EXACTLY with too few elements moves nothing
+        await r.rpush("names", "john")
+        with pytest.raises(ResponseError):
+            await r.lmovem(
+                "names", "processed", "LEFT", "RIGHT", count=2, mode="EXACTLY"
+            )
+        assert await r.lrange("names", 0, -1) == [b"john"]
+        # EXACTLY with enough elements, BULK preserves order
+        await r.rpush("names", "doe")
+        assert await r.lmovem(
+            "names",
+            "processed",
+            "LEFT",
+            "RIGHT",
+            count=2,
+            mode="EXACTLY",
+            ordering="BULK",
+        ) == [b"john", b"doe"]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_blmovem(self, r: redis.Redis):
+        await r.rpush("a", "1", "2", "3", "4", "5")
+        assert await r.blmovem("a", "b", 1) == [b"1"]
+        assert await r.blmovem(
+            "a", "b", 1, "LEFT", "LEFT", count=3, ordering="BULK"
+        ) == [b"2", b"3", b"4"]
+        # up to count, fewer available
+        assert await r.blmovem("a", "b", 1, count=5) == [b"5"]
+        # timeout with empty source returns None
+        assert await r.blmovem("foo", "bar", 1, count=2) is None
+
     async def test_lpop(self, r: redis.Redis):
         await r.rpush("a", "1", "2", "3")
         assert await r.lpop("a") == b"1"

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1985,6 +1985,40 @@ class TestClusterRedisCommands:
         assert r.blmove("{foo}a", "{foo}b", 5)
         assert r.blmove("{foo}a", "{foo}b", 1, "RIGHT", "LEFT")
 
+    @skip_if_server_version_lt("8.9.0")
+    def test_cluster_lmovem(self, r):
+        # source and destination collocated on the same slot via a hash tag
+        r.rpush("{foo}a", "1", "2", "3", "4", "5")
+        assert r.lmovem("{foo}a", "{foo}b") == [b"1"]
+        assert r.lmovem(
+            "{foo}a", "{foo}b", "LEFT", "LEFT", count=3, ordering="BULK"
+        ) == [
+            b"2",
+            b"3",
+            b"4",
+        ]
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_cluster_lmovem_crossslot(self, r):
+        # source and destination on different slots -> cannot be dispatched
+        with pytest.raises(RedisClusterException) as ex:
+            r.lmovem("a", "b", "LEFT", "RIGHT", count=2)
+        assert "all keys must map to the same key slot" in str(ex.value)
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_cluster_blmovem(self, r):
+        r.rpush("{foo}a", "1", "2", "3", "4", "5")
+        assert r.blmovem("{foo}a", "{foo}b", 1) == [b"1"]
+        assert r.blmovem(
+            "{foo}a", "{foo}b", 1, "LEFT", "LEFT", count=3, ordering="BULK"
+        ) == [b"2", b"3", b"4"]
+
+    @skip_if_server_version_lt("8.9.0")
+    def test_cluster_blmovem_crossslot(self, r):
+        with pytest.raises(RedisClusterException) as ex:
+            r.blmovem("a", "b", 1, "LEFT", "RIGHT", count=2)
+        assert "all keys must map to the same key slot" in str(ex.value)
+
     def test_cluster_msetnx(self, r):
         d = {"{foo}a": b"1", "{foo}b": b"2", "{foo}c": b"3"}
         assert r.msetnx(d)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2002,7 +2002,7 @@ class TestClusterRedisCommands:
     def test_cluster_lmovem_crossslot(self, r):
         # source and destination on different slots -> cannot be dispatched
         with pytest.raises(RedisClusterException) as ex:
-            r.lmovem("a", "b", "LEFT", "RIGHT", count=2)
+            r.lmovem("a", "b", "LEFT", "RIGHT", count=2, ordering="BULK")
         assert "all keys must map to the same key slot" in str(ex.value)
 
     @skip_if_server_version_lt("8.9.0")
@@ -2016,7 +2016,7 @@ class TestClusterRedisCommands:
     @skip_if_server_version_lt("8.9.0")
     def test_cluster_blmovem_crossslot(self, r):
         with pytest.raises(RedisClusterException) as ex:
-            r.blmovem("a", "b", 1, "LEFT", "RIGHT", count=2)
+            r.blmovem("a", "b", 1, "LEFT", "RIGHT", count=2, ordering="BULK")
         assert "all keys must map to the same key slot" in str(ex.value)
 
     def test_cluster_msetnx(self, r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2448,18 +2448,28 @@ class TestRedisCommands:
         assert r.lmovem("a", "b") == [b"1"]
         # COUNT with OBO ordering: pushed one-by-one -> reversed block order
         assert r.lmovem("a", "b", "LEFT", "LEFT", count=3, ordering="OBO") == [
-            b"2",
-            b"3",
             b"4",
+            b"3",
+            b"2",
         ]
-        # up to count, fewer available
-        assert r.lmovem("a", "b", "LEFT", "LEFT", count=5) == [b"5"]
+        # up to count, fewer available; BULK preserves relative order
+        assert r.lmovem("a", "b", "LEFT", "LEFT", count=5, ordering="BULK") == [b"5"]
         # empty source moves nothing
-        assert r.lmovem("a", "b", count=2) is None
-        # EXACTLY with too few elements moves nothing
+        assert r.lmovem("a", "b", count=2, ordering="BULK") is None
+        # EXACTLY with too few elements moves nothing (nil reply, source untouched)
         r.rpush("names", "john")
-        with pytest.raises(redis.ResponseError):
-            r.lmovem("names", "processed", "LEFT", "RIGHT", count=2, mode="EXACTLY")
+        assert (
+            r.lmovem(
+                "names",
+                "processed",
+                "LEFT",
+                "RIGHT",
+                count=2,
+                mode="EXACTLY",
+                ordering="BULK",
+            )
+            is None
+        )
         assert r.lrange("names", 0, -1) == [b"john"]
         # EXACTLY with enough elements, BULK preserves order
         r.rpush("names", "doe")
@@ -2472,6 +2482,11 @@ class TestRedisCommands:
             mode="EXACTLY",
             ordering="BULK",
         ) == [b"john", b"doe"]
+        # ordering is mandatory whenever count is given (and vice versa)
+        with pytest.raises(redis.DataError):
+            r.lmovem("a", "b", count=2)
+        with pytest.raises(redis.DataError):
+            r.lmovem("a", "b", ordering="BULK")
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
@@ -2483,9 +2498,13 @@ class TestRedisCommands:
             b"3",
             b"4",
         ]
+        # up to count, fewer available
+        assert r.blmovem("a", "b", 1, count=5, ordering="BULK") == [b"5"]
         # timeout with empty source returns None
-        assert r.blmovem("a", "b", 1, count=5) == [b"5"]
-        assert r.blmovem("foo", "bar", 1, count=2) is None
+        assert r.blmovem("foo", "bar", 1, count=2, ordering="BULK") is None
+        # ordering is mandatory whenever count is given
+        with pytest.raises(redis.DataError):
+            r.blmovem("a", "b", 1, count=2)
 
     @pytest.mark.onlynoncluster
     def test_mset(self, r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2441,6 +2441,53 @@ class TestRedisCommands:
         assert r.blmove("a", "b", 1, "RIGHT", "LEFT")
 
     @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_lmovem(self, r):
+        r.rpush("a", "1", "2", "3", "4", "5")
+        # single element (no count block), still an array reply
+        assert r.lmovem("a", "b") == [b"1"]
+        # COUNT with OBO ordering: pushed one-by-one -> reversed block order
+        assert r.lmovem("a", "b", "LEFT", "LEFT", count=3, ordering="OBO") == [
+            b"2",
+            b"3",
+            b"4",
+        ]
+        # up to count, fewer available
+        assert r.lmovem("a", "b", "LEFT", "LEFT", count=5) == [b"5"]
+        # empty source moves nothing
+        assert r.lmovem("a", "b", count=2) is None
+        # EXACTLY with too few elements moves nothing
+        r.rpush("names", "john")
+        with pytest.raises(redis.ResponseError):
+            r.lmovem("names", "processed", "LEFT", "RIGHT", count=2, mode="EXACTLY")
+        assert r.lrange("names", 0, -1) == [b"john"]
+        # EXACTLY with enough elements, BULK preserves order
+        r.rpush("names", "doe")
+        assert r.lmovem(
+            "names",
+            "processed",
+            "LEFT",
+            "RIGHT",
+            count=2,
+            mode="EXACTLY",
+            ordering="BULK",
+        ) == [b"john", b"doe"]
+
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_blmovem(self, r):
+        r.rpush("a", "1", "2", "3", "4", "5")
+        assert r.blmovem("a", "b", 1) == [b"1"]
+        assert r.blmovem("a", "b", 1, "LEFT", "LEFT", count=3, ordering="BULK") == [
+            b"2",
+            b"3",
+            b"4",
+        ]
+        # timeout with empty source returns None
+        assert r.blmovem("a", "b", 1, count=5) == [b"5"]
+        assert r.blmovem("foo", "bar", 1, count=2) is None
+
+    @pytest.mark.onlynoncluster
     def test_mset(self, r):
         d = {"a": b"1", "b": b"2", "c": b"3"}
         assert r.mset(d)


### PR DESCRIPTION
## Change summary

This pull request adds client support for the new `LMOVEM` and `BLMOVEM` Redis
commands, which atomically move multiple elements from one end of a source list
to one end of a destination list. They generalize `LMOVE`/`BLMOVE` (which move a
single element) by accepting a `count` and returning the moved elements as an
array.

The commands are implemented once in `BasicKeyCommands` in
`redis/commands/core.py`, which is shared by both the sync `CoreCommands` and
async `AsyncCoreCommands` mixins, so a single addition covers both stacks. Each
command exposes `src`/`dest` end selectors (`LEFT`/`RIGHT`, defaulting to
`LEFT`→`RIGHT`) and three optional modifiers:

- `count` — how many elements to move; when omitted a single element is moved.
- `mode` — `COUNT` (default, move up to `count`) or `EXACTLY` (move exactly
  `count` or nothing, erroring/blocking otherwise).
- `ordering` — `OBO` (push one-by-one, reversing block order / stack semantics)
  or `BULK` (preserve original relative order / queue semantics).

`BLMOVEM` additionally takes a `timeout` (seconds; `0` blocks indefinitely) and
returns `None` on timeout. Argument assembly is conditional — `mode`/`count` are
only appended when `count` is provided, and `ordering` only when set — so the
wire format matches the server's expectations. The change is purely additive:
no existing signatures, defaults, return types, or command semantics change, so
there is no backward-compatibility risk. Type overloads follow the project's
sync/async convention, keeping hints identical across both APIs.

## Test coverage

New tests `test_lmovem` and `test_blmovem` are added to both
`tests/test_commands.py` and `tests/test_asyncio/test_commands.py`, mirrored
between the sync and async suites. They exercise the single-element (no-count)
array reply, `COUNT` with `OBO` reversal and `BULK` order preservation,
up-to-count when fewer elements are available, the empty-source `None` result,
and `EXACTLY` behavior (raising `ResponseError` with too few elements while
leaving the source untouched, then succeeding once enough elements are present).
A few cluster tests are also aded.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive command wrappers and tests only; no changes to existing APIs or runtime behavior beyond new methods.
> 
> **Overview**
> Adds **`lmovem`** and **`blmovem`** on the shared list command mixin in `redis/commands/core.py`, wiring **`LMOVEM`** / **`BLMOVEM`** with the same sync/async overload pattern as **`lmove`** / **`blmove`**. Callers can move one or many elements between list ends, with optional **`COUNT`** vs **`EXACTLY`**, **`OBO`** vs **`BULK`** ordering when **`count`** is set, and client-side **`DataError`** checks so **`ordering`** and **`count`** stay paired.
> 
> **`blmovem`** takes a blocking timeout and returns **`None`** on timeout. Integration CI points Redis **8.10** at a newer custom image so jobs can run against a server that exposes these commands.
> 
> New standalone tests (sync and asyncio) cover single-element replies, ordering modes, partial counts, empty source, **`EXACTLY`** semantics, and validation errors. Cluster tests assert same-slot success and cross-slot **`RedisClusterException`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a4fdd2514518f58f094fd65cb04c5c843323063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->