### PR TITLE
Fix ipv6 parsing. Removing dead code for OSS maint notifications

### DIFF
--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -253,7 +253,7 @@ class MaintenanceNotificationsParser:
             host, port = None, None
         else:
             value = safe_str(response[3])
-            host, port = value.split(":")
+            host, port = value.rsplit(":", 1)
             port = int(port) if port is not None else None
 
         return NodeMovingNotification(id, host, port, ttl)

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -403,17 +403,6 @@ class AsyncOSSMaintNotificationsHandler:
         self._lock = asyncio.Lock()
         self._background_tasks: set[asyncio.Task] = set()
 
-    def get_handler_for_connection(self) -> "AsyncOSSMaintNotificationsHandler":
-        # Copy all data that should be shared between connections
-        # but each connection should have its own handler
-        # since each connection can be in a different state
-        copy = AsyncOSSMaintNotificationsHandler(self.cluster_client, self.config)
-        copy._processed_notifications = self._processed_notifications
-        copy._in_progress = self._in_progress
-        copy._lock = self._lock
-        copy._background_tasks = self._background_tasks
-        return copy
-
     async def remove_expired_notifications(self) -> None:
         async with self._lock:
             for n in tuple(self._processed_notifications):
@@ -509,7 +498,7 @@ class AsyncOSSMaintNotificationsHandler:
                 src_address,
                 dest_mappings,
             ) in notification.nodes_to_slots_mapping.items():
-                src_host, src_port = src_address.split(":")
+                src_host, src_port = src_address.rsplit(":", 1)
                 src_node = self.cluster_client.nodes_manager.get_node(
                     host=src_host, port=int(src_port)
                 )
@@ -517,7 +506,7 @@ class AsyncOSSMaintNotificationsHandler:
                     affected_nodes.add(src_node)
                 for dest_mapping in dest_mappings:
                     for dest_address in dest_mapping.keys():
-                        dest_host, dest_port = dest_address.split(":")
+                        dest_host, dest_port = dest_address.rsplit(":", 1)
                         additional_startup_nodes_info.append(
                             (dest_host, int(dest_port))
                         )

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -1124,16 +1124,6 @@ class OSSMaintNotificationsHandler:
         self._in_progress = set()
         self._lock = threading.RLock()
 
-    def get_handler_for_connection(self):
-        # Copy all data that should be shared between connections
-        # but each connection should have its own pool handler
-        # since each connection can be in a different state
-        copy = OSSMaintNotificationsHandler(self.cluster_client, self.config)
-        copy._processed_notifications = self._processed_notifications
-        copy._in_progress = self._in_progress
-        copy._lock = self._lock
-        return copy
-
     def remove_expired_notifications(self):
         with self._lock:
             for notification in tuple(self._processed_notifications):
@@ -1182,16 +1172,16 @@ class OSSMaintNotificationsHandler:
                 src_address,
                 dest_mappings,
             ) in notification.nodes_to_slots_mapping.items():
-                src_host, src_port = src_address.split(":")
+                src_host, src_port = src_address.rsplit(":", 1)
                 src_node = self.cluster_client.nodes_manager.get_node(
-                    host=src_host, port=src_port
+                    host=src_host, port=int(src_port)
                 )
                 if src_node is not None:
                     affected_nodes.add(src_node)
 
                 for dest_mapping in dest_mappings:
                     for dest_address in dest_mapping.keys():
-                        dest_host, dest_port = dest_address.split(":")
+                        dest_host, dest_port = dest_address.rsplit(":", 1)
                         additional_startup_nodes_info.append(
                             (dest_host, int(dest_port))
                         )

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -28,6 +28,7 @@ from redis.maint_notifications import (
     NodeMigratedNotification,
     NodeMigratingNotification,
     NodeMovingNotification,
+    OSSNodeMigratedNotification,
 )
 from redis.utils import SENTINEL
 
@@ -494,6 +495,55 @@ async def test_async_pool_update_oss_handler_wires_existing_connections():
     assert new_connection._parser.node_moving_push_handler_func is None
     assert new_connection._oss_cluster_maint_notifications_handler is oss_handler
     assert new_connection._parser.oss_cluster_maint_push_handler_func is not None
+
+
+def _make_async_oss_handler():
+    cluster_client = MagicMock()
+    # Keep the affected-nodes set and the node-reconnect loop empty so the test
+    # focuses purely on how src/dest addresses are parsed.
+    cluster_client.nodes_manager.get_node.return_value = None
+    cluster_client.nodes_manager.nodes_cache.values.return_value = []
+    cluster_client.nodes_manager.initialize = AsyncMock()
+    config = MaintNotificationsConfig(enabled=True)
+    return AsyncOSSMaintNotificationsHandler(cluster_client, config), cluster_client
+
+
+@pytest.mark.asyncio
+async def test_async_handle_smigrated_parses_ipv4_addresses():
+    handler, cluster_client = _make_async_oss_handler()
+    notification = OSSNodeMigratedNotification(
+        id=1,
+        nodes_to_slots_mapping={"127.0.0.1:6379": [{"127.0.0.1:6380": "1-100"}]},
+    )
+
+    await handler.handle_oss_maintenance_completed_notification(notification)
+
+    cluster_client.nodes_manager.get_node.assert_called_once_with(
+        host="127.0.0.1", port=6379
+    )
+    cluster_client.nodes_manager.initialize.assert_called_once_with(
+        additional_startup_nodes_info=[("127.0.0.1", 6380)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handle_smigrated_parses_ipv6_addresses():
+    handler, cluster_client = _make_async_oss_handler()
+    # IPv6 literals contain multiple colons; a naive split(":") would raise
+    # ValueError on the host/port unpack.
+    notification = OSSNodeMigratedNotification(
+        id=1,
+        nodes_to_slots_mapping={"2001:db8::1:6379": [{"2001:db8::2:6380": "1-100"}]},
+    )
+
+    await handler.handle_oss_maintenance_completed_notification(notification)
+
+    cluster_client.nodes_manager.get_node.assert_called_once_with(
+        host="2001:db8::1", port=6379
+    )
+    cluster_client.nodes_manager.initialize.assert_called_once_with(
+        additional_startup_nodes_info=[("2001:db8::2", 6380)],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/maint_notifications/test_maint_notifications.py
+++ b/tests/maint_notifications/test_maint_notifications.py
@@ -2,6 +2,7 @@ import threading
 from unittest.mock import Mock, call, patch, MagicMock
 import pytest
 
+from redis._parsers.base import MaintenanceNotificationsParser
 from redis.connection import ConnectionInterface, MaintNotificationsAbstractConnection
 
 from redis.maint_notifications import (
@@ -16,6 +17,7 @@ from redis.maint_notifications import (
     MaintNotificationsConfig,
     MaintNotificationsPoolHandler,
     MaintNotificationsConnectionHandler,
+    OSSMaintNotificationsHandler,
     MaintenanceState,
     EndpointType,
 )
@@ -636,6 +638,86 @@ class TestOSSNodeMigratedNotification:
         assert (
             len(notification_set) == 2
         )  # notification1 and notification2 should be the same
+
+
+@pytest.mark.fixed_client
+class TestOSSMaintNotificationsHandler:
+    """Test address parsing in the OSS SMIGRATED handler."""
+
+    def _make_handler(self):
+        cluster_client = MagicMock()
+        # Keep the affected-nodes set and the node-reconnect loop empty so the
+        # test focuses purely on how src/dest addresses are parsed.
+        cluster_client.nodes_manager.get_node.return_value = None
+        cluster_client.nodes_manager.nodes_cache.values.return_value = []
+        config = MaintNotificationsConfig(enabled=True)
+        return OSSMaintNotificationsHandler(cluster_client, config), cluster_client
+
+    def test_handle_smigrated_parses_ipv4_addresses(self):
+        handler, cluster_client = self._make_handler()
+        notification = OSSNodeMigratedNotification(
+            id=1,
+            nodes_to_slots_mapping={"127.0.0.1:6379": [{"127.0.0.1:6380": "1-100"}]},
+        )
+
+        handler.handle_oss_maintenance_completed_notification(notification)
+
+        cluster_client.nodes_manager.get_node.assert_called_once_with(
+            host="127.0.0.1", port=6379
+        )
+        cluster_client.nodes_manager.initialize.assert_called_once_with(
+            disconnect_startup_nodes_pools=False,
+            additional_startup_nodes_info=[("127.0.0.1", 6380)],
+        )
+
+    def test_handle_smigrated_parses_ipv6_addresses(self):
+        handler, cluster_client = self._make_handler()
+        # IPv6 literals contain multiple colons; a naive split(":") would raise
+        # ValueError on the host/port unpack.
+        notification = OSSNodeMigratedNotification(
+            id=1,
+            nodes_to_slots_mapping={
+                "2001:db8::1:6379": [{"2001:db8::2:6380": "1-100"}]
+            },
+        )
+
+        handler.handle_oss_maintenance_completed_notification(notification)
+
+        cluster_client.nodes_manager.get_node.assert_called_once_with(
+            host="2001:db8::1", port=6379
+        )
+        cluster_client.nodes_manager.initialize.assert_called_once_with(
+            disconnect_startup_nodes_pools=False,
+            additional_startup_nodes_info=[("2001:db8::2", 6380)],
+        )
+
+
+@pytest.mark.fixed_client
+class TestMaintenanceNotificationsParser:
+    """Test endpoint parsing in the shared MOVING push parser."""
+
+    def test_parse_moving_msg_ipv4_endpoint(self):
+        notification = MaintenanceNotificationsParser.parse_moving_msg(
+            ["MOVING", 1, 10, "1.2.3.4:6379"]
+        )
+        assert notification.new_node_host == "1.2.3.4"
+        assert notification.new_node_port == 6379
+
+    def test_parse_moving_msg_ipv6_endpoint(self):
+        # IPv6 literals contain multiple colons; a naive split(":") would raise
+        # ValueError on the host/port unpack.
+        notification = MaintenanceNotificationsParser.parse_moving_msg(
+            ["MOVING", 1, 10, "2001:db8::1:6379"]
+        )
+        assert notification.new_node_host == "2001:db8::1"
+        assert notification.new_node_port == 6379
+
+    def test_parse_moving_msg_none_endpoint(self):
+        notification = MaintenanceNotificationsParser.parse_moving_msg(
+            ["MOVING", 1, 10, None]
+        )
+        assert notification.new_node_host is None
+        assert notification.new_node_port is None
 
 
 @pytest.mark.fixed_client


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster maintenance topology refresh and MOVING endpoint parsing; incorrect parsing could mis-route reconnects, though scope is limited to maint-notification paths and is covered by new tests.
> 
> **Overview**
> Fixes **maintenance notification** parsing when endpoints use **IPv6** (or any address with multiple colons) by splitting `host:port` on the **last** colon (`rsplit(":", 1)`) instead of `split(":")`, which could raise `ValueError` or mis-split addresses like `2001:db8::1:6379`.
> 
> This applies to **MOVING** push parsing (`parse_moving_msg`) and **OSS SMIGRATED** handling when resolving source/destination nodes for cluster re-initialization. The sync OSS path also passes **`int(src_port)`** into `nodes_manager.get_node`.
> 
> Removes unused **`get_handler_for_connection`** from sync and async **`OSSMaintNotificationsHandler`** (pool-level handlers still use their own copy pattern). Adds unit tests for IPv4/IPv6 address parsing on the parser and both OSS handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4949c6d50f7ba04816d063adfbac43b833da5957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->