### PR TITLE
feat: add async maintenance-notifications support for standalone and cluster clients

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -29,6 +29,7 @@ numpy>=1.24.0,<2.0 ; platform_python_implementation == "PyPy"
 
 redis-entraid==1.2.1
 pybreaker>=1.4.0
+aiohttp>=3.9.0
 
 xxhash==3.6.0
 

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -253,7 +253,7 @@ class MaintenanceNotificationsParser:
             host, port = None, None
         else:
             value = safe_str(response[3])
-            host, port = value.split(":")
+            host, port = value.rsplit(":", 1)
             port = int(port) if port is not None else None
 
         return NodeMovingNotification(id, host, port, ttl)

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -81,12 +81,14 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
+from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
 from redis.typing import ChannelT, EncodableT, KeyT, PubSubHandler, Subscription
 from redis.utils import (
     SENTINEL,
     SSL_AVAILABLE,
     _set_info_logger,
+    check_protocol_version,
     deprecated_args,
     deprecated_function,
     safe_str,
@@ -288,6 +290,7 @@ class Redis(
         protocol: int | None = None,
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
     ):
         """
         Initialize a new Redis client.
@@ -323,6 +326,14 @@ class Redis(
             options that are not available are skipped. Pass `None` or `{}` to
             avoid setting additional TCP keepalive options. Argument is ignored
             when connection_pool is provided.
+        maint_notifications_config:
+            configures the pool to support maintenance notifications - see
+            `redis.maint_notifications.MaintNotificationsConfig` for details.
+            Only supported with RESP3
+            If not provided and protocol is RESP3, the maintenance notifications
+            will be enabled by default (logic is included in the connection pool
+            initialization).
+            Argument is ignored when connection_pool is provided.
         """
         kwargs: Dict[str, Any]
         if event_dispatcher is None:
@@ -376,10 +387,21 @@ class Redis(
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:
+                if (
+                    maint_notifications_config
+                    and maint_notifications_config.enabled is True
+                ):
+                    raise RedisError(
+                        "Maintenance notifications are not supported with Unix "
+                        "domain socket connections"
+                    )
                 kwargs.update(
                     {
                         "path": unix_socket_path,
                         "connection_class": UnixDomainSocketConnection,
+                        "maint_notifications_config": MaintNotificationsConfig(
+                            enabled=False
+                        ),
                     }
                 )
             else:
@@ -412,6 +434,19 @@ class Redis(
                             "ssl_password": ssl_password,
                         }
                     )
+            maint_notifications_enabled = (
+                maint_notifications_config and maint_notifications_config.enabled
+            )
+            if maint_notifications_enabled and not check_protocol_version(protocol, 3):
+                raise RedisError(
+                    "Maintenance notifications handlers on connection are only supported with RESP version 3"
+                )
+            if maint_notifications_config:
+                kwargs.update(
+                    {
+                        "maint_notifications_config": maint_notifications_config,
+                    }
+                )
             # This arg only used if no pool is passed in
             self.auto_close_connection_pool = auto_close_connection_pool
             connection_pool = ConnectionPool(**kwargs)
@@ -764,7 +799,7 @@ class Redis(
         if close_connection_pool or (
             close_connection_pool is None and self.auto_close_connection_pool
         ):
-            await self.connection_pool.disconnect()
+            await self.connection_pool.aclose()
 
     @deprecated_function(version="5.0.1", reason="Use aclose() instead", name="close")
     async def close(self, close_connection_pool: Optional[bool] = None) -> None:
@@ -865,10 +900,15 @@ class Redis(
             )
             raise
         finally:
-            if self.single_connection_client:
-                self._single_conn_lock.release()
-            if not self.connection:
-                await pool.release(conn)
+            try:
+                if self.single_connection_client and conn and conn.should_reconnect():
+                    await self._close_connection(conn)
+                    await conn.connect()
+            finally:
+                if self.single_connection_client:
+                    self._single_conn_lock.release()
+                if not self.connection:
+                    await pool.release(conn)
 
     async def parse_response(
         self, connection: Connection, command_name: Union[str, bytes], **options

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -56,6 +56,7 @@ from redis.asyncio.connection import (
     parse_url,
 )
 from redis.asyncio.lock import Lock
+from redis.asyncio.maint_notifications import AsyncOSSMaintNotificationsHandler
 from redis.asyncio.observability.recorder import (
     record_error_count,
     record_operation_duration,
@@ -111,6 +112,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
+from redis.maint_notifications import MaintNotificationsConfig
 from redis.typing import (
     AnyKeyT,
     ChannelT,
@@ -122,6 +124,7 @@ from redis.typing import (
 from redis.utils import (
     SENTINEL,
     SSL_AVAILABLE,
+    check_protocol_version,
     deprecated_args,
     deprecated_function,
     safe_str,
@@ -143,7 +146,72 @@ TargetNodesT = TypeVar(
 )
 
 
-class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommands):
+class AsyncMaintNotificationsAbstractRedisCluster:
+    """
+    Mixin for async cluster maintenance notifications handling.
+
+    Intended to be used with multiple inheritance alongside RedisCluster.
+    All logic related to cluster-level maintenance notifications is encapsulated here.
+    """
+
+    def __init__(
+        self,
+        maint_notifications_config: MaintNotificationsConfig | None,
+        **kwargs,
+    ) -> None:
+        # The RESP3 requirement is validated in RedisCluster.__init__ before the
+        # NodesManager is constructed; this mixin is only ever run from there, so
+        # the config it receives has already been validated.
+        is_protocol_supported = check_protocol_version(kwargs.get("protocol"), 3)
+
+        if maint_notifications_config is None and is_protocol_supported:
+            maint_notifications_config = MaintNotificationsConfig()
+
+        self.maint_notifications_config = maint_notifications_config
+
+        if self.maint_notifications_config and self.maint_notifications_config.enabled:
+            self._oss_cluster_maint_notifications_handler = (
+                AsyncOSSMaintNotificationsHandler(self, self.maint_notifications_config)
+            )
+            self._update_connection_kwargs_for_maint_notifications(
+                self._oss_cluster_maint_notifications_handler
+            )
+            # Connections are created lazily via ClusterNode.acquire_connection()
+            # during nodes_manager.initialize() (which runs after __init__), so
+            # injecting into the shared connection_kwargs covers nodes discovered
+            # later. Startup nodes are the exception — they were built before this
+            # runs with their own kwargs snapshot — so the helper above also
+            # updates them directly.
+        else:
+            self._oss_cluster_maint_notifications_handler = None
+
+    def _update_connection_kwargs_for_maint_notifications(
+        self,
+        oss_cluster_maint_notifications_handler: AsyncOSSMaintNotificationsHandler,
+    ) -> None:
+        maint_kwargs = {
+            "oss_cluster_maint_notifications_handler": oss_cluster_maint_notifications_handler,
+            "maint_notifications_config": oss_cluster_maint_notifications_handler.config,
+        }
+        # Shared template used for every node created from now on (e.g. nodes
+        # discovered during nodes_manager.initialize()).
+        self.nodes_manager.connection_kwargs.update(maint_kwargs)
+        # Startup nodes were constructed before this mixin ran, so each one
+        # snapshotted connection_kwargs without the handler. Their connections
+        # are created lazily, so updating their per-node kwargs now is in time —
+        # otherwise initialize() opens the topology-discovery connection (CLUSTER
+        # SLOTS) on a startup node with no push handler wired and silently drops
+        # the maintenance notifications carried on that connection.
+        for node in self.nodes_manager.startup_nodes.values():
+            node.connection_kwargs.update(maint_kwargs)
+
+
+class RedisCluster(
+    AbstractRedis,
+    AbstractRedisCluster,
+    AsyncMaintNotificationsAbstractRedisCluster,
+    AsyncRedisClusterCommands,
+):
     """
     Create a new RedisCluster client.
 
@@ -294,6 +362,8 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
     __slots__ = (
         "_initialize",
         "_lock",
+        "maint_notifications_config",
+        "_oss_cluster_maint_notifications_handler",
         "retry",
         "command_flags",
         "commands_parser",
@@ -378,6 +448,7 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
         address_remap: Callable[[Tuple[str, int]], Tuple[str, int]] | None = None,
         event_dispatcher: EventDispatcher | None = None,
         policy_resolver: AsyncPolicyResolver = AsyncStaticPolicyResolver(),
+        maint_notifications_config: MaintNotificationsConfig | None = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -474,6 +545,22 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             kwargs["response_callbacks"]["CLUSTER SHARDS"] = parse_cluster_shards
         self.connection_kwargs = kwargs
 
+        # Validate maint_notifications_config before NodesManager is constructed
+        # so that a bad config doesn't leak an open NodesManager.
+        if (
+            maint_notifications_config
+            and maint_notifications_config.enabled
+            and not check_protocol_version(protocol, 3)
+        ):
+            raise RedisError(
+                "Maintenance notifications are only supported with RESP version 3"
+            )
+        if check_protocol_version(protocol, 3) and maint_notifications_config is None:
+            maint_notifications_config = MaintNotificationsConfig()
+        # Initialize to None so aclose() and any error-path code never sees an
+        # unset slot, even if __init__ raises before the mixin runs.
+        self._oss_cluster_maint_notifications_handler = None
+
         if startup_nodes:
             passed_nodes = []
             for node in startup_nodes:
@@ -499,6 +586,11 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             dynamic_startup_nodes=dynamic_startup_nodes,
             address_remap=address_remap,
             event_dispatcher=self._event_dispatcher,
+        )
+        AsyncMaintNotificationsAbstractRedisCluster.__init__(
+            self,
+            maint_notifications_config=maint_notifications_config,
+            protocol=protocol,
         )
         self.encoder = Encoder(encoding, encoding_errors, decode_responses)
         self.read_from_replicas = read_from_replicas
@@ -588,6 +680,13 @@ class RedisCluster(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterCommand
             async with self._lock:
                 if not self._initialize:
                     self._initialize = True
+                    if self._oss_cluster_maint_notifications_handler:
+                        tasks = list(
+                            self._oss_cluster_maint_notifications_handler._background_tasks
+                        )
+                        for task in tasks:
+                            task.cancel()
+                        await asyncio.gather(*tasks, return_exceptions=True)
                     await self.nodes_manager.aclose()
                     await self.nodes_manager.aclose("startup_nodes")
 
@@ -1846,11 +1945,26 @@ class NodesManager:
 
         for name, node in new.items():
             if name in old:
-                # Preserve the existing node but mark connections for reconnect.
-                # This method is sync so we can't call disconnect_free_connections()
-                # which is async. Instead, we mark free connections for reconnect
-                # and they will be lazily disconnected when acquired via
-                # disconnect_if_needed() to avoid race conditions.
+                # Preserve the existing node but mark ALL its connections for
+                # reconnect on every topology refresh.
+                #
+                # Why recycle every preserved node's connections, not just the
+                # ones whose slots/role changed?
+                #   set_nodes only sees the old vs new node dicts; it does not
+                #   track which specific nodes had slot-ownership or role changes
+                #   during this refresh. Rather than try to diff that (and risk
+                #   serving a connection whose cached routing/READONLY state is
+                #   now stale), we conservatively refresh every preserved node.
+                #   Reconnect is lazy and cheap, so the extra churn is acceptable
+                #   in exchange for never serving a stale connection after a
+                #   topology change.
+                #
+                # Why mark-for-reconnect instead of disconnecting here?
+                #   set_nodes is sync but disconnect_free_connections() is async,
+                #   so we cannot disconnect inline. Marking both in-use and free
+                #   connections for reconnect lets them be lazily disconnected on
+                #   next acquire via disconnect_if_needed(), which avoids races.
+                #
                 # TODO: Make this method async in the next major release to allow
                 # immediate disconnection of free connections.
                 existing_node = old[name]

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -342,6 +342,12 @@ class AsyncMaintNotificationsAbstractConnection:
         parser.set_oss_cluster_maint_push_handler(
             oss_cluster_maint_notifications_handler.handle_notification
         )
+        # OSS cluster mode and pool-handler mode are mutually exclusive. Clear
+        # any node-moving/pool handler a default (RESP3 "auto") pool wired in
+        # __init__ so this existing connection is not configured with both.
+        parser.set_node_moving_push_handler(None)
+        self._maint_notifications_pool_handler = None
+
         self._oss_cluster_maint_notifications_handler = (
             oss_cluster_maint_notifications_handler
         )

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -63,6 +63,7 @@ else:
 from redis.asyncio.maint_notifications import (
     AsyncMaintNotificationsConnectionHandler,
     AsyncMaintNotificationsPoolHandler,
+    AsyncOSSMaintNotificationsHandler,
 )
 from redis.asyncio.observability.recorder import (
     record_connection_closed,
@@ -163,6 +164,9 @@ class AsyncMaintNotificationsAbstractConnection:
         orig_host_address: str | None = None,
         orig_socket_timeout: float | None = None,
         orig_socket_connect_timeout: float | None = None,
+        oss_cluster_maint_notifications_handler: (
+            AsyncOSSMaintNotificationsHandler | None
+        ) = None,
         parser: BaseParser | None = None,
     ) -> None:
         self.maint_notifications_config = maint_notifications_config
@@ -175,6 +179,7 @@ class AsyncMaintNotificationsAbstractConnection:
             orig_host_address,
             orig_socket_timeout,
             orig_socket_connect_timeout,
+            oss_cluster_maint_notifications_handler,
             parser,
         )
 
@@ -221,6 +226,9 @@ class AsyncMaintNotificationsAbstractConnection:
         orig_host_address: str | None = None,
         orig_socket_timeout: float | None = None,
         orig_socket_connect_timeout: float | None = None,
+        oss_cluster_maint_notifications_handler: (
+            AsyncOSSMaintNotificationsHandler | None
+        ) = None,
         parser: BaseParser | None = None,
     ) -> None:
         if (
@@ -229,6 +237,7 @@ class AsyncMaintNotificationsAbstractConnection:
         ):
             self._maint_notifications_pool_handler = None
             self._maint_notifications_connection_handler = None
+            self._oss_cluster_maint_notifications_handler = None
             return
 
         if not parser:
@@ -253,10 +262,6 @@ class AsyncMaintNotificationsAbstractConnection:
                 maint_notifications_pool_handler.get_handler_for_connection()
             )
             self._maint_notifications_pool_handler.set_connection(self)
-            # Set up pool handler to parser
-            parser.set_node_moving_push_handler(
-                self._maint_notifications_pool_handler.handle_notification
-            )
         else:
             self._maint_notifications_pool_handler = None
 
@@ -265,6 +270,23 @@ class AsyncMaintNotificationsAbstractConnection:
                 self, self.maint_notifications_config
             )
         )
+
+        if oss_cluster_maint_notifications_handler:
+            self._oss_cluster_maint_notifications_handler = (
+                oss_cluster_maint_notifications_handler
+            )
+            parser.set_oss_cluster_maint_push_handler(
+                oss_cluster_maint_notifications_handler.handle_notification
+            )
+        else:
+            self._oss_cluster_maint_notifications_handler = None
+
+        # Set up pool handler to parser if available
+        if self._maint_notifications_pool_handler:
+            parser.set_node_moving_push_handler(
+                self._maint_notifications_pool_handler.handle_notification
+            )
+
         # Set up connection handler
         parser.set_maintenance_push_handler(
             self._maint_notifications_connection_handler.handle_notification
@@ -310,6 +332,33 @@ class AsyncMaintNotificationsAbstractConnection:
         else:
             self._maint_notifications_connection_handler.config = (
                 maint_notifications_pool_handler.config
+            )
+
+    def set_maint_notifications_cluster_handler_for_connection(
+        self,
+        oss_cluster_maint_notifications_handler: AsyncOSSMaintNotificationsHandler,
+    ) -> None:
+        parser = self._get_push_notifications_parser()
+        parser.set_oss_cluster_maint_push_handler(
+            oss_cluster_maint_notifications_handler.handle_notification
+        )
+        self._oss_cluster_maint_notifications_handler = (
+            oss_cluster_maint_notifications_handler
+        )
+
+        # Update maintenance notification connection handler if it doesn't exist
+        if not self._maint_notifications_connection_handler:
+            self._maint_notifications_connection_handler = (
+                AsyncMaintNotificationsConnectionHandler(
+                    self, oss_cluster_maint_notifications_handler.config
+                )
+            )
+            parser.set_maintenance_push_handler(
+                self._maint_notifications_connection_handler.handle_notification
+            )
+        else:
+            self._maint_notifications_connection_handler.config = (
+                oss_cluster_maint_notifications_handler.config
             )
 
     async def activate_maint_notifications_handling_if_enabled(
@@ -395,27 +444,15 @@ class AsyncMaintNotificationsAbstractConnection:
             # Stream might not be connected or peer address lookup might fail.
             pass
 
-        # Method 2: Fallback to DNS resolution of the host.
-        # This is less accurate but works when stream peer info is not available.
-        try:
-            host = getattr(self, "host", None)
-            port = getattr(self, "port", 6379)
-            if host:
-                # Use getaddrinfo to resolve the hostname to IP.
-                # This mimics what the connection would do during _connect().
-                addr_info = socket.getaddrinfo(
-                    host, port, socket.AF_UNSPEC, socket.SOCK_STREAM
-                )
-                if addr_info:
-                    # Return the IP from the first result.
-                    # addr_info[0] is (family, socktype, proto, canonname, sockaddr).
-                    # sockaddr[0] is the IP address.
-                    return str(addr_info[0][4][0])
-        except (AttributeError, OSError, socket.gaierror):
-            # DNS resolution might fail.
-            pass
-
-        return None
+        # Method 2: Fall back to the configured host (which may be an IP or an
+        # FQDN). We intentionally do NOT call socket.getaddrinfo() here: this
+        # method is only used for debug logging and runs on the event loop, so a
+        # blocking DNS resolution would stall it. During maintenance the debug-log
+        # path is invoked once per notification while connections are repeatedly
+        # disconnected/reconnected (so getpeername() returns None) — a blocking
+        # getaddrinfo on an FQDN host there can freeze the loop for seconds and
+        # trip unrelated connect timeouts.
+        return getattr(self, "host", None)
 
     @property
     def maintenance_state(self) -> MaintenanceState:
@@ -574,6 +611,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         orig_host_address: str | None = None,
         orig_socket_timeout: float | None = None,
         orig_socket_connect_timeout: float | None = None,
+        oss_cluster_maint_notifications_handler: (
+            AsyncOSSMaintNotificationsHandler | None
+        ) = None,
     ):
         """
         Initialize a new async Connection.
@@ -671,6 +711,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             orig_host_address,
             orig_socket_timeout,
             orig_socket_connect_timeout,
+            oss_cluster_maint_notifications_handler,
             self._parser,
         )
 
@@ -1816,6 +1857,9 @@ class AsyncMaintNotificationsAbstractConnectionPool:
     def __init__(
         self,
         maint_notifications_config: MaintNotificationsConfig | None = None,
+        oss_cluster_maint_notifications_handler: (
+            "AsyncOSSMaintNotificationsHandler | None"
+        ) = None,
         **kwargs: Any,
     ) -> None:
         protocol = kwargs.get("protocol")
@@ -1859,6 +1903,7 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                         "without a host"
                     )
                 self._maint_notifications_pool_handler = None
+                self._oss_cluster_maint_notifications_handler = None
                 return
 
             if not is_protocol_supported:
@@ -1866,14 +1911,25 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                     "Maintenance notifications handlers on connection are only supported with RESP version 3"
                 )
 
-            self._maint_notifications_pool_handler = AsyncMaintNotificationsPoolHandler(
-                self, maint_notifications_config
-            )
-            self._update_connection_kwargs_for_maint_notifications(
-                maint_notifications_pool_handler=self._maint_notifications_pool_handler
-            )
+            if oss_cluster_maint_notifications_handler:
+                self._oss_cluster_maint_notifications_handler = (
+                    oss_cluster_maint_notifications_handler
+                )
+                self._update_connection_kwargs_for_maint_notifications(
+                    oss_cluster_maint_notifications_handler=self._oss_cluster_maint_notifications_handler
+                )
+                self._maint_notifications_pool_handler = None
+            else:
+                self._oss_cluster_maint_notifications_handler = None
+                self._maint_notifications_pool_handler = (
+                    AsyncMaintNotificationsPoolHandler(self, maint_notifications_config)
+                )
+                self._update_connection_kwargs_for_maint_notifications(
+                    maint_notifications_pool_handler=self._maint_notifications_pool_handler
+                )
         else:
             self._maint_notifications_pool_handler = None
+            self._oss_cluster_maint_notifications_handler = None
 
     async def _on_close(self) -> None:
         """Hook invoked from the pool's ``aclose()`` before the pool is shut down."""
@@ -1927,16 +1983,24 @@ class AsyncMaintNotificationsAbstractConnectionPool:
             The maintenance notifications config is stored in the pool handler.
             If the pool handler is not set, the maintenance notifications are not enabled.
         """
-        maint_notifications_config = (
-            self._maint_notifications_pool_handler.config
-            if self._maint_notifications_pool_handler
-            else None
-        )
+        if self._oss_cluster_maint_notifications_handler:
+            maint_notifications_config = (
+                self._oss_cluster_maint_notifications_handler.config
+            )
+        else:
+            maint_notifications_config = (
+                self._maint_notifications_pool_handler.config
+                if self._maint_notifications_pool_handler
+                else None
+            )
         return maint_notifications_config and maint_notifications_config.enabled
 
     async def update_maint_notifications_config(
         self,
         maint_notifications_config: MaintNotificationsConfig,
+        oss_cluster_maint_notifications_handler: (
+            AsyncOSSMaintNotificationsHandler | None
+        ) = None,
     ) -> None:
         """
         Updates the maintenance notifications configuration.
@@ -1953,58 +2017,75 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 "Cannot disable maintenance notifications after enabling them"
             )
 
-        if (
-            maint_notifications_config.enabled
-            and not self._maintenance_notifications_supported()
-        ):
-            if maint_notifications_config.enabled is True:
-                # Unix sockets do not have a host endpoint for CLIENT
-                # MAINT_NOTIFICATIONS to describe.
-                if "path" in self.connection_kwargs:
-                    raise RedisError(
-                        "Maintenance notifications are not supported for "
-                        "Unix domain socket connections"
-                    )
-
-                # Custom connection classes must inherit the async maintenance
-                # mixin so handlers can update connection state safely.
-                if not self._maintenance_notifications_connection_class_supported():
-                    connection_class = getattr(self, "connection_class", None)
-                    connection_class_name = getattr(
-                        connection_class, "__name__", connection_class
-                    )
-                    raise RedisError(
-                        "Maintenance notifications are not supported for "
-                        f"connection class {connection_class_name}"
-                    )
-
-                # TCP-like connections still need a host to identify the
-                # endpoint that can move during maintenance.
-                raise RedisError(
-                    "Maintenance notifications are not supported for connections "
-                    "without a host"
-                )
-            self._maint_notifications_pool_handler = None
-            return
-
-        if not self._maint_notifications_pool_handler:
-            self._maint_notifications_pool_handler = AsyncMaintNotificationsPoolHandler(
-                self, maint_notifications_config
+        if oss_cluster_maint_notifications_handler:
+            self._oss_cluster_maint_notifications_handler = (
+                oss_cluster_maint_notifications_handler
             )
+            # OSS cluster mode and pool-handler mode are mutually exclusive
+            # (see __init__). A pool created with the default RESP3 "auto"
+            # config wires a pool handler before this method runs; clear it so
+            # new and existing connections are not configured with both handlers.
+            self._maint_notifications_pool_handler = None
         else:
-            self._maint_notifications_pool_handler.config = maint_notifications_config
+            if (
+                maint_notifications_config.enabled
+                and not self._maintenance_notifications_supported()
+            ):
+                if maint_notifications_config.enabled is True:
+                    # Unix sockets do not have a host endpoint for CLIENT
+                    # MAINT_NOTIFICATIONS to describe.
+                    if "path" in self.connection_kwargs:
+                        raise RedisError(
+                            "Maintenance notifications are not supported for "
+                            "Unix domain socket connections"
+                        )
+
+                    # Custom connection classes must inherit the async maintenance
+                    # mixin so handlers can update connection state safely.
+                    if not self._maintenance_notifications_connection_class_supported():
+                        connection_class = getattr(self, "connection_class", None)
+                        connection_class_name = getattr(
+                            connection_class, "__name__", connection_class
+                        )
+                        raise RedisError(
+                            "Maintenance notifications are not supported for "
+                            f"connection class {connection_class_name}"
+                        )
+
+                    # TCP-like connections still need a host to identify the
+                    # endpoint that can move during maintenance.
+                    raise RedisError(
+                        "Maintenance notifications are not supported for connections "
+                        "without a host"
+                    )
+                self._maint_notifications_pool_handler = None
+                return
+
+            if not self._maint_notifications_pool_handler:
+                self._maint_notifications_pool_handler = (
+                    AsyncMaintNotificationsPoolHandler(self, maint_notifications_config)
+                )
+            else:
+                self._maint_notifications_pool_handler.config = (
+                    maint_notifications_config
+                )
 
         self._update_connection_kwargs_for_maint_notifications(
-            maint_notifications_pool_handler=self._maint_notifications_pool_handler
+            maint_notifications_pool_handler=self._maint_notifications_pool_handler,
+            oss_cluster_maint_notifications_handler=self._oss_cluster_maint_notifications_handler,
         )
         await self._update_maint_notifications_configs_for_connections(
-            maint_notifications_pool_handler=self._maint_notifications_pool_handler
+            maint_notifications_pool_handler=self._maint_notifications_pool_handler,
+            oss_cluster_maint_notifications_handler=self._oss_cluster_maint_notifications_handler,
         )
 
     def _update_connection_kwargs_for_maint_notifications(
         self,
         maint_notifications_pool_handler: (
             AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        oss_cluster_maint_notifications_handler: (
+            AsyncOSSMaintNotificationsHandler | None
         ) = None,
     ) -> None:
         """
@@ -2020,6 +2101,17 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                     "maint_notifications_config": maint_notifications_pool_handler.config,
                 }
             )
+        if oss_cluster_maint_notifications_handler:
+            self.connection_kwargs.update(
+                {
+                    "oss_cluster_maint_notifications_handler": oss_cluster_maint_notifications_handler,
+                    "maint_notifications_config": oss_cluster_maint_notifications_handler.config,
+                }
+            )
+            # OSS cluster mode and pool-handler mode are mutually exclusive.
+            # Drop any pool handler a default (RESP3 "auto") pool creation may
+            # have wired so future connections are not configured with both.
+            self.connection_kwargs.pop("maint_notifications_pool_handler", None)
 
         # Store original connection parameters for maintenance notifications.
         if self.connection_kwargs.get("orig_host_address", None) is None:
@@ -2042,29 +2134,61 @@ class AsyncMaintNotificationsAbstractConnectionPool:
         maint_notifications_pool_handler: (
             AsyncMaintNotificationsPoolHandler | None
         ) = None,
+        oss_cluster_maint_notifications_handler: (
+            AsyncOSSMaintNotificationsHandler | None
+        ) = None,
     ) -> None:
         """Update the maintenance notifications config for all connections in the pool."""
         async with self._get_pool_lock():
-            for conn in self._get_free_connections():
-                if not maint_notifications_pool_handler:
-                    raise ValueError("maint_notifications_pool_handler must be set")
-                conn.set_maint_notifications_pool_handler_for_connection(
-                    maint_notifications_pool_handler
-                )
-                conn.maint_notifications_config = (
-                    maint_notifications_pool_handler.config
-                )
+            for conn in list(self._get_free_connections()):
+                if oss_cluster_maint_notifications_handler:
+                    conn.set_maint_notifications_cluster_handler_for_connection(
+                        oss_cluster_maint_notifications_handler
+                    )
+                    conn.maint_notifications_config = (
+                        oss_cluster_maint_notifications_handler.config
+                    )
+                elif maint_notifications_pool_handler:
+                    conn.set_maint_notifications_pool_handler_for_connection(
+                        maint_notifications_pool_handler
+                    )
+                    conn.maint_notifications_config = (
+                        maint_notifications_pool_handler.config
+                    )
+                else:
+                    raise ValueError(
+                        "Either maint_notifications_pool_handler or "
+                        "oss_cluster_maint_notifications_handler must be set"
+                    )
                 await conn.disconnect()
 
-            for conn in self._get_in_use_connections():
-                if not maint_notifications_pool_handler:
-                    raise ValueError("maint_notifications_pool_handler must be set")
-                conn.set_maint_notifications_pool_handler_for_connection(
-                    maint_notifications_pool_handler
-                )
-                conn.maint_notifications_config = (
-                    maint_notifications_pool_handler.config
-                )
+            for conn in list(self._get_in_use_connections()):
+                if oss_cluster_maint_notifications_handler:
+                    # Use set_maint_notifications_cluster_handler_for_connection
+                    # (not _configure_maintenance_notifications) so the parser is
+                    # obtained from the connection itself. _configure_* requires a
+                    # parser argument and would raise here; it would also reset the
+                    # connection's orig_* settings, which is wrong for an in-use
+                    # (active) connection. This mirrors the idle-connection branch
+                    # above and the pool-handler branches.
+                    conn.set_maint_notifications_cluster_handler_for_connection(
+                        oss_cluster_maint_notifications_handler
+                    )
+                    conn.maint_notifications_config = (
+                        oss_cluster_maint_notifications_handler.config
+                    )
+                elif maint_notifications_pool_handler:
+                    conn.set_maint_notifications_pool_handler_for_connection(
+                        maint_notifications_pool_handler
+                    )
+                    conn.maint_notifications_config = (
+                        maint_notifications_pool_handler.config
+                    )
+                else:
+                    raise ValueError(
+                        "Either maint_notifications_pool_handler or "
+                        "oss_cluster_maint_notifications_handler must be set"
+                    )
                 conn.mark_for_reconnect()
 
     def _should_update_connection(

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -451,13 +451,14 @@ class AsyncMaintNotificationsAbstractConnection:
             pass
 
         # Method 2: Fall back to the configured host (which may be an IP or an
-        # FQDN). We intentionally do NOT call socket.getaddrinfo() here: this
-        # method is only used for debug logging and runs on the event loop, so a
-        # blocking DNS resolution would stall it. During maintenance the debug-log
-        # path is invoked once per notification while connections are repeatedly
-        # disconnected/reconnected (so getpeername() returns None) — a blocking
-        # getaddrinfo on an FQDN host there can freeze the loop for seconds and
-        # trip unrelated connect timeouts.
+        # FQDN). Unlike the sync client we intentionally do NOT call
+        # socket.getaddrinfo() here: this method runs on the event loop, so a
+        # blocking DNS resolution would stall it. On the endpoint-type handshake
+        # path (get_endpoint_type) getpeername() above always succeeds because the
+        # writer was just connected, so this fallback is only reached by the
+        # debug-log call sites during reconnects — where returning the host is
+        # fine. A blocking getaddrinfo on an FQDN host there can freeze the loop
+        # for seconds and trip unrelated connect timeouts.
         return getattr(self, "host", None)
 
     @property

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2224,7 +2224,7 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 return False
         elif matching_pattern == "notification_hash":
             if (
-                matching_notification_hash
+                matching_notification_hash is not None
                 and conn.maintenance_notification_hash != matching_notification_hash
             ):
                 return False

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import copy
 import inspect
 import math
@@ -12,9 +13,11 @@ from itertools import chain
 from types import MappingProxyType
 from typing import (
     Any,
+    AsyncIterator,
     Callable,
     Iterable,
     List,
+    Literal,
     Mapping,
     Optional,
     Protocol,
@@ -57,6 +60,10 @@ if sys.version_info >= (3, 11, 3):
 else:
     from async_timeout import timeout as async_timeout
 
+from redis.asyncio.maint_notifications import (
+    AsyncMaintNotificationsConnectionHandler,
+    AsyncMaintNotificationsPoolHandler,
+)
 from redis.asyncio.observability.recorder import (
     record_connection_closed,
     record_connection_count,
@@ -77,12 +84,20 @@ from redis.exceptions import (
     ResponseError,
     TimeoutError,
 )
+from redis.maint_notifications import (
+    MaintenanceState,
+    MaintNotificationsConfig,
+    NodeMovingNotification,
+    _build_moving_cleanup_connection_kwargs,
+    _build_moving_connection_kwargs,
+)
 from redis.observability.metrics import CloseReason
 from redis.typing import EncodableT
 from redis.utils import (
     DEFAULT_RESP_VERSION,
     HIREDIS_AVAILABLE,
     SENTINEL,
+    check_protocol_version,
     str_if_bytes,
 )
 
@@ -93,6 +108,7 @@ from .._defaults import (
     get_default_socket_keepalive_options,
 )
 from .._parsers import (
+    AsyncPushNotificationsParser,
     BaseParser,
     Encoder,
     _AsyncHiredisParser,
@@ -105,7 +121,6 @@ SYM_DOLLAR = b"$"
 SYM_CRLF = b"\r\n"
 SYM_LF = b"\n"
 SYM_EMPTY = b""
-
 
 DefaultParser: Type[Union[_AsyncRESP2Parser, _AsyncRESP3Parser, _AsyncHiredisParser]]
 if HIREDIS_AVAILABLE:
@@ -125,7 +140,367 @@ class AsyncConnectCallbackProtocol(Protocol):
 ConnectCallbackT = Union[ConnectCallbackProtocol, AsyncConnectCallbackProtocol]
 
 
-class AbstractConnection:
+class AsyncMaintNotificationsAbstractConnection:
+    """
+    Internal mixin for async maintenance notification state and parser handlers.
+
+    The sync implementation uses the same mixin-style structure. The async
+    version keeps the notification state and parser handler installation close
+    to the connection without sending the server-side handshake; that is wired
+    in a later step.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        maint_notifications_config: MaintNotificationsConfig | None,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        maintenance_state: MaintenanceState = MaintenanceState.NONE,
+        maintenance_notification_hash: int | None = None,
+        orig_host_address: str | None = None,
+        orig_socket_timeout: float | None = None,
+        orig_socket_connect_timeout: float | None = None,
+        parser: BaseParser | None = None,
+    ) -> None:
+        self.maint_notifications_config = maint_notifications_config
+        self.maintenance_state = maintenance_state
+        self.maintenance_notification_hash = maintenance_notification_hash
+        self._processed_start_maint_notifications: set[int] = set()
+        self._skipped_end_maint_notifications: set[int] = set()
+        self._configure_maintenance_notifications(
+            maint_notifications_pool_handler,
+            orig_host_address,
+            orig_socket_timeout,
+            orig_socket_connect_timeout,
+            parser,
+        )
+
+    @abstractmethod
+    def _get_parser(self) -> BaseParser:
+        pass
+
+    def _get_push_notifications_parser(self) -> AsyncPushNotificationsParser:
+        parser = self._get_parser()
+        if not isinstance(parser, (_AsyncHiredisParser, _AsyncRESP3Parser)):
+            raise RedisError(
+                "Maintenance notifications are only supported with hiredis and RESP3 parsers!"
+            )
+        return parser
+
+    @abstractmethod
+    def get_protocol(self):
+        pass
+
+    @abstractmethod
+    async def send_command(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    @abstractmethod
+    async def read_response(
+        self,
+        disable_decoding: bool = False,
+        timeout: float | None = None,
+        *,
+        disconnect_on_error: bool = True,
+        push_request: bool | None = False,
+    ) -> Any:
+        pass
+
+    @abstractmethod
+    def getpeername(self) -> str | None:
+        pass
+
+    def _configure_maintenance_notifications(
+        self,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        orig_host_address: str | None = None,
+        orig_socket_timeout: float | None = None,
+        orig_socket_connect_timeout: float | None = None,
+        parser: BaseParser | None = None,
+    ) -> None:
+        if (
+            not self.maint_notifications_config
+            or not self.maint_notifications_config.enabled
+        ):
+            self._maint_notifications_pool_handler = None
+            self._maint_notifications_connection_handler = None
+            return
+
+        if not parser:
+            raise RedisError(
+                "To configure maintenance notifications, a parser must be provided!"
+            )
+
+        if not isinstance(parser, _AsyncHiredisParser) and not isinstance(
+            parser, _AsyncRESP3Parser
+        ):
+            raise RedisError(
+                "Maintenance notifications are only supported with hiredis and RESP3 parsers!"
+            )
+
+        if maint_notifications_pool_handler:
+            # Extract a reference to a new pool handler that copies all properties
+            # of the original one and has a different connection reference
+            # This is needed because when we attach the handler to the parser
+            # we need to make sure that the handler has a reference to the
+            # connection that the parser is attached to.
+            self._maint_notifications_pool_handler = (
+                maint_notifications_pool_handler.get_handler_for_connection()
+            )
+            self._maint_notifications_pool_handler.set_connection(self)
+            # Set up pool handler to parser
+            parser.set_node_moving_push_handler(
+                self._maint_notifications_pool_handler.handle_notification
+            )
+        else:
+            self._maint_notifications_pool_handler = None
+
+        self._maint_notifications_connection_handler = (
+            AsyncMaintNotificationsConnectionHandler(
+                self, self.maint_notifications_config
+            )
+        )
+        # Set up connection handler
+        parser.set_maintenance_push_handler(
+            self._maint_notifications_connection_handler.handle_notification
+        )
+
+        self.orig_host_address = orig_host_address if orig_host_address else self.host
+        self.orig_socket_timeout = (
+            orig_socket_timeout if orig_socket_timeout else self.socket_timeout
+        )
+        self.orig_socket_connect_timeout = (
+            orig_socket_connect_timeout
+            if orig_socket_connect_timeout
+            else self.socket_connect_timeout
+        )
+
+    def set_maint_notifications_pool_handler_for_connection(
+        self, maint_notifications_pool_handler: AsyncMaintNotificationsPoolHandler
+    ) -> None:
+        # Deep copy the pool handler to avoid sharing the same pool handler
+        # between multiple connections, because otherwise each connection will override
+        # the connection reference and the pool handler will only hold a reference
+        # to the last connection that was set.
+        maint_notifications_pool_handler_copy = (
+            maint_notifications_pool_handler.get_handler_for_connection()
+        )
+        maint_notifications_pool_handler_copy.set_connection(self)
+        parser = self._get_push_notifications_parser()
+        parser.set_node_moving_push_handler(
+            maint_notifications_pool_handler_copy.handle_notification
+        )
+        self._maint_notifications_pool_handler = maint_notifications_pool_handler_copy
+
+        # Update maintenance notification connection handler if it doesn't exist
+        if not self._maint_notifications_connection_handler:
+            self._maint_notifications_connection_handler = (
+                AsyncMaintNotificationsConnectionHandler(
+                    self, maint_notifications_pool_handler.config
+                )
+            )
+            parser.set_maintenance_push_handler(
+                self._maint_notifications_connection_handler.handle_notification
+            )
+        else:
+            self._maint_notifications_connection_handler.config = (
+                maint_notifications_pool_handler.config
+            )
+
+    async def activate_maint_notifications_handling_if_enabled(
+        self, check_health: bool = True
+    ) -> None:
+        # Send maintenance notifications handshake if RESP3 is active
+        # and maintenance notifications are enabled
+        # and we have a host to determine the endpoint type from
+        # When the maint_notifications_config enabled mode is "auto",
+        # we just log a warning if the handshake fails
+        # When the mode is enabled=True, we raise an exception in case of failure
+        host = getattr(self, "host", None)
+        if (
+            check_protocol_version(self.get_protocol(), 3)
+            and self.maint_notifications_config
+            and self.maint_notifications_config.enabled
+            and self._maint_notifications_connection_handler
+            and host is not None
+        ):
+            await self._enable_maintenance_notifications(
+                maint_notifications_config=self.maint_notifications_config,
+                check_health=check_health,
+            )
+
+    async def _enable_maintenance_notifications(
+        self,
+        maint_notifications_config: MaintNotificationsConfig,
+        check_health: bool = True,
+    ) -> None:
+        try:
+            host = getattr(self, "host", None)
+            if host is None:
+                raise ValueError(
+                    "Cannot enable maintenance notifications for connection"
+                    " object that doesn't have a host attribute."
+                )
+
+            endpoint_type = maint_notifications_config.get_endpoint_type(host, self)
+            await self.send_command(
+                "CLIENT",
+                "MAINT_NOTIFICATIONS",
+                "ON",
+                "moving-endpoint-type",
+                endpoint_type.value,
+                check_health=check_health,
+            )
+            response = await self.read_response()
+            if not response or str_if_bytes(response) != "OK":
+                raise ResponseError(
+                    "The server doesn't support maintenance notifications"
+                )
+        except Exception as e:
+            if (
+                isinstance(e, ResponseError)
+                and maint_notifications_config.enabled == "auto"
+            ):
+                # Log warning but don't fail the connection
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.debug(f"Failed to enable maintenance notifications: {e}")
+            else:
+                raise
+
+    def get_resolved_ip(self) -> str | None:
+        """
+        Extract the resolved IP address from an established connection or host.
+
+        First tries to get the actual peer IP from the async stream writer, then
+        falls back to DNS resolution if needed.
+
+        Returns:
+            The resolved IP address, or None if it cannot be determined.
+        """
+
+        # Method 1: Try to get the actual IP from the established stream.
+        # This is most accurate as it shows the exact IP being used.
+        try:
+            peer_addr = self.getpeername()
+            if peer_addr:
+                return peer_addr
+        except (AttributeError, OSError):
+            # Stream might not be connected or peer address lookup might fail.
+            pass
+
+        # Method 2: Fallback to DNS resolution of the host.
+        # This is less accurate but works when stream peer info is not available.
+        try:
+            host = getattr(self, "host", None)
+            port = getattr(self, "port", 6379)
+            if host:
+                # Use getaddrinfo to resolve the hostname to IP.
+                # This mimics what the connection would do during _connect().
+                addr_info = socket.getaddrinfo(
+                    host, port, socket.AF_UNSPEC, socket.SOCK_STREAM
+                )
+                if addr_info:
+                    # Return the IP from the first result.
+                    # addr_info[0] is (family, socktype, proto, canonname, sockaddr).
+                    # sockaddr[0] is the IP address.
+                    return str(addr_info[0][4][0])
+        except (AttributeError, OSError, socket.gaierror):
+            # DNS resolution might fail.
+            pass
+
+        return None
+
+    @property
+    def maintenance_state(self) -> MaintenanceState:
+        return self._maintenance_state
+
+    @maintenance_state.setter
+    def maintenance_state(self, state: MaintenanceState) -> None:
+        self._maintenance_state = state
+
+    def add_maint_start_notification(self, id: int) -> None:
+        self._processed_start_maint_notifications.add(id)
+
+    def get_processed_start_notifications(self) -> set[int]:
+        return self._processed_start_maint_notifications
+
+    def add_skipped_end_notification(self, id: int) -> None:
+        self._skipped_end_maint_notifications.add(id)
+
+    def get_skipped_end_notifications(self) -> set[int]:
+        return self._skipped_end_maint_notifications
+
+    def reset_received_notifications(self) -> None:
+        self._processed_start_maint_notifications.clear()
+        self._skipped_end_maint_notifications.clear()
+
+    def update_current_socket_timeout(
+        self, relaxed_timeout: float | None = None
+    ) -> None:
+        timeout = relaxed_timeout if relaxed_timeout != -1 else self.socket_timeout
+        self._reschedule_active_read_timeout(timeout)
+
+    def _reschedule_active_read_timeout(self, timeout: float | None) -> None:
+        timeout_context = getattr(self, "_active_read_timeout", None)
+        if timeout_context is None:
+            # No read_response call is currently inside its socket timeout
+            # context, so there is no in-flight deadline to relax or restore.
+            return
+
+        if timeout is None:
+            # A None socket timeout means the active read should become blocking.
+            # Python 3.11's timeout context supports clearing the deadline.
+            if hasattr(timeout_context, "reschedule"):
+                timeout_context.reschedule(None)
+            # Older async-timeout contexts cannot clear a deadline, so reject the
+            # current timeout instead of leaving a stale relaxed deadline active.
+            elif hasattr(timeout_context, "reject"):
+                timeout_context.reject()
+            return
+
+        # Active read timeouts are stored as loop-time deadlines, not durations.
+        deadline = asyncio.get_running_loop().time() + timeout
+        if hasattr(timeout_context, "reschedule"):
+            # Python 3.11 asyncio.timeout exposes reschedule().
+            timeout_context.reschedule(deadline)
+        elif hasattr(timeout_context, "update"):
+            # async-timeout exposes update() for the same deadline adjustment.
+            timeout_context.update(deadline)
+
+    def set_tmp_settings(
+        self,
+        tmp_host_address: str | object | None = SENTINEL,
+        tmp_relaxed_timeout: float | None = -1,
+    ) -> None:
+        """
+        SENTINEL keeps the host unchanged. -1 keeps the relaxed timeout unchanged.
+        """
+        if tmp_host_address and tmp_host_address != SENTINEL:
+            self.host = str(tmp_host_address)
+        if tmp_relaxed_timeout != -1:
+            self.socket_timeout = tmp_relaxed_timeout
+            self.socket_connect_timeout = tmp_relaxed_timeout
+
+    def reset_tmp_settings(
+        self,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+    ) -> None:
+        if reset_host_address:
+            self.host = self.orig_host_address
+        if reset_relaxed_timeout:
+            self.socket_timeout = self.orig_socket_timeout
+            self.socket_connect_timeout = self.orig_socket_connect_timeout
+
+
+class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
     """Manages communication to and from a Redis server"""
 
     __slots__ = (
@@ -150,6 +525,7 @@ class AbstractConnection:
         "_reader",
         "_writer",
         "_parser",
+        "_active_read_timeout",
         "_connect_callbacks",
         "_buffer_cutoff",
         "_lock",
@@ -189,6 +565,15 @@ class AbstractConnection:
         protocol: int | None = None,
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+        maintenance_state: MaintenanceState = MaintenanceState.NONE,
+        maintenance_notification_hash: int | None = None,
+        orig_host_address: str | None = None,
+        orig_socket_timeout: float | None = None,
+        orig_socket_connect_timeout: float | None = None,
     ):
         """
         Initialize a new async Connection.
@@ -253,6 +638,7 @@ class AbstractConnection:
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._socket_read_size = socket_read_size
+        self._active_read_timeout = None
         self._connect_callbacks: List[weakref.WeakMethod[ConnectCallbackT]] = []
         self._buffer_cutoff = 6000
         self._re_auth_token: Optional[TokenInterface] = None
@@ -276,6 +662,17 @@ class AbstractConnection:
             elif self.protocol == 2 and parser_class == _AsyncRESP3Parser:
                 parser_class = _AsyncRESP2Parser
         self.set_parser(parser_class)
+        AsyncMaintNotificationsAbstractConnection.__init__(
+            self,
+            maint_notifications_config,
+            maint_notifications_pool_handler,
+            maintenance_state,
+            maintenance_notification_hash,
+            orig_host_address,
+            orig_socket_timeout,
+            orig_socket_connect_timeout,
+            self._parser,
+        )
 
     def __del__(self, _warnings: Any = warnings):
         # For some reason, the individual streams don't get properly garbage
@@ -343,6 +740,21 @@ class AbstractConnection:
         :param parser_class: The required parser class
         """
         self._parser = parser_class(socket_read_size=self._socket_read_size)
+
+    def _get_parser(self) -> BaseParser:
+        return self._parser
+
+    def getpeername(self) -> str | None:
+        """
+        Returns the peer name of the connection.
+        """
+        writer = self._writer
+        if writer is None:
+            return None
+        peername = writer.get_extra_info("peername")
+        if isinstance(peername, tuple) and peername:
+            return str(peername[0])
+        return None
 
     async def connect(self):
         """Connects to the Redis server if not already connected"""
@@ -477,7 +889,7 @@ class AbstractConnection:
 
             # if resp version is specified and we have auth args,
             # we need to send them via HELLO
-        if auth_args and self.protocol not in [2, "2"]:
+        if auth_args and check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _AsyncRESP2Parser):
                 self.set_parser(_AsyncRESP3Parser)
                 # update cluster exception classes
@@ -514,7 +926,7 @@ class AbstractConnection:
                 raise AuthenticationError("Invalid Username or Password")
 
         # if resp version is specified, switch to it
-        elif self.protocol not in [2, "2"]:
+        elif check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _AsyncRESP2Parser):
                 self.set_parser(_AsyncRESP3Parser)
                 # update cluster exception classes
@@ -526,6 +938,13 @@ class AbstractConnection:
             #     "proto"
             # ) != self.protocol:
             #     raise ConnectionError("Invalid RESP version")
+
+        # Activate maintenance notifications for this connection
+        # if enabled in the configuration
+        # This is a no-op if maintenance notifications are not enabled
+        await self.activate_maint_notifications_handling_if_enabled(
+            check_health=check_health
+        )
 
         # if a client_name is given, set it
         if self.client_name:
@@ -643,6 +1062,16 @@ class AbstractConnection:
                 close_reason=CloseReason.APPLICATION_CLOSE,
             )
 
+        if self.maintenance_state == MaintenanceState.MAINTENANCE:
+            # MOVING state is owned by the pool-level TTL cleanup. Regular
+            # maintenance timeout relaxation can be restored when this
+            # connection closes, matching the sync lifecycle.
+            self.reset_tmp_settings(reset_relaxed_timeout=True)
+            self.maintenance_state = MaintenanceState.NONE
+            # reset the sets that keep track of received start maint
+            # notifications and skipped end maint notifications
+            self.reset_received_notifications()
+
     async def _send_ping(self):
         """Send PING, expect PONG in return"""
         await self.send_command("PING", check_health=False)
@@ -742,10 +1171,10 @@ class AbstractConnection:
     async def read_response(
         self,
         disable_decoding: bool = False,
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
         *,
         disconnect_on_error: bool = True,
-        push_request: Optional[bool] = False,
+        push_request: bool | None = False,
     ):
         """Read the response from a previously sent command.
 
@@ -778,23 +1207,28 @@ class AbstractConnection:
             read_timeout = timeout if timeout is not None else self.socket_timeout
         host_error = self._host_error()
         try:
-            if read_timeout is not None and self.protocol in ["3", 3]:
-                async with async_timeout(read_timeout):
-                    response = await self._parser.read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
-                    )
-            elif read_timeout is not None:
-                async with async_timeout(read_timeout):
-                    response = await self._parser.read_response(
-                        disable_decoding=disable_decoding
-                    )
-            elif self.protocol in ["3", 3]:
-                response = await self._parser.read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
-                )
+            if read_timeout is not None:
+                timeout_context = async_timeout(read_timeout)
+                if timeout is None:
+                    async with timeout_context as active_timeout:
+                        self._active_read_timeout = active_timeout
+                        try:
+                            response = await self._read_response_from_parser(
+                                disable_decoding=disable_decoding,
+                                push_request=push_request,
+                            )
+                        finally:
+                            self._active_read_timeout = None
+                else:
+                    async with timeout_context:
+                        response = await self._read_response_from_parser(
+                            disable_decoding=disable_decoding,
+                            push_request=push_request,
+                        )
             else:
-                response = await self._parser.read_response(
-                    disable_decoding=disable_decoding
+                response = await self._read_response_from_parser(
+                    disable_decoding=disable_decoding,
+                    push_request=push_request,
                 )
         except asyncio.TimeoutError:
             if timeout is not None:
@@ -823,6 +1257,15 @@ class AbstractConnection:
         if isinstance(response, ResponseError):
             raise response from None
         return response
+
+    async def _read_response_from_parser(
+        self, disable_decoding: bool = False, push_request: bool | None = False
+    ):
+        if check_protocol_version(self.protocol, 3):
+            return await self._parser.read_response(
+                disable_decoding=disable_decoding, push_request=push_request
+            )
+        return await self._parser.read_response(disable_decoding=disable_decoding)
 
     def pack_command(self, *args: EncodableT) -> List[bytes]:
         """Pack a series of arguments into the Redis protocol"""
@@ -1360,7 +1803,592 @@ class ConnectionPoolInterface(ABC):
         pass
 
 
-class ConnectionPool(ConnectionPoolInterface):
+class AsyncMaintNotificationsAbstractConnectionPool:
+    """
+    Internal mixin for async maintenance notification pool wiring.
+
+    The handler owns notification policy.
+    This mixin owns pool state mutation because `_available_connections`,
+    `_in_use_connections`, `connection_kwargs`, and the non-reentrant `asyncio.Lock`
+    all live on the pool.
+    """
+
+    def __init__(
+        self,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        protocol = kwargs.get("protocol")
+        is_protocol_supported = check_protocol_version(protocol, 3)
+        is_connection_supported = self._maintenance_notifications_supported()
+
+        if (
+            maint_notifications_config is None
+            and is_protocol_supported
+            and is_connection_supported
+        ):
+            maint_notifications_config = MaintNotificationsConfig()
+
+        if maint_notifications_config and maint_notifications_config.enabled:
+            if not is_connection_supported:
+                if maint_notifications_config.enabled is True:
+                    # Unix sockets do not have a host endpoint for CLIENT
+                    # MAINT_NOTIFICATIONS to describe.
+                    if "path" in self.connection_kwargs:
+                        raise RedisError(
+                            "Maintenance notifications are not supported for "
+                            "Unix domain socket connections"
+                        )
+
+                    # Custom connection classes must inherit the async maintenance
+                    # mixin so handlers can update connection state safely.
+                    if not self._maintenance_notifications_connection_class_supported():
+                        connection_class = getattr(self, "connection_class", None)
+                        connection_class_name = getattr(
+                            connection_class, "__name__", connection_class
+                        )
+                        raise RedisError(
+                            "Maintenance notifications are not supported for "
+                            f"connection class {connection_class_name}"
+                        )
+
+                    # TCP-like connections still need a host to identify the
+                    # endpoint that can move during maintenance.
+                    raise RedisError(
+                        "Maintenance notifications are not supported for connections "
+                        "without a host"
+                    )
+                self._maint_notifications_pool_handler = None
+                return
+
+            if not is_protocol_supported:
+                raise RedisError(
+                    "Maintenance notifications handlers on connection are only supported with RESP version 3"
+                )
+
+            self._maint_notifications_pool_handler = AsyncMaintNotificationsPoolHandler(
+                self, maint_notifications_config
+            )
+            self._update_connection_kwargs_for_maint_notifications(
+                maint_notifications_pool_handler=self._maint_notifications_pool_handler
+            )
+        else:
+            self._maint_notifications_pool_handler = None
+
+    async def _on_close(self) -> None:
+        """Hook invoked from the pool's ``aclose()`` before the pool is shut down."""
+        if self._maint_notifications_pool_handler is not None:
+            await self._maint_notifications_pool_handler.cancel_scheduled_tasks()
+
+    @property
+    @abstractmethod
+    def connection_kwargs(self) -> dict[str, Any]:
+        pass
+
+    @connection_kwargs.setter
+    @abstractmethod
+    def connection_kwargs(self, value: dict[str, Any]) -> None:
+        pass
+
+    @abstractmethod
+    def _get_pool_lock(self) -> asyncio.Lock:
+        pass
+
+    @abstractmethod
+    def _get_free_connections(self) -> Iterable["AbstractConnection"]:
+        pass
+
+    @abstractmethod
+    def _get_in_use_connections(self) -> Iterable["AbstractConnection"]:
+        pass
+
+    def _maintenance_notifications_supported(self) -> bool:
+        if "path" in self.connection_kwargs:
+            return False
+        if not self._maintenance_notifications_connection_class_supported():
+            return False
+        return bool(self.connection_kwargs.get("host"))
+
+    def _maintenance_notifications_connection_class_supported(self) -> bool:
+        connection_class = getattr(self, "connection_class", None)
+        if connection_class is None:
+            return False
+        try:
+            return issubclass(
+                connection_class, AsyncMaintNotificationsAbstractConnection
+            )
+        except TypeError:
+            return False
+
+    def maint_notifications_enabled(self):
+        """
+        Returns:
+            True if the maintenance notifications are enabled, False otherwise.
+            The maintenance notifications config is stored in the pool handler.
+            If the pool handler is not set, the maintenance notifications are not enabled.
+        """
+        maint_notifications_config = (
+            self._maint_notifications_pool_handler.config
+            if self._maint_notifications_pool_handler
+            else None
+        )
+        return maint_notifications_config and maint_notifications_config.enabled
+
+    async def update_maint_notifications_config(
+        self,
+        maint_notifications_config: MaintNotificationsConfig,
+    ) -> None:
+        """
+        Updates the maintenance notifications configuration.
+        This method should be called only if the pool was created
+        without enabling the maintenance notifications and
+        in a later point in time maintenance notifications
+        are requested to be enabled.
+        """
+        if (
+            self.maint_notifications_enabled()
+            and not maint_notifications_config.enabled
+        ):
+            raise ValueError(
+                "Cannot disable maintenance notifications after enabling them"
+            )
+
+        if (
+            maint_notifications_config.enabled
+            and not self._maintenance_notifications_supported()
+        ):
+            if maint_notifications_config.enabled is True:
+                # Unix sockets do not have a host endpoint for CLIENT
+                # MAINT_NOTIFICATIONS to describe.
+                if "path" in self.connection_kwargs:
+                    raise RedisError(
+                        "Maintenance notifications are not supported for "
+                        "Unix domain socket connections"
+                    )
+
+                # Custom connection classes must inherit the async maintenance
+                # mixin so handlers can update connection state safely.
+                if not self._maintenance_notifications_connection_class_supported():
+                    connection_class = getattr(self, "connection_class", None)
+                    connection_class_name = getattr(
+                        connection_class, "__name__", connection_class
+                    )
+                    raise RedisError(
+                        "Maintenance notifications are not supported for "
+                        f"connection class {connection_class_name}"
+                    )
+
+                # TCP-like connections still need a host to identify the
+                # endpoint that can move during maintenance.
+                raise RedisError(
+                    "Maintenance notifications are not supported for connections "
+                    "without a host"
+                )
+            self._maint_notifications_pool_handler = None
+            return
+
+        if not self._maint_notifications_pool_handler:
+            self._maint_notifications_pool_handler = AsyncMaintNotificationsPoolHandler(
+                self, maint_notifications_config
+            )
+        else:
+            self._maint_notifications_pool_handler.config = maint_notifications_config
+
+        self._update_connection_kwargs_for_maint_notifications(
+            maint_notifications_pool_handler=self._maint_notifications_pool_handler
+        )
+        await self._update_maint_notifications_configs_for_connections(
+            maint_notifications_pool_handler=self._maint_notifications_pool_handler
+        )
+
+    def _update_connection_kwargs_for_maint_notifications(
+        self,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+    ) -> None:
+        """
+        Update the connection kwargs for all future connections.
+        """
+        if not self.maint_notifications_enabled():
+            return
+
+        if maint_notifications_pool_handler:
+            self.connection_kwargs.update(
+                {
+                    "maint_notifications_pool_handler": maint_notifications_pool_handler,
+                    "maint_notifications_config": maint_notifications_pool_handler.config,
+                }
+            )
+
+        # Store original connection parameters for maintenance notifications.
+        if self.connection_kwargs.get("orig_host_address", None) is None:
+            # If orig_host_address is None it means we haven't
+            # configured the original values yet
+            self.connection_kwargs.update(
+                {
+                    "orig_host_address": self.connection_kwargs.get("host"),
+                    "orig_socket_timeout": self.connection_kwargs.get(
+                        "socket_timeout", DEFAULT_SOCKET_TIMEOUT
+                    ),
+                    "orig_socket_connect_timeout": self.connection_kwargs.get(
+                        "socket_connect_timeout", DEFAULT_SOCKET_CONNECT_TIMEOUT
+                    ),
+                }
+            )
+
+    async def _update_maint_notifications_configs_for_connections(
+        self,
+        maint_notifications_pool_handler: (
+            AsyncMaintNotificationsPoolHandler | None
+        ) = None,
+    ) -> None:
+        """Update the maintenance notifications config for all connections in the pool."""
+        async with self._get_pool_lock():
+            for conn in self._get_free_connections():
+                if not maint_notifications_pool_handler:
+                    raise ValueError("maint_notifications_pool_handler must be set")
+                conn.set_maint_notifications_pool_handler_for_connection(
+                    maint_notifications_pool_handler
+                )
+                conn.maint_notifications_config = (
+                    maint_notifications_pool_handler.config
+                )
+                await conn.disconnect()
+
+            for conn in self._get_in_use_connections():
+                if not maint_notifications_pool_handler:
+                    raise ValueError("maint_notifications_pool_handler must be set")
+                conn.set_maint_notifications_pool_handler_for_connection(
+                    maint_notifications_pool_handler
+                )
+                conn.maint_notifications_config = (
+                    maint_notifications_pool_handler.config
+                )
+                conn.mark_for_reconnect()
+
+    def _should_update_connection(
+        self,
+        conn: "AbstractConnection",
+        matching_pattern: str = "connected_address",
+        matching_address: str | None = None,
+        matching_notification_hash: int | None = None,
+    ) -> bool:
+        """
+        Check if the connection should be updated based on the matching criteria.
+        """
+        if matching_pattern == "connected_address":
+            if matching_address and conn.getpeername() != matching_address:
+                return False
+        elif matching_pattern == "configured_address":
+            if matching_address and conn.host != matching_address:
+                return False
+        elif matching_pattern == "notification_hash":
+            if (
+                matching_notification_hash
+                and conn.maintenance_notification_hash != matching_notification_hash
+            ):
+                return False
+        return True
+
+    def update_connection_settings(
+        self,
+        conn: "AsyncMaintNotificationsAbstractConnection",
+        state: MaintenanceState | None = None,
+        maintenance_notification_hash: int | None = None,
+        host_address: str | None = None,
+        relaxed_timeout: float | None = None,
+        update_notification_hash: bool = False,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+    ) -> None:
+        """
+        Update the settings for a single connection.
+        """
+        if state:
+            conn.maintenance_state = state
+
+        if update_notification_hash:
+            # update the notification hash only if requested
+            conn.maintenance_notification_hash = maintenance_notification_hash
+
+        if host_address is not None:
+            conn.set_tmp_settings(tmp_host_address=host_address)
+
+        if relaxed_timeout is not None:
+            conn.set_tmp_settings(tmp_relaxed_timeout=relaxed_timeout)
+
+        if reset_relaxed_timeout or reset_host_address:
+            conn.reset_tmp_settings(
+                reset_host_address=reset_host_address,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+            )
+
+        conn.update_current_socket_timeout(relaxed_timeout)
+
+    async def update_connections_settings(
+        self,
+        state: MaintenanceState | None = None,
+        maintenance_notification_hash: int | None = None,
+        host_address: str | None = None,
+        relaxed_timeout: float | None = None,
+        matching_address: str | None = None,
+        matching_notification_hash: int | None = None,
+        matching_pattern: Literal[
+            "connected_address", "configured_address", "notification_hash"
+        ] = "connected_address",
+        update_notification_hash: bool = False,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+        include_free_connections: bool = True,
+    ) -> None:
+        """
+        Update the settings for all matching connections in the pool.
+
+        This method does not create new connections.
+        This method does not affect the connection kwargs.
+
+        :param state: The maintenance state to set for the connection.
+        :param maintenance_notification_hash: The hash of the maintenance notification
+                                               to set for the connection.
+        :param host_address: The host address to set for the connection.
+        :param relaxed_timeout: The relaxed timeout to set for the connection.
+        :param matching_address: The address to match for the connection.
+        :param matching_notification_hash: The notification hash to match for the connection.
+        :param matching_pattern: The pattern to match for the connection.
+        :param update_notification_hash: Whether to update the notification hash for the connection.
+        :param reset_host_address: Whether to reset the host address to the original address.
+        :param reset_relaxed_timeout: Whether to reset the relaxed timeout to the original timeout.
+        :param include_free_connections: Whether to include free/available connections.
+        """
+        async with self._get_pool_lock():
+            self._update_connections_settings_without_locking(
+                state=state,
+                maintenance_notification_hash=maintenance_notification_hash,
+                host_address=host_address,
+                relaxed_timeout=relaxed_timeout,
+                matching_address=matching_address,
+                matching_notification_hash=matching_notification_hash,
+                matching_pattern=matching_pattern,
+                update_notification_hash=update_notification_hash,
+                reset_host_address=reset_host_address,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+                include_free_connections=include_free_connections,
+            )
+
+    def _update_connections_settings_without_locking(
+        self,
+        state: MaintenanceState | None = None,
+        maintenance_notification_hash: int | None = None,
+        host_address: str | None = None,
+        relaxed_timeout: float | None = None,
+        matching_address: str | None = None,
+        matching_notification_hash: int | None = None,
+        matching_pattern: Literal[
+            "connected_address", "configured_address", "notification_hash"
+        ] = "connected_address",
+        update_notification_hash: bool = False,
+        reset_host_address: bool = False,
+        reset_relaxed_timeout: bool = False,
+        include_free_connections: bool = True,
+    ) -> None:
+        """
+        Update matching connections while the caller already holds the pool lock.
+
+        This helper intentionally does not acquire the pool lock so callers can
+        compose several pool mutations inside one critical section without
+        deadlocking the non-reentrant `asyncio.Lock`.
+        """
+        for conn in self._get_in_use_connections():
+            if self._should_update_connection(
+                conn,
+                matching_pattern,
+                matching_address,
+                matching_notification_hash,
+            ):
+                self.update_connection_settings(
+                    conn,
+                    state=state,
+                    maintenance_notification_hash=maintenance_notification_hash,
+                    host_address=host_address,
+                    relaxed_timeout=relaxed_timeout,
+                    update_notification_hash=update_notification_hash,
+                    reset_host_address=reset_host_address,
+                    reset_relaxed_timeout=reset_relaxed_timeout,
+                )
+
+        if include_free_connections:
+            for conn in self._get_free_connections():
+                if self._should_update_connection(
+                    conn,
+                    matching_pattern,
+                    matching_address,
+                    matching_notification_hash,
+                ):
+                    self.update_connection_settings(
+                        conn,
+                        state=state,
+                        maintenance_notification_hash=maintenance_notification_hash,
+                        host_address=host_address,
+                        relaxed_timeout=relaxed_timeout,
+                        update_notification_hash=update_notification_hash,
+                        reset_host_address=reset_host_address,
+                        reset_relaxed_timeout=reset_relaxed_timeout,
+                    )
+
+    def update_connection_kwargs(self, **kwargs: Any) -> None:
+        """
+        Update the connection kwargs for all future connections.
+
+        This method updates the connection kwargs for all future connections created by the pool.
+        Existing connections are not affected.
+        """
+        self.connection_kwargs.update(kwargs)
+
+    async def apply_moving_notification(
+        self,
+        notification: NodeMovingNotification,
+        config: MaintNotificationsConfig,
+        moving_address_src: str | None,
+        run_proactive_reconnect: bool = False,
+    ) -> None:
+        """
+        Apply the pool state transition for a MOVING notification atomically.
+
+        Async pools use a non-reentrant `asyncio.Lock`, so the handler cannot
+        safely compose several separately locked calls. Existing connection
+        updates, optional proactive reconnect, and future `connection_kwargs`
+        changes must happen under one pool-owned lock; otherwise a connection
+        can move between active/free lists and escape handling.
+        """
+        async with self._get_pool_lock():
+            # Opt BlockingConnectionPool into serializing its get/release
+            # with this critical section. Other pools do not define
+            # set_in_maintenance and this is a no-op for them.
+            self._set_in_maintenance(True)
+            try:
+                self._update_connections_settings_without_locking(
+                    state=MaintenanceState.MOVING,
+                    maintenance_notification_hash=hash(notification),
+                    relaxed_timeout=config.relaxed_timeout,
+                    host_address=notification.new_node_host,
+                    matching_address=moving_address_src,
+                    matching_pattern="connected_address",
+                    update_notification_hash=True,
+                    include_free_connections=True,
+                )
+
+                if run_proactive_reconnect:
+                    await self._run_proactive_reconnect_without_locking(
+                        moving_address_src
+                    )
+
+                self.update_connection_kwargs(
+                    **_build_moving_connection_kwargs(notification, config)
+                )
+            finally:
+                self._set_in_maintenance(False)
+
+    async def run_proactive_reconnect(
+        self,
+        moving_address_src: str | None = None,
+    ) -> None:
+        """
+        Mark active connections and disconnect free connections atomically.
+
+        This operation is pool-owned because the active/free lists can change
+        while tasks acquire or release connections. Keeping the mark/disconnect
+        pass under one lock avoids a connection moving between lists between
+        separately locked calls.
+        """
+        async with self._get_pool_lock():
+            await self._run_proactive_reconnect_without_locking(moving_address_src)
+
+    async def _run_proactive_reconnect_without_locking(
+        self,
+        moving_address_src: str | None = None,
+    ) -> None:
+        """
+        Mark and disconnect matching connections while the caller holds the pool lock.
+
+        This helper intentionally does not acquire the pool lock so it can be
+        reused by larger atomic operations that already hold the non-reentrant
+        `asyncio.Lock`.
+        """
+        for conn in self._get_in_use_connections():
+            if self._should_update_connection(
+                conn, "connected_address", moving_address_src
+            ):
+                conn.mark_for_reconnect()
+
+        free_connections = [
+            conn
+            for conn in self._get_free_connections()
+            if self._should_update_connection(
+                conn, "connected_address", moving_address_src
+            )
+        ]
+        await self._disconnect_connections(free_connections)
+
+    async def cleanup_moving_notification(
+        self,
+        notification_hash: int,
+        reset_relaxed_timeout: bool,
+        reset_host_address: bool,
+    ) -> None:
+        """
+        Revert MOVING pool state atomically after the notification TTL.
+
+        Future connection kwargs and existing connection state must be cleaned
+        up in the same critical section. Splitting the cleanup lets an
+        acquire/release interleave, which can leave stale MOVING state or undo a
+        newer overlapping MOVING notification.
+        """
+        async with self._get_pool_lock():
+            kwargs = _build_moving_cleanup_connection_kwargs(
+                self.connection_kwargs, notification_hash
+            )
+            if kwargs is not None:
+                self.update_connection_kwargs(**kwargs)
+
+            self._update_connections_settings_without_locking(
+                relaxed_timeout=-1,
+                state=MaintenanceState.NONE,
+                maintenance_notification_hash=None,
+                matching_notification_hash=notification_hash,
+                matching_pattern="notification_hash",
+                update_notification_hash=True,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+                reset_host_address=reset_host_address,
+                include_free_connections=True,
+            )
+
+    async def _disconnect_connections(
+        self, connections: Iterable["AbstractConnection"]
+    ) -> None:
+        connections = tuple(connections)
+        if not connections:
+            return
+        results = await asyncio.gather(
+            *(connection.disconnect() for connection in connections),
+            return_exceptions=True,
+        )
+        exc = next(
+            (result for result in results if isinstance(result, BaseException)), None
+        )
+        if exc:
+            raise exc
+
+    def _set_in_maintenance(self, in_maintenance: bool) -> None:
+        """Flip the pool's maintenance flag if it exposes one (BlockingConnectionPool)."""
+        set_in_maintenance = getattr(self, "set_in_maintenance", None)
+        if callable(set_in_maintenance):
+            set_in_maintenance(in_maintenance)
+
+
+class ConnectionPool(
+    AsyncMaintNotificationsAbstractConnectionPool, ConnectionPoolInterface
+):
     """
     Create a connection pool. ``If max_connections`` is set, then this
     object raises :py:class:`~redis.ConnectionError` when the pool's
@@ -1426,6 +2454,7 @@ class ConnectionPool(ConnectionPoolInterface):
         self,
         connection_class: Type[AbstractConnection] = Connection,
         max_connections: Optional[int] = None,
+        maint_notifications_config: MaintNotificationsConfig | None = None,
         **connection_kwargs,
     ):
         max_connections = max_connections or 100
@@ -1433,7 +2462,7 @@ class ConnectionPool(ConnectionPoolInterface):
             raise ValueError('"max_connections" must be a positive integer')
 
         self.connection_class = connection_class
-        self.connection_kwargs = connection_kwargs
+        self._connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
         self._available_connections: List[AbstractConnection] = []
@@ -1443,6 +2472,12 @@ class ConnectionPool(ConnectionPoolInterface):
         self._event_dispatcher = self.connection_kwargs.get("event_dispatcher", None)
         if self._event_dispatcher is None:
             self._event_dispatcher = EventDispatcher()
+
+        AsyncMaintNotificationsAbstractConnectionPool.__init__(
+            self,
+            maint_notifications_config=maint_notifications_config,
+            **connection_kwargs,
+        )
 
     # Keys that should be redacted in __repr__ to avoid exposing sensitive information
     SENSITIVE_REPR_KEYS = frozenset(
@@ -1466,6 +2501,23 @@ class ConnectionPool(ConnectionPoolInterface):
             f"(<{self.connection_class.__module__}.{self.connection_class.__name__}"
             f"({conn_kwargs})>)>"
         )
+
+    @property
+    def connection_kwargs(self) -> dict[str, Any]:
+        return self._connection_kwargs
+
+    @connection_kwargs.setter
+    def connection_kwargs(self, value: dict[str, Any]) -> None:
+        self._connection_kwargs = value
+
+    def _get_pool_lock(self) -> asyncio.Lock:
+        return self._lock
+
+    def _get_free_connections(self) -> Iterable[AbstractConnection]:
+        return self._available_connections
+
+    def _get_in_use_connections(self) -> Iterable[AbstractConnection]:
+        return self._in_use_connections
 
     def get_protocol(self):
         """
@@ -1635,24 +2687,26 @@ class ConnectionPool(ConnectionPoolInterface):
         # pool before all data has been read or the socket has been
         # closed. either way, reconnect and verify everything is good.
         try:
-            if await connection.can_read():
+            if await connection.can_read() and not self.maint_notifications_enabled():
                 raise ConnectionError("Connection has data") from None
         except (ConnectionError, TimeoutError, OSError):
             await connection.disconnect()
             await connection.connect()
-            if await connection.can_read():
+            if await connection.can_read() and not self.maint_notifications_enabled():
                 raise ConnectionError("Connection not ready") from None
 
     async def release(self, connection: AbstractConnection):
         """Releases the connection back to the pool"""
         # Connections should always be returned to the correct pool,
         # not doing so is an error that will cause an exception here.
-        self._in_use_connections.remove(connection)
+        async with self._lock:
+            self._in_use_connections.remove(connection)
 
-        if connection.should_reconnect():
-            await connection.disconnect()
+            if connection.should_reconnect():
+                await connection.disconnect()
 
-        self._available_connections.append(connection)
+            self._available_connections.append(connection)
+
         await self._event_dispatcher.dispatch_async(
             AsyncAfterConnectionReleasedEvent(connection)
         )
@@ -1703,6 +2757,7 @@ class ConnectionPool(ConnectionPoolInterface):
 
     async def aclose(self) -> None:
         """Close the pool, disconnecting all connections"""
+        await self._on_close()
         await self.disconnect()
 
     def set_retry(self, retry: "Retry") -> None:
@@ -1805,6 +2860,28 @@ class BlockingConnectionPool(ConnectionPool):
         )
         self._condition = asyncio.Condition()
         self.timeout = timeout
+        self._in_maintenance = False
+
+    def set_in_maintenance(self, in_maintenance: bool) -> None:
+        """
+        Toggle the pool's maintenance mode.
+
+        While maintenance mode is on, ``get_connection`` and ``release``
+        serialize their pool mutations through ``self._lock`` so they cannot
+        interleave with a MOVING notification handler that is currently
+        rewriting pool state under the same lock. Outside of maintenance the
+        mutations skip the lock, since their critical sections are pure-Python
+        and already atomic under asyncio's single-threaded scheduling.
+        """
+        self._in_maintenance = in_maintenance
+
+    @contextlib.asynccontextmanager
+    async def _maybe_pool_lock(self) -> AsyncIterator[None]:
+        if self._in_maintenance:
+            async with self._lock:
+                yield
+        else:
+            yield
 
     @deprecated_args(
         args_to_warn=["*"],
@@ -1820,16 +2897,17 @@ class BlockingConnectionPool(ConnectionPool):
             async with self._condition:
                 async with async_timeout(self.timeout):
                     await self._condition.wait_for(self.can_get_connection)
-                    # Track connection count before to detect if a new connection is created
-                    connections_before = len(self._available_connections) + len(
-                        self._in_use_connections
-                    )
-                    start_time_created = time.monotonic()
-                    connection = super().get_available_connection()
-                    connections_after = len(self._available_connections) + len(
-                        self._in_use_connections
-                    )
-                    is_created = connections_after > connections_before
+                    async with self._maybe_pool_lock():
+                        # Track connection count before to detect if a new connection is created
+                        connections_before = len(self._available_connections) + len(
+                            self._in_use_connections
+                        )
+                        start_time_created = time.monotonic()
+                        connection = super().get_available_connection()
+                        connections_after = len(self._available_connections) + len(
+                            self._in_use_connections
+                        )
+                        is_created = connections_after > connections_before
         except asyncio.TimeoutError as err:
             raise ConnectionError("No connection available.") from err
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2067,7 +2067,15 @@ class AsyncMaintNotificationsAbstractConnectionPool:
                 self._maint_notifications_pool_handler = None
                 return
 
-            if not self._maint_notifications_pool_handler:
+            if self._oss_cluster_maint_notifications_handler:
+                # Pool already in OSS cluster mode; update the OSS handler config
+                # instead of creating a mutually-exclusive pool handler (which
+                # would be silently ignored because the OSS handler wins priority
+                # in both update helpers below).
+                self._oss_cluster_maint_notifications_handler.config = (
+                    maint_notifications_config
+                )
+            elif not self._maint_notifications_pool_handler:
                 self._maint_notifications_pool_handler = (
                     AsyncMaintNotificationsPoolHandler(self, maint_notifications_config)
                 )

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -13,7 +14,6 @@ from redis.maint_notifications import (
     MaintNotificationsConfig,
     NodeMovingNotification,
     OSSNodeMigratedNotification,
-    OSSNodeMigratingNotification,
     _get_maintenance_notification_name,
     _get_maintenance_notification_type,
     _should_skip_connection_timeout_update,
@@ -21,11 +21,31 @@ from redis.maint_notifications import (
 from redis.observability.attributes import get_pool_name
 
 if TYPE_CHECKING:
+    from redis.asyncio.cluster import RedisCluster
     from redis.asyncio.connection import AsyncMaintNotificationsAbstractConnection
 
 logger = logging.getLogger(__name__)
 
 _ScheduledCallback = Callable[..., Awaitable[None]]
+
+
+def _log_task_exception(message: str, task: "asyncio.Task[Any]") -> None:
+    """Task done-callback that surfaces a failed task's exception in the logs.
+
+    Without it, an unhandled exception in a fire-and-forget task is only
+    reported by asyncio as a noisy "Task exception was never retrieved"
+    warning. Retrieving the exception here suppresses that warning and logs a
+    meaningful error instead. Cancellation is expected and left unlogged.
+
+    Bind ``message`` with ``functools.partial`` before passing to
+    ``add_done_callback`` (which supplies ``task``).
+    """
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc:
+        logger.error(message, exc_info=exc)
 
 
 def add_debug_log_for_notification(
@@ -219,7 +239,12 @@ class AsyncMaintNotificationsPoolHandler:
         task = asyncio.create_task(self._run_after(deadline, callback, *args))
         self._scheduled_tasks.add(task)
         task.add_done_callback(self._scheduled_tasks.discard)
-        task.add_done_callback(self._log_scheduled_task_result)
+        task.add_done_callback(
+            functools.partial(
+                _log_task_exception,
+                "Error handling scheduled maintenance notification",
+            )
+        )
 
     async def _run_after(
         self,
@@ -239,17 +264,6 @@ class AsyncMaintNotificationsPoolHandler:
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
-
-    @staticmethod
-    def _log_scheduled_task_result(task: asyncio.Task[None]) -> None:
-        try:
-            exc = task.exception()
-        except asyncio.CancelledError:
-            return
-        if exc:
-            logger.error(
-                "Error handling scheduled maintenance notification", exc_info=exc
-            )
 
 
 class AsyncMaintNotificationsConnectionHandler:
@@ -286,13 +300,6 @@ class AsyncMaintNotificationsConnectionHandler:
             network_peer_port=self.connection.port,
             maint_notification=maint_notification,
         )
-
-        if isinstance(
-            notification,
-            (OSSNodeMigratingNotification, OSSNodeMigratedNotification),
-        ):
-            logger.error(f"Unhandled notification type: {notification}")
-            return
 
         if notification_type is None:
             logger.error(f"Unhandled notification type: {notification}")
@@ -361,3 +368,210 @@ class AsyncMaintNotificationsConnectionHandler:
                 maint_notification=maint_notification,
                 relaxed=False,
             )
+
+
+class AsyncOSSMaintNotificationsHandler:
+    """
+    Cluster-wide handler for OSS (open-source) cluster maintenance notifications.
+
+    Reacts to SMIGRATED (slot migration completed) push notifications and
+    triggers topology re-initialization via nodes_manager.initialize().
+
+    Lock discipline: _lock is held across the whole pool mutation, including
+    await initialize(), so the topology refresh and the subsequent connection
+    marking/disconnect happen as one atomic operation — releasing the lock
+    mid-mutation would let other tasks observe partial state.
+
+    Re-entrancy is not a deadlock risk here even though asyncio.Lock is
+    non-reentrant: initialize() may dispatch commands whose responses carry new
+    push notifications, but handle_notification schedules the actual handling as
+    a separate background task rather than calling into it inline, so the
+    re-entrant arrival never tries to re-acquire the lock on this call stack.
+    The cheap _in_progress/_processed dedup that gates that scheduling runs
+    without the lock — those sets are only mutated from the single event loop.
+    """
+
+    def __init__(
+        self,
+        cluster_client: "RedisCluster",
+        config: MaintNotificationsConfig,
+    ) -> None:
+        self.cluster_client = cluster_client
+        self.config = config
+        self._processed_notifications: set[MaintenanceNotification] = set()
+        self._in_progress: set[MaintenanceNotification] = set()
+        self._lock = asyncio.Lock()
+        self._background_tasks: set[asyncio.Task] = set()
+
+    def get_handler_for_connection(self) -> "AsyncOSSMaintNotificationsHandler":
+        # Copy all data that should be shared between connections
+        # but each connection should have its own handler
+        # since each connection can be in a different state
+        copy = AsyncOSSMaintNotificationsHandler(self.cluster_client, self.config)
+        copy._processed_notifications = self._processed_notifications
+        copy._in_progress = self._in_progress
+        copy._lock = self._lock
+        copy._background_tasks = self._background_tasks
+        return copy
+
+    async def remove_expired_notifications(self) -> None:
+        async with self._lock:
+            for n in tuple(self._processed_notifications):
+                if n.is_expired():
+                    self._processed_notifications.remove(n)
+
+    async def handle_notification(self, notification: MaintenanceNotification) -> None:
+        # Synchronous pre-dedup BEFORE scheduling a task.
+        #
+        # The same SMIGRATED notification is delivered by the server on every
+        # connection, so under load this callback fires many times for the same
+        # notification. Without this guard we would schedule one background task
+        # per arrival - a flood of tasks that each acquire the lock and dedup,
+        # saturating the single event loop. Reserving the notification in
+        # _in_progress here (and skipping if already in-progress/processed) caps
+        # it at exactly ONE handling task per unique notification.
+        #
+        # These sets are only mutated from the single event loop, so this
+        # check-and-add is race-free without holding the lock.
+        if (
+            notification in self._in_progress
+            or notification in self._processed_notifications
+        ):
+            return
+        self._in_progress.add(notification)
+
+        # Schedule as a background task so the parser's read path is not blocked.
+        # This also breaks the inline call chain that would otherwise deadlock:
+        # initialize() dispatches commands whose responses may carry more push
+        # notifications; as a separate task it can run while this one awaits.
+        #
+        # If scheduling the task (or wiring its callbacks) fails, release the
+        # in-progress reservation made above. Otherwise the notification would be
+        # stuck in _in_progress forever - the dedup guard would skip it on every
+        # future arrival, and _do_handle_notification's finally (which normally
+        # clears it) never runs because the task was never started.
+        try:
+            task = asyncio.get_running_loop().create_task(
+                self._do_handle_notification(notification)
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(
+                functools.partial(
+                    _log_task_exception,
+                    "Error handling maintenance notification background task",
+                )
+            )
+        except Exception:
+            self._in_progress.discard(notification)
+            raise
+
+    async def _do_handle_notification(
+        self, notification: MaintenanceNotification
+    ) -> None:
+        try:
+            if isinstance(notification, OSSNodeMigratedNotification):
+                await self.handle_oss_maintenance_completed_notification(notification)
+            else:
+                logger.error(f"Unhandled notification type: {notification}")
+        finally:
+            # Release the in-progress reservation. On success the notification is
+            # also in _processed_notifications (so it won't be re-handled); on
+            # failure it is not, allowing a later retry.
+            self._in_progress.discard(notification)
+
+    async def handle_oss_maintenance_completed_notification(
+        self, notification: OSSNodeMigratedNotification
+    ) -> None:
+        await self.remove_expired_notifications()
+
+        async with self._lock:
+            # handle_notification already reserved this notification in
+            # _in_progress and guaranteed uniqueness; the processed check here is
+            # defensive (e.g. across handler copies sharing the same sets).
+            if notification in self._processed_notifications:
+                return
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Handling SMIGRATED notification: {notification}")
+
+            # Extract the information about the src and destination nodes that are
+            # affected by the maintenance. nodes_to_slots_mapping structure:
+            # {
+            #     "src_host:port": [
+            #         {"dest_host:port": "slot_range"},
+            #         ...
+            #     ],
+            #     ...
+            # }
+            additional_startup_nodes_info = []
+            affected_nodes = set()
+            for (
+                src_address,
+                dest_mappings,
+            ) in notification.nodes_to_slots_mapping.items():
+                src_host, src_port = src_address.split(":")
+                src_node = self.cluster_client.nodes_manager.get_node(
+                    host=src_host, port=int(src_port)
+                )
+                if src_node is not None:
+                    affected_nodes.add(src_node)
+                for dest_mapping in dest_mappings:
+                    for dest_address in dest_mapping.keys():
+                        dest_host, dest_port = dest_address.split(":")
+                        additional_startup_nodes_info.append(
+                            (dest_host, int(dest_port))
+                        )
+            # Updates the cluster slots cache with the new slots mapping
+            # This will also update the nodes cache with the new nodes mapping
+            await self.cluster_client.nodes_manager.initialize(
+                additional_startup_nodes_info=additional_startup_nodes_info,
+            )
+
+            all_nodes = set(affected_nodes)
+            all_nodes = all_nodes.union(
+                self.cluster_client.nodes_manager.nodes_cache.values()
+            )
+            for current_node in all_nodes:
+                handoff_recorded = False
+                if current_node in affected_nodes:
+                    # mark for reconnect all in-use connections to the node — this
+                    # forces them to disconnect after completing their current command
+                    free_set = set(current_node._free)
+                    for conn in current_node._connections:
+                        if conn not in free_set:
+                            add_debug_log_for_notification(
+                                conn, "SMIGRATED - mark for reconnect"
+                            )
+                            conn.mark_for_reconnect()
+                    await record_connection_handoff(
+                        pool_name=f"{current_node.host}:{current_node.port}"
+                    )
+                    handoff_recorded = True
+                else:
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            f"SMIGRATED: Node {current_node.name} not affected "
+                            f"by maintenance, skipping mark for reconnect"
+                        )
+                if (
+                    current_node
+                    not in self.cluster_client.nodes_manager.nodes_cache.values()
+                ):
+                    task = asyncio.get_running_loop().create_task(
+                        current_node.disconnect_free_connections()
+                    )
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                    task.add_done_callback(
+                        functools.partial(
+                            _log_task_exception,
+                            "Error disconnecting free connections after "
+                            "maintenance notification",
+                        )
+                    )
+                    if not handoff_recorded:
+                        await record_connection_handoff(
+                            pool_name=f"{current_node.host}:{current_node.port}"
+                        )
+
+            self._processed_notifications.add(notification)

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -14,6 +14,7 @@ from redis.maint_notifications import (
     MaintNotificationsConfig,
     NodeMovingNotification,
     OSSNodeMigratedNotification,
+    OSSNodeMigratingNotification,
     _get_maintenance_notification_name,
     _get_maintenance_notification_type,
     _should_skip_connection_timeout_update,
@@ -331,6 +332,11 @@ class AsyncMaintNotificationsConnectionHandler:
             tmp_relaxed_timeout=self.config.relaxed_timeout
         )
         self.connection.update_current_socket_timeout(self.config.relaxed_timeout)
+        if isinstance(notification, OSSNodeMigratingNotification):
+            # add the notification id to the set of processed start maint notifications
+            # this is used to skip the unrelaxing of the timeouts if we have received more than
+            # one start notification before the the final end notification
+            self.connection.add_maint_start_notification(notification.id)
 
         maint_notification = _get_maintenance_notification_name(notification)
         await record_connection_relaxed_timeout(

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -403,17 +403,6 @@ class AsyncOSSMaintNotificationsHandler:
         self._lock = asyncio.Lock()
         self._background_tasks: set[asyncio.Task] = set()
 
-    def get_handler_for_connection(self) -> "AsyncOSSMaintNotificationsHandler":
-        # Copy all data that should be shared between connections
-        # but each connection should have its own handler
-        # since each connection can be in a different state
-        copy = AsyncOSSMaintNotificationsHandler(self.cluster_client, self.config)
-        copy._processed_notifications = self._processed_notifications
-        copy._in_progress = self._in_progress
-        copy._lock = self._lock
-        copy._background_tasks = self._background_tasks
-        return copy
-
     async def remove_expired_notifications(self) -> None:
         async with self._lock:
             for n in tuple(self._processed_notifications):
@@ -509,7 +498,7 @@ class AsyncOSSMaintNotificationsHandler:
                 src_address,
                 dest_mappings,
             ) in notification.nodes_to_slots_mapping.items():
-                src_host, src_port = src_address.split(":")
+                src_host, src_port = src_address.rsplit(":", 1)
                 src_node = self.cluster_client.nodes_manager.get_node(
                     host=src_host, port=int(src_port)
                 )
@@ -517,7 +506,7 @@ class AsyncOSSMaintNotificationsHandler:
                     affected_nodes.add(src_node)
                 for dest_mapping in dest_mappings:
                     for dest_address in dest_mapping.keys():
-                        dest_host, dest_port = dest_address.split(":")
+                        dest_host, dest_port = dest_address.rsplit(":", 1)
                         additional_startup_nodes_info.append(
                             (dest_host, int(dest_port))
                         )

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -213,18 +213,23 @@ class AsyncMaintNotificationsPoolHandler:
         callback: _ScheduledCallback,
         *args: Any,
     ) -> None:
-        task = asyncio.create_task(self._run_after(delay, callback, *args))
+        # Record the absolute deadline now so that any lag between create_task
+        # and the task's first execution slice does not push the fire time out.
+        deadline = asyncio.get_running_loop().time() + delay
+        task = asyncio.create_task(self._run_after(deadline, callback, *args))
         self._scheduled_tasks.add(task)
         task.add_done_callback(self._scheduled_tasks.discard)
         task.add_done_callback(self._log_scheduled_task_result)
 
     async def _run_after(
         self,
-        delay: float,
+        deadline: float,
         callback: _ScheduledCallback,
         *args: Any,
     ) -> None:
-        await asyncio.sleep(delay)
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
         await callback(*args)
 
     async def cancel_scheduled_tasks(self) -> None:

--- a/redis/asyncio/maint_notifications.py
+++ b/redis/asyncio/maint_notifications.py
@@ -1,0 +1,358 @@
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from redis.asyncio.observability.recorder import (
+    record_connection_handoff,
+    record_connection_relaxed_timeout,
+    record_maint_notification_count,
+)
+from redis.maint_notifications import (
+    MaintenanceNotification,
+    MaintenanceState,
+    MaintNotificationsConfig,
+    NodeMovingNotification,
+    OSSNodeMigratedNotification,
+    OSSNodeMigratingNotification,
+    _get_maintenance_notification_name,
+    _get_maintenance_notification_type,
+    _should_skip_connection_timeout_update,
+)
+from redis.observability.attributes import get_pool_name
+
+if TYPE_CHECKING:
+    from redis.asyncio.connection import AsyncMaintNotificationsAbstractConnection
+
+logger = logging.getLogger(__name__)
+
+_ScheduledCallback = Callable[..., Awaitable[None]]
+
+
+def add_debug_log_for_notification(
+    connection: object,
+    notification: str | MaintenanceNotification,
+) -> None:
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    socket_address = None
+    try:
+        writer = getattr(connection, "_writer", None)
+        socket_name = writer.get_extra_info("sockname") if writer else None
+        socket_address = (
+            socket_name[1] if socket_name and len(socket_name) > 1 else None
+        )
+    except (AttributeError, OSError, TypeError):
+        pass
+
+    resolved_ip = None
+    try:
+        get_resolved_ip = getattr(connection, "get_resolved_ip", None)
+        if callable(get_resolved_ip):
+            resolved_ip = get_resolved_ip()
+    except (AttributeError, OSError):
+        pass
+
+    logger.debug(
+        f"Handling maintenance notification: {notification}, "
+        f"with connection: {connection}, connected to ip {resolved_ip}, "
+        f"local socket port: {socket_address}",
+    )
+
+
+class AsyncMaintNotificationsPoolHandler:
+    def __init__(
+        self,
+        pool: Any,
+        config: MaintNotificationsConfig,
+    ) -> None:
+        self.pool = pool
+        self.config = config
+        self._processed_notifications: set[MaintenanceNotification] = set()
+        self._scheduled_tasks: set[asyncio.Task[None]] = set()
+        self._lock = asyncio.Lock()
+        self.connection: Any | None = None
+
+    def set_connection(
+        self, connection: "AsyncMaintNotificationsAbstractConnection"
+    ) -> None:
+        self.connection = connection
+
+    def get_handler_for_connection(self) -> "AsyncMaintNotificationsPoolHandler":
+        # Copy all data that should be shared between connections, while each
+        # connection gets its own handler instance and current connection state.
+        copy = AsyncMaintNotificationsPoolHandler(self.pool, self.config)
+        copy._processed_notifications = self._processed_notifications
+        copy._scheduled_tasks = self._scheduled_tasks
+        copy._lock = self._lock
+        copy.connection = None
+        return copy
+
+    async def remove_expired_notifications(self) -> None:
+        async with self._lock:
+            for notification in tuple(self._processed_notifications):
+                if notification.is_expired():
+                    self._processed_notifications.remove(notification)
+
+    async def handle_notification(self, notification: MaintenanceNotification) -> None:
+        await self.remove_expired_notifications()
+
+        if isinstance(notification, NodeMovingNotification):
+            await self.handle_node_moving_notification(notification)
+        else:
+            logger.error(f"Unhandled notification type: {notification}")
+
+    async def handle_node_moving_notification(
+        self, notification: NodeMovingNotification
+    ) -> None:
+        if (
+            not self.config.proactive_reconnect
+            and not self.config.is_relaxed_timeouts_enabled()
+        ):
+            return
+
+        async with self._lock:
+            if notification in self._processed_notifications:
+                # nothing to do in the connection pool handling
+                # the notification has already been handled or is expired
+                # just return
+                return
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Handling node MOVING notification: {notification}, "
+                    f"with connection: {self.connection}, connected to ip "
+                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                )
+            # Get the current connected address - if any
+            # This is the address that is being moved
+            # and we need to handle only connections
+            # connected to the same address
+            moving_address_src = (
+                self.connection.getpeername() if self.connection else None
+            )
+
+            # The async pool owns the active/free connection collections and
+            # asyncio.Lock is not reentrant, so the whole MOVING pool mutation
+            # has to be one pool-owned atomic operation. The handler still owns
+            # the notification policy and passes the already-decided inputs.
+            await self.pool.apply_moving_notification(
+                notification=notification,
+                config=self.config,
+                moving_address_src=moving_address_src,
+                run_proactive_reconnect=(
+                    self.config.proactive_reconnect
+                    and notification.new_node_host is not None
+                ),
+            )
+
+            if self.config.proactive_reconnect and notification.new_node_host is None:
+                self._schedule(
+                    notification.ttl / 2,
+                    self.run_proactive_reconnect,
+                    moving_address_src,
+                )
+
+            self._schedule(
+                notification.ttl,
+                self.handle_node_moved_notification,
+                notification,
+            )
+
+            await record_connection_handoff(
+                pool_name=get_pool_name(self.pool),
+            )
+
+            self._processed_notifications.add(notification)
+
+    async def run_proactive_reconnect(
+        self, moving_address_src: str | None = None
+    ) -> None:
+        """
+        Run proactive reconnect for the pool.
+        Active connections are marked for reconnect after they complete the current command.
+        Inactive connections are disconnected and will be connected on next use.
+        """
+        async with self._lock:
+            # This delayed reconnect must be atomic for the same reason as the
+            # initial MOVING mutation: a connection can move between active and
+            # free lists while another task is acquiring or releasing it.
+            await self.pool.run_proactive_reconnect(
+                moving_address_src=moving_address_src,
+            )
+
+    async def handle_node_moved_notification(
+        self, notification: NodeMovingNotification
+    ) -> None:
+        """
+        Handle the cleanup after a node moving notification expires.
+        """
+        notification_hash = hash(notification)
+
+        async with self._lock:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Reverting temporary changes related to notification: {notification}, "
+                    f"with connection: {self.connection}, connected to ip "
+                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                )
+            reset_relaxed_timeout = self.config.is_relaxed_timeouts_enabled()
+            reset_host_address = self.config.proactive_reconnect
+
+            # Cleanup has to reset future connection kwargs and existing
+            # matching connections together under the pool lock. Splitting it
+            # lets an acquire/release interleave and leaves stale MOVING state.
+            await self.pool.cleanup_moving_notification(
+                notification_hash=notification_hash,
+                reset_relaxed_timeout=reset_relaxed_timeout,
+                reset_host_address=reset_host_address,
+            )
+
+    def _schedule(
+        self,
+        delay: float,
+        callback: _ScheduledCallback,
+        *args: Any,
+    ) -> None:
+        task = asyncio.create_task(self._run_after(delay, callback, *args))
+        self._scheduled_tasks.add(task)
+        task.add_done_callback(self._scheduled_tasks.discard)
+        task.add_done_callback(self._log_scheduled_task_result)
+
+    async def _run_after(
+        self,
+        delay: float,
+        callback: _ScheduledCallback,
+        *args: Any,
+    ) -> None:
+        await asyncio.sleep(delay)
+        await callback(*args)
+
+    async def cancel_scheduled_tasks(self) -> None:
+        if not self._scheduled_tasks:
+            return
+        tasks = tuple(self._scheduled_tasks)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    @staticmethod
+    def _log_scheduled_task_result(task: asyncio.Task[None]) -> None:
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc:
+            logger.error(
+                "Error handling scheduled maintenance notification", exc_info=exc
+            )
+
+
+class AsyncMaintNotificationsConnectionHandler:
+    def __init__(
+        self,
+        connection: "AsyncMaintNotificationsAbstractConnection",
+        config: MaintNotificationsConfig,
+    ) -> None:
+        self.connection = connection
+        self.config = config
+
+    def _get_pool_name(self) -> str:
+        """
+        Get the pool name from the connection's pool handler.
+        Falls back to connection representation if pool is not available.
+        """
+        pool_handler = getattr(
+            self.connection, "_maint_notifications_pool_handler", None
+        )
+        if pool_handler and getattr(pool_handler, "pool", None):
+            return get_pool_name(pool_handler.pool)
+        # Fallback for standalone connections without a pool
+        return repr(self.connection)
+
+    async def handle_notification(self, notification: MaintenanceNotification) -> None:
+        # 1 for start, 0 for end notification type, None for unknown.
+        notification_type = _get_maintenance_notification_type(notification)
+        maint_notification = _get_maintenance_notification_name(notification)
+
+        await record_maint_notification_count(
+            server_address=self.connection.host,
+            server_port=self.connection.port,
+            network_peer_address=self.connection.host,
+            network_peer_port=self.connection.port,
+            maint_notification=maint_notification,
+        )
+
+        if isinstance(
+            notification,
+            (OSSNodeMigratingNotification, OSSNodeMigratedNotification),
+        ):
+            logger.error(f"Unhandled notification type: {notification}")
+            return
+
+        if notification_type is None:
+            logger.error(f"Unhandled notification type: {notification}")
+            return
+
+        if notification_type:
+            await self.handle_maintenance_start_notification(
+                MaintenanceState.MAINTENANCE, notification
+            )
+        else:
+            await self.handle_maintenance_completed_notification(
+                notification=notification
+            )
+
+    async def handle_maintenance_start_notification(
+        self,
+        maintenance_state: MaintenanceState,
+        notification: MaintenanceNotification,
+    ) -> None:
+        add_debug_log_for_notification(self.connection, notification)
+
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
+        ):
+            return
+
+        self.connection.maintenance_state = maintenance_state
+        self.connection.set_tmp_settings(
+            tmp_relaxed_timeout=self.config.relaxed_timeout
+        )
+        self.connection.update_current_socket_timeout(self.config.relaxed_timeout)
+
+        maint_notification = _get_maintenance_notification_name(notification)
+        await record_connection_relaxed_timeout(
+            connection_name=self._get_pool_name(),
+            maint_notification=maint_notification,
+            relaxed=True,
+        )
+
+    async def handle_maintenance_completed_notification(self, **kwargs: Any) -> None:
+        # Only reset timeouts if state is not MOVING and relaxed timeouts are enabled
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
+        ):
+            return
+
+        notification = None
+        if kwargs.get("notification"):
+            notification = kwargs["notification"]
+        add_debug_log_for_notification(
+            self.connection, notification if notification else "MAINTENANCE_COMPLETED"
+        )
+        self.connection.reset_tmp_settings(reset_relaxed_timeout=True)
+        # Maintenance completed - reset the connection
+        # timeouts by providing -1 as the relaxed timeout
+        self.connection.update_current_socket_timeout(-1)
+        self.connection.maintenance_state = MaintenanceState.NONE
+        # reset the sets that keep track of received start maint
+        # notifications and skipped end maint notifications
+        self.connection.reset_received_notifications()
+
+        if notification:
+            maint_notification = _get_maintenance_notification_name(notification)
+            await record_connection_relaxed_timeout(
+                connection_name=self._get_pool_name(),
+                maint_notification=maint_notification,
+                relaxed=False,
+            )

--- a/redis/client.py
+++ b/redis/client.py
@@ -754,7 +754,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             self.connection_pool.release(conn)
 
         if self.auto_close_connection_pool:
-            self.connection_pool.disconnect()
+            self.connection_pool.close()
 
     def _send_command_parse_response(self, conn, command_name, *args, **options):
         """
@@ -846,13 +846,15 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             raise
 
         finally:
-            if conn and conn.should_reconnect():
-                self._close_connection(conn)
-                conn.connect()
-            if self._single_connection_client:
-                self.single_connection_lock.release()
-            if not self.connection:
-                pool.release(conn)
+            try:
+                if conn and conn.should_reconnect():
+                    self._close_connection(conn)
+                    conn.connect()
+            finally:
+                if self._single_connection_client:
+                    self.single_connection_lock.release()
+                if not self.connection:
+                    pool.release(conn)
 
     def parse_response(self, connection, command_name, **options):
         """Parses a response from the Redis server"""

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -340,17 +340,12 @@ class MaintNotificationsAbstractRedisCluster:
         maint_notifications_config: Optional[MaintNotificationsConfig],
         **kwargs,
     ):
-        # Initialize maintenance notifications
+        # Initialize maintenance notifications.
+        # The RESP3 requirement is validated in RedisCluster.__init__ before the
+        # NodesManager is constructed; this mixin is only ever run from there, so
+        # the config it receives has already been validated.
         is_protocol_supported = check_protocol_version(kwargs.get("protocol"), 3)
 
-        if (
-            maint_notifications_config
-            and maint_notifications_config.enabled
-            and not is_protocol_supported
-        ):
-            raise RedisError(
-                "Maintenance notifications handlers on connection are only supported with RESP version 3"
-            )
         if maint_notifications_config is None and is_protocol_supported:
             maint_notifications_config = MaintNotificationsConfig()
 
@@ -880,7 +875,11 @@ class RedisCluster(
         if (cache_config or cache) and not check_protocol_version(protocol, 3):
             raise RedisError("Client caching is only supported with RESP version 3")
 
-        if maint_notifications_config and not check_protocol_version(protocol, 3):
+        if (
+            maint_notifications_config
+            and maint_notifications_config.enabled
+            and not check_protocol_version(protocol, 3)
+        ):
             raise RedisError(
                 "Maintenance notifications are only supported with RESP version 3"
             )

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2522,7 +2522,15 @@ class MaintNotificationsAbstractConnectionPool:
             self._maint_notifications_pool_handler = None
         else:
             # first update pool settings
-            if not self._maint_notifications_pool_handler:
+            if self._oss_cluster_maint_notifications_handler:
+                # Pool already in OSS cluster mode; update the OSS handler config
+                # instead of creating a mutually-exclusive pool handler (which
+                # would be silently ignored because the OSS handler wins priority
+                # in both update helpers below).
+                self._oss_cluster_maint_notifications_handler.config = (
+                    maint_notifications_config
+                )
+            elif not self._maint_notifications_pool_handler:
                 self._maint_notifications_pool_handler = MaintNotificationsPoolHandler(
                     self, maint_notifications_config
                 )

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -38,7 +38,7 @@ from ._defaults import (
     DEFAULT_SOCKET_TIMEOUT,
     get_default_socket_keepalive_options,
 )
-from ._parsers import Encoder, _HiredisParser, _RESP2Parser, _RESP3Parser
+from ._parsers import BaseParser, Encoder, _HiredisParser, _RESP2Parser, _RESP3Parser
 from .auth.token import TokenInterface
 from .backoff import NoBackoff
 from .credentials import CredentialProvider, UsernamePasswordCredentialProvider
@@ -336,7 +336,7 @@ class MaintNotificationsAbstractConnection:
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
-        parser: Optional[Union[_HiredisParser, _RESP3Parser]] = None,
+        parser: Optional[BaseParser] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
     ):
         """
@@ -351,7 +351,7 @@ class MaintNotificationsAbstractConnection:
             orig_socket_timeout (Optional[float]): The original socket timeout of the connection.
             orig_socket_connect_timeout (Optional[float]): The original socket connect timeout of the connection.
             oss_cluster_maint_notifications_handler (Optional[OSSMaintNotificationsHandler]): The OSS cluster handler for maintenance notifications.
-            parser (Optional[Union[_HiredisParser, _RESP3Parser]]): The parser to use for maintenance notifications.
+            parser (Optional[BaseParser]): The parser to use for maintenance notifications.
                     If not provided, the parser from the connection is used.
                     This is useful when the parser is created after this object.
         """
@@ -376,8 +376,16 @@ class MaintNotificationsAbstractConnection:
         self._skipped_end_maint_notifications = set()
 
     @abstractmethod
-    def _get_parser(self) -> Union[_HiredisParser, _RESP3Parser]:
+    def _get_parser(self) -> BaseParser:
         pass
+
+    def _get_push_notifications_parser(self) -> Union[_HiredisParser, _RESP3Parser]:
+        parser = self._get_parser()
+        if not isinstance(parser, (_HiredisParser, _RESP3Parser)):
+            raise RedisError(
+                "Maintenance notifications are only supported with hiredis and RESP3 parsers!"
+            )
+        return parser
 
     @abstractmethod
     def _get_socket(self) -> Optional[socket.socket]:
@@ -441,6 +449,10 @@ class MaintNotificationsAbstractConnection:
     def disconnect(self, *args, **kwargs):
         pass
 
+    @abstractmethod
+    def mark_for_reconnect(self):
+        pass
+
     def _configure_maintenance_notifications(
         self,
         maint_notifications_pool_handler: Optional[
@@ -452,7 +464,7 @@ class MaintNotificationsAbstractConnection:
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
-        parser: Optional[Union[_HiredisParser, _RESP3Parser]] = None,
+        parser: Optional[BaseParser] = None,
     ):
         """
         Enable maintenance notifications by setting up
@@ -545,7 +557,8 @@ class MaintNotificationsAbstractConnection:
         )
 
         maint_notifications_pool_handler_copy.set_connection(self)
-        self._get_parser().set_node_moving_push_handler(
+        parser = self._get_push_notifications_parser()
+        parser.set_node_moving_push_handler(
             maint_notifications_pool_handler_copy.handle_notification
         )
 
@@ -558,7 +571,7 @@ class MaintNotificationsAbstractConnection:
                     self, maint_notifications_pool_handler.config
                 )
             )
-            self._get_parser().set_maintenance_push_handler(
+            parser.set_maintenance_push_handler(
                 self._maint_notifications_connection_handler.handle_notification
             )
         else:
@@ -569,7 +582,8 @@ class MaintNotificationsAbstractConnection:
     def set_maint_notifications_cluster_handler_for_connection(
         self, oss_cluster_maint_notifications_handler: OSSMaintNotificationsHandler
     ):
-        self._get_parser().set_oss_cluster_maint_push_handler(
+        parser = self._get_push_notifications_parser()
+        parser.set_oss_cluster_maint_push_handler(
             oss_cluster_maint_notifications_handler.handle_notification
         )
 
@@ -584,7 +598,7 @@ class MaintNotificationsAbstractConnection:
                     self, oss_cluster_maint_notifications_handler.config
                 )
             )
-            self._get_parser().set_maintenance_push_handler(
+            parser.set_maintenance_push_handler(
                 self._maint_notifications_connection_handler.handle_notification
             )
         else:
@@ -601,7 +615,7 @@ class MaintNotificationsAbstractConnection:
         # When the mode is enabled=True, we raise an exception in case of failure
         host = getattr(self, "host", None)
         if (
-            self.get_protocol() not in [2, "2"]
+            check_protocol_version(self.get_protocol(), 3)
             and self.maint_notifications_config
             and self.maint_notifications_config.enabled
             and self._maint_notifications_connection_handler
@@ -755,10 +769,10 @@ class MaintNotificationsAbstractConnection:
     def set_tmp_settings(
         self,
         tmp_host_address: Optional[Union[str, object]] = SENTINEL,
-        tmp_relaxed_timeout: Optional[float] = None,
+        tmp_relaxed_timeout: Optional[float] = -1,
     ):
         """
-        The value of SENTINEL is used to indicate that the property should not be updated.
+        SENTINEL keeps the host unchanged. -1 keeps the relaxed timeout unchanged.
         """
         if tmp_host_address and tmp_host_address != SENTINEL:
             self.host = str(tmp_host_address)
@@ -1104,7 +1118,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
 
         # if resp version is specified and we have auth args,
         # we need to send them via HELLO
-        if auth_args and self.protocol not in [2, "2"]:
+        if auth_args and check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _RESP2Parser):
                 self.set_parser(_RESP3Parser)
                 # update cluster exception classes
@@ -1141,7 +1155,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 raise AuthenticationError("Invalid Username or Password")
 
         # if resp version is specified, switch to it
-        elif self.protocol not in [2, "2"]:
+        elif check_protocol_version(self.protocol, 3):
             if isinstance(self._parser, _RESP2Parser):
                 self.set_parser(_RESP3Parser)
                 # update cluster exception classes
@@ -1943,7 +1957,7 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
     def set_tmp_settings(
         self,
         tmp_host_address: Optional[str] = None,
-        tmp_relaxed_timeout: Optional[float] = None,
+        tmp_relaxed_timeout: Optional[float] = -1,
     ):
         con = self._get_maint_notifications_connection_instance(self._conn)
         con.set_tmp_settings(tmp_host_address, tmp_relaxed_timeout)
@@ -3172,7 +3186,11 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
             except (ConnectionError, TimeoutError, OSError):
                 connection.disconnect()
                 connection.connect()
-                if connection.can_read():
+                if (
+                    connection.can_read()
+                    and self.cache is None
+                    and not self.maint_notifications_enabled()
+                ):
                     raise ConnectionError("Connection not ready")
         except BaseException:
             # release the connection back to the pool so that we don't
@@ -3608,12 +3626,20 @@ class BlockingConnectionPool(ConnectionPool):
             # pool before all data has been read or the socket has been
             # closed. either way, reconnect and verify everything is good.
             try:
-                if connection.can_read():
+                if (
+                    connection.can_read()
+                    and self.cache is None
+                    and not self.maint_notifications_enabled()
+                ):
                     raise ConnectionError("Connection has data")
             except (ConnectionError, TimeoutError, OSError):
                 connection.disconnect()
                 connection.connect()
-                if connection.can_read():
+                if (
+                    connection.can_read()
+                    and self.cache is None
+                    and not self.maint_notifications_enabled()
+                ):
                     raise ConnectionError("Connection not ready")
         except BaseException:
             # release the connection back to the pool so that we don't leak it

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2678,7 +2678,7 @@ class MaintNotificationsAbstractConnectionPool:
                 return False
         elif matching_pattern == "notification_hash":
             if (
-                matching_notification_hash
+                matching_notification_hash is not None
                 and conn.maintenance_notification_hash != matching_notification_hash
             ):
                 return False

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -514,14 +514,12 @@ class MaintNotificationsAbstractConnection:
             self._oss_cluster_maint_notifications_handler = (
                 oss_cluster_maint_notifications_handler
             )
-        else:
-            self._oss_cluster_maint_notifications_handler = None
-
-        # Set up OSS cluster handler to parser if available
-        if self._oss_cluster_maint_notifications_handler:
+            # Set up OSS cluster handler to parser
             parser.set_oss_cluster_maint_push_handler(
                 self._oss_cluster_maint_notifications_handler.handle_notification
             )
+        else:
+            self._oss_cluster_maint_notifications_handler = None
 
         # Set up pool handler to parser if available
         if self._maint_notifications_pool_handler:
@@ -2512,6 +2510,11 @@ class MaintNotificationsAbstractConnectionPool:
             self._oss_cluster_maint_notifications_handler = (
                 oss_cluster_maint_notifications_handler
             )
+            # OSS cluster mode and pool-handler mode are mutually exclusive
+            # (see __init__). A pool created with the default RESP3 "auto"
+            # config wires a pool handler before this method runs; clear it so
+            # new and existing connections are not configured with both handlers.
+            self._maint_notifications_pool_handler = None
         else:
             # first update pool settings
             if not self._maint_notifications_pool_handler:
@@ -2561,6 +2564,10 @@ class MaintNotificationsAbstractConnectionPool:
                     "maint_notifications_config": oss_cluster_maint_notifications_handler.config,
                 }
             )
+            # OSS cluster mode and pool-handler mode are mutually exclusive.
+            # Drop any pool handler a default (RESP3 "auto") pool creation may
+            # have wired so future connections are not configured with both.
+            self.connection_kwargs.pop("maint_notifications_pool_handler", None)
 
         # Store original connection parameters for maintenance notifications.
         if self.connection_kwargs.get("orig_host_address", None) is None:
@@ -2612,11 +2619,18 @@ class MaintNotificationsAbstractConnectionPool:
                 conn.disconnect()
             for conn in self._get_in_use_connections():
                 if oss_cluster_maint_notifications_handler:
+                    # Use set_maint_notifications_cluster_handler_for_connection
+                    # (not _configure_maintenance_notifications) so the parser is
+                    # obtained from the connection itself. _configure_* requires a
+                    # parser argument and would raise here; it would also reset the
+                    # connection's orig_* settings, which is wrong for an in-use
+                    # (active) connection. This mirrors the idle-connection branch
+                    # above and the pool-handler branches.
+                    conn.set_maint_notifications_cluster_handler_for_connection(
+                        oss_cluster_maint_notifications_handler
+                    )
                     conn.maint_notifications_config = (
                         oss_cluster_maint_notifications_handler.config
-                    )
-                    conn._configure_maintenance_notifications(
-                        oss_cluster_maint_notifications_handler=oss_cluster_maint_notifications_handler
                     )
                 elif maint_notifications_pool_handler:
                     conn.set_maint_notifications_pool_handler_for_connection(

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -584,6 +584,11 @@ class MaintNotificationsAbstractConnection:
         parser.set_oss_cluster_maint_push_handler(
             oss_cluster_maint_notifications_handler.handle_notification
         )
+        # OSS cluster mode and pool-handler mode are mutually exclusive. Clear
+        # any node-moving/pool handler a default (RESP3 "auto") pool wired in
+        # __init__ so this existing connection is not configured with both.
+        parser.set_node_moving_push_handler(None)
+        self._maint_notifications_pool_handler = None
 
         self._oss_cluster_maint_notifications_handler = (
             oss_cluster_maint_notifications_handler

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -1124,16 +1124,6 @@ class OSSMaintNotificationsHandler:
         self._in_progress = set()
         self._lock = threading.RLock()
 
-    def get_handler_for_connection(self):
-        # Copy all data that should be shared between connections
-        # but each connection should have its own pool handler
-        # since each connection can be in a different state
-        copy = OSSMaintNotificationsHandler(self.cluster_client, self.config)
-        copy._processed_notifications = self._processed_notifications
-        copy._in_progress = self._in_progress
-        copy._lock = self._lock
-        return copy
-
     def remove_expired_notifications(self):
         with self._lock:
             for notification in tuple(self._processed_notifications):
@@ -1182,16 +1172,16 @@ class OSSMaintNotificationsHandler:
                 src_address,
                 dest_mappings,
             ) in notification.nodes_to_slots_mapping.items():
-                src_host, src_port = src_address.split(":")
+                src_host, src_port = src_address.rsplit(":", 1)
                 src_node = self.cluster_client.nodes_manager.get_node(
-                    host=src_host, port=src_port
+                    host=src_host, port=int(src_port)
                 )
                 if src_node is not None:
                     affected_nodes.add(src_node)
 
                 for dest_mapping in dest_mappings:
                     for dest_address in dest_mapping.keys():
-                        dest_host, dest_port = dest_address.split(":")
+                        dest_host, dest_port = dest_address.rsplit(":", 1)
                         additional_startup_nodes_info.append(
                             (dest_host, int(dest_port))
                         )

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -1157,93 +1157,98 @@ class OSSMaintNotificationsHandler:
                 logger.debug(f"Handling SMIGRATED notification: {notification}")
             self._in_progress.add(notification)
 
-            # Extract the information about the src and destination nodes that are affected
-            # by the maintenance. nodes_to_slots_mapping structure:
-            # {
-            #     "src_host:port": [
-            #         {"dest_host:port": "slot_range"},
-            #         ...
-            #     ],
-            #     ...
-            # }
-            additional_startup_nodes_info = []
-            affected_nodes = set()
-            for (
-                src_address,
-                dest_mappings,
-            ) in notification.nodes_to_slots_mapping.items():
-                src_host, src_port = src_address.rsplit(":", 1)
-                src_node = self.cluster_client.nodes_manager.get_node(
-                    host=src_host, port=int(src_port)
+            try:
+                # Extract the information about the src and destination nodes that are affected
+                # by the maintenance. nodes_to_slots_mapping structure:
+                # {
+                #     "src_host:port": [
+                #         {"dest_host:port": "slot_range"},
+                #         ...
+                #     ],
+                #     ...
+                # }
+                additional_startup_nodes_info = []
+                affected_nodes = set()
+                for (
+                    src_address,
+                    dest_mappings,
+                ) in notification.nodes_to_slots_mapping.items():
+                    src_host, src_port = src_address.rsplit(":", 1)
+                    src_node = self.cluster_client.nodes_manager.get_node(
+                        host=src_host, port=int(src_port)
+                    )
+                    if src_node is not None:
+                        affected_nodes.add(src_node)
+
+                    for dest_mapping in dest_mappings:
+                        for dest_address in dest_mapping.keys():
+                            dest_host, dest_port = dest_address.rsplit(":", 1)
+                            additional_startup_nodes_info.append(
+                                (dest_host, int(dest_port))
+                            )
+
+                # Updates the cluster slots cache with the new slots mapping
+                # This will also update the nodes cache with the new nodes mapping
+                self.cluster_client.nodes_manager.initialize(
+                    disconnect_startup_nodes_pools=False,
+                    additional_startup_nodes_info=additional_startup_nodes_info,
                 )
-                if src_node is not None:
-                    affected_nodes.add(src_node)
 
-                for dest_mapping in dest_mappings:
-                    for dest_address in dest_mapping.keys():
-                        dest_host, dest_port = dest_address.rsplit(":", 1)
-                        additional_startup_nodes_info.append(
-                            (dest_host, int(dest_port))
-                        )
+                all_nodes = set(affected_nodes)
+                all_nodes = all_nodes.union(
+                    self.cluster_client.nodes_manager.nodes_cache.values()
+                )
 
-            # Updates the cluster slots cache with the new slots mapping
-            # This will also update the nodes cache with the new nodes mapping
-            self.cluster_client.nodes_manager.initialize(
-                disconnect_startup_nodes_pools=False,
-                additional_startup_nodes_info=additional_startup_nodes_info,
-            )
+                for current_node in all_nodes:
+                    if current_node.redis_connection is None:
+                        continue
+                    with current_node.redis_connection.connection_pool._lock:
+                        handoff_recorded = False
+                        if current_node in affected_nodes:
+                            # mark for reconnect all in use connections to the node - this will force them to
+                            # disconnect after they complete their current commands
+                            # Some of them might be used by sub sub and we don't know which ones - so we disconnect
+                            # all in flight connections after they are done with current command execution
+                            for conn in current_node.redis_connection.connection_pool._get_in_use_connections():
+                                add_debug_log_for_notification(
+                                    conn, "SMIGRATED - mark for reconnect"
+                                )
+                                conn.mark_for_reconnect()
 
-            all_nodes = set(affected_nodes)
-            all_nodes = all_nodes.union(
-                self.cluster_client.nodes_manager.nodes_cache.values()
-            )
-
-            for current_node in all_nodes:
-                if current_node.redis_connection is None:
-                    continue
-                with current_node.redis_connection.connection_pool._lock:
-                    handoff_recorded = False
-                    if current_node in affected_nodes:
-                        # mark for reconnect all in use connections to the node - this will force them to
-                        # disconnect after they complete their current commands
-                        # Some of them might be used by sub sub and we don't know which ones - so we disconnect
-                        # all in flight connections after they are done with current command execution
-                        for conn in current_node.redis_connection.connection_pool._get_in_use_connections():
-                            add_debug_log_for_notification(
-                                conn, "SMIGRATED - mark for reconnect"
-                            )
-                            conn.mark_for_reconnect()
-
-                        record_connection_handoff(
-                            pool_name=get_pool_name(
-                                current_node.redis_connection.connection_pool
-                            )
-                        )
-                        handoff_recorded = True
-                    else:
-                        if logger.isEnabledFor(logging.DEBUG):
-                            logger.debug(
-                                f"SMIGRATED: Node {current_node.name} not affected by maintenance, "
-                                f"skipping mark for reconnect"
-                            )
-
-                    if (
-                        current_node
-                        not in self.cluster_client.nodes_manager.nodes_cache.values()
-                    ):
-                        # disconnect all free connections to the node - this node will be dropped
-                        # from the cluster, so we don't need to revert the timeouts
-                        for conn in current_node.redis_connection.connection_pool._get_free_connections():
-                            conn.disconnect()
-
-                        # Only record handoff if not already recorded for this node
-                        if not handoff_recorded:
                             record_connection_handoff(
                                 pool_name=get_pool_name(
                                     current_node.redis_connection.connection_pool
                                 )
                             )
+                            handoff_recorded = True
+                        else:
+                            if logger.isEnabledFor(logging.DEBUG):
+                                logger.debug(
+                                    f"SMIGRATED: Node {current_node.name} not affected by maintenance, "
+                                    f"skipping mark for reconnect"
+                                )
 
-            # mark the notification as processed
-            self._processed_notifications.add(notification)
-            self._in_progress.discard(notification)
+                        if (
+                            current_node
+                            not in self.cluster_client.nodes_manager.nodes_cache.values()
+                        ):
+                            # disconnect all free connections to the node - this node will be dropped
+                            # from the cluster, so we don't need to revert the timeouts
+                            for conn in current_node.redis_connection.connection_pool._get_free_connections():
+                                conn.disconnect()
+
+                            # Only record handoff if not already recorded for this node
+                            if not handoff_recorded:
+                                record_connection_handoff(
+                                    pool_name=get_pool_name(
+                                        current_node.redis_connection.connection_pool
+                                    )
+                                )
+
+                # mark the notification as processed
+                self._processed_notifications.add(notification)
+            finally:
+                # Release the in-progress reservation. On success the notification
+                # is also in _processed_notifications (so it won't be re-handled);
+                # on failure it is not, allowing a later redelivery to retry.
+                self._in_progress.discard(notification)

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -5,7 +5,16 @@ import re
 import threading
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Union,
+)
 
 from redis.observability.attributes import get_pool_name
 from redis.observability.recorder import (
@@ -42,6 +51,7 @@ class EndpointType(enum.Enum):
 
 
 if TYPE_CHECKING:
+    from redis.asyncio.connection import AsyncMaintNotificationsAbstractConnection
     from redis.connection import (
         MaintNotificationsAbstractConnection,
         MaintNotificationsAbstractConnectionPool,
@@ -675,7 +685,9 @@ class MaintNotificationsConfig:
         return self.relaxed_timeout != -1
 
     def get_endpoint_type(
-        self, host: str, connection: "MaintNotificationsAbstractConnection"
+        self,
+        host: str,
+        connection: "MaintNotificationsAbstractConnection | AsyncMaintNotificationsAbstractConnection",
     ) -> EndpointType:
         """
         Determine the appropriate endpoint type for CLIENT MAINT_NOTIFICATIONS command.
@@ -729,6 +741,86 @@ class MaintNotificationsConfig:
         return EndpointType.INTERNAL_FQDN if is_private else EndpointType.EXTERNAL_FQDN
 
 
+_MAINTENANCE_START_NOTIFICATION_TYPES = (
+    NodeMigratingNotification,
+    NodeFailingOverNotification,
+    OSSNodeMigratingNotification,
+)
+_MAINTENANCE_COMPLETED_NOTIFICATION_TYPES = (
+    NodeMigratedNotification,
+    NodeFailedOverNotification,
+    OSSNodeMigratedNotification,
+)
+
+
+def _get_maintenance_notification_type(
+    notification: MaintenanceNotification,
+) -> Optional[int]:
+    if notification.__class__ in _MAINTENANCE_START_NOTIFICATION_TYPES:
+        return 1
+    if notification.__class__ in _MAINTENANCE_COMPLETED_NOTIFICATION_TYPES:
+        return 0
+    return None
+
+
+def _get_maintenance_notification_name(
+    notification: MaintenanceNotification,
+) -> str:
+    return notification_types_mapping.get(notification.__class__, "")
+
+
+def _should_skip_connection_timeout_update(
+    maintenance_state: MaintenanceState,
+    config: MaintNotificationsConfig,
+) -> bool:
+    return (
+        maintenance_state == MaintenanceState.MOVING
+        or not config.is_relaxed_timeouts_enabled()
+    )
+
+
+def _build_moving_connection_kwargs(
+    notification: NodeMovingNotification,
+    config: MaintNotificationsConfig,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "maintenance_state": MaintenanceState.MOVING,
+        "maintenance_notification_hash": hash(notification),
+    }
+    if notification.new_node_host is not None:
+        # the host is not updated if the new node host is None
+        # this happens when the MOVING push notification does not contain
+        # the new node host - in this case we only update the timeouts
+        kwargs["host"] = notification.new_node_host
+    if config.is_relaxed_timeouts_enabled():
+        kwargs.update(
+            {
+                "socket_timeout": config.relaxed_timeout,
+                "socket_connect_timeout": config.relaxed_timeout,
+            }
+        )
+    return kwargs
+
+
+def _build_moving_cleanup_connection_kwargs(
+    connection_kwargs: Mapping[str, Any],
+    notification_hash: int,
+) -> Optional[dict[str, Any]]:
+    # if the current maintenance_notification_hash in kwargs is not matching the notification
+    # it means there has been a new moving notification after this one
+    # and we don't need to revert the kwargs yet
+    if connection_kwargs.get("maintenance_notification_hash") != notification_hash:
+        return None
+
+    return {
+        "maintenance_state": MaintenanceState.NONE,
+        "maintenance_notification_hash": None,
+        "host": connection_kwargs.get("orig_host_address"),
+        "socket_timeout": connection_kwargs.get("orig_socket_timeout"),
+        "socket_connect_timeout": connection_kwargs.get("orig_socket_connect_timeout"),
+    }
+
+
 class MaintNotificationsPoolHandler:
     def __init__(
         self,
@@ -774,6 +866,7 @@ class MaintNotificationsPoolHandler:
             and not self.config.is_relaxed_timeouts_enabled()
         ):
             return
+
         with self._lock:
             if notification in self._processed_notifications:
                 # nothing to do in the connection pool handling
@@ -782,79 +875,58 @@ class MaintNotificationsPoolHandler:
                 return
 
             with self.pool._lock:
-                logger.debug(
-                    f"Handling node MOVING notification: {notification}, "
-                    f"with connection: {self.connection}, connected to ip "
-                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"Handling node MOVING notification: {notification}, "
+                        f"with connection: {self.connection}, connected to ip "
+                        f"{self.connection.get_resolved_ip() if self.connection else None}"
+                    )
+                # Get the current connected address - if any
+                # This is the address that is being moved
+                # and we need to handle only connections
+                # connected to the same address
+                moving_address_src = (
+                    self.connection.getpeername() if self.connection else None
                 )
-                if (
-                    self.config.proactive_reconnect
-                    or self.config.is_relaxed_timeouts_enabled()
-                ):
-                    # Get the current connected address - if any
-                    # This is the address that is being moved
-                    # and we need to handle only connections
-                    # connected to the same address
-                    moving_address_src = (
-                        self.connection.getpeername() if self.connection else None
-                    )
 
-                    if getattr(self.pool, "set_in_maintenance", False):
-                        # Set pool in maintenance mode - executed only if
-                        # BlockingConnectionPool is used
-                        self.pool.set_in_maintenance(True)
+                if getattr(self.pool, "set_in_maintenance", False):
+                    # Set pool in maintenance mode - executed only if
+                    # BlockingConnectionPool is used
+                    self.pool.set_in_maintenance(True)
 
-                    # Update maintenance state, timeout and optionally host address
-                    # connection settings for matching connections
-                    self.pool.update_connections_settings(
-                        state=MaintenanceState.MOVING,
-                        maintenance_notification_hash=hash(notification),
-                        relaxed_timeout=self.config.relaxed_timeout,
-                        host_address=notification.new_node_host,
-                        matching_address=moving_address_src,
-                        matching_pattern="connected_address",
-                        update_notification_hash=True,
-                        include_free_connections=True,
-                    )
+                # Update maintenance state, timeout and optionally host address
+                # connection settings for matching connections
+                self.pool.update_connections_settings(
+                    state=MaintenanceState.MOVING,
+                    maintenance_notification_hash=hash(notification),
+                    relaxed_timeout=self.config.relaxed_timeout,
+                    host_address=notification.new_node_host,
+                    matching_address=moving_address_src,
+                    matching_pattern="connected_address",
+                    update_notification_hash=True,
+                    include_free_connections=True,
+                )
 
-                    if self.config.proactive_reconnect:
-                        if notification.new_node_host is not None:
-                            self.run_proactive_reconnect(moving_address_src)
-                        else:
-                            threading.Timer(
-                                notification.ttl / 2,
-                                self.run_proactive_reconnect,
-                                args=(moving_address_src,),
-                            ).start()
-
-                    # Update config for new connections:
-                    # Set state to MOVING
-                    # update host
-                    # if relax timeouts are enabled - update timeouts
-                    kwargs: dict = {
-                        "maintenance_state": MaintenanceState.MOVING,
-                        "maintenance_notification_hash": hash(notification),
-                    }
+                if self.config.proactive_reconnect:
                     if notification.new_node_host is not None:
-                        # the host is not updated if the new node host is None
-                        # this happens when the MOVING push notification does not contain
-                        # the new node host - in this case we only update the timeouts
-                        kwargs.update(
-                            {
-                                "host": notification.new_node_host,
-                            }
-                        )
-                    if self.config.is_relaxed_timeouts_enabled():
-                        kwargs.update(
-                            {
-                                "socket_timeout": self.config.relaxed_timeout,
-                                "socket_connect_timeout": self.config.relaxed_timeout,
-                            }
-                        )
-                    self.pool.update_connection_kwargs(**kwargs)
+                        self.run_proactive_reconnect(moving_address_src)
+                    else:
+                        threading.Timer(
+                            notification.ttl / 2,
+                            self.run_proactive_reconnect,
+                            args=(moving_address_src,),
+                        ).start()
 
-                    if getattr(self.pool, "set_in_maintenance", False):
-                        self.pool.set_in_maintenance(False)
+                # Update config for new connections:
+                # Set state to MOVING
+                # update host
+                # if relax timeouts are enabled - update timeouts
+                self.pool.update_connection_kwargs(
+                    **_build_moving_connection_kwargs(notification, self.config)
+                )
+
+                if getattr(self.pool, "set_in_maintenance", False):
+                    self.pool.set_in_maintenance(False)
 
             threading.Timer(
                 notification.ttl,
@@ -894,32 +966,16 @@ class MaintNotificationsPoolHandler:
         notification_hash = hash(notification)
 
         with self._lock:
-            logger.debug(
-                f"Reverting temporary changes related to notification: {notification}, "
-                f"with connection: {self.connection}, connected to ip "
-                f"{self.connection.get_resolved_ip() if self.connection else None}"
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Reverting temporary changes related to notification: {notification}, "
+                    f"with connection: {self.connection}, connected to ip "
+                    f"{self.connection.get_resolved_ip() if self.connection else None}"
+                )
+            kwargs = _build_moving_cleanup_connection_kwargs(
+                self.pool.connection_kwargs, notification_hash
             )
-            # if the current maintenance_notification_hash in kwargs is not matching the notification
-            # it means there has been a new moving notification after this one
-            # and we don't need to revert the kwargs yet
-            if (
-                self.pool.connection_kwargs.get("maintenance_notification_hash")
-                == notification_hash
-            ):
-                orig_host = self.pool.connection_kwargs.get("orig_host_address")
-                orig_socket_timeout = self.pool.connection_kwargs.get(
-                    "orig_socket_timeout"
-                )
-                orig_connect_timeout = self.pool.connection_kwargs.get(
-                    "orig_socket_connect_timeout"
-                )
-                kwargs: dict = {
-                    "maintenance_state": MaintenanceState.NONE,
-                    "maintenance_notification_hash": None,
-                    "host": orig_host,
-                    "socket_timeout": orig_socket_timeout,
-                    "socket_connect_timeout": orig_connect_timeout,
-                }
+            if kwargs is not None:
                 self.pool.update_connection_kwargs(**kwargs)
 
             with self.pool._lock:
@@ -972,9 +1028,10 @@ class MaintNotificationsConnectionHandler:
         return repr(self.connection)
 
     def handle_notification(self, notification: MaintenanceNotification):
-        # get the notification type by checking its class in the _NOTIFICATION_TYPES dict
-        notification_type = self._NOTIFICATION_TYPES.get(notification.__class__, None)
-        maint_notification = notification_types_mapping.get(notification.__class__, "")
+        # get the notification type by checking its class
+        # 1 for start, 0 for end notification type, None for unknown
+        notification_type = _get_maintenance_notification_type(notification)
+        maint_notification = _get_maintenance_notification_name(notification)
 
         record_maint_notification_count(
             server_address=self.connection.host,
@@ -1000,9 +1057,8 @@ class MaintNotificationsConnectionHandler:
     ):
         add_debug_log_for_notification(self.connection, notification)
 
-        if (
-            self.connection.maintenance_state == MaintenanceState.MOVING
-            or not self.config.is_relaxed_timeouts_enabled()
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
         ):
             return
 
@@ -1018,20 +1074,20 @@ class MaintNotificationsConnectionHandler:
             # one start notification before the the final end notification
             self.connection.add_maint_start_notification(notification.id)
 
-        maint_notification = notification_types_mapping.get(notification.__class__, "")
+        maint_notification = _get_maintenance_notification_name(notification)
         record_connection_relaxed_timeout(
             connection_name=self._get_pool_name(),
             maint_notification=maint_notification,
             relaxed=True,
         )
 
-    def handle_maintenance_completed_notification(self, **kwargs):
+    def handle_maintenance_completed_notification(self, **kwargs: Any) -> None:
         # Only reset timeouts if state is not MOVING and relaxed timeouts are enabled
-        if (
-            self.connection.maintenance_state == MaintenanceState.MOVING
-            or not self.config.is_relaxed_timeouts_enabled()
+        if _should_skip_connection_timeout_update(
+            self.connection.maintenance_state, self.config
         ):
             return
+
         notification = None
         if kwargs.get("notification"):
             notification = kwargs["notification"]
@@ -1048,9 +1104,7 @@ class MaintNotificationsConnectionHandler:
         self.connection.reset_received_notifications()
 
         if notification:
-            maint_notification = notification_types_mapping.get(
-                notification.__class__, ""
-            )
+            maint_notification = _get_maintenance_notification_name(notification)
             record_connection_relaxed_timeout(
                 connection_name=self._get_pool_name(),
                 maint_notification=maint_notification,

--- a/redis/maint_notifications.py
+++ b/redis/maint_notifications.py
@@ -1256,4 +1256,4 @@ class OSSMaintNotificationsHandler:
 
             # mark the notification as processed
             self._processed_notifications.add(notification)
-            self._in_progress.remove(notification)
+            self._in_progress.discard(notification)

--- a/redis/utils.py
+++ b/redis/utils.py
@@ -284,9 +284,9 @@ DEFAULT_RESP_VERSION = 3
 
 
 def check_protocol_version(
-    protocol: Optional[Union[str, int]], expected_version: int = 3
+    protocol: str | int | object | None, expected_version: int = 3
 ) -> bool:
-    if protocol is None:
+    if protocol is None or protocol is SENTINEL:
         protocol = DEFAULT_RESP_VERSION
     if isinstance(protocol, str):
         try:

--- a/tests/maint_notifications/test_async_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_cluster_maint_notifications_handling.py
@@ -1,0 +1,771 @@
+import asyncio
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+
+import redis.asyncio as redis
+from redis.asyncio.cluster import ClusterNode
+from redis.maint_notifications import MaintNotificationsConfig, MaintenanceState
+from tests.maint_notifications.proxy_server_helpers import (
+    ProxyInterceptorHelper,
+    RespTranslator,
+    SlotsRange,
+)
+
+NODE_PORT_1 = 15379
+NODE_PORT_2 = 15380
+NODE_PORT_3 = 15381
+
+NODE_PORT_NEW = 15382
+
+# IP addresses used in tests
+NODE_IP_LOCALHOST = "127.0.0.1"
+NODE_IP_PROXY = "0.0.0.0"
+
+DEFAULT_SOCKET_TIMEOUT = 5
+
+# Initial cluster node configuration for proxy-based tests
+PROXY_CLUSTER_NODES = [
+    ClusterNode("127.0.0.1", NODE_PORT_1),
+    ClusterNode("127.0.0.1", NODE_PORT_2),
+    ClusterNode("127.0.0.1", NODE_PORT_3),
+]
+
+CLUSTER_SLOTS_INTERCEPTOR_NAME = "test_topology"
+
+
+def _preserve_startup_nodes_order(_startup_nodes):
+    pass
+
+
+def _node_free_connections(node: ClusterNode):
+    """Return the free/idle connections of an async ClusterNode."""
+    return list(node._free)
+
+
+def _node_in_use_connections(node: ClusterNode):
+    """Return the in-use connections of an async ClusterNode.
+
+    In the async cluster, the ClusterNode IS the connection pool. In-use
+    connections are those tracked in ``_connections`` but not currently
+    sitting in the ``_free`` deque.
+    """
+    free = set(node._free)
+    return [conn for conn in node._connections if conn not in free]
+
+
+def _node_all_connections(node: ClusterNode):
+    """Return all connections (free + in-use) of an async ClusterNode."""
+    return list(node._connections)
+
+
+class TestAsyncClusterMaintNotificationsBase:
+    """Base class for async cluster maintenance notifications handling tests."""
+
+    async def _create_cluster_client(
+        self,
+        max_connections=10,
+        maint_config=None,
+        protocol=3,
+    ) -> "redis.RedisCluster":
+        """Create an async RedisCluster instance and initialize its topology.
+
+        Unlike the sync client, the async RedisCluster discovers the cluster
+        topology lazily, so we explicitly ``await initialize()`` here to make
+        ``nodes_manager.nodes_cache`` available to the tests.
+
+        Note: unlike the sync cluster, the async RedisCluster does not support
+        client-side caching (no ``cache_config``) nor a pluggable
+        ``connection_pool_class`` (the ClusterNode is its own pool), so the
+        corresponding sync config tests are intentionally omitted here.
+        """
+        if maint_config is None and hasattr(self, "config") and self.config is not None:
+            maint_config = self.config
+
+        test_redis_client = redis.RedisCluster(
+            protocol=protocol,
+            startup_nodes=PROXY_CLUSTER_NODES,
+            maint_notifications_config=maint_config,
+            max_connections=max_connections,
+        )
+        await test_redis_client.initialize()
+
+        return test_redis_client
+
+    async def _warm_up_connection_pools(
+        self, cluster: "redis.RedisCluster", created_connections_count: int = 3
+    ):
+        """Warm up node pools by acquiring, connecting and releasing connections.
+
+        The connections must be actually connected so that the proxy can push
+        maintenance notifications onto them and so that the maintenance push
+        handlers get installed on each connection's parser (this happens during
+        ``on_connect``).
+        """
+        for node in cluster.nodes_manager.nodes_cache.values():
+            node_connections = []
+            for _ in range(created_connections_count):
+                conn = node.acquire_connection()
+                await conn.connect()
+                node_connections.append(conn)
+            for conn in node_connections:
+                node.release(conn)
+            node_connections.clear()
+
+    async def _drain_maint_notification_tasks(self, cluster: "redis.RedisCluster"):
+        """Wait for any in-flight async OSS maintenance handling tasks to finish.
+
+        SMIGRATED notifications are handled by ``AsyncOSSMaintNotificationsHandler``
+        in background tasks scheduled from the parser's push callback. Unlike the
+        sync client - where SMIGRATED handling completes inline while reading the
+        command response - the async client returns from the command before the
+        topology update finishes. Tests must drain these tasks before asserting on
+        the resulting topology / connection state.
+        """
+        handler = cluster._oss_cluster_maint_notifications_handler
+        if handler is None:
+            return
+        # The handler may schedule further tasks (e.g. disconnect_free_connections)
+        # while draining, so loop until no tasks remain.
+        for _ in range(100):
+            tasks = [t for t in handler._background_tasks if not t.done()]
+            if not tasks:
+                break
+            await asyncio.gather(*tasks, return_exceptions=True)
+        # Give the event loop a chance to run any done-callbacks.
+        await asyncio.sleep(0.001)
+
+
+@pytest.mark.asyncio
+@pytest.mark.fixed_client
+class TestAsyncClusterMaintNotificationsConfig(TestAsyncClusterMaintNotificationsBase):
+    """Test the maint_notifications_config parameter of async RedisCluster."""
+
+    def _validate_maint_config_on_cluster(
+        self,
+        cluster: "redis.RedisCluster",
+        expected_enabled,
+        expected_proactive_reconnect: bool,
+        expected_relaxed_timeout: int,
+    ) -> None:
+        """Validate maint_notifications_config stored on the cluster client.
+
+        Note: the async cluster stores the config on the client itself (via the
+        AsyncMaintNotificationsAbstractRedisCluster mixin), not on the
+        NodesManager as the sync client does.
+        """
+        assert cluster.maint_notifications_config is not None
+        assert cluster.maint_notifications_config.enabled == expected_enabled
+        assert (
+            cluster.maint_notifications_config.proactive_reconnect
+            == expected_proactive_reconnect
+        )
+        assert (
+            cluster.maint_notifications_config.relaxed_timeout
+            == expected_relaxed_timeout
+        )
+
+    def _validate_handler_on_nodes(
+        self,
+        cluster: "redis.RedisCluster",
+        should_have_handler: bool = True,
+    ) -> None:
+        """Validate the OSS cluster handler propagation to nodes' connection kwargs.
+
+        Covers both discovered nodes (nodes_cache, populated during initialize())
+        and startup nodes. Startup nodes are built before the maint mixin runs and
+        keep their own connection_kwargs snapshot, so they must be wired explicitly;
+        if they are not, initialize() opens its CLUSTER SLOTS discovery connection
+        on a startup node with no push handler and drops maintenance notifications.
+        """
+        nodes = list(cluster.nodes_manager.nodes_cache.values())
+        startup_nodes = list(cluster.nodes_manager.startup_nodes.values())
+        assert len(nodes) > 0, "Cluster should have at least one node"
+        assert len(startup_nodes) > 0, "Cluster should have at least one startup node"
+
+        for node in nodes + startup_nodes:
+            handler = node.connection_kwargs.get(
+                "oss_cluster_maint_notifications_handler"
+            )
+            if should_have_handler:
+                assert handler is not None
+                assert handler is cluster._oss_cluster_maint_notifications_handler
+            else:
+                assert handler is None
+
+    async def test_maint_notifications_config(self):
+        """maint_notifications_config is stored on the client and handler propagated."""
+        maint_config = MaintNotificationsConfig(
+            enabled=False, proactive_reconnect=True, relaxed_timeout=30
+        )
+
+        cluster = await self._create_cluster_client(maint_config=maint_config)
+
+        try:
+            self._validate_maint_config_on_cluster(cluster, False, True, 30)
+            # enabled=False -> no handler created/propagated
+            self._validate_handler_on_nodes(cluster, should_have_handler=False)
+
+            # Verify we can execute commands without errors
+            await cluster.set("test", "VAL")
+            res = await cluster.get("test")
+            assert res == b"VAL"
+        finally:
+            await cluster.aclose()
+
+    async def test_config_propagation_to_new_nodes(self):
+        """When a new node is discovered, it receives the same handler via kwargs."""
+        maint_config = MaintNotificationsConfig(
+            enabled="auto", proactive_reconnect=True, relaxed_timeout=25
+        )
+
+        cluster = await self._create_cluster_client(maint_config=maint_config)
+
+        try:
+            initial_node_count = len(cluster.nodes_manager.nodes_cache)
+            self._validate_handler_on_nodes(cluster, should_have_handler=True)
+
+            # Reinitialize to ensure all nodes are (re)discovered
+            await cluster.nodes_manager.initialize()
+
+            new_node_count = len(cluster.nodes_manager.nodes_cache)
+            assert new_node_count >= initial_node_count
+            self._validate_handler_on_nodes(cluster, should_have_handler=True)
+        finally:
+            await cluster.aclose()
+
+    async def test_none_config_default_behavior(self):
+        """maint_notifications_config=None with protocol 3 -> default config created."""
+        cluster = await self._create_cluster_client(maint_config=None)
+
+        try:
+            assert cluster.nodes_manager is not None
+            # for protocol 3, maint_notifications_config should default to "auto"
+            assert cluster.maint_notifications_config is not None
+            assert cluster.maint_notifications_config.enabled == "auto"
+            assert len(cluster.nodes_manager.nodes_cache) > 0
+
+            await cluster.set("test", "VAL")
+            res = await cluster.get("test")
+            assert res == b"VAL"
+        finally:
+            await cluster.aclose()
+
+    async def test_none_config_default_behavior_for_protocol_2(self):
+        """maint_notifications_config=None with protocol 2 -> not initialized."""
+        cluster = await self._create_cluster_client(protocol=2)
+
+        try:
+            assert cluster.nodes_manager is not None
+            # for protocol 2, maint_notifications_config should not be created
+            assert cluster.maint_notifications_config is None
+            assert len(cluster.nodes_manager.nodes_cache) > 0
+
+            await cluster.set("test", "VAL")
+            res = await cluster.get("test")
+            assert res == b"VAL"
+        finally:
+            await cluster.aclose()
+
+    async def test_config_with_enabled_false(self):
+        """enabled=False -> handlers are not created/propagated."""
+        maint_config = MaintNotificationsConfig(
+            enabled=False, proactive_reconnect=False, relaxed_timeout=-1
+        )
+
+        cluster = await self._create_cluster_client(maint_config=maint_config)
+
+        try:
+            self._validate_maint_config_on_cluster(cluster, False, False, -1)
+            self._validate_handler_on_nodes(cluster, should_have_handler=False)
+            assert cluster._oss_cluster_maint_notifications_handler is None
+
+            await cluster.set("test", "VAL")
+            res = await cluster.get("test")
+            assert res == b"VAL"
+        finally:
+            await cluster.aclose()
+
+    async def test_config_with_pipeline_operations(self):
+        """maint_notifications_config works with pipelined commands."""
+        maint_config = MaintNotificationsConfig(
+            enabled="auto", proactive_reconnect=True, relaxed_timeout=10
+        )
+
+        cluster = await self._create_cluster_client(maint_config=maint_config)
+
+        try:
+            self._validate_maint_config_on_cluster(cluster, "auto", True, 10)
+            self._validate_handler_on_nodes(cluster, should_have_handler=True)
+
+            pipe = cluster.pipeline()
+            pipe.set("pipe_key1", "value1")
+            pipe.set("pipe_key2", "value2")
+            pipe.get("pipe_key1")
+            pipe.get("pipe_key2")
+            results = await pipe.execute()
+
+            assert results[0] is True or results[0] == b"OK"
+            assert results[1] is True or results[1] == b"OK"
+            assert results[2] == b"value1"
+            assert results[3] == b"value2"
+        finally:
+            await cluster.aclose()
+
+    async def test_explicit_enable_without_resp3_raises(self):
+        """Explicit enabled=True with protocol 2 raises RedisError."""
+        from redis.exceptions import RedisError
+
+        maint_config = MaintNotificationsConfig(enabled=True)
+        with pytest.raises(RedisError):
+            redis.RedisCluster(
+                protocol=2,
+                startup_nodes=PROXY_CLUSTER_NODES,
+                maint_notifications_config=maint_config,
+            )
+
+    async def test_handler_wired_on_startup_nodes_before_initialize(self):
+        """Startup nodes must carry the OSS handler before initialize() runs.
+
+        Regression test for the startup-node kwargs snapshot bug: startup
+        ClusterNodes are constructed before the maint mixin runs and keep their
+        own connection_kwargs copy. If the handler is injected only into the
+        shared nodes_manager.connection_kwargs, the startup nodes stay stale and
+        initialize() opens its CLUSTER SLOTS discovery connection with no push
+        handler wired, silently dropping maintenance notifications on it.
+
+        This must be asserted *before* initialize(): with the default
+        dynamic_startup_nodes=True, initialize() replaces startup_nodes with the
+        (handler-wired) discovered nodes, which would mask the original defect.
+        """
+        maint_config = MaintNotificationsConfig(enabled=True)
+        cluster = redis.RedisCluster(
+            protocol=3,
+            startup_nodes=PROXY_CLUSTER_NODES,
+            maint_notifications_config=maint_config,
+        )
+        try:
+            handler = cluster._oss_cluster_maint_notifications_handler
+            assert handler is not None
+
+            startup_nodes = list(cluster.nodes_manager.startup_nodes.values())
+            assert len(startup_nodes) == len(PROXY_CLUSTER_NODES)
+            for node in startup_nodes:
+                assert (
+                    node.connection_kwargs.get(
+                        "oss_cluster_maint_notifications_handler"
+                    )
+                    is handler
+                )
+        finally:
+            await cluster.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.fixed_client
+class TestAsyncClusterMaintNotificationsHandler(TestAsyncClusterMaintNotificationsBase):
+    """Test AsyncOSSMaintNotificationsHandler propagation to connections."""
+
+    def _validate_connection_handlers(self, conn, cluster_client, config):
+        """Validate that the connection's parser handlers are properly set."""
+        # The oss cluster handler function is correctly set on the parser
+        oss_handler = conn._parser.oss_cluster_maint_push_handler_func
+        assert oss_handler is not None
+        assert hasattr(oss_handler, "__self__")
+        assert hasattr(oss_handler, "__func__")
+        assert oss_handler.__self__.cluster_client is cluster_client
+        assert (
+            oss_handler.__self__._lock
+            is cluster_client._oss_cluster_maint_notifications_handler._lock
+        )
+        assert (
+            oss_handler.__self__._processed_notifications
+            is cluster_client._oss_cluster_maint_notifications_handler._processed_notifications
+        )
+
+        # The maintenance (connection-level) handler is correctly set on the parser
+        maint_handler = conn._parser.maintenance_push_handler_func
+        assert maint_handler is not None
+        assert hasattr(maint_handler, "__self__")
+        assert hasattr(maint_handler, "__func__")
+        assert maint_handler.__self__ is conn._maint_notifications_connection_handler
+        assert (
+            maint_handler.__func__
+            is conn._maint_notifications_connection_handler.handle_notification.__func__
+        )
+
+        assert conn._maint_notifications_connection_handler.config is config
+
+    async def test_oss_maint_handler_propagation(self):
+        """OSSMaintNotificationsHandler is propagated to all connections."""
+        config = MaintNotificationsConfig(
+            enabled="auto", proactive_reconnect=True, relaxed_timeout=30
+        )
+        cluster = await self._create_cluster_client(maint_config=config)
+        try:
+            await self._warm_up_connection_pools(cluster, created_connections_count=3)
+            for node in cluster.nodes_manager.nodes_cache.values():
+                for conn in _node_all_connections(node):
+                    assert conn._oss_cluster_maint_notifications_handler is not None
+                    self._validate_connection_handlers(
+                        conn, cluster, cluster.maint_notifications_config
+                    )
+        finally:
+            await cluster.aclose()
+
+
+class TestAsyncClusterMaintNotificationsHandlingBase(
+    TestAsyncClusterMaintNotificationsBase
+):
+    """Base class for async maintenance notifications handling tests.
+
+    Uses an autouse async fixture (instead of sync setup_method/teardown_method)
+    because cluster creation requires ``await initialize()``.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def _setup_cluster(self):
+        self.proxy_helper = ProxyInterceptorHelper()
+        self.proxy_helper.cleanup_interceptors(CLUSTER_SLOTS_INTERCEPTOR_NAME)
+
+        self.config = MaintNotificationsConfig(
+            enabled="auto", proactive_reconnect=True, relaxed_timeout=30
+        )
+        self.cluster = await self._create_cluster_client(maint_config=self.config)
+        try:
+            yield
+        finally:
+            await self.cluster.aclose()
+            self.proxy_helper.cleanup_interceptors()
+
+
+@dataclass
+class ConnectionStateExpectation:
+    """Holds expected connection state details for validation."""
+
+    node_port: int
+    changed_connections_count: int = 0
+    state: MaintenanceState = MaintenanceState.NONE
+    relaxed_timeout: Optional[int] = None
+
+
+@pytest.mark.asyncio
+@pytest.mark.fixed_client
+class TestAsyncClusterMaintNotificationsHandling(
+    TestAsyncClusterMaintNotificationsHandlingBase
+):
+    """Test maintenance notifications handling with async RedisCluster."""
+
+    def _get_expected_node_state(
+        self, expectations_list: List[ConnectionStateExpectation], node_port: int
+    ) -> Optional[ConnectionStateExpectation]:
+        for expectation in expectations_list:
+            if expectation.node_port == node_port:
+                return expectation
+        return None
+
+    def _validate_connections_states(
+        self,
+        cluster: "redis.RedisCluster",
+        expected_states: List[ConnectionStateExpectation],
+    ):
+        """Validate per-node connection maintenance state / relaxed timeout."""
+        default_maint_state = MaintenanceState.NONE
+        default_timeout = None
+        for node in list(cluster.nodes_manager.nodes_cache.values()):
+            expected_state = self._get_expected_node_state(expected_states, node.port)
+            if expected_state is None:
+                continue
+            changed_connections_count = 0
+            for conn in _node_all_connections(node):
+                if (
+                    conn.maintenance_state != default_maint_state
+                    and conn.maintenance_state == expected_state.state
+                ) or (
+                    conn.socket_timeout != default_timeout
+                    and conn.socket_timeout == expected_state.relaxed_timeout
+                ):
+                    changed_connections_count += 1
+            assert changed_connections_count == expected_state.changed_connections_count
+
+    def _validate_removed_node_connections(self, node: ClusterNode):
+        """Validate connections in a removed node are disconnected / for reconnect."""
+        for conn in _node_free_connections(node):
+            assert conn._sock is None
+        for conn in _node_in_use_connections(node):
+            assert conn.should_reconnect()
+
+    async def test_receive_smigrating_notification(self):
+        """Receiving an SMIGRATING notification relaxes timeout on one connection."""
+        await self._warm_up_connection_pools(self.cluster, created_connections_count=3)
+
+        notification = RespTranslator.oss_maint_notification_to_resp(
+            "SMIGRATING 12 123,456,5000-7000"
+        )
+        self.proxy_helper.send_notification(notification)
+
+        # validate no timeout is relaxed on any connection yet
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(NODE_PORT_1, 0),
+                ConnectionStateExpectation(NODE_PORT_2, 0),
+                ConnectionStateExpectation(NODE_PORT_3, 0),
+            ],
+        )
+
+        # execute a command that will receive the notification
+        res = await self.cluster.set("anyprefix:{3}:k", "VAL")
+        assert res is True
+
+        # SMIGRATING is handled at the connection level (synchronously while reading
+        # the response) - no background task draining needed here.
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(
+                    NODE_PORT_1,
+                    changed_connections_count=1,
+                    state=MaintenanceState.MAINTENANCE,
+                    relaxed_timeout=self.config.relaxed_timeout,
+                ),
+                ConnectionStateExpectation(NODE_PORT_2, 0),
+                ConnectionStateExpectation(NODE_PORT_3, 0),
+            ],
+        )
+
+    async def test_receive_smigrating_with_disabled_relaxed_timeout(self):
+        """SMIGRATING with relaxed_timeout disabled does not change any connection."""
+        disabled_config = MaintNotificationsConfig(
+            enabled="auto",
+            relaxed_timeout=-1,  # disabled
+        )
+        cluster = await self._create_cluster_client(maint_config=disabled_config)
+        try:
+            await self._warm_up_connection_pools(cluster, created_connections_count=3)
+
+            notification = RespTranslator.oss_maint_notification_to_resp(
+                "SMIGRATING 12 123,456,5000-7000"
+            )
+            self.proxy_helper.send_notification(notification)
+
+            await cluster.set("anyprefix:{3}:k", "VAL")
+
+            self._validate_connections_states(
+                cluster,
+                [
+                    ConnectionStateExpectation(NODE_PORT_1, 0),
+                    ConnectionStateExpectation(NODE_PORT_2, 0),
+                    ConnectionStateExpectation(NODE_PORT_3, 0),
+                ],
+            )
+        finally:
+            await cluster.aclose()
+
+    async def test_receive_smigrated_notification(self):
+        """Receiving an SMIGRATED notification updates the cluster topology."""
+        await self._warm_up_connection_pools(self.cluster, created_connections_count=3)
+
+        self.proxy_helper.set_cluster_slots(
+            CLUSTER_SLOTS_INTERCEPTOR_NAME,
+            [
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_NEW, 0, 5460),
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_2, 5461, 10922),
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_3, 10923, 16383),
+            ],
+        )
+        notification = RespTranslator.oss_maint_notification_to_resp(
+            f"SMIGRATED 12 {NODE_IP_PROXY}:{NODE_PORT_1} "
+            f"{NODE_IP_PROXY}:{NODE_PORT_2} 123,456,5000-7000"
+        )
+        self.proxy_helper.send_notification(notification)
+
+        # execute a command that will receive the notification
+        res = await self.cluster.set("anyprefix:{3}:k", "VAL")
+        assert res is True
+
+        # SMIGRATED is handled in a background task in the async client
+        await self._drain_maint_notification_tasks(self.cluster)
+
+        new_node = self.cluster.nodes_manager.get_node(
+            host=NODE_IP_PROXY, port=NODE_PORT_NEW
+        )
+        assert new_node is not None
+
+    async def test_receive_smigrated_notification_with_two_nodes(self):
+        """SMIGRATED affecting two destination nodes updates the topology."""
+        await self._warm_up_connection_pools(self.cluster, created_connections_count=3)
+
+        self.proxy_helper.set_cluster_slots(
+            CLUSTER_SLOTS_INTERCEPTOR_NAME,
+            [
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_NEW, 0, 5460),
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_2, 5461, 10922),
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_3, 10923, 16383),
+            ],
+        )
+        notification = RespTranslator.oss_maint_notification_to_resp(
+            f"SMIGRATED 12 {NODE_IP_PROXY}:{NODE_PORT_1} "
+            f"{NODE_IP_PROXY}:{NODE_PORT_2} 123,456,5000-7000 "
+            f"{NODE_IP_PROXY}:{NODE_PORT_1} {NODE_IP_PROXY}:{NODE_PORT_NEW} 110-120"
+        )
+        self.proxy_helper.send_notification(notification)
+
+        res = await self.cluster.set("anyprefix:{3}:k", "VAL")
+        assert res is True
+
+        await self._drain_maint_notification_tasks(self.cluster)
+
+        new_node = self.cluster.nodes_manager.get_node(
+            host=NODE_IP_PROXY, port=NODE_PORT_NEW
+        )
+        assert new_node is not None
+
+    async def test_smigrating_smigrated_on_the_same_node_two_slot_ranges(self):
+        """Second in-progress migration must not unrelax the timeouts early."""
+        await self._warm_up_connection_pools(self.cluster, created_connections_count=1)
+
+        smigrating_node_1 = RespTranslator.oss_maint_notification_to_resp(
+            "SMIGRATING 12 1000-2000,2500-3000"
+        )
+        self.proxy_helper.send_notification(smigrating_node_1)
+        await self.cluster.set("anyprefix:{3}:k", "VAL")
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(
+                    NODE_PORT_1,
+                    changed_connections_count=1,
+                    state=MaintenanceState.MAINTENANCE,
+                    relaxed_timeout=self.config.relaxed_timeout,
+                ),
+            ],
+        )
+
+        smigrated_node_1 = RespTranslator.oss_maint_notification_to_resp(
+            f"SMIGRATED 14 {NODE_IP_PROXY}:{NODE_PORT_1} "
+            f"{NODE_IP_PROXY}:{NODE_PORT_2} 1000-2000 "
+            f"{NODE_IP_PROXY}:{NODE_PORT_1} {NODE_IP_PROXY}:{NODE_PORT_3} 2500-3000"
+        )
+        self.proxy_helper.send_notification(smigrated_node_1)
+        await self.cluster.set("anyprefix:{3}:k", "VAL")
+        await self._drain_maint_notification_tasks(self.cluster)
+
+        # second migration still in progress -> timeout remains relaxed
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(NODE_PORT_1),
+            ],
+        )
+
+        smigrated_node_1_2 = RespTranslator.oss_maint_notification_to_resp(
+            f"SMIGRATED 15 {NODE_IP_PROXY}:{NODE_PORT_1} "
+            f"{NODE_IP_PROXY}:{NODE_PORT_3} 3000-4000"
+        )
+        self.proxy_helper.send_notification(smigrated_node_1_2)
+        await self.cluster.set("anyprefix:{3}:k", "VAL")
+        await self._drain_maint_notification_tasks(self.cluster)
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(
+                    NODE_PORT_1,
+                    changed_connections_count=0,
+                ),
+            ],
+        )
+
+    async def test_smigrated_node_replacement_resets_topology_connection_configs(self):
+        """End-to-end node replacement over the proxy with three warmed-up nodes.
+
+        Start with three nodes, each with 3 connections created and used. An
+        SMIGRATING notification relaxes a connection on NODE_PORT_1, then an
+        SMIGRATED notification migrates all of NODE_PORT_1's slots to
+        NODE_PORT_NEW - so NODE_PORT_1 leaves the topology and NODE_PORT_NEW joins.
+
+        After the async handler drains, validate the end result:
+          * the topology was updated (NODE_PORT_NEW in, NODE_PORT_1 out);
+          * every node remaining in the topology has its connections back at the
+            default (non-relaxed) config - i.e. no connection is left in
+            MAINTENANCE / with a relaxed timeout;
+          * the replaced node's connections were cleaned up (each is either
+            disconnected or marked for reconnect, so none can serve a command
+            with the stale relaxed timeout).
+        """
+        await self._warm_up_connection_pools(self.cluster, created_connections_count=3)
+
+        # Grab the node that will be replaced before it leaves the topology.
+        removed_node = self.cluster.nodes_manager.get_node(
+            host=NODE_IP_PROXY, port=NODE_PORT_1
+        )
+        assert removed_node is not None
+        assert len(_node_all_connections(removed_node)) == 3
+
+        # 1) SMIGRATING relaxes a connection on NODE_PORT_1 (the migrating source).
+        self.proxy_helper.send_notification(
+            RespTranslator.oss_maint_notification_to_resp(
+                "SMIGRATING 12 123,456,5000-7000"
+            )
+        )
+        assert await self.cluster.set("anyprefix:{3}:k", "VAL") is True
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(
+                    NODE_PORT_1,
+                    changed_connections_count=1,
+                    state=MaintenanceState.MAINTENANCE,
+                    relaxed_timeout=self.config.relaxed_timeout,
+                ),
+                ConnectionStateExpectation(NODE_PORT_2, 0),
+                ConnectionStateExpectation(NODE_PORT_3, 0),
+            ],
+        )
+
+        # 2) SMIGRATED migrates all of NODE_PORT_1's slots to NODE_PORT_NEW, so
+        # NODE_PORT_1 is dropped from the topology and NODE_PORT_NEW is added.
+        self.proxy_helper.set_cluster_slots(
+            CLUSTER_SLOTS_INTERCEPTOR_NAME,
+            [
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_NEW, 0, 5460),
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_2, 5461, 10922),
+                SlotsRange(NODE_IP_PROXY, NODE_PORT_3, 10923, 16383),
+            ],
+        )
+        self.proxy_helper.send_notification(
+            RespTranslator.oss_maint_notification_to_resp(
+                f"SMIGRATED 13 {NODE_IP_PROXY}:{NODE_PORT_1} "
+                f"{NODE_IP_PROXY}:{NODE_PORT_NEW} 0-5460"
+            )
+        )
+        assert await self.cluster.set("anyprefix:{3}:k", "VAL") is True
+        await self._drain_maint_notification_tasks(self.cluster)
+
+        # Topology updated: new node joined, replaced node gone.
+        assert (
+            self.cluster.nodes_manager.get_node(host=NODE_IP_PROXY, port=NODE_PORT_NEW)
+            is not None
+        )
+        assert (
+            self.cluster.nodes_manager.get_node(host=NODE_IP_PROXY, port=NODE_PORT_1)
+            is None
+        )
+
+        # Every node remaining in the topology is back at the default config -
+        # no connection left relaxed / in MAINTENANCE.
+        self._validate_connections_states(
+            self.cluster,
+            [
+                ConnectionStateExpectation(NODE_PORT_NEW, 0),
+                ConnectionStateExpectation(NODE_PORT_2, 0),
+                ConnectionStateExpectation(NODE_PORT_3, 0),
+            ],
+        )
+
+        # The replaced node's connections were cleaned up: each is either
+        # disconnected (free connections) or marked for reconnect (in-use), so
+        # none can be reused with the stale relaxed timeout.
+        for conn in _node_all_connections(removed_node):
+            assert (not conn.is_connected) or conn.should_reconnect()

--- a/tests/maint_notifications/test_async_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_cluster_maint_notifications_handling.py
@@ -470,7 +470,17 @@ class TestAsyncClusterMaintNotificationsHandling(
         cluster: "redis.RedisCluster",
         expected_states: List[ConnectionStateExpectation],
     ):
-        """Validate per-node connection maintenance state / relaxed timeout."""
+        """Validate per-node connection maintenance state / relaxed timeout.
+
+        A connection is counted as "changed" when it deviates from the default
+        (non-maintenance) config - i.e. its ``maintenance_state`` is not
+        ``NONE`` or its ``socket_timeout`` is not the default. For every node
+        with an expectation, exactly ``changed_connections_count`` connections
+        must be changed; a zero expectation therefore asserts that no connection
+        deviates from the default config. When a non-default state is expected,
+        the changed connections must additionally match the expected ``state`` /
+        ``relaxed_timeout``.
+        """
         default_maint_state = MaintenanceState.NONE
         default_timeout = None
         for node in list(cluster.nodes_manager.nodes_cache.values()):
@@ -478,16 +488,26 @@ class TestAsyncClusterMaintNotificationsHandling(
             if expected_state is None:
                 continue
             changed_connections_count = 0
+            matching_expected_count = 0
             for conn in _node_all_connections(node):
                 if (
                     conn.maintenance_state != default_maint_state
-                    and conn.maintenance_state == expected_state.state
-                ) or (
-                    conn.socket_timeout != default_timeout
-                    and conn.socket_timeout == expected_state.relaxed_timeout
+                    or conn.socket_timeout != default_timeout
                 ):
                     changed_connections_count += 1
+                if (
+                    conn.maintenance_state == expected_state.state
+                    and conn.socket_timeout == expected_state.relaxed_timeout
+                ):
+                    matching_expected_count += 1
             assert changed_connections_count == expected_state.changed_connections_count
+            if (
+                expected_state.state != default_maint_state
+                or expected_state.relaxed_timeout != default_timeout
+            ):
+                assert (
+                    matching_expected_count == expected_state.changed_connections_count
+                )
 
     def _validate_removed_node_connections(self, node: ClusterNode):
         """Validate connections in a removed node are disconnected / for reconnect."""
@@ -656,7 +676,12 @@ class TestAsyncClusterMaintNotificationsHandling(
         self._validate_connections_states(
             self.cluster,
             [
-                ConnectionStateExpectation(NODE_PORT_1),
+                ConnectionStateExpectation(
+                    NODE_PORT_1,
+                    changed_connections_count=1,
+                    state=MaintenanceState.MAINTENANCE,
+                    relaxed_timeout=self.config.relaxed_timeout,
+                ),
             ],
         )
 

--- a/tests/maint_notifications/test_async_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_cluster_maint_notifications_handling.py
@@ -1,6 +1,7 @@
 import asyncio
 from dataclasses import dataclass
 from typing import List, Optional
+from unittest.mock import patch
 
 import pytest
 
@@ -88,6 +89,7 @@ class TestAsyncClusterMaintNotificationsBase:
             startup_nodes=PROXY_CLUSTER_NODES,
             maint_notifications_config=maint_config,
             max_connections=max_connections,
+            socket_timeout=DEFAULT_SOCKET_TIMEOUT,
         )
         await test_redis_client.initialize()
 
@@ -469,20 +471,21 @@ class TestAsyncClusterMaintNotificationsHandling(
         self,
         cluster: "redis.RedisCluster",
         expected_states: List[ConnectionStateExpectation],
+        default_timeout: Optional[float] = DEFAULT_SOCKET_TIMEOUT,
     ):
         """Validate per-node connection maintenance state / relaxed timeout.
 
         A connection is counted as "changed" when it deviates from the default
         (non-maintenance) config - i.e. its ``maintenance_state`` is not
-        ``NONE`` or its ``socket_timeout`` is not the default. For every node
-        with an expectation, exactly ``changed_connections_count`` connections
-        must be changed; a zero expectation therefore asserts that no connection
-        deviates from the default config. When a non-default state is expected,
-        the changed connections must additionally match the expected ``state`` /
-        ``relaxed_timeout``.
+        ``NONE`` or its ``socket_timeout`` is not ``default_timeout`` (the
+        socket timeout the client's connections are created with). For every
+        node with an expectation, exactly ``changed_connections_count``
+        connections must be changed; a zero expectation therefore asserts that
+        no connection deviates from the default config. When a non-default state
+        is expected, the changed connections must additionally match the
+        expected ``state`` / ``relaxed_timeout``.
         """
         default_maint_state = MaintenanceState.NONE
-        default_timeout = None
         for node in list(cluster.nodes_manager.nodes_cache.values()):
             expected_state = self._get_expected_node_state(expected_states, node.port)
             if expected_state is None:
@@ -642,8 +645,17 @@ class TestAsyncClusterMaintNotificationsHandling(
         )
         assert new_node is not None
 
-    async def test_smigrating_smigrated_on_the_same_node_two_slot_ranges(self):
-        """Second in-progress migration must not unrelax the timeouts early."""
+    async def test_smigrated_resets_relaxed_timeout_on_migrating_node(self):
+        """The relaxed timeout is reverted once the migrating node's connection
+        goes through a reconnect.
+
+        SMIGRATING relaxes the timeout on the connection that processes it. In
+        the async client the relaxation is not reverted inline from the push
+        handler; instead it is rolled back when the connection reconnects (on
+        disconnect). The migrating node stays in the topology here, so we consume
+        its connections and force them through a reconnect, then assert the
+        relaxed timeout has been reset to the default.
+        """
         await self._warm_up_connection_pools(self.cluster, created_connections_count=1)
 
         smigrating_node_1 = RespTranslator.oss_maint_notification_to_resp(
@@ -672,26 +684,20 @@ class TestAsyncClusterMaintNotificationsHandling(
         await self.cluster.set("anyprefix:{3}:k", "VAL")
         await self._drain_maint_notification_tasks(self.cluster)
 
-        # second migration still in progress -> timeout remains relaxed
-        self._validate_connections_states(
-            self.cluster,
-            [
-                ConnectionStateExpectation(
-                    NODE_PORT_1,
-                    changed_connections_count=1,
-                    state=MaintenanceState.MAINTENANCE,
-                    relaxed_timeout=self.config.relaxed_timeout,
-                ),
-            ],
+        # Node 1 keeps some slots, so it stays in the topology. Consume its
+        # connections and force them through a reconnect - the disconnect reverts
+        # the maintenance relaxation (socket timeout and maintenance state are
+        # restored to the defaults).
+        node_1 = self.cluster.nodes_manager.get_node(
+            host=NODE_IP_PROXY, port=NODE_PORT_1
         )
-
-        smigrated_node_1_2 = RespTranslator.oss_maint_notification_to_resp(
-            f"SMIGRATED 15 {NODE_IP_PROXY}:{NODE_PORT_1} "
-            f"{NODE_IP_PROXY}:{NODE_PORT_3} 3000-4000"
-        )
-        self.proxy_helper.send_notification(smigrated_node_1_2)
+        assert node_1 is not None
+        for conn in _node_all_connections(node_1):
+            await conn.disconnect()
+        # Reconnect on next use.
         await self.cluster.set("anyprefix:{3}:k", "VAL")
-        await self._drain_maint_notification_tasks(self.cluster)
+
+        # After the reconnect the relaxed timeout is reset to the default.
         self._validate_connections_states(
             self.cluster,
             [
@@ -702,6 +708,7 @@ class TestAsyncClusterMaintNotificationsHandling(
             ],
         )
 
+    @patch("redis.asyncio.cluster.random.shuffle", new=_preserve_startup_nodes_order)
     async def test_smigrated_node_replacement_resets_topology_connection_configs(self):
         """End-to-end node replacement over the proxy with three warmed-up nodes.
 

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -15,6 +15,7 @@ from redis.asyncio.connection import (
 from redis.asyncio.maint_notifications import (
     AsyncMaintNotificationsConnectionHandler,
     AsyncMaintNotificationsPoolHandler,
+    AsyncOSSMaintNotificationsHandler,
 )
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError, ResponseError
@@ -27,7 +28,6 @@ from redis.maint_notifications import (
     NodeMigratedNotification,
     NodeMigratingNotification,
     NodeMovingNotification,
-    OSSNodeMigratingNotification,
 )
 from redis.utils import SENTINEL
 
@@ -210,30 +210,6 @@ async def test_async_connection_handler_handles_failover_start_and_end():
     assert connection.maintenance_state == MaintenanceState.NONE
     assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
     assert relaxed_timeout_metric.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_async_connection_handler_ignores_oss_cluster_notifications():
-    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
-    connection = DummyAsyncConnection()
-    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
-
-    with (
-        mock.patch(
-            "redis.asyncio.maint_notifications.record_maint_notification_count",
-            new=AsyncMock(),
-        ) as notification_count,
-        mock.patch(
-            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
-            new=AsyncMock(),
-        ) as relaxed_timeout_metric,
-    ):
-        await handler.handle_notification(OSSNodeMigratingNotification(id=1))
-
-    assert connection.maintenance_state == MaintenanceState.NONE
-    assert connection.timeout_updates == []
-    notification_count.assert_awaited_once()
-    relaxed_timeout_metric.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -457,6 +433,67 @@ async def test_async_pool_update_config_wires_existing_connections():
     assert pool.connection_kwargs["maint_notifications_pool_handler"] is (
         pool._maint_notifications_pool_handler
     )
+
+
+@pytest.mark.asyncio
+async def test_async_pool_update_oss_handler_wires_existing_connections():
+    """update_maint_notifications_config wires an OSS cluster handler onto every
+    existing connection in the pool.
+
+    Each connection's parser receives the OSS cluster and maintenance push
+    handlers and the connection references the handler. In-use connections are
+    marked for reconnect; free connections are wired then disconnected.
+    """
+    config = MaintNotificationsConfig(enabled=True)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    free_connection = pool.make_connection()
+    in_use_connection = pool.make_connection()
+    pool._available_connections.append(free_connection)
+    pool._in_use_connections.add(in_use_connection)
+
+    oss_handler = AsyncOSSMaintNotificationsHandler(MagicMock(), config)
+
+    await pool.update_maint_notifications_config(
+        config, oss_cluster_maint_notifications_handler=oss_handler
+    )
+
+    # In-use connection: parser has the OSS + maintenance push handlers wired
+    # and the connection is marked for reconnect.
+    assert in_use_connection._oss_cluster_maint_notifications_handler is oss_handler
+    in_use_oss_func = in_use_connection._parser.oss_cluster_maint_push_handler_func
+    assert in_use_oss_func is not None
+    assert in_use_oss_func.__func__ is oss_handler.handle_notification.__func__
+    assert in_use_connection._parser.maintenance_push_handler_func is not None
+    assert in_use_connection.should_reconnect()
+
+    # Free connection — the idle OSS path, wired then disconnected.
+    assert free_connection._oss_cluster_maint_notifications_handler is oss_handler
+    assert free_connection._parser.oss_cluster_maint_push_handler_func is not None
+    assert free_connection._parser.maintenance_push_handler_func is not None
+
+    # OSS cluster mode and pool-handler mode are mutually exclusive. The pool
+    # was created with the default (enabled) config, which wires a pool handler
+    # in __init__; switching to OSS mode must clear it from both the pool
+    # attribute and the shared connection kwargs so future connections are not
+    # configured with both handlers.
+    assert pool._maint_notifications_pool_handler is None
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+    assert (
+        pool.connection_kwargs.get("oss_cluster_maint_notifications_handler")
+        is oss_handler
+    )
+
+    # A connection created after the switch gets only the OSS cluster handler.
+    new_connection = pool.make_connection()
+    assert new_connection._maint_notifications_pool_handler is None
+    assert new_connection._parser.node_moving_push_handler_func is None
+    assert new_connection._oss_cluster_maint_notifications_handler is oss_handler
+    assert new_connection._parser.oss_cluster_maint_push_handler_func is not None
 
 
 @pytest.mark.asyncio

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -1,0 +1,1639 @@
+import asyncio
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import redis.asyncio as redis
+from redis._defaults import DEFAULT_SOCKET_CONNECT_TIMEOUT, DEFAULT_SOCKET_TIMEOUT
+from redis.asyncio.connection import (
+    BlockingConnectionPool,
+    Connection,
+    ConnectionPool,
+    UnixDomainSocketConnection,
+)
+from redis.asyncio.maint_notifications import (
+    AsyncMaintNotificationsConnectionHandler,
+    AsyncMaintNotificationsPoolHandler,
+)
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError, ResponseError
+from redis.maint_notifications import (
+    EndpointType,
+    MaintenanceState,
+    MaintNotificationsConfig,
+    NodeFailedOverNotification,
+    NodeFailingOverNotification,
+    NodeMigratedNotification,
+    NodeMigratingNotification,
+    NodeMovingNotification,
+    OSSNodeMigratingNotification,
+)
+from redis.utils import SENTINEL
+
+
+DEFAULT_HOST = "12.45.34.56"
+DEFAULT_PORT = 6379
+MOVED_HOST = "1.2.3.4"
+MOVED_PORT = 6380
+RELAXED_TIMEOUT = 30
+
+
+class DummyAsyncConnection:
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, peer=DEFAULT_HOST):
+        self.host = host
+        self.port = port
+        self.peer = peer
+        self.socket_timeout = DEFAULT_SOCKET_TIMEOUT
+        self.socket_connect_timeout = DEFAULT_SOCKET_CONNECT_TIMEOUT
+        self.orig_host_address = host
+        self.orig_socket_timeout = DEFAULT_SOCKET_TIMEOUT
+        self.orig_socket_connect_timeout = DEFAULT_SOCKET_CONNECT_TIMEOUT
+        self.maintenance_state = MaintenanceState.NONE
+        self.maintenance_notification_hash = None
+        self.connected = True
+        self.disconnect_calls = 0
+        self.timeout_updates = []
+        self.reset_notifications_calls = 0
+        self._should_reconnect = False
+
+    def __repr__(self):
+        return f"<DummyAsyncConnection(host={self.host},port={self.port})>"
+
+    def getpeername(self):
+        return self.peer
+
+    def get_resolved_ip(self):
+        return self.peer
+
+    def set_tmp_settings(
+        self,
+        tmp_host_address: str | object | None = SENTINEL,
+        tmp_relaxed_timeout: float | None = -1,
+    ):
+        if tmp_host_address and tmp_host_address != SENTINEL:
+            self.host = str(tmp_host_address)
+        if tmp_relaxed_timeout != -1:
+            self.socket_timeout = tmp_relaxed_timeout
+            self.socket_connect_timeout = tmp_relaxed_timeout
+
+    def reset_tmp_settings(
+        self,
+        reset_host_address=False,
+        reset_relaxed_timeout=False,
+    ):
+        if reset_host_address:
+            self.host = self.orig_host_address
+        if reset_relaxed_timeout:
+            self.socket_timeout = self.orig_socket_timeout
+            self.socket_connect_timeout = self.orig_socket_connect_timeout
+
+    def update_current_socket_timeout(self, relaxed_timeout=None):
+        self.timeout_updates.append(relaxed_timeout)
+
+    def reset_received_notifications(self):
+        self.reset_notifications_calls += 1
+
+    def mark_for_reconnect(self):
+        self._should_reconnect = True
+
+    def should_reconnect(self):
+        return self._should_reconnect
+
+    async def disconnect(self, *args, **kwargs):
+        self.disconnect_calls += 1
+        self.connected = False
+
+
+class UnsupportedAsyncConnection:
+    def __init__(self, host=DEFAULT_HOST, **kwargs):
+        self.host = host
+        self.kwargs = kwargs
+
+
+def _assert_connection_in_moving_state(
+    connection,
+    *,
+    expected_host=MOVED_HOST,
+    expected_timeout=RELAXED_TIMEOUT,
+    expected_notification_hash=None,
+):
+    assert connection.maintenance_state == MaintenanceState.MOVING
+    if expected_notification_hash is not None:
+        assert connection.maintenance_notification_hash == expected_notification_hash
+    assert connection.host == expected_host
+    assert connection.socket_timeout == expected_timeout
+    assert connection.socket_connect_timeout == expected_timeout
+
+
+def _assert_connection_in_default_state(connection, *, expected_host=DEFAULT_HOST):
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.maintenance_notification_hash is None
+    assert connection.host == expected_host
+    assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+    assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_applies_start_and_end_notifications():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ) as notification_count,
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeMigratingNotification(id=1, ttl=5))
+        await handler.handle_notification(NodeMigratedNotification(id=1))
+
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+    assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+    assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
+    assert connection.reset_notifications_calls == 1
+    assert notification_count.await_count == 2
+    assert relaxed_timeout_metric.await_count == 2
+    assert relaxed_timeout_metric.await_args_list[0].kwargs["relaxed"] is True
+    assert relaxed_timeout_metric.await_args_list[1].kwargs["relaxed"] is False
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_skips_timeout_changes_when_moving():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    connection.maintenance_state = MaintenanceState.MOVING
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeFailingOverNotification(id=1, ttl=5))
+
+    assert connection.maintenance_state == MaintenanceState.MOVING
+    assert connection.timeout_updates == []
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_handles_failover_start_and_end():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeFailingOverNotification(id=2, ttl=5))
+        await handler.handle_notification(NodeFailedOverNotification(id=2))
+
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
+    assert relaxed_timeout_metric.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_connection_handler_ignores_oss_cluster_notifications():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ) as notification_count,
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(OSSNodeMigratingNotification(id=1))
+
+    assert connection.maintenance_state == MaintenanceState.NONE
+    assert connection.timeout_updates == []
+    notification_count.assert_awaited_once()
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "start_notification,end_notification",
+    [
+        (NodeMigratingNotification(id=1, ttl=5), NodeMigratedNotification(id=1)),
+        (
+            NodeFailingOverNotification(id=2, ttl=5),
+            NodeFailedOverNotification(id=2),
+        ),
+    ],
+)
+async def test_async_connection_handler_ignores_relaxed_timeout_when_disabled(
+    start_notification, end_notification
+):
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=-1)
+    connection = DummyAsyncConnection()
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ) as notification_count,
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(start_notification)
+        await handler.handle_notification(end_notification)
+
+    _assert_connection_in_default_state(connection)
+    assert connection.timeout_updates == []
+    assert notification_count.await_count == 2
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_handler_logs_non_moving_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+    pool = MagicMock()
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+
+    with (
+        mock.patch.object(handler, "remove_expired_notifications", new=AsyncMock()),
+        mock.patch.object(
+            handler, "handle_node_moving_notification", new=AsyncMock()
+        ) as handle_moving,
+        mock.patch("redis.asyncio.maint_notifications.logger.error") as log_error,
+    ):
+        await handler.handle_notification(NodeMigratingNotification(id=1, ttl=5))
+
+    handle_moving.assert_not_awaited()
+    log_error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_parser_routes_maintenance_push_notifications_to_connection_handler():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ),
+    ):
+        await connection._parser.handle_push_response(["MIGRATING", 1, 5])
+        assert connection.maintenance_state == MaintenanceState.MAINTENANCE
+        assert connection.socket_timeout == RELAXED_TIMEOUT
+
+        await connection._parser.handle_push_response(["MIGRATED", 1])
+        assert connection.maintenance_state == MaintenanceState.NONE
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+
+        await connection._parser.handle_push_response(["FAILING_OVER", 2, 5])
+        assert connection.maintenance_state == MaintenanceState.MAINTENANCE
+        assert connection.socket_timeout == RELAXED_TIMEOUT
+
+        await connection._parser.handle_push_response(["FAILED_OVER", 2])
+        assert connection.maintenance_state == MaintenanceState.NONE
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_async_parser_routes_moving_push_notification_to_pool_handler():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = pool.make_connection()
+    pool._in_use_connections.add(connection)
+    connection._maint_notifications_pool_handler._schedule = MagicMock()
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ):
+        await connection._parser.handle_push_response(
+            ["MOVING", 1, 5, f"{MOVED_HOST}:{MOVED_PORT}"]
+        )
+
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    assert pool.connection_kwargs["maintenance_notification_hash"] == hash(
+        NodeMovingNotification(1, MOVED_HOST, MOVED_PORT, 5)
+    )
+    assert pool.connection_kwargs["host"] == MOVED_HOST
+
+
+@pytest.mark.asyncio
+async def test_async_parser_routes_moving_push_without_target():
+    config = MaintNotificationsConfig(enabled=True, relaxed_timeout=RELAXED_TIMEOUT)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = pool.make_connection()
+    pool._in_use_connections.add(connection)
+    connection._maint_notifications_pool_handler._schedule = MagicMock()
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ):
+        await connection._parser.handle_push_response(["MOVING", 1, 5, None])
+
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    assert pool.connection_kwargs["host"] == DEFAULT_HOST
+    connection._maint_notifications_pool_handler._schedule.assert_has_calls(
+        [
+            mock.call(
+                2.5,
+                connection._maint_notifications_pool_handler.run_proactive_reconnect,
+                None,
+            ),
+            mock.call(
+                5,
+                connection._maint_notifications_pool_handler.handle_node_moved_notification,
+                mock.ANY,
+            ),
+        ]
+    )
+
+
+def test_async_connection_installs_maintenance_parser_handlers():
+    config = MaintNotificationsConfig(enabled=True)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+
+    connection = pool.make_connection()
+    pool_handler = pool._maint_notifications_pool_handler
+
+    node_moving_handler = connection._parser.node_moving_push_handler_func
+    maintenance_handler = connection._parser.maintenance_push_handler_func
+
+    assert node_moving_handler is not None
+    assert node_moving_handler.__self__.connection is connection
+    assert node_moving_handler.__self__.pool is pool
+    assert node_moving_handler.__self__._lock is pool_handler._lock
+    assert (
+        node_moving_handler.__self__._processed_notifications
+        is pool_handler._processed_notifications
+    )
+
+    assert maintenance_handler is not None
+    assert (
+        maintenance_handler.__self__
+        is connection._maint_notifications_connection_handler
+    )
+    assert connection._maint_notifications_connection_handler.config is config
+
+
+@pytest.mark.asyncio
+async def test_async_pool_update_config_wires_existing_connections():
+    disabled_config = MaintNotificationsConfig(enabled=False)
+    enabled_config = MaintNotificationsConfig(enabled=True)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=disabled_config,
+    )
+    free_connection = pool.make_connection()
+    in_use_connection = pool.make_connection()
+    pool._available_connections.append(free_connection)
+    pool._in_use_connections.add(in_use_connection)
+
+    await pool.update_maint_notifications_config(enabled_config)
+
+    assert free_connection._parser.node_moving_push_handler_func is not None
+    assert free_connection._parser.maintenance_push_handler_func is not None
+    assert free_connection.maint_notifications_config is enabled_config
+    assert not free_connection.should_reconnect()
+
+    assert in_use_connection._parser.node_moving_push_handler_func is not None
+    assert in_use_connection._parser.maintenance_push_handler_func is not None
+    assert in_use_connection.maint_notifications_config is enabled_config
+    assert in_use_connection.should_reconnect()
+
+    assert pool.connection_kwargs["maint_notifications_config"] is enabled_config
+    assert pool.connection_kwargs["maint_notifications_pool_handler"] is (
+        pool._maint_notifications_pool_handler
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_sends_maint_notifications_command():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        endpoint_type=EndpointType.INTERNAL_FQDN,
+    )
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection.send_command = AsyncMock()
+    connection.read_response = AsyncMock(return_value=b"OK")
+
+    await connection.activate_maint_notifications_handling_if_enabled(
+        check_health=False
+    )
+
+    connection.send_command.assert_awaited_once_with(
+        "CLIENT",
+        "MAINT_NOTIFICATIONS",
+        "ON",
+        "moving-endpoint-type",
+        "internal-fqdn",
+        check_health=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_auto_suppresses_response_error():
+    config = MaintNotificationsConfig(enabled="auto")
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection.send_command = AsyncMock()
+    connection.read_response = AsyncMock(side_effect=ResponseError("unsupported"))
+
+    await connection.activate_maint_notifications_handling_if_enabled()
+
+    connection.send_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_handshake_enabled_raises_response_error():
+    config = MaintNotificationsConfig(enabled=True)
+    connection = Connection(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection.send_command = AsyncMock()
+    connection.read_response = AsyncMock(side_effect=ResponseError("unsupported"))
+
+    with pytest.raises(ResponseError):
+        await connection.activate_maint_notifications_handling_if_enabled()
+
+
+def test_async_pool_auto_enables_maint_notifications_for_default_resp3():
+    pool = ConnectionPool(host=DEFAULT_HOST, port=DEFAULT_PORT)
+
+    assert pool.maint_notifications_enabled() == "auto"
+    assert isinstance(
+        pool.connection_kwargs["maint_notifications_config"],
+        MaintNotificationsConfig,
+    )
+    assert pool.connection_kwargs["maint_notifications_pool_handler"] is (
+        pool._maint_notifications_pool_handler
+    )
+
+
+def test_async_pool_does_not_auto_enable_maint_notifications_without_valid_host():
+    pool = ConnectionPool(host=None, port=DEFAULT_PORT, protocol=3)
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+
+def test_async_pool_rejects_enabled_maint_notifications_without_valid_host():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported for connections without a host",
+    ):
+        ConnectionPool(
+            host=None,
+            port=DEFAULT_PORT,
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+def test_async_custom_connection_does_not_auto_enable_maint_notifications():
+    pool = ConnectionPool(
+        connection_class=UnsupportedAsyncConnection,
+        host=DEFAULT_HOST,
+        protocol=3,
+    )
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+
+def test_async_custom_connection_rejects_enabled_maint_notifications_config():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match=(
+            "Maintenance notifications are not supported for connection class "
+            "UnsupportedAsyncConnection"
+        ),
+    ):
+        ConnectionPool(
+            connection_class=UnsupportedAsyncConnection,
+            host=DEFAULT_HOST,
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+def test_async_unix_socket_pool_does_not_auto_enable_maint_notifications():
+    pool = ConnectionPool(
+        connection_class=UnixDomainSocketConnection,
+        path="/tmp/redis.sock",
+        protocol=3,
+    )
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+    assert "orig_host_address" not in pool.connection_kwargs
+
+
+@pytest.mark.asyncio
+async def test_async_unix_socket_pool_auto_maint_notifications_noop():
+    config = MaintNotificationsConfig(enabled="auto")
+    pool = ConnectionPool(
+        connection_class=UnixDomainSocketConnection,
+        path="/tmp/redis.sock",
+        protocol=3,
+    )
+
+    await pool.update_maint_notifications_config(config)
+
+    assert pool._maint_notifications_pool_handler is None
+    assert not pool.maint_notifications_enabled()
+    assert "maint_notifications_config" not in pool.connection_kwargs
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+
+
+def test_async_unix_socket_pool_rejects_enabled_maint_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported for Unix domain socket connections",
+    ):
+        ConnectionPool(
+            connection_class=UnixDomainSocketConnection,
+            path="/tmp/redis.sock",
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+def test_async_redis_unix_socket_rejects_enabled_maint_notifications():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications are not supported with Unix domain socket connections",
+    ):
+        redis.Redis(
+            unix_socket_path="/tmp/redis.sock",
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+async def test_async_pool_applies_and_cleans_up_moving_notification(pool_class):
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = pool_class(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    active_matching = DummyAsyncConnection(peer=DEFAULT_HOST)
+    active_other = DummyAsyncConnection(peer="8.8.8.8")
+    free_matching = DummyAsyncConnection(peer=DEFAULT_HOST)
+    free_other = DummyAsyncConnection(peer="8.8.8.8")
+    pool._in_use_connections.update({active_matching, active_other})
+    pool._available_connections.extend([free_matching, free_other])
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+
+    for connection in (active_matching, free_matching):
+        assert connection.maintenance_state == MaintenanceState.MOVING
+        assert connection.maintenance_notification_hash == hash(notification)
+        assert connection.host == MOVED_HOST
+        assert connection.socket_timeout == RELAXED_TIMEOUT
+        assert connection.socket_connect_timeout == RELAXED_TIMEOUT
+        assert connection.timeout_updates == [RELAXED_TIMEOUT]
+
+    assert active_matching.should_reconnect()
+    assert free_matching.disconnect_calls == 1
+    assert active_other.maintenance_state == MaintenanceState.NONE
+    assert free_other.maintenance_state == MaintenanceState.NONE
+
+    assert pool.connection_kwargs["host"] == MOVED_HOST
+    assert pool.connection_kwargs["port"] == DEFAULT_PORT
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    assert pool.connection_kwargs["maintenance_notification_hash"] == hash(notification)
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(notification),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    for connection in (active_matching, free_matching):
+        assert connection.maintenance_state == MaintenanceState.NONE
+        assert connection.maintenance_notification_hash is None
+        assert connection.host == DEFAULT_HOST
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+        assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+        assert connection.timeout_updates == [RELAXED_TIMEOUT, -1]
+
+    assert pool.connection_kwargs["host"] == DEFAULT_HOST
+    assert pool.connection_kwargs["port"] == DEFAULT_PORT
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.NONE
+    assert pool.connection_kwargs["maintenance_notification_hash"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+async def test_async_pool_moving_with_disabled_relaxed_timeout_preserves_timeouts(
+    pool_class,
+):
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=-1,
+    )
+    pool = pool_class(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+
+    assert connection.maintenance_state == MaintenanceState.MOVING
+    assert connection.maintenance_notification_hash == hash(notification)
+    assert connection.host == MOVED_HOST
+    assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+    assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+    assert connection.timeout_updates == [-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+async def test_async_new_connections_inherit_moving_settings_until_cleanup(pool_class):
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = pool_class(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+
+    moving_connection = pool.make_connection()
+    _assert_connection_in_moving_state(
+        moving_connection,
+        expected_notification_hash=hash(notification),
+    )
+    assert moving_connection.orig_host_address == DEFAULT_HOST
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(notification),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    restored_connection = pool.make_connection()
+    _assert_connection_in_default_state(restored_connection)
+    assert restored_connection.orig_host_address == DEFAULT_HOST
+
+
+@pytest.mark.asyncio
+async def test_async_migrated_after_moving_does_not_clear_moving_state():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    connection = DummyAsyncConnection()
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    pool._in_use_connections.add(connection)
+    moving_notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=moving_notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+
+    handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await handler.handle_notification(NodeMigratedNotification(id=2))
+
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(moving_notification),
+    )
+    assert pool.connection_kwargs["maintenance_state"] == MaintenanceState.MOVING
+    relaxed_timeout_metric.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_overlapping_moving_cleanup_only_reverts_latest_notification():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    first = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+    second_host = "5.6.7.8"
+    second = NodeMovingNotification(
+        id=2,
+        new_node_host=second_host,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(first, config, DEFAULT_HOST)
+    await pool.apply_moving_notification(second, config, DEFAULT_HOST)
+
+    assert pool.connection_kwargs["host"] == second_host
+    _assert_connection_in_moving_state(
+        connection,
+        expected_host=second_host,
+        expected_notification_hash=hash(second),
+    )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(first),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    assert pool.connection_kwargs["host"] == second_host
+    assert pool.connection_kwargs["maintenance_notification_hash"] == hash(second)
+    _assert_connection_in_moving_state(
+        connection,
+        expected_host=second_host,
+        expected_notification_hash=hash(second),
+    )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(second),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    assert pool.connection_kwargs["host"] == DEFAULT_HOST
+    _assert_connection_in_default_state(connection)
+
+
+@pytest.mark.asyncio
+async def test_async_moving_without_target_marks_for_reconnect_on_delayed_run():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    active = DummyAsyncConnection(peer=DEFAULT_HOST)
+    free = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(active)
+    pool._available_connections.append(free)
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=None,
+        new_node_port=None,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+
+    assert not active.should_reconnect()
+    assert free.disconnect_calls == 0
+    _assert_connection_in_moving_state(
+        active,
+        expected_host=DEFAULT_HOST,
+        expected_notification_hash=hash(notification),
+    )
+
+    await pool.run_proactive_reconnect(DEFAULT_HOST)
+
+    assert active.should_reconnect()
+    assert free.disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_moving_notifications_only_update_matching_address_connections():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host="test.address.com",
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    key1_connections = [
+        DummyAsyncConnection(host="test.address.com", peer="1.2.3.4"),
+        DummyAsyncConnection(host="test.address.com", peer="1.2.3.4"),
+    ]
+    key2_connections = [
+        DummyAsyncConnection(host="test.address.com", peer="5.6.7.8"),
+        DummyAsyncConnection(host="test.address.com", peer="5.6.7.8"),
+    ]
+    key3_connection = DummyAsyncConnection(host="test.address.com", peer="9.10.11.12")
+    pool._in_use_connections.update(
+        {key1_connections[0], key2_connections[0], key3_connection}
+    )
+    pool._available_connections.extend([key1_connections[1], key2_connections[1]])
+    first = NodeMovingNotification(
+        id=1,
+        new_node_host="13.14.15.16",
+        new_node_port=DEFAULT_PORT,
+        ttl=5,
+    )
+    second = NodeMovingNotification(
+        id=2,
+        new_node_host="17.18.19.20",
+        new_node_port=DEFAULT_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(first, config, "1.2.3.4")
+
+    for connection in key1_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="13.14.15.16",
+            expected_notification_hash=hash(first),
+        )
+    for connection in (*key2_connections, key3_connection):
+        _assert_connection_in_default_state(
+            connection, expected_host="test.address.com"
+        )
+
+    await pool.apply_moving_notification(second, config, "5.6.7.8")
+
+    for connection in key1_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="13.14.15.16",
+            expected_notification_hash=hash(first),
+        )
+    for connection in key2_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="17.18.19.20",
+            expected_notification_hash=hash(second),
+        )
+    _assert_connection_in_default_state(
+        key3_connection, expected_host="test.address.com"
+    )
+
+    key2_handler = AsyncMaintNotificationsConnectionHandler(key2_connections[0], config)
+    key3_handler = AsyncMaintNotificationsConnectionHandler(key3_connection, config)
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ),
+    ):
+        await key2_handler.handle_notification(NodeMigratingNotification(id=3, ttl=5))
+        await key2_handler.handle_notification(NodeMigratedNotification(id=3))
+        await key3_handler.handle_notification(NodeMigratingNotification(id=4, ttl=5))
+        await key3_handler.handle_notification(NodeMigratedNotification(id=4))
+
+    _assert_connection_in_moving_state(
+        key2_connections[0],
+        expected_host="17.18.19.20",
+        expected_notification_hash=hash(second),
+    )
+    _assert_connection_in_default_state(
+        key3_connection, expected_host="test.address.com"
+    )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(first),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    for connection in key1_connections:
+        _assert_connection_in_default_state(
+            connection, expected_host="test.address.com"
+        )
+    for connection in key2_connections:
+        _assert_connection_in_moving_state(
+            connection,
+            expected_host="17.18.19.20",
+            expected_notification_hash=hash(second),
+        )
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(second),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    for connection in (*key1_connections, *key2_connections, key3_connection):
+        _assert_connection_in_default_state(
+            connection, expected_host="test.address.com"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_moving_migrating_migrated_failed_over_state_transitions():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    free_connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    pool._available_connections.append(free_connection)
+    moving = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    await pool.apply_moving_notification(
+        moving,
+        config,
+        DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(moving),
+    )
+    _assert_connection_in_moving_state(
+        free_connection,
+        expected_notification_hash=hash(moving),
+    )
+
+    connection_handler = AsyncMaintNotificationsConnectionHandler(connection, config)
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ) as relaxed_timeout_metric,
+    ):
+        await connection_handler.handle_notification(
+            NodeMigratingNotification(id=2, ttl=5)
+        )
+        await connection_handler.handle_notification(NodeMigratedNotification(id=2))
+        await connection_handler.handle_notification(
+            NodeFailingOverNotification(id=3, ttl=5)
+        )
+        await connection_handler.handle_notification(NodeFailedOverNotification(id=3))
+
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(moving),
+    )
+    relaxed_timeout_metric.assert_not_awaited()
+
+    await pool.cleanup_moving_notification(
+        notification_hash=hash(moving),
+        reset_relaxed_timeout=True,
+        reset_host_address=True,
+    )
+
+    _assert_connection_in_default_state(connection)
+    _assert_connection_in_default_state(free_connection)
+
+    with (
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_maint_notification_count",
+            new=AsyncMock(),
+        ),
+        mock.patch(
+            "redis.asyncio.maint_notifications.record_connection_relaxed_timeout",
+            new=AsyncMock(),
+        ),
+    ):
+        await connection_handler.handle_notification(
+            NodeFailingOverNotification(id=4, ttl=5)
+        )
+        assert connection.maintenance_state == MaintenanceState.MAINTENANCE
+        await connection_handler.handle_notification(NodeFailedOverNotification(id=4))
+
+    _assert_connection_in_default_state(connection)
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_moving_notification_handling_is_deduplicated():
+    config = MaintNotificationsConfig(
+        enabled=True,
+        proactive_reconnect=True,
+        relaxed_timeout=RELAXED_TIMEOUT,
+    )
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    connection = DummyAsyncConnection(peer=DEFAULT_HOST)
+    pool._in_use_connections.add(connection)
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+    handler.set_connection(connection)
+    handler._schedule = MagicMock()
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ) as handoff_metric:
+        await asyncio.gather(
+            *(handler.handle_notification(notification) for _ in range(5))
+        )
+
+    _assert_connection_in_moving_state(
+        connection,
+        expected_notification_hash=hash(notification),
+    )
+    assert len(handler._processed_notifications) == 1
+    handler._schedule.assert_called_once_with(
+        notification.ttl,
+        handler.handle_node_moved_notification,
+        notification,
+    )
+    handoff_metric.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_handler_deduplicates_moving_notifications():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    pool = MagicMock()
+    pool.apply_moving_notification = AsyncMock()
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+    handler.set_connection(DummyAsyncConnection())
+    handler._schedule = MagicMock()
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=MOVED_HOST,
+        new_node_port=MOVED_PORT,
+        ttl=5,
+    )
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ) as handoff_metric:
+        await handler.handle_notification(notification)
+        await handler.handle_notification(notification)
+
+    pool.apply_moving_notification.assert_awaited_once_with(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=True,
+    )
+    handler._schedule.assert_called_once_with(
+        notification.ttl,
+        handler.handle_node_moved_notification,
+        notification,
+    )
+    handoff_metric.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_handler_schedules_delayed_reconnect_for_unknown_target():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    pool = MagicMock()
+    pool.apply_moving_notification = AsyncMock()
+    handler = AsyncMaintNotificationsPoolHandler(pool, config)
+    handler.set_connection(DummyAsyncConnection())
+    handler._schedule = MagicMock()
+    notification = NodeMovingNotification(
+        id=1,
+        new_node_host=None,
+        new_node_port=None,
+        ttl=10,
+    )
+
+    with mock.patch(
+        "redis.asyncio.maint_notifications.record_connection_handoff",
+        new=AsyncMock(),
+    ):
+        await handler.handle_notification(notification)
+
+    pool.apply_moving_notification.assert_awaited_once_with(
+        notification=notification,
+        config=config,
+        moving_address_src=DEFAULT_HOST,
+        run_proactive_reconnect=False,
+    )
+    handler._schedule.assert_has_calls(
+        [
+            mock.call(
+                notification.ttl / 2, handler.run_proactive_reconnect, DEFAULT_HOST
+            ),
+            mock.call(
+                notification.ttl, handler.handle_node_moved_notification, notification
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_blocking_pool_locks_get_only_during_maintenance():
+    pool = BlockingConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+
+    real_lock = pool._lock
+    pool._lock = MagicMock(wraps=real_lock)
+
+    fake_conn = MagicMock()
+    fake_conn.connect = AsyncMock()
+    fake_conn.can_read = AsyncMock(return_value=False)
+    fake_conn.should_reconnect = MagicMock(return_value=False)
+    fake_conn.re_auth = AsyncMock()
+    pool._available_connections.append(fake_conn)
+
+    # Outside maintenance: get_connection does not acquire _lock,
+    # but release() still does (it goes through ConnectionPool.release).
+    conn = await pool.get_connection()
+    await pool.release(conn)
+    assert pool._lock.__aenter__.call_count == 1
+
+    # Inside maintenance: get_connection now also acquires _lock.
+    pool.set_in_maintenance(True)
+    try:
+        conn = await pool.get_connection()
+        await pool.release(conn)
+    finally:
+        pool.set_in_maintenance(False)
+    assert pool._lock.__aenter__.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_apply_moving_notification_toggles_set_in_maintenance():
+    pool = BlockingConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+    observed = []
+    original = pool.set_in_maintenance
+
+    def spy(value: bool) -> None:
+        observed.append(value)
+        original(value)
+
+    pool.set_in_maintenance = spy  # type: ignore[assignment]
+
+    notification = NodeMovingNotification(
+        id=1, new_node_host=MOVED_HOST, new_node_port=MOVED_PORT, ttl=5
+    )
+    await pool.apply_moving_notification(
+        notification=notification,
+        config=pool._maint_notifications_pool_handler.config,
+        moving_address_src=None,
+        run_proactive_reconnect=False,
+    )
+
+    assert observed == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_tasks_cancels_pending_and_awaits():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    handler = AsyncMaintNotificationsPoolHandler(MagicMock(), config)
+
+    callback = AsyncMock()
+    handler._schedule(60, callback)
+    handler._schedule(60, callback)
+    tasks = tuple(handler._scheduled_tasks)
+    assert len(tasks) == 2
+
+    await handler.cancel_scheduled_tasks()
+
+    for task in tasks:
+        assert task.done()
+        assert task.cancelled()
+    callback.assert_not_awaited()
+    assert handler._scheduled_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_tasks_noop_when_empty():
+    config = MaintNotificationsConfig(enabled=True, proactive_reconnect=True)
+    handler = AsyncMaintNotificationsPoolHandler(MagicMock(), config)
+    await handler.cancel_scheduled_tasks()
+    assert handler._scheduled_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_pool_aclose_cancels_handler_scheduled_tasks():
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+    handler = pool._maint_notifications_pool_handler
+    assert handler is not None
+
+    callback = AsyncMock()
+    handler._schedule(60, callback)
+    handler._schedule(60, callback)
+    tasks = tuple(handler._scheduled_tasks)
+    assert len(tasks) == 2
+
+    await pool.aclose()
+
+    for task in tasks:
+        assert task.cancelled()
+    callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pool_disconnect_does_not_cancel_scheduled_tasks():
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True
+        ),
+    )
+    handler = pool._maint_notifications_pool_handler
+    assert handler is not None
+
+    handler._schedule(60, AsyncMock())
+    tasks = tuple(handler._scheduled_tasks)
+
+    try:
+        await pool.disconnect()
+        for task in tasks:
+            assert not task.done()
+    finally:
+        await handler.cancel_scheduled_tasks()
+
+
+@pytest.mark.asyncio
+async def test_async_pool_ensure_connection_allows_pending_push_when_enabled():
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(enabled=True),
+    )
+    connection = MagicMock()
+    connection.connect = AsyncMock()
+    connection.can_read = AsyncMock(return_value=True)
+    connection.disconnect = AsyncMock()
+
+    await pool.ensure_connection(connection)
+
+    connection.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled, raises", [(True, False), (False, True)])
+async def test_async_pool_ensure_connection_handles_pending_push_after_reconnect(
+    enabled, raises
+):
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=MaintNotificationsConfig(enabled=enabled),
+    )
+    connection = MagicMock()
+    connection.connect = AsyncMock()
+    connection.can_read = AsyncMock(side_effect=[RedisConnectionError("closed"), True])
+    connection.disconnect = AsyncMock()
+
+    if raises:
+        with pytest.raises(RedisConnectionError, match="Connection not ready"):
+            await pool.ensure_connection(connection)
+    else:
+        await pool.ensure_connection(connection)
+
+    assert connection.connect.await_count == 2
+    connection.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_read_response_reschedules_active_socket_timeout():
+    connection = Connection(socket_timeout=0.01)
+
+    class RelaxingParser:
+        async def read_response(self, disable_decoding=False, push_request=False):
+            connection.update_current_socket_timeout(0.2)
+            await asyncio.sleep(0.05)
+            return b"OK"
+
+    connection._parser = RelaxingParser()
+
+    assert await connection.read_response() == b"OK"
+    assert connection._active_read_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_read_response_reschedules_active_socket_timeout_to_blocking():
+    connection = Connection(socket_timeout=0.01)
+
+    class RelaxingParser:
+        async def read_response(self, disable_decoding=False, push_request=False):
+            connection.update_current_socket_timeout(None)
+            await asyncio.sleep(0.05)
+            return b"OK"
+
+    connection._parser = RelaxingParser()
+
+    assert await connection.read_response() == b"OK"
+    assert connection._active_read_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_read_response_does_not_reschedule_explicit_timeout():
+    connection = Connection(socket_timeout=0.2)
+
+    class RelaxingParser:
+        async def read_response(self, disable_decoding=False, push_request=False):
+            connection.update_current_socket_timeout(0.2)
+            await asyncio.sleep(0.05)
+            return b"OK"
+
+    connection._parser = RelaxingParser()
+
+    assert await connection.read_response(timeout=0.01) is None
+
+
+def test_async_redis_maint_notifications_config_forwarded_to_internal_pool():
+    config = MaintNotificationsConfig(enabled=True)
+    client = redis.Redis(protocol=3, maint_notifications_config=config)
+
+    assert (
+        client.connection_pool.connection_kwargs["maint_notifications_config"] is config
+    )
+    assert client.connection_pool._maint_notifications_pool_handler.config is config
+
+
+def test_async_redis_maint_notifications_config_requires_resp3():
+    config = MaintNotificationsConfig(enabled=True)
+
+    with pytest.raises(
+        RedisError,
+        match="Maintenance notifications handlers on connection are only supported",
+    ):
+        redis.Redis(protocol=2, maint_notifications_config=config)
+
+
+def test_async_redis_maint_notifications_config_ignored_with_explicit_pool():
+    pool = MagicMock()
+    pool.connection_kwargs = {"protocol": 2, "legacy_responses": True}
+    pool.get_encoder.return_value = MagicMock()
+    config = MaintNotificationsConfig(enabled=True)
+
+    client = redis.Redis(connection_pool=pool, maint_notifications_config=config)
+
+    assert client.connection_pool is pool
+    assert "maint_notifications_config" not in pool.connection_kwargs
+
+
+async def _make_retry_call(do, fail, is_retryable=None, with_failure_count=False):
+    return await do()
+
+
+def _mock_single_connection_pool(connection):
+    pool = MagicMock()
+    pool.get_connection = AsyncMock(return_value=connection)
+    pool.release = AsyncMock()
+    pool.get_encoder.return_value = MagicMock()
+    pool.get_protocol.return_value = 2
+    return pool
+
+
+def _mock_single_connection(should_reconnect):
+    connection = MagicMock()
+    connection.host = "localhost"
+    connection.port = DEFAULT_PORT
+    connection.db = 0
+    connection.should_reconnect.return_value = should_reconnect
+    connection.disconnect = AsyncMock()
+    connection.connect = AsyncMock()
+    connection.retry = MagicMock()
+    connection.retry.call_with_retry = _make_retry_call
+    connection.retry.get_retries.return_value = 0
+    return connection
+
+
+@pytest.mark.asyncio
+async def test_single_connection_client_reconnects_marked_connection():
+    connection = _mock_single_connection(should_reconnect=True)
+    pool = _mock_single_connection_pool(connection)
+    client = redis.Redis(connection_pool=pool, single_connection_client=True)
+
+    async def mock_send(*args, **kwargs):
+        return b"PONG"
+
+    client._send_command_parse_response = mock_send
+
+    assert await client.execute_command("PING") == b"PONG"
+    connection.disconnect.assert_awaited_once_with(error=None, failure_count=None)
+    connection.connect.assert_awaited_once()
+    pool.release.assert_not_awaited()
+
+    await client.aclose(close_connection_pool=False)
+
+
+@pytest.mark.asyncio
+async def test_single_connection_client_does_not_reconnect_unmarked_connection():
+    connection = _mock_single_connection(should_reconnect=False)
+    pool = _mock_single_connection_pool(connection)
+    client = redis.Redis(connection_pool=pool, single_connection_client=True)
+
+    async def mock_send(*args, **kwargs):
+        return b"PONG"
+
+    client._send_command_parse_response = mock_send
+
+    assert await client.execute_command("PING") == b"PONG"
+    connection.disconnect.assert_not_awaited()
+    connection.connect.assert_not_awaited()
+    pool.release.assert_not_awaited()
+
+    await client.aclose(close_connection_pool=False)

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -506,6 +506,56 @@ async def test_async_pool_update_oss_handler_wires_existing_connections():
     assert new_connection._parser.oss_cluster_maint_push_handler_func is not None
 
 
+@pytest.mark.asyncio
+async def test_async_update_config_on_oss_pool_updates_oss_handler():
+    """A config-only update on a pool already in OSS cluster mode must update
+    the OSS handler's config instead of being silently discarded.
+
+    OSS cluster mode and pool-handler mode are mutually exclusive, so the update
+    must not create a pool handler; it must apply the new config to the existing
+    OSS handler and propagate it to connection kwargs and existing connections.
+    """
+    config = MaintNotificationsConfig(enabled=True)
+    pool = ConnectionPool(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        protocol=3,
+        maint_notifications_config=config,
+    )
+    free_connection = pool.make_connection()
+    pool._available_connections.append(free_connection)
+
+    oss_handler = AsyncOSSMaintNotificationsHandler(MagicMock(), config)
+    await pool.update_maint_notifications_config(
+        config, oss_cluster_maint_notifications_handler=oss_handler
+    )
+
+    # Now issue a config-only update (no OSS handler passed).
+    new_config = MaintNotificationsConfig(
+        enabled=True, proactive_reconnect=True, relaxed_timeout=30
+    )
+    await pool.update_maint_notifications_config(new_config)
+
+    # The new config must land on the existing OSS handler, and the pool must
+    # remain in OSS mode without an orphaned pool handler.
+    assert oss_handler.config is new_config
+    assert pool._oss_cluster_maint_notifications_handler is oss_handler
+    assert pool._maint_notifications_pool_handler is None
+    assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+    assert pool.connection_kwargs.get("maint_notifications_config") is new_config
+
+    # Existing free connections must receive the new config, not the stale one.
+    assert free_connection.maint_notifications_config is new_config
+
+    # Disabling an already-enabled OSS pool is not allowed and must not be
+    # silently accepted by the config-only update path.
+    with pytest.raises(ValueError, match="Cannot disable maintenance notifications"):
+        await pool.update_maint_notifications_config(
+            MaintNotificationsConfig(enabled=False)
+        )
+    assert oss_handler.config is new_config
+
+
 def _make_async_oss_handler():
     cluster_client = MagicMock()
     # Keep the affected-nodes set and the node-reconnect loop empty so the test

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -28,6 +28,7 @@ from redis.maint_notifications import (
     NodeMigratedNotification,
     NodeMigratingNotification,
     NodeMovingNotification,
+    OSSNodeMigratedNotification,
 )
 from redis.utils import SENTINEL
 
@@ -494,6 +495,55 @@ async def test_async_pool_update_oss_handler_wires_existing_connections():
     assert new_connection._parser.node_moving_push_handler_func is None
     assert new_connection._oss_cluster_maint_notifications_handler is oss_handler
     assert new_connection._parser.oss_cluster_maint_push_handler_func is not None
+
+
+def _make_async_oss_handler():
+    cluster_client = MagicMock()
+    # Keep the affected-nodes set and the node-reconnect loop empty so the test
+    # focuses purely on how src/dest addresses are parsed.
+    cluster_client.nodes_manager.get_node.return_value = None
+    cluster_client.nodes_manager.nodes_cache.values.return_value = []
+    cluster_client.nodes_manager.initialize = AsyncMock()
+    config = MaintNotificationsConfig(enabled=True)
+    return AsyncOSSMaintNotificationsHandler(cluster_client, config), cluster_client
+
+
+@pytest.mark.asyncio
+async def test_async_handle_smigrated_parses_ipv4_addresses():
+    handler, cluster_client = _make_async_oss_handler()
+    notification = OSSNodeMigratedNotification(
+        id=1,
+        nodes_to_slots_mapping={"127.0.0.1:6379": [{"127.0.0.1:6380": "1-100"}]},
+    )
+
+    await handler.handle_oss_maintenance_completed_notification(notification)
+
+    cluster_client.nodes_manager.get_node.assert_called_once_with(
+        host="127.0.0.1", port=6379
+    )
+    cluster_client.nodes_manager.initialize.assert_called_once_with(
+        additional_startup_nodes_info=[("127.0.0.1", 6380)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handle_smigrated_parses_ipv6_addresses():
+    handler, cluster_client = _make_async_oss_handler()
+    # IPv6 literals contain multiple colons; a naive split(":") would raise
+    # ValueError on the host/port unpack.
+    notification = OSSNodeMigratedNotification(
+        id=1,
+        nodes_to_slots_mapping={"2001:db8::1:6379": [{"2001:db8::2:6380": "1-100"}]},
+    )
+
+    await handler.handle_oss_maintenance_completed_notification(notification)
+
+    cluster_client.nodes_manager.get_node.assert_called_once_with(
+        host="2001:db8::1", port=6379
+    )
+    cluster_client.nodes_manager.initialize.assert_called_once_with(
+        additional_startup_nodes_info=[("2001:db8::2", 6380)],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/maint_notifications/test_async_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_async_maint_notifications_handling.py
@@ -477,6 +477,15 @@ async def test_async_pool_update_oss_handler_wires_existing_connections():
     assert free_connection._parser.oss_cluster_maint_push_handler_func is not None
     assert free_connection._parser.maintenance_push_handler_func is not None
 
+    # Existing connections must not retain the orphaned pool-handler binding.
+    # A default (enabled) pool wires node_moving on each connection at __init__;
+    # switching to OSS mode must clear it so no existing connection is configured
+    # with both the node-moving and OSS cluster handlers.
+    assert in_use_connection._parser.node_moving_push_handler_func is None
+    assert in_use_connection._maint_notifications_pool_handler is None
+    assert free_connection._parser.node_moving_push_handler_func is None
+    assert free_connection._maint_notifications_pool_handler is None
+
     # OSS cluster mode and pool-handler mode are mutually exclusive. The pool
     # was created with the default (enabled) config, which wires a pool handler
     # in __init__; switching to OSS mode must clear it from both the pool

--- a/tests/maint_notifications/test_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_cluster_maint_notifications_handling.py
@@ -94,6 +94,7 @@ class TestClusterMaintNotificationsBase:
             maint_notifications_config=maint_config,
             connection_pool_class=pool_class,
             max_connections=max_connections,
+            socket_timeout=DEFAULT_SOCKET_TIMEOUT,
             **kwargs,
         )
 
@@ -511,20 +512,21 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
         self,
         cluster: RedisCluster,
         expected_states: List[ConnectionStateExpectation],
+        default_timeout: Optional[float] = DEFAULT_SOCKET_TIMEOUT,
     ):
         """Validate connections states.
 
         A connection is counted as "changed" when it deviates from the default
         (non-maintenance) config - i.e. its ``maintenance_state`` is not
-        ``NONE`` or its ``socket_timeout`` is not the default. For every node
-        with an expectation, exactly ``changed_connections_count`` connections
-        must be changed; a zero expectation therefore asserts that no connection
-        deviates from the default config. When a non-default state is expected,
-        the changed connections must additionally match the expected ``state`` /
-        ``relaxed_timeout``.
+        ``NONE`` or its ``socket_timeout`` is not ``default_timeout`` (the
+        socket timeout the client's connections are created with). For every
+        node with an expectation, exactly ``changed_connections_count``
+        connections must be changed; a zero expectation therefore asserts that
+        no connection deviates from the default config. When a non-default state
+        is expected, the changed connections must additionally match the
+        expected ``state`` / ``relaxed_timeout``.
         """
         default_maint_state = MaintenanceState.NONE
-        default_timeout = None
         nodes = list(cluster.nodes_manager.nodes_cache.values())
         for node in nodes:
             cluster_node = cast(ClusterNode, node)
@@ -644,7 +646,7 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
 
             # validate no timeout is relaxed on any connection
             self._validate_connections_states(
-                self.cluster,
+                cluster,
                 [
                     ConnectionStateExpectation(
                         node_port=NODE_PORT_1, changed_connections_count=0
@@ -1011,70 +1013,6 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
 
         # validate the connections in removed node are in the correct state
         self._validate_removed_node_connections(node_2)
-
-    def test_smigrating_smigrated_on_the_same_node_two_slot_ranges(
-        self,
-    ):
-        """
-        Test receiving an OSS maintenance notification on the same node twice.
-        The focus here is to validate that the timeouts are not unrelaxed if a second
-        migration is in progress
-        """
-        # warm up connection pools - create several connections in each pool
-        self._warm_up_connection_pools(self.cluster, created_connections_count=1)
-
-        smigrating_node_1 = RespTranslator.oss_maint_notification_to_resp(
-            "SMIGRATING 12 1000-2000,2500-3000"
-        )
-        self.proxy_helper.send_notification(smigrating_node_1)
-        # execute command with node 1 connection
-        self.cluster.set("anyprefix:{3}:k", "VAL")
-        self._validate_connections_states(
-            self.cluster,
-            [
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_1,
-                    changed_connections_count=1,
-                    state=MaintenanceState.MAINTENANCE,
-                    relaxed_timeout=self.config.relaxed_timeout,
-                ),
-            ],
-        )
-
-        smigrated_node_1 = RespTranslator.oss_maint_notification_to_resp(
-            f"SMIGRATED 14 {NODE_IP_PROXY}:{NODE_PORT_1} {NODE_IP_PROXY}:{NODE_PORT_2} 1000-2000 {NODE_IP_PROXY}:{NODE_PORT_1} {NODE_IP_PROXY}:{NODE_PORT_3} 2500-3000"
-        )
-        self.proxy_helper.send_notification(smigrated_node_1)
-        # execute command with node 1 connection
-        self.cluster.set("anyprefix:{3}:k", "VAL")
-
-        # validate the timeout is still relaxed
-        self._validate_connections_states(
-            self.cluster,
-            [
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_1,
-                    changed_connections_count=1,
-                    state=MaintenanceState.MAINTENANCE,
-                    relaxed_timeout=self.config.relaxed_timeout,
-                ),
-            ],
-        )
-        smigrated_node_1_2 = RespTranslator.oss_maint_notification_to_resp(
-            f"SMIGRATED 15 {NODE_IP_PROXY}:{NODE_PORT_1} {NODE_IP_PROXY}:{NODE_PORT_3} 3000-4000"
-        )
-        self.proxy_helper.send_notification(smigrated_node_1_2)
-        # execute command with node 1 connection
-        self.cluster.set("anyprefix:{3}:k", "VAL")
-        self._validate_connections_states(
-            self.cluster,
-            [
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_1,
-                    changed_connections_count=0,
-                ),
-            ],
-        )
 
     def test_smigrating_smigrated_with_sharded_pubsub(
         self,

--- a/tests/maint_notifications/test_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_cluster_maint_notifications_handling.py
@@ -512,7 +512,17 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
         cluster: RedisCluster,
         expected_states: List[ConnectionStateExpectation],
     ):
-        """Validate connections states."""
+        """Validate connections states.
+
+        A connection is counted as "changed" when it deviates from the default
+        (non-maintenance) config - i.e. its ``maintenance_state`` is not
+        ``NONE`` or its ``socket_timeout`` is not the default. For every node
+        with an expectation, exactly ``changed_connections_count`` connections
+        must be changed; a zero expectation therefore asserts that no connection
+        deviates from the default config. When a non-default state is expected,
+        the changed connections must additionally match the expected ``state`` /
+        ``relaxed_timeout``.
+        """
         default_maint_state = MaintenanceState.NONE
         default_timeout = None
         nodes = list(cluster.nodes_manager.nodes_cache.values())
@@ -528,19 +538,29 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
                 # No expectation for this node
                 continue
             changed_connections_count = 0
+            matching_expected_count = 0
             for conn in (
                 *connection_pool._get_in_use_connections(),
                 *connection_pool._get_free_connections(),
             ):
                 if (
                     conn.maintenance_state != default_maint_state
-                    and conn.maintenance_state == expected_state.state
-                ) or (
-                    conn.socket_timeout != default_timeout
-                    and conn.socket_timeout == expected_state.relaxed_timeout
+                    or conn.socket_timeout != default_timeout
                 ):
                     changed_connections_count += 1
+                if (
+                    conn.maintenance_state == expected_state.state
+                    and conn.socket_timeout == expected_state.relaxed_timeout
+                ):
+                    matching_expected_count += 1
             assert changed_connections_count == expected_state.changed_connections_count
+            if (
+                expected_state.state != default_maint_state
+                or expected_state.relaxed_timeout != default_timeout
+            ):
+                assert (
+                    matching_expected_count == expected_state.changed_connections_count
+                )
 
     def _validate_removed_node_connections(self, node):
         """Validate connections in a removed node."""
@@ -1034,6 +1054,9 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
             [
                 ConnectionStateExpectation(
                     node_port=NODE_PORT_1,
+                    changed_connections_count=1,
+                    state=MaintenanceState.MAINTENANCE,
+                    relaxed_timeout=self.config.relaxed_timeout,
                 ),
             ],
         )

--- a/tests/maint_notifications/test_cluster_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_cluster_maint_notifications_handling.py
@@ -409,35 +409,43 @@ class TestClusterMaintNotificationsHandler(TestClusterMaintNotificationsBase):
     def test_oss_maint_handler_propagation(self):
         """Test that OSSMaintNotificationsHandler is propagated to all connections."""
         cluster = self._create_cluster_client()
-        # Verify all nodes have the handler
-        for node in cluster.nodes_manager.nodes_cache.values():
-            assert node.redis_connection is not None
-            assert node.redis_connection.connection_pool is not None
-            for conn in (
-                *node.redis_connection.connection_pool._get_in_use_connections(),
-                *node.redis_connection.connection_pool._get_free_connections(),
-            ):
-                assert conn._oss_cluster_maint_notifications_handler is not None
-                self._validate_connection_handlers(
-                    conn, cluster, cluster.maint_notifications_config
-                )
+        try:
+            # Verify all nodes have the handler
+            for node in cluster.nodes_manager.nodes_cache.values():
+                assert node.redis_connection is not None
+                assert node.redis_connection.connection_pool is not None
+                for conn in (
+                    *node.redis_connection.connection_pool._get_in_use_connections(),
+                    *node.redis_connection.connection_pool._get_free_connections(),
+                ):
+                    assert conn._oss_cluster_maint_notifications_handler is not None
+                    self._validate_connection_handlers(
+                        conn, cluster, cluster.maint_notifications_config
+                    )
+        finally:
+            cluster.close()
 
     @skip_if_server_version_lt("7.4.0")
     def test_oss_maint_handler_propagation_cache_enabled(self):
         """Test that OSSMaintNotificationsHandler is propagated to all connections."""
         cluster = self._create_cluster_client(enable_cache=True)
-        # Verify all nodes have the handler
-        for node in cluster.nodes_manager.nodes_cache.values():
-            assert node.redis_connection is not None
-            assert node.redis_connection.connection_pool is not None
-            for conn in (
-                *node.redis_connection.connection_pool._get_in_use_connections(),
-                *node.redis_connection.connection_pool._get_free_connections(),
-            ):
-                assert conn._conn._oss_cluster_maint_notifications_handler is not None
-                self._validate_connection_handlers(
-                    conn._conn, cluster, cluster.maint_notifications_config
-                )
+        try:
+            # Verify all nodes have the handler
+            for node in cluster.nodes_manager.nodes_cache.values():
+                assert node.redis_connection is not None
+                assert node.redis_connection.connection_pool is not None
+                for conn in (
+                    *node.redis_connection.connection_pool._get_in_use_connections(),
+                    *node.redis_connection.connection_pool._get_free_connections(),
+                ):
+                    assert (
+                        conn._conn._oss_cluster_maint_notifications_handler is not None
+                    )
+                    self._validate_connection_handlers(
+                        conn._conn, cluster, cluster.maint_notifications_config
+                    )
+        finally:
+            cluster.close()
 
 
 class TestClusterMaintNotificationsHandlingBase(TestClusterMaintNotificationsBase):
@@ -604,31 +612,33 @@ class TestClusterMaintNotificationsHandling(TestClusterMaintNotificationsHandlin
             relaxed_timeout=-1,  # This means the relaxed timeout is Disabled
         )
         cluster = self._create_cluster_client(maint_config=disabled_config)
+        try:
+            # warm up connection pools
+            self._warm_up_connection_pools(cluster, created_connections_count=3)
 
-        # warm up connection pools
-        self._warm_up_connection_pools(cluster, created_connections_count=3)
+            # send a notification to node 1
+            notification = RespTranslator.oss_maint_notification_to_resp(
+                "SMIGRATING 12 123,456,5000-7000"
+            )
+            self.proxy_helper.send_notification(notification)
 
-        # send a notification to node 1
-        notification = RespTranslator.oss_maint_notification_to_resp(
-            "SMIGRATING 12 123,456,5000-7000"
-        )
-        self.proxy_helper.send_notification(notification)
-
-        # validate no timeout is relaxed on any connection
-        self._validate_connections_states(
-            self.cluster,
-            [
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_1, changed_connections_count=0
-                ),
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_2, changed_connections_count=0
-                ),
-                ConnectionStateExpectation(
-                    node_port=NODE_PORT_3, changed_connections_count=0
-                ),
-            ],
-        )
+            # validate no timeout is relaxed on any connection
+            self._validate_connections_states(
+                self.cluster,
+                [
+                    ConnectionStateExpectation(
+                        node_port=NODE_PORT_1, changed_connections_count=0
+                    ),
+                    ConnectionStateExpectation(
+                        node_port=NODE_PORT_2, changed_connections_count=0
+                    ),
+                    ConnectionStateExpectation(
+                        node_port=NODE_PORT_3, changed_connections_count=0
+                    ),
+                ],
+            )
+        finally:
+            cluster.close()
 
     def test_receive_smigrated_notification(self):
         """Test receiving an OSS maintenance completed notification."""

--- a/tests/maint_notifications/test_maint_notifications.py
+++ b/tests/maint_notifications/test_maint_notifications.py
@@ -2,6 +2,7 @@ import threading
 from unittest.mock import Mock, call, patch, MagicMock
 import pytest
 
+from redis._parsers.base import MaintenanceNotificationsParser
 from redis.connection import ConnectionInterface, MaintNotificationsAbstractConnection
 
 from redis.maint_notifications import (
@@ -16,6 +17,7 @@ from redis.maint_notifications import (
     MaintNotificationsConfig,
     MaintNotificationsPoolHandler,
     MaintNotificationsConnectionHandler,
+    OSSMaintNotificationsHandler,
     MaintenanceState,
     EndpointType,
 )
@@ -636,6 +638,86 @@ class TestOSSNodeMigratedNotification:
         assert (
             len(notification_set) == 2
         )  # notification1 and notification2 should be the same
+
+
+@pytest.mark.fixed_client
+class TestOSSMaintNotificationsHandler:
+    """Test address parsing in the OSS SMIGRATED handler."""
+
+    def _make_handler(self):
+        cluster_client = MagicMock()
+        # Keep the affected-nodes set and the node-reconnect loop empty so the
+        # test focuses purely on how src/dest addresses are parsed.
+        cluster_client.nodes_manager.get_node.return_value = None
+        cluster_client.nodes_manager.nodes_cache.values.return_value = []
+        config = MaintNotificationsConfig(enabled=True)
+        return OSSMaintNotificationsHandler(cluster_client, config), cluster_client
+
+    def test_handle_smigrated_parses_ipv4_addresses(self):
+        handler, cluster_client = self._make_handler()
+        notification = OSSNodeMigratedNotification(
+            id=1,
+            nodes_to_slots_mapping={"127.0.0.1:6379": [{"127.0.0.1:6380": "1-100"}]},
+        )
+
+        handler.handle_oss_maintenance_completed_notification(notification)
+
+        cluster_client.nodes_manager.get_node.assert_called_once_with(
+            host="127.0.0.1", port=6379
+        )
+        cluster_client.nodes_manager.initialize.assert_called_once_with(
+            disconnect_startup_nodes_pools=False,
+            additional_startup_nodes_info=[("127.0.0.1", 6380)],
+        )
+
+    def test_handle_smigrated_parses_ipv6_addresses(self):
+        handler, cluster_client = self._make_handler()
+        # IPv6 literals contain multiple colons; a naive split(":") would raise
+        # ValueError on the host/port unpack.
+        notification = OSSNodeMigratedNotification(
+            id=1,
+            nodes_to_slots_mapping={
+                "2001:db8::1:6379": [{"2001:db8::2:6380": "1-100"}]
+            },
+        )
+
+        handler.handle_oss_maintenance_completed_notification(notification)
+
+        cluster_client.nodes_manager.get_node.assert_called_once_with(
+            host="2001:db8::1", port=6379
+        )
+        cluster_client.nodes_manager.initialize.assert_called_once_with(
+            disconnect_startup_nodes_pools=False,
+            additional_startup_nodes_info=[("2001:db8::2", 6380)],
+        )
+
+
+@pytest.mark.fixed_client
+class TestMaintenanceNotificationsParser:
+    """Test endpoint parsing in the shared MOVING push parser."""
+
+    def test_parse_moving_msg_ipv4_endpoint(self):
+        notification = MaintenanceNotificationsParser.parse_moving_msg(
+            ["MOVING", 1, 10, "1.2.3.4:6379"]
+        )
+        assert notification.new_node_host == "1.2.3.4"
+        assert notification.new_node_port == 6379
+
+    def test_parse_moving_msg_ipv6_endpoint(self):
+        # IPv6 literals contain multiple colons; a naive split(":") would raise
+        # ValueError on the host/port unpack.
+        notification = MaintenanceNotificationsParser.parse_moving_msg(
+            ["MOVING", 1, 10, "2001:db8::1:6379"]
+        )
+        assert notification.new_node_host == "2001:db8::1"
+        assert notification.new_node_port == 6379
+
+    def test_parse_moving_msg_none_endpoint(self):
+        notification = MaintenanceNotificationsParser.parse_moving_msg(
+            ["MOVING", 1, 10, None]
+        )
+        assert notification.new_node_host is None
+        assert notification.new_node_port is None
 
 
 @pytest.mark.fixed_client

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -745,6 +745,15 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
         assert free_connection._parser.oss_cluster_maint_push_handler_func is not None
         assert free_connection._parser.maintenance_push_handler_func is not None
 
+        # Existing connections must not retain the orphaned pool-handler binding.
+        # A default (enabled) pool wires node_moving on each connection at
+        # __init__; switching to OSS mode must clear it so no existing connection
+        # is configured with both the node-moving and OSS cluster handlers.
+        assert in_use_connection._parser.node_moving_push_handler_func is None
+        assert in_use_connection._maint_notifications_pool_handler is None
+        assert free_connection._parser.node_moving_push_handler_func is None
+        assert free_connection._maint_notifications_pool_handler is None
+
         # OSS cluster mode and pool-handler mode are mutually exclusive. The pool
         # was created with the default (enabled) config, which wires a pool
         # handler in __init__; switching to OSS mode must clear it from both the

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -773,6 +773,57 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
         assert new_connection._oss_cluster_maint_notifications_handler is oss_handler
         assert new_connection._parser.oss_cluster_maint_push_handler_func is not None
 
+    def test_update_config_on_oss_pool_updates_oss_handler(self):
+        """A config-only update on a pool already in OSS cluster mode must update
+        the OSS handler's config instead of being silently discarded.
+
+        OSS cluster mode and pool-handler mode are mutually exclusive, so the
+        update must not create a pool handler; it must apply the new config to
+        the existing OSS handler and propagate it to connection kwargs and to
+        existing connections.
+        """
+        config = MaintNotificationsConfig(enabled=True)
+        pool = ConnectionPool(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            protocol=3,
+            maint_notifications_config=config,
+        )
+        free_connection = pool.make_connection()
+        pool._available_connections.append(free_connection)
+
+        oss_handler = OSSMaintNotificationsHandler(MagicMock(), config)
+        pool.update_maint_notifications_config(
+            config, oss_cluster_maint_notifications_handler=oss_handler
+        )
+
+        # Now issue a config-only update (no OSS handler passed).
+        new_config = MaintNotificationsConfig(
+            enabled=True, proactive_reconnect=True, relaxed_timeout=30
+        )
+        pool.update_maint_notifications_config(new_config)
+
+        # The new config must land on the existing OSS handler, and the pool must
+        # remain in OSS mode without an orphaned pool handler.
+        assert oss_handler.config is new_config
+        assert pool._oss_cluster_maint_notifications_handler is oss_handler
+        assert pool._maint_notifications_pool_handler is None
+        assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+        assert pool.connection_kwargs.get("maint_notifications_config") is new_config
+
+        # Existing free connections must receive the new config, not the stale one.
+        assert free_connection.maint_notifications_config is new_config
+
+        # Disabling an already-enabled OSS pool is not allowed and must not be
+        # silently accepted by the config-only update path.
+        with pytest.raises(
+            ValueError, match="Cannot disable maintenance notifications"
+        ):
+            pool.update_maint_notifications_config(
+                MaintNotificationsConfig(enabled=False)
+            )
+        assert oss_handler.config is new_config
+
     @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
     def test_connection_pool_creation_with_maintenance_notifications(self, pool_class):
         """Test that connection pools are created with maintenance notifications configuration."""

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -28,6 +28,7 @@ from redis.maint_notifications import (
     MaintNotificationsPoolHandler,
     NodeMovingNotification,
     OSSMaintNotificationsHandler,
+    OSSNodeMigratedNotification,
 )
 
 
@@ -823,6 +824,50 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
                 MaintNotificationsConfig(enabled=False)
             )
         assert oss_handler.config is new_config
+
+    def test_smigrated_failure_releases_in_progress_for_retry(self):
+        """A SMIGRATED handling that raises must not leave the notification wedged
+        in _in_progress.
+
+        The in-progress reservation dedupes concurrent redeliveries of the same
+        notification (arriving on different connections). If handling raises
+        (e.g. nodes_manager.initialize() fails because startup nodes are briefly
+        unreachable mid-migration), the notification must be released so a later
+        redelivery can retry — otherwise the dedup guard skips it forever and the
+        topology is never refreshed from that notification.
+        """
+        config = MaintNotificationsConfig(enabled=True)
+        cluster_client = MagicMock()
+        cluster_client.nodes_manager.nodes_cache = {}
+        handler = OSSMaintNotificationsHandler(cluster_client, config)
+
+        notification = OSSNodeMigratedNotification(
+            id=5,
+            nodes_to_slots_mapping={
+                f"{DEFAULT_ADDRESS}": [{AFTER_MOVING_ADDRESS: "0-100"}]
+            },
+        )
+
+        # First delivery: initialize() fails, so handling raises.
+        cluster_client.nodes_manager.initialize.side_effect = RedisConnectionError(
+            "startup nodes unreachable"
+        )
+        with pytest.raises(RedisConnectionError):
+            handler.handle_oss_maintenance_completed_notification(notification)
+
+        # The notification is released from _in_progress and was not marked
+        # processed, so a redelivery is allowed to retry.
+        assert notification not in handler._in_progress
+        assert notification not in handler._processed_notifications
+
+        # Second delivery (retry): initialize() now succeeds, so handling
+        # completes and the notification is marked processed exactly once.
+        cluster_client.nodes_manager.initialize.side_effect = None
+        cluster_client.nodes_manager.get_node.return_value = None
+        handler.handle_oss_maintenance_completed_notification(notification)
+
+        assert notification not in handler._in_progress
+        assert notification in handler._processed_notifications
 
     @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
     def test_connection_pool_creation_with_maintenance_notifications(self, pool_class):

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -27,6 +27,7 @@ from redis.maint_notifications import (
     NodeFailedOverNotification,
     MaintNotificationsPoolHandler,
     NodeMovingNotification,
+    OSSMaintNotificationsHandler,
 )
 
 
@@ -703,6 +704,65 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
         # Clean up connections
         test_redis_client.connection_pool.release(existing_conn)
         test_redis_client.connection_pool.release(new_conn)
+
+    def test_update_oss_handler_wires_existing_connections(self):
+        """update_maint_notifications_config wires an OSS cluster handler onto every
+        existing connection in the pool.
+
+        Each connection's parser receives the OSS cluster and maintenance push
+        handlers and the connection references the handler. In-use connections are
+        marked for reconnect; free connections are wired then disconnected.
+        """
+        config = MaintNotificationsConfig(enabled=True)
+        pool = ConnectionPool(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            protocol=3,
+            maint_notifications_config=config,
+        )
+        free_connection = pool.make_connection()
+        in_use_connection = pool.make_connection()
+        pool._available_connections.append(free_connection)
+        pool._in_use_connections.add(in_use_connection)
+
+        oss_handler = OSSMaintNotificationsHandler(MagicMock(), config)
+
+        pool.update_maint_notifications_config(
+            config, oss_cluster_maint_notifications_handler=oss_handler
+        )
+
+        # In-use connection: parser has the OSS + maintenance push handlers wired
+        # and the connection is marked for reconnect.
+        assert in_use_connection._oss_cluster_maint_notifications_handler is oss_handler
+        in_use_oss_func = in_use_connection._parser.oss_cluster_maint_push_handler_func
+        assert in_use_oss_func is not None
+        assert in_use_oss_func.__func__ is oss_handler.handle_notification.__func__
+        assert in_use_connection._parser.maintenance_push_handler_func is not None
+        assert in_use_connection.should_reconnect()
+
+        # Free connection — the idle OSS path, wired then disconnected.
+        assert free_connection._oss_cluster_maint_notifications_handler is oss_handler
+        assert free_connection._parser.oss_cluster_maint_push_handler_func is not None
+        assert free_connection._parser.maintenance_push_handler_func is not None
+
+        # OSS cluster mode and pool-handler mode are mutually exclusive. The pool
+        # was created with the default (enabled) config, which wires a pool
+        # handler in __init__; switching to OSS mode must clear it from both the
+        # pool attribute and the shared connection kwargs so future connections
+        # are not configured with both handlers.
+        assert pool._maint_notifications_pool_handler is None
+        assert "maint_notifications_pool_handler" not in pool.connection_kwargs
+        assert (
+            pool.connection_kwargs.get("oss_cluster_maint_notifications_handler")
+            is oss_handler
+        )
+
+        # A connection created after the switch gets only the OSS cluster handler.
+        new_connection = pool.make_connection()
+        assert new_connection._maint_notifications_pool_handler is None
+        assert new_connection._parser.node_moving_push_handler_func is None
+        assert new_connection._oss_cluster_maint_notifications_handler is oss_handler
+        assert new_connection._parser.oss_cluster_maint_push_handler_func is not None
 
     @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
     def test_connection_pool_creation_with_maintenance_notifications(self, pool_class):

--- a/tests/maint_notifications/test_maint_notifications_handling.py
+++ b/tests/maint_notifications/test_maint_notifications_handling.py
@@ -1,7 +1,7 @@
 import socket
 import threading
 from typing import List, Union
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from time import sleep
@@ -16,6 +16,7 @@ from redis.connection import (
     BlockingConnectionPool,
     MaintenanceState,
 )
+from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import ResponseError
 from redis.maint_notifications import (
     EndpointType,
@@ -626,6 +627,40 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
 
         self._validate_connection_handlers(conn, pool_handler, self.config)
 
+    def test_moving_update_with_disabled_relaxed_timeout_preserves_timeouts(self):
+        config = MaintNotificationsConfig(
+            enabled=True,
+            proactive_reconnect=True,
+            relaxed_timeout=-1,
+        )
+        pool = ConnectionPool(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            protocol=3,
+            maint_notifications_config=config,
+        )
+        connection = Connection(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            protocol=3,
+            maint_notifications_config=config,
+        )
+
+        pool.update_connection_settings(
+            connection,
+            state=MaintenanceState.MOVING,
+            maintenance_notification_hash=hash(MOVING_NOTIFICATION),
+            host_address=AFTER_MOVING_ADDRESS.split(":")[0],
+            relaxed_timeout=config.relaxed_timeout,
+            update_notification_hash=True,
+        )
+
+        assert connection.maintenance_state == MaintenanceState.MOVING
+        assert connection.maintenance_notification_hash == hash(MOVING_NOTIFICATION)
+        assert connection.host == AFTER_MOVING_ADDRESS.split(":")[0]
+        assert connection.socket_timeout == DEFAULT_SOCKET_TIMEOUT
+        assert connection.socket_connect_timeout == DEFAULT_SOCKET_CONNECT_TIMEOUT
+
     def test_maint_handler_init_for_existing_connections(self):
         """Test that maintenance notification handlers are properly set on existing and new connections
         when configuration is enabled after client creation."""
@@ -708,6 +743,47 @@ class TestMaintenanceNotificationsHandlingSingleProxy(TestMaintenanceNotificatio
         finally:
             if hasattr(test_pool, "disconnect"):
                 test_pool.disconnect()
+
+    @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
+    @pytest.mark.parametrize("enabled, raises", [(True, False), (False, True)])
+    def test_pool_get_connection_handles_pending_push_after_reconnect(
+        self, pool_class, enabled, raises
+    ):
+        max_connections = 3 if pool_class == BlockingConnectionPool else 10
+        pool = pool_class(
+            host=DEFAULT_ADDRESS.split(":")[0],
+            port=int(DEFAULT_ADDRESS.split(":")[1]),
+            max_connections=max_connections,
+            protocol=3,
+            maint_notifications_config=MaintNotificationsConfig(enabled=enabled),
+        )
+        connection = MagicMock()
+        connection.pid = pool.pid
+        connection.can_read.side_effect = [RedisConnectionError("closed"), True]
+        connection.should_reconnect.return_value = False
+
+        if pool_class == BlockingConnectionPool:
+            pool.pool.get_nowait()
+            pool.pool.put_nowait(connection)
+            pool._connections.append(connection)
+        else:
+            pool._available_connections.append(connection)
+
+        returned_connection = None
+        try:
+            if raises:
+                with pytest.raises(RedisConnectionError, match="Connection not ready"):
+                    pool.get_connection()
+            else:
+                returned_connection = pool.get_connection()
+                assert returned_connection is connection
+
+            assert connection.connect.call_count == 2
+            connection.disconnect.assert_called_once()
+        finally:
+            if returned_connection is connection:
+                pool.release(connection)
+            pool.disconnect()
 
     @pytest.mark.parametrize("pool_class", [ConnectionPool, BlockingConnectionPool])
     def test_redis_operations_with_mock_sockets(self, pool_class):

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -187,6 +187,21 @@ def test_connection_parser_matches_protocol(
     assert isinstance(conn._parser, expected_parser_class)
 
 
+def test_get_resolved_ip_uses_async_writer_peer_before_dns():
+    conn = Connection(host="redis.example.test")
+    writer = mock.Mock()
+    writer.get_extra_info.return_value = ("10.0.0.7", 6379)
+    conn._writer = writer
+
+    with mock.patch.object(socket, "getaddrinfo") as getaddrinfo:
+        try:
+            assert conn.get_resolved_ip() == "10.0.0.7"
+        finally:
+            conn._writer = None
+
+    getaddrinfo.assert_not_called()
+
+
 @pytest.mark.fixed_client
 @pytest.mark.parametrize(
     "client_kwargs",

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -23,6 +23,14 @@ from .conftest import asynccontextmanager
 from .test_pubsub import wait_for_message
 
 
+def assert_kwargs_subset(actual, expected):
+    for key, value in expected.items():
+        assert key in actual, f"missing key {key!r} in {actual!r}"
+        assert actual[key] == value, (
+            f"value mismatch for {key!r}: {actual[key]!r} != {value!r}"
+        )
+
+
 @pytest.mark.onlynoncluster
 class TestRedisAutoReleaseConnectionPool:
     @pytest_asyncio.fixture
@@ -159,7 +167,7 @@ class TestConnectionPool:
         ) as pool:
             connection = await pool.get_connection()
             assert isinstance(connection, DummyConnection)
-            assert connection.kwargs == connection_kwargs
+            assert_kwargs_subset(connection.kwargs, connection_kwargs)
 
     @pytest.mark.fixed_client
     async def test_aclosing(self):
@@ -338,7 +346,7 @@ class TestBlockingConnectionPool:
         async with self.get_pool(connection_kwargs=connection_kwargs) as pool:
             connection = await pool.get_connection()
             assert isinstance(connection, DummyConnection)
-            assert connection.kwargs == connection_kwargs
+            assert_kwargs_subset(connection.kwargs, connection_kwargs)
 
     async def test_pool_disconnect(self, master_host):
         connection_kwargs = {
@@ -458,23 +466,27 @@ class TestConnectionPoolURLParsing:
     def test_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my.host")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "my.host"}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
     def test_quoted_hostname(self):
         pool = redis.ConnectionPool.from_url("redis://my %2F host %2B%3D+")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "my / host +=+"}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my / host +=+"})
 
     def test_port(self):
         pool = redis.ConnectionPool.from_url("redis://localhost:6380")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "port": 6380}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "port": 6380}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self):
         pool = redis.ConnectionPool.from_url("redis://myuser:@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "username": "myuser"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "username": "myuser"}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_quoted_username(self):
@@ -482,50 +494,61 @@ class TestConnectionPoolURLParsing:
             "redis://%2Fmyuser%2F%2B name%3D%24+:@localhost"
         )
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "username": "/myuser/+ name=$+",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "username": "/myuser/+ name=$+",
+            },
+        )
 
     def test_password(self):
         pool = redis.ConnectionPool.from_url("redis://:mypassword@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "password": "mypassword"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "password": "mypassword"}
+        )
 
     def test_quoted_password(self):
         pool = redis.ConnectionPool.from_url(
             "redis://:%2Fmypass%2F%2B word%3D%24+@localhost"
         )
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "password": "/mypass/+ word=$+",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "password": "/mypass/+ word=$+",
+            },
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_username_and_password(self):
         pool = redis.ConnectionPool.from_url("redis://myuser:mypass@localhost")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "username": "myuser",
-            "password": "mypass",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "username": "myuser",
+                "password": "mypass",
+            },
+        )
 
     def test_db_as_argument(self):
         pool = redis.ConnectionPool.from_url("redis://localhost", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 1}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "localhost", "db": 1})
 
     def test_db_in_path(self):
         pool = redis.ConnectionPool.from_url("redis://localhost/2", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 2}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "localhost", "db": 2})
 
     def test_db_in_querystring(self):
         pool = redis.ConnectionPool.from_url("redis://localhost/2?db=3", db=1)
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "db": 3}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "localhost", "db": 3})
 
     def test_extra_typed_querystring_options(self):
         pool = redis.ConnectionPool.from_url(
@@ -534,13 +557,16 @@ class TestConnectionPoolURLParsing:
         )
 
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "db": 2,
-            "socket_timeout": 20.0,
-            "socket_connect_timeout": 10.0,
-            "retry_on_timeout": True,
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "db": 2,
+                "socket_timeout": 20.0,
+                "socket_connect_timeout": 10.0,
+                "retry_on_timeout": True,
+            },
+        )
         assert pool.max_connections == 10
 
     def test_boolean_parsing(self):
@@ -576,7 +602,9 @@ class TestConnectionPoolURLParsing:
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("redis://localhost?a=1&b=2")
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {"host": "localhost", "a": "1", "b": "2"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"host": "localhost", "a": "1", "b": "2"}
+        )
 
     def test_calling_from_subclass_returns_correct_instance(self):
         pool = redis.BlockingConnectionPool.from_url("redis://localhost")
@@ -585,7 +613,7 @@ class TestConnectionPoolURLParsing:
     def test_client_creates_connection_pool(self):
         r = redis.Redis.from_url("redis://myhost")
         assert r.connection_pool.connection_class == redis.Connection
-        assert r.connection_pool.connection_kwargs == {"host": "myhost"}
+        assert_kwargs_subset(r.connection_pool.connection_kwargs, {"host": "myhost"})
 
     def test_invalid_scheme_raises_error(self):
         with pytest.raises(ValueError) as cm:
@@ -605,13 +633,16 @@ class TestBlockingConnectionPoolURLParsing:
         )
 
         assert pool.connection_class == redis.Connection
-        assert pool.connection_kwargs == {
-            "host": "localhost",
-            "db": 2,
-            "socket_timeout": 20.0,
-            "socket_connect_timeout": 10.0,
-            "retry_on_timeout": True,
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "host": "localhost",
+                "db": 2,
+                "socket_timeout": 20.0,
+                "socket_connect_timeout": 10.0,
+                "retry_on_timeout": True,
+            },
+        )
         assert pool.max_connections == 10
         assert pool.timeout == 13.37
 
@@ -696,7 +727,7 @@ class TestSSLConnectionURLParsing:
     def test_host(self):
         pool = redis.ConnectionPool.from_url("rediss://my.host")
         assert pool.connection_class == redis.SSLConnection
-        assert pool.connection_kwargs == {"host": "my.host"}
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
     def test_cert_reqs_options(self):
         import ssl
@@ -806,13 +837,14 @@ class TestConnection:
         connection = redis.Redis.from_url("redis://localhost:6379?db=0")
         pool = connection.connection_pool
 
-        assert re.match(
+        conn_name, pool_name, conn_kwargs = re.match(
             r"< .*?([^\.]+) \( < .*?([^\.]+) \( (.+) \) > \) >", repr(pool), re.VERBOSE
-        ).groups() == (
-            "ConnectionPool",
-            "Connection",
-            "db=0,host=localhost,port=6379",
-        )
+        ).groups()
+        assert conn_name == "ConnectionPool"
+        assert pool_name == "Connection"
+        assert "db=0" in conn_kwargs
+        assert "host=localhost" in conn_kwargs
+        assert "port=6379" in conn_kwargs
 
     @pytest.mark.fixed_client
     def test_connect_from_url_unix(self):

--- a/tests/test_asyncio/test_scenario/async_fault_injector_client.py
+++ b/tests/test_asyncio/test_scenario/async_fault_injector_client.py
@@ -1,0 +1,395 @@
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+import aiohttp
+import pytest
+
+from tests.maint_notifications.proxy_server_helpers import (
+    ProxyInterceptorHelper,
+    SlotsRange,
+)
+from tests.test_scenario.fault_injector_client import (
+    ActionRequest,
+    ActionType,
+    DEFAULT_BDB_ID,
+    MockProxyFaultInjector,
+    SlotMigrateEffects,
+    TaskStatuses,
+    TopologyChangeStandaloneEffects,
+)
+
+
+class AsyncFaultInjectorClient(ABC):
+    """Async counterpart to FaultInjectorClient — all I/O methods are coroutines."""
+
+    @abstractmethod
+    async def get_operation_result(
+        self,
+        action_id: str,
+        timeout: int = 60,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def create_database(
+        self,
+        bdb_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def delete_database(
+        self,
+        bdb_id: int,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def find_database_id_by_name(
+        self,
+        database_name: str,
+        force_cluster_info_refresh: bool = True,
+    ) -> Optional[int]:
+        pass
+
+    @abstractmethod
+    def get_moving_ttl(self) -> int:
+        pass
+
+    @abstractmethod
+    async def get_slot_migrate_triggers(
+        self,
+        effect_name: SlotMigrateEffects,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def trigger_effect(
+        self,
+        endpoint_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: Optional[str] = None,
+        source_node: Optional[str] = None,
+        target_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+    ) -> str:
+        pass
+
+
+class AsyncREFaultInjector(AsyncFaultInjectorClient):
+    """Async fault injector client for Redis Enterprise cluster setup."""
+
+    MOVING_TTL = 15
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self._cluster_nodes_info: Optional[str] = None
+        self._current_db_id: Optional[int] = None
+
+    async def _make_request(
+        self, method: str, path: str, data: Optional[Dict] = None
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        headers = {"Content-Type": "application/json"} if data else {}
+        async with aiohttp.ClientSession() as session:
+            async with session.request(
+                method, url, json=data, headers=headers
+            ) as response:
+                if response.status == 422:
+                    error_body = await response.json()
+                    raise ValueError(f"Validation Error: {error_body}")
+                response.raise_for_status()
+                return await response.json()
+
+    async def trigger_action(self, action_request: ActionRequest) -> Dict[str, Any]:
+        return await self._make_request("POST", "/action", action_request.to_dict())
+
+    async def get_action_status(self, action_id: str) -> Dict[str, Any]:
+        return await self._make_request("GET", f"/action/{action_id}")
+
+    async def get_operation_result(
+        self,
+        action_id: str,
+        timeout: int = 60,
+    ) -> Dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
+        check_interval = 0.3
+
+        while loop.time() - start_time < timeout:
+            try:
+                status_result = await self.get_action_status(action_id)
+                operation_status = status_result.get("status", "unknown")
+
+                if operation_status in TaskStatuses.COMPLETED_STATUSES:
+                    logging.debug(
+                        f"Operation {action_id} completed with status: "
+                        f"{operation_status}"
+                    )
+                    if operation_status != TaskStatuses.SUCCESS:
+                        pytest.fail(f"Operation {action_id} failed: {status_result}")
+                    return status_result
+
+                await asyncio.sleep(check_interval)
+            except Exception as e:
+                logging.warning(f"Error checking operation status: {e}")
+                await asyncio.sleep(check_interval)
+
+        pytest.fail(f"Timeout waiting for operation {action_id} after {timeout}s")
+
+    async def create_database(
+        self,
+        bdb_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        logging.debug(f"Creating database with config: {bdb_config}")
+        result = await self.trigger_action(
+            ActionRequest(ActionType.CREATE_DATABASE, {"database_config": bdb_config})
+        )
+        action_id = result.get("action_id")
+        if not action_id:
+            raise Exception(f"Failed to trigger create database action: {result}")
+
+        response = await self.get_operation_result(action_id)
+        logging.debug(f"Create database action result: {response}")
+
+        if response.get("status") != TaskStatuses.SUCCESS:
+            raise Exception(f"Create database action failed: {response}")
+
+        self._current_db_id = response["output"]["bdb_id"]
+        return response["output"]
+
+    async def delete_database(
+        self,
+        bdb_id: int,
+    ) -> Dict[str, Any]:
+        logging.debug(f"Deleting database with id: {bdb_id}")
+        result = await self.trigger_action(
+            ActionRequest(ActionType.DELETE_DATABASE, {"bdb_id": bdb_id})
+        )
+        action_id = result.get("action_id")
+        if not action_id:
+            raise Exception(f"Failed to trigger delete database action: {result}")
+
+        response = await self.get_operation_result(action_id)
+        self._current_db_id = None
+
+        if response.get("status") != TaskStatuses.SUCCESS:
+            raise Exception(f"Delete database action failed: {response}")
+        logging.debug(f"Delete database action result: {response}")
+        return response
+
+    async def _get_cluster_nodes_info(self) -> None:
+        try:
+            action = ActionRequest(
+                ActionType.EXECUTE_RLADMIN_COMMAND,
+                {
+                    "rladmin_command": "status",
+                    "bdb_id": DEFAULT_BDB_ID
+                    if self._current_db_id is None
+                    else self._current_db_id,
+                },
+            )
+            trigger_result = await self.trigger_action(action)
+            action_id = trigger_result.get("action_id")
+            if not action_id:
+                raise ValueError(
+                    f"Failed to trigger get cluster status action: {trigger_result}"
+                )
+
+            response = await self.get_operation_result(action_id)
+
+            if response.get("status") != TaskStatuses.SUCCESS:
+                raise Exception(f"Get cluster status action failed: {response}")
+            self._cluster_nodes_info = response.get("output", {}).get("output", "")
+        except Exception as e:
+            pytest.fail(f"Failed to get cluster nodes info: {e}")
+
+    async def find_database_id_by_name(
+        self,
+        database_name: str,
+        force_cluster_info_refresh: bool = True,
+    ) -> Optional[int]:
+        if self._cluster_nodes_info is None or force_cluster_info_refresh:
+            await self._get_cluster_nodes_info()
+
+        if not self._cluster_nodes_info:
+            raise ValueError("No cluster status info found")
+
+        lines = self._cluster_nodes_info.split("\n")
+        databases_section_started = False
+
+        for line in lines:
+            line = line.strip()
+            if line.startswith("DATABASES:"):
+                databases_section_started = True
+                continue
+            elif databases_section_started and line and not line.startswith("DB:ID"):
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == database_name:
+                    return int(parts[0].replace("db:", ""))
+
+        raise ValueError(f"Database {database_name} not found")
+
+    async def get_slot_migrate_triggers(
+        self,
+        effect_name: SlotMigrateEffects,
+    ) -> Dict[str, Any]:
+        return await self._make_request(
+            "GET", f"/slot-migrate?effect={effect_name.value}&cluster_index=0"
+        )
+
+    async def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        return await self._make_request(
+            "GET",
+            f"/topology-change-standalone?effect={effect_name.value}&cluster_index=0",
+        )
+
+    async def trigger_effect(
+        self,
+        endpoint_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: str,
+        source_node: Optional[str] = None,
+        target_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+    ) -> str:
+        bdb_id = endpoint_config.get("bdb_id")
+        parameters: Dict[str, Any] = {
+            "bdb_id": bdb_id,
+            "cluster_index": 0,
+            "effect": effect_name,
+            "trigger": trigger_name,
+        }
+        if source_node:
+            parameters["source_node"] = source_node
+        if target_node:
+            parameters["target_node"] = target_node
+
+        action_type = (
+            ActionType.SLOT_MIGRATE
+            if isinstance(effect_name, SlotMigrateEffects)
+            else ActionType.TOPOLOGY_CHANGE_STANDALONE
+        )
+        logging.debug(f"Executing {action_type.value} with parameters: {parameters}")
+
+        try:
+            result = await self.trigger_action(ActionRequest(action_type, parameters))
+            logging.debug(f"Trigger effect action result: {result}")
+            action_id = result.get("action_id")
+            if not action_id:
+                raise Exception(f"Failed to trigger slot migrate action: {result}")
+            return action_id
+        except Exception as e:
+            raise Exception(f"Failed to execute slot migrate: {e}")
+
+    def get_moving_ttl(self) -> int:
+        return self.MOVING_TTL
+
+
+class AsyncProxyServerFaultInjector(MockProxyFaultInjector, AsyncFaultInjectorClient):
+    """Async fault injector client for proxy server setup."""
+
+    NODE_PORT_1 = 15379
+    NODE_PORT_2 = 15380
+    NODE_PORT_3 = 15381
+
+    DEFAULT_CLUSTER_SLOTS = [
+        SlotsRange("127.0.0.1", NODE_PORT_1, 0, 8191),
+        SlotsRange("127.0.0.1", NODE_PORT_2, 8192, 16383),
+    ]
+
+    CLUSTER_SLOTS_INTERCEPTOR_NAME = "test_topology"
+    SLEEP_TIME_BETWEEN_START_END_NOTIFICATIONS = 2
+    MOVING_TTL = 4
+
+    def __init__(self, oss_cluster: bool = False):
+        self.oss_cluster = oss_cluster
+        self.proxy_helper = ProxyInterceptorHelper()
+        logging.info(
+            f"Setting up initial cluster slots -> {self.DEFAULT_CLUSTER_SLOTS}"
+        )
+        self.proxy_helper.set_cluster_slots(
+            self.CLUSTER_SLOTS_INTERCEPTOR_NAME, self.DEFAULT_CLUSTER_SLOTS
+        )
+
+    async def get_operation_result(
+        self,
+        action_id: str,
+        timeout: int = 60,
+    ) -> Dict[str, Any]:
+        return {"status": "done"}
+
+    async def create_database(
+        self,
+        bdb_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "bdb_id": 1,
+            "username": "default",
+            "password": "",
+            "tls": False,
+            "raw_endpoints": [
+                {
+                    "addr": ["127.0.0.1"],
+                    "addr_type": "external",
+                    "dns_name": "localhost",
+                    "oss_cluster_api_preferred_endpoint_type": "ip",
+                    "oss_cluster_api_preferred_ip_type": "internal",
+                    "port": 15379,
+                    "proxy_policy": "all-master-shards",
+                    "uid": "1:1",
+                }
+            ],
+            "endpoints": ["redis://127.0.0.1:15379"],
+        }
+
+    async def delete_database(
+        self,
+        bdb_id: int,
+    ) -> Dict[str, Any]:
+        return {}
+
+    async def find_database_id_by_name(
+        self,
+        database_name: str,
+        force_cluster_info_refresh: bool = True,
+    ) -> Optional[int]:
+        return 1
+
+    def get_moving_ttl(self) -> int:
+        return self.MOVING_TTL
+
+    async def get_slot_migrate_triggers(
+        self,
+        effect_name: SlotMigrateEffects,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Not implemented for proxy server")
+
+    async def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Not implemented for proxy server")
+
+    async def trigger_effect(
+        self,
+        endpoint_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: Optional[str] = None,
+        source_node: Optional[str] = None,
+        target_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+    ) -> str:
+        raise NotImplementedError("Not implemented for proxy server")

--- a/tests/test_asyncio/test_scenario/conftest.py
+++ b/tests/test_asyncio/test_scenario/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Optional
+from urllib.parse import urlparse
 
 import pytest
 import pytest_asyncio
@@ -13,11 +14,22 @@ from redis.asyncio.multidb.config import (
 )
 from redis.asyncio.multidb.event import AsyncActiveDatabaseChanged
 from redis.asyncio.retry import Retry
-from redis.backoff import ExponentialBackoff
+from redis.backoff import ExponentialBackoff, ExponentialWithJitterBackoff, NoBackoff
 from redis.event import AsyncEventListenerInterface, EventDispatcher
+from redis.maint_notifications import EndpointType, MaintNotificationsConfig
 from redis.multidb.failure_detector import DEFAULT_MIN_NUM_FAILURES
-from tests.test_scenario.conftest import get_endpoints_config, extract_cluster_fqdn
-from tests.test_scenario.fault_injector_client import REFaultInjector
+from tests.test_scenario.conftest import (
+    CLIENT_TIMEOUT,
+    RELAXED_TIMEOUT,
+    _prepare_ssl_certificates,
+    extract_cluster_fqdn,
+    get_endpoints_config,
+    use_mock_proxy,
+)
+from tests.test_asyncio.test_scenario.async_fault_injector_client import (
+    AsyncProxyServerFaultInjector,
+    AsyncREFaultInjector,
+)
 
 
 class CheckActiveDatabaseChangedListener(AsyncEventListenerInterface):
@@ -30,8 +42,99 @@ class CheckActiveDatabaseChangedListener(AsyncEventListenerInterface):
 
 @pytest.fixture()
 def fault_injector_client():
-    url = os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324")
-    return REFaultInjector(url)
+    if use_mock_proxy():
+        return AsyncProxyServerFaultInjector(oss_cluster=False)
+    else:
+        url = os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324")
+        return AsyncREFaultInjector(url)
+
+
+def _get_async_client_maint_notifications(
+    endpoints_config,
+    protocol: int = 3,
+    enable_maintenance_notifications: bool = True,
+    endpoint_type: Optional[EndpointType] = None,
+    enable_relaxed_timeout: bool = True,
+    enable_proactive_reconnect: bool = True,
+    disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
+    socket_timeout: Optional[float] = None,
+    host_config: Optional[str] = None,
+) -> Redis:
+    """Create async Redis client with maintenance notifications enabled."""
+    username = endpoints_config.get("username")
+    password = endpoints_config.get("password")
+
+    endpoints = endpoints_config.get("endpoints", [])
+    if not endpoints:
+        raise ValueError("No endpoints found in configuration")
+
+    parsed = urlparse(endpoints[0])
+    host = parsed.hostname if host_config is None else host_config
+    port = parsed.port
+
+    if not host:
+        raise ValueError(f"Could not parse host from endpoint URL: {endpoints[0]}")
+
+    if port is None:
+        raise ValueError(f"Could not parse port from endpoint URL: {endpoints[0]}")
+
+    maintenance_config = MaintNotificationsConfig(
+        enabled=enable_maintenance_notifications,
+        proactive_reconnect=enable_proactive_reconnect,
+        relaxed_timeout=RELAXED_TIMEOUT if enable_relaxed_timeout else -1,
+        endpoint_type=endpoint_type,
+    )
+
+    if disable_retries:
+        retry = Retry(NoBackoff(), 0)
+    else:
+        retry = Retry(
+            backoff=ExponentialWithJitterBackoff(base=0.01, cap=1), retries=10
+        )
+
+    tls_enabled = parsed.scheme == "rediss"
+    tls_kwargs = {"ssl": tls_enabled}
+    if tls_enabled:
+        ssl_config = _prepare_ssl_certificates(auth_ssl_client_certs)
+        tls_kwargs.update(ssl_config)
+
+    return Redis(
+        host=host,
+        port=port,
+        socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
+        username=username,
+        password=password,
+        protocol=protocol,
+        maint_notifications_config=maintenance_config,
+        retry=retry,
+        **tls_kwargs,
+    )
+
+
+def get_async_standalone_client_maint_notifications(
+    endpoints_config,
+    protocol: int = 3,
+    enable_maintenance_notifications: bool = True,
+    endpoint_type: Optional[EndpointType] = None,
+    enable_relaxed_timeout: bool = True,
+    enable_proactive_reconnect: bool = True,
+    disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
+    socket_timeout: Optional[float] = None,
+) -> Redis:
+    """Create async Redis standalone client with maintenance notifications enabled."""
+    return _get_async_client_maint_notifications(
+        endpoints_config=endpoints_config,
+        protocol=protocol,
+        enable_maintenance_notifications=enable_maintenance_notifications,
+        endpoint_type=endpoint_type,
+        enable_relaxed_timeout=enable_relaxed_timeout,
+        enable_proactive_reconnect=enable_proactive_reconnect,
+        disable_retries=disable_retries,
+        auth_ssl_client_certs=auth_ssl_client_certs,
+        socket_timeout=socket_timeout,
+    )
 
 
 @pytest_asyncio.fixture()

--- a/tests/test_asyncio/test_scenario/conftest.py
+++ b/tests/test_asyncio/test_scenario/conftest.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import pytest
 import pytest_asyncio
 
-from redis.asyncio import Redis
+from redis.asyncio import Redis, RedisCluster
 from redis.asyncio.multidb.client import MultiDBClient
 from redis.asyncio.multidb.config import (
     DatabaseConfig,
@@ -44,6 +44,16 @@ class CheckActiveDatabaseChangedListener(AsyncEventListenerInterface):
 def fault_injector_client():
     if use_mock_proxy():
         return AsyncProxyServerFaultInjector(oss_cluster=False)
+    else:
+        url = os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324")
+        return AsyncREFaultInjector(url)
+
+
+@pytest.fixture()
+def fault_injector_client_oss_api():
+    """Async fault injector client targeting the OSS-cluster API."""
+    if use_mock_proxy():
+        return AsyncProxyServerFaultInjector(oss_cluster=True)
     else:
         url = os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324")
         return AsyncREFaultInjector(url)
@@ -134,6 +144,71 @@ def get_async_standalone_client_maint_notifications(
         disable_retries=disable_retries,
         auth_ssl_client_certs=auth_ssl_client_certs,
         socket_timeout=socket_timeout,
+    )
+
+
+def get_async_cluster_client_maint_notifications(
+    endpoints_config,
+    protocol: int = 3,
+    enable_maintenance_notifications: bool = True,
+    endpoint_type: Optional[EndpointType] = None,
+    enable_relaxed_timeout: bool = True,
+    enable_proactive_reconnect: bool = True,
+    disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
+    socket_timeout: Optional[float] = None,
+    socket_connect_timeout: Optional[float] = None,
+) -> RedisCluster:
+    """Create async RedisCluster client with maintenance notifications enabled."""
+    username = endpoints_config.get("username")
+    password = endpoints_config.get("password")
+
+    endpoints = endpoints_config.get("endpoints", [])
+    if not endpoints:
+        raise ValueError("No endpoints found in configuration")
+
+    parsed = urlparse(endpoints[0])
+    host = parsed.hostname
+    port = parsed.port
+
+    if not host:
+        raise ValueError(f"Could not parse host from endpoint URL: {endpoints[0]}")
+    if port is None:
+        raise ValueError(f"Could not parse port from endpoint URL: {endpoints[0]}")
+
+    maintenance_config = MaintNotificationsConfig(
+        enabled=enable_maintenance_notifications,
+        proactive_reconnect=enable_proactive_reconnect,
+        relaxed_timeout=RELAXED_TIMEOUT if enable_relaxed_timeout else -1,
+        endpoint_type=endpoint_type,
+    )
+
+    if disable_retries:
+        retry = Retry(NoBackoff(), 0)
+    else:
+        retry = Retry(
+            backoff=ExponentialWithJitterBackoff(base=0.01, cap=1), retries=10
+        )
+
+    tls_enabled = parsed.scheme == "rediss"
+    tls_kwargs = {"ssl": tls_enabled}
+    if tls_enabled:
+        ssl_config = _prepare_ssl_certificates(auth_ssl_client_certs)
+        tls_kwargs.update(ssl_config)
+
+    return RedisCluster(
+        host=host,
+        port=port,
+        socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
+        socket_connect_timeout=(
+            CLIENT_TIMEOUT if socket_connect_timeout is None else socket_connect_timeout
+        ),
+        username=username,
+        password=password,
+        protocol=protocol,
+        maint_notifications_config=maintenance_config,
+        retry=retry,
+        **tls_kwargs,
     )
 
 

--- a/tests/test_asyncio/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_asyncio/test_scenario/maint_notifications_helpers.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import pytest
+
+from redis.asyncio import Redis
+from redis.maint_notifications import MaintenanceState
+
+
+class AsyncClientValidations:
+    @staticmethod
+    async def get_default_connection(redis_client: Redis):
+        return await redis_client.connection_pool.get_connection()
+
+    @staticmethod
+    async def release_connection(redis_client: Redis, connection):
+        await redis_client.connection_pool.release(connection)
+
+    @staticmethod
+    async def wait_push_notification(
+        redis_client: Redis,
+        timeout: float = 120,
+        fail_on_timeout: bool = True,
+        connection=None,
+        expected_state: Optional[MaintenanceState] = None,
+    ):
+        """Wait for a push notification to be received."""
+        start_time = time.time()
+        check_interval = 0.2
+        test_conn = (
+            connection
+            if connection
+            else await AsyncClientValidations.get_default_connection(redis_client)
+        )
+        logging.info(
+            f"Waiting for push notification on connection: {test_conn}, "
+            f"peer: {test_conn.getpeername()}"
+        )
+
+        try:
+            if (
+                expected_state is not None
+                and test_conn.maintenance_state == expected_state
+            ):
+                logging.debug(
+                    f"Connection already in expected state {expected_state}, "
+                    f"returning immediately"
+                )
+                return
+
+            while time.time() - start_time < timeout:
+                try:
+                    if await test_conn.can_read():
+                        push_response = await test_conn.read_response(push_request=True)
+                        logging.debug(
+                            f"Push notification received. Response: {push_response}"
+                        )
+                        if test_conn.should_reconnect():
+                            logging.debug("Connection is marked for reconnect")
+                        if (
+                            expected_state is None
+                            or test_conn.maintenance_state == expected_state
+                        ):
+                            return
+                except Exception as e:
+                    logging.error(f"Error reading push notification: {e}")
+                    raise
+                await asyncio.sleep(check_interval)
+            if fail_on_timeout:
+                pytest.fail(
+                    f"Timeout waiting for push notification: "
+                    f"waiting > {time.time() - start_time} seconds."
+                )
+        finally:
+            try:
+                if not connection:
+                    await AsyncClientValidations.release_connection(
+                        redis_client, test_conn
+                    )
+            except Exception as e:
+                logging.error(f"Error releasing connection: {e}")

--- a/tests/test_asyncio/test_scenario/test_active_active.py
+++ b/tests/test_asyncio/test_scenario/test_active_active.py
@@ -29,12 +29,14 @@ async def trigger_network_failure_action(
         parameters={"bdb_id": config["bdb_id"], "delay": 3, "cluster_index": 0},
     )
 
-    result = fault_injector_client.trigger_action(action_request)
-    status_result = fault_injector_client.get_action_status(result["action_id"])
+    result = await fault_injector_client.trigger_action(action_request)
+    status_result = await fault_injector_client.get_action_status(result["action_id"])
 
     while status_result["status"] != "success":
         await asyncio.sleep(0.1)
-        status_result = fault_injector_client.get_action_status(result["action_id"])
+        status_result = await fault_injector_client.get_action_status(
+            result["action_id"]
+        )
         logger.info(
             f"Waiting for action to complete. Status: {status_result['status']}"
         )

--- a/tests/test_asyncio/test_scenario/test_maint_notifications.py
+++ b/tests/test_asyncio/test_scenario/test_maint_notifications.py
@@ -1,21 +1,24 @@
-"""Tests for Redis Enterprise maintenance push notifications — async standalone client."""
+"""Tests for Redis Enterprise maintenance push notifications — async client."""
 
 import asyncio
 import json
 import logging
+import random
 import time
 from typing import Any, Dict, List, Literal, Optional, Union
 
 import pytest
 import pytest_asyncio
 
-from redis.asyncio import Redis
+from redis.asyncio import Redis, RedisCluster
+from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.maint_notifications import (
     EndpointType,
     MaintenanceState,
 )
 from tests.test_asyncio.test_scenario.conftest import (
     _get_async_client_maint_notifications,
+    get_async_cluster_client_maint_notifications,
     get_async_standalone_client_maint_notifications,
 )
 from tests.test_asyncio.test_scenario.maint_notifications_helpers import (
@@ -24,6 +27,7 @@ from tests.test_asyncio.test_scenario.maint_notifications_helpers import (
 from tests.test_scenario.conftest import (
     CLIENT_TIMEOUT,
     RELAXED_TIMEOUT,
+    _FAULT_INJECTOR_CLIENT_OSS_API,
     _FAULT_INJECTOR_STANDALONE_CLIENT,
     use_mock_proxy,
 )
@@ -36,6 +40,7 @@ from tests.test_scenario.fault_injector_client import (
     TopologyChangeStandaloneEffects,
 )
 from tests.test_scenario.maint_notifications_helpers import (
+    KeyGenerationHelpers,
     generate_params,
     is_endpoint_configured_correctly,
 )
@@ -47,12 +52,16 @@ logging.basicConfig(
 )
 
 logging.getLogger("redis.asyncio.maint_notifications").setLevel(logging.DEBUG)
+logging.getLogger("redis.asyncio.cluster").setLevel(logging.DEBUG)
 
 STANDALONE_MAINT_TIMEOUT = 60
 SLOT_SHUFFLE_TIMEOUT = 120
+SMIGRATING_TIMEOUT = 20
+SMIGRATED_TIMEOUT = 40
 
 DEFAULT_BIND_TTL = 15
 DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
+DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT = 1
 
 
 class TestAsyncPushNotificationsBase:
@@ -1190,6 +1199,542 @@ class TestAsyncStandaloneClientCommandsExecutionWithPushNotificationsWithEffectT
             expected_matching_conns_count=10,
             configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
         )
+
+        error_items = []
+        while not errors.empty():
+            error_items.append(errors.get_nowait())
+        assert not error_items, f"Errors occurred in tasks: {error_items}"
+
+
+class TestAsyncClusterClientPushNotificationsWithEffectTriggerBase(
+    TestAsyncPushNotificationsBase
+):
+    async def setup_env(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        db_config: Dict[str, Any],
+    ):
+        self._fault_injector = fault_injector_client
+        await self.delete_prev_db(fault_injector_client, db_config["name"])
+
+        cluster_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        self._bdb_name = db_config["name"]
+
+        socket_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
+        socket_connect_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
+
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
+            else False
+        )
+
+        self._client = get_async_cluster_client_maint_notifications(
+            endpoints_config=cluster_endpoint_config,
+            disable_retries=True,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            enable_maintenance_notifications=True,
+            auth_ssl_client_certs=auth_ssl_client_certs,
+        )
+        # The async cluster discovers its topology lazily.
+        await self._client.initialize()
+        return self._client, cluster_endpoint_config
+
+    async def _acquire_connected_connection(self, node):
+        """Acquire a connection from an async ClusterNode and connect it.
+
+        The async ClusterNode is its own pool. ``acquire_connection`` returns a
+        (possibly fresh) connection that is not yet connected; we connect it so
+        the maintenance push handlers are installed and the handshake is sent.
+        """
+        conn = node.acquire_connection()
+        await conn.connect()
+        return conn
+
+    async def _drain_maint_notification_tasks(self, client: RedisCluster):
+        """Wait for in-flight async OSS maintenance handling tasks to finish.
+
+        Unlike the sync client (where SMIGRATED handling completes inline while
+        reading the command response), the async client schedules the topology
+        update in a background task. Tests must drain these before asserting on
+        the resulting topology / connection state.
+        """
+        handler = client._oss_cluster_maint_notifications_handler
+        if handler is None:
+            return
+        for _ in range(100):
+            tasks = [t for t in handler._background_tasks if not t.done()]
+            if not tasks:
+                break
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.sleep(0)
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def setup_and_cleanup(self):
+        self.maintenance_ops_tasks = []
+        self._bdb_name = None
+        self._fault_injector = None
+        self._client: RedisCluster | None = None
+
+        yield
+
+        logging.info("Starting cleanup...")
+
+        logging.info("Waiting for maintenance operation tasks to finish...")
+        if self.maintenance_ops_tasks:
+            await asyncio.gather(*self.maintenance_ops_tasks, return_exceptions=True)
+
+        if self._client is not None:
+            await self._client.aclose()
+
+        if self._bdb_name and self._fault_injector:
+            await self.delete_prev_db(self._fault_injector, self._bdb_name)
+
+        logging.info("Cleanup finished")
+
+
+class TestAsyncClusterClientPushNotificationsHandlingWithEffectTrigger(
+    TestAsyncClusterClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_CLIENT_OSS_API, [SlotMigrateEffects.SLOT_SHUFFLE]
+        ),
+    )
+    async def test_notification_handling_during_node_shuffle_no_node_replacement(
+        self,
+        fault_injector_client_oss_api: AsyncFaultInjectorClient,
+        effect_name: SlotMigrateEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        """Slots are moved between existing nodes; no node appears/disappears."""
+        logging.info(f"DB name: {db_name}")
+
+        client, cluster_endpoint_config = await self.setup_env(
+            fault_injector_client_oss_api, db_config
+        )
+
+        logging.info("Creating one connection in each node's pool.")
+        initial_cluster_nodes = client.nodes_manager.nodes_cache.copy()
+        in_use_connections = {}
+        for node in initial_cluster_nodes.values():
+            in_use_connections[node] = await self._acquire_connected_connection(node)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client_oss_api,
+                cluster_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for SMIGRATING push notifications in all connections...")
+        for conn in in_use_connections.values():
+            await AsyncClientValidations.wait_push_notification(
+                client,
+                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                connection=conn,
+            )
+
+        logging.info("Validating connection maintenance state...")
+        for conn in in_use_connections.values():
+            assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+            assert conn.socket_timeout == RELAXED_TIMEOUT
+            assert conn.should_reconnect() is False
+
+        assert len(initial_cluster_nodes) == len(client.nodes_manager.nodes_cache)
+        for node_key in initial_cluster_nodes.keys():
+            assert node_key in client.nodes_manager.nodes_cache
+
+        logging.info("Waiting for SMIGRATED push notifications...")
+        con_to_read_smigrated = random.choice(list(in_use_connections.values()))
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=SMIGRATED_TIMEOUT,
+            connection=con_to_read_smigrated,
+        )
+        # SMIGRATED handling runs in a background task in the async client.
+        await self._drain_maint_notification_tasks(client)
+
+        logging.info("Validating connection state after SMIGRATED ...")
+        updated_cluster_nodes = client.nodes_manager.nodes_cache.copy()
+        removed_nodes = set(initial_cluster_nodes.values()) - set(
+            updated_cluster_nodes.values()
+        )
+        assert len(removed_nodes) == 0
+        assert len(initial_cluster_nodes) == len(updated_cluster_nodes)
+
+        marked_conns_for_reconnect = 0
+        for conn in in_use_connections.values():
+            if conn.should_reconnect():
+                marked_conns_for_reconnect += 1
+        # Async-specific: unlike the sync client (which marks only the src node's
+        # connection), the async NodesManager.set_nodes marks ALL preserved nodes'
+        # in-use connections for reconnect on every initialize() — the cluster
+        # topology refresh triggered while handling SMIGRATED defers disconnection
+        # via lazy reconnect since set_nodes is sync. So at least the src node's
+        # connection is marked; in practice every held connection is.
+        assert marked_conns_for_reconnect >= 1
+
+        logging.info("Releasing connections back to the pool...")
+        for node, conn in in_use_connections.items():
+            node.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_CLIENT_OSS_API,
+            [SlotMigrateEffects.REMOVE_ADD],
+        ),
+    )
+    async def test_notification_handling_with_node_replace(
+        self,
+        fault_injector_client_oss_api: AsyncFaultInjectorClient,
+        effect_name: SlotMigrateEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        """A node is removed and a new node is added during slot movement."""
+        logging.info(f"DB name: {db_name}")
+
+        client, cluster_endpoint_config = await self.setup_env(
+            fault_injector_client_oss_api, db_config
+        )
+
+        logging.info("Creating one connection in each node's pool.")
+        initial_cluster_nodes = client.nodes_manager.nodes_cache.copy()
+        in_use_connections = {}
+        for node in initial_cluster_nodes.values():
+            in_use_connections[node] = await self._acquire_connected_connection(node)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client_oss_api,
+                cluster_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for SMIGRATING push notifications in all connections...")
+        for conn in in_use_connections.values():
+            await AsyncClientValidations.wait_push_notification(
+                client,
+                timeout=SMIGRATING_TIMEOUT,
+                connection=conn,
+            )
+
+        logging.info("Validating connection maintenance state...")
+        for conn in in_use_connections.values():
+            assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+            assert conn.socket_timeout == RELAXED_TIMEOUT
+            assert conn.should_reconnect() is False
+
+        assert len(initial_cluster_nodes) == len(client.nodes_manager.nodes_cache)
+
+        logging.info("Waiting for SMIGRATED push notifications...")
+        con_to_read_smigrated = random.choice(list(in_use_connections.values()))
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=SMIGRATED_TIMEOUT,
+            connection=con_to_read_smigrated,
+        )
+        await self._drain_maint_notification_tasks(client)
+
+        logging.info("Validating connection state after SMIGRATED ...")
+        updated_cluster_nodes = client.nodes_manager.nodes_cache.copy()
+
+        removed_nodes = set(initial_cluster_nodes.values()) - set(
+            updated_cluster_nodes.values()
+        )
+        assert len(removed_nodes) == 1
+        removed_node = removed_nodes.pop()
+        assert removed_node is not None
+
+        added_nodes = set(updated_cluster_nodes.values()) - set(
+            initial_cluster_nodes.values()
+        )
+        assert len(added_nodes) == 1
+
+        conn = in_use_connections.get(removed_node)
+        # connection will be dropped, but it is marked for reconnect before
+        # being released; timeouts/state are not updated so are not checked
+        assert conn is not None
+        assert conn.should_reconnect() is True
+
+        logging.info("Releasing connections back to the pool...")
+        for node, conn in in_use_connections.items():
+            node.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_CLIENT_OSS_API,
+            [SlotMigrateEffects.REMOVE],
+        ),
+    )
+    async def test_notification_handling_with_node_remove(
+        self,
+        fault_injector_client_oss_api: AsyncFaultInjectorClient,
+        effect_name: SlotMigrateEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        """A node is removed during slot movement (no replacement added)."""
+        logging.info(f"DB name: {db_name}")
+
+        client, cluster_endpoint_config = await self.setup_env(
+            fault_injector_client_oss_api, db_config
+        )
+
+        logging.info("Creating one connection in each node's pool.")
+        initial_cluster_nodes = client.nodes_manager.nodes_cache.copy()
+        in_use_connections = {}
+        for node in initial_cluster_nodes.values():
+            in_use_connections[node] = await self._acquire_connected_connection(node)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client_oss_api,
+                cluster_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for SMIGRATING push notifications in all connections...")
+        for conn in in_use_connections.values():
+            await AsyncClientValidations.wait_push_notification(
+                client,
+                timeout=int(SLOT_SHUFFLE_TIMEOUT / 2),
+                connection=conn,
+            )
+
+        logging.info("Validating connection maintenance state...")
+        for conn in in_use_connections.values():
+            assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+            assert conn.socket_timeout == RELAXED_TIMEOUT
+            assert conn.should_reconnect() is False
+
+        assert len(initial_cluster_nodes) == len(client.nodes_manager.nodes_cache)
+
+        logging.info("Waiting for SMIGRATED push notifications...")
+        con_to_read_smigrated = random.choice(list(in_use_connections.values()))
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=SMIGRATED_TIMEOUT,
+            connection=con_to_read_smigrated,
+        )
+        await self._drain_maint_notification_tasks(client)
+
+        logging.info("Validating connection state after SMIGRATED ...")
+        updated_cluster_nodes = client.nodes_manager.nodes_cache.copy()
+
+        removed_nodes = set(initial_cluster_nodes.values()) - set(
+            updated_cluster_nodes.values()
+        )
+        assert len(removed_nodes) == 1
+        removed_node = removed_nodes.pop()
+        assert removed_node is not None
+
+        assert len(initial_cluster_nodes) == len(updated_cluster_nodes) + 1
+
+        conn = in_use_connections.get(removed_node)
+        assert conn is not None
+        assert conn.should_reconnect() is True
+
+        # Async-specific: the async NodesManager.set_nodes marks all preserved
+        # nodes' in-use connections for reconnect on initialize() (lazy reconnect,
+        # since set_nodes is sync), in addition to the removed node's connection.
+        # So at least the removed node's connection is marked; in practice all are.
+        marked_conns_for_reconnect = 0
+        for conn in in_use_connections.values():
+            if conn.should_reconnect():
+                marked_conns_for_reconnect += 1
+        assert marked_conns_for_reconnect >= 1
+
+        logging.info("Releasing connections back to the pool...")
+        for node, conn in in_use_connections.items():
+            node.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+
+class TestAsyncClusterClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
+    TestAsyncClusterClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_CLIENT_OSS_API,
+            [
+                SlotMigrateEffects.SLOT_SHUFFLE,
+                SlotMigrateEffects.REMOVE,
+                SlotMigrateEffects.ADD,
+            ],
+        ),
+    )
+    async def test_command_execution_during_slot_shuffle_no_node_replacement(
+        self,
+        fault_injector_client_oss_api: AsyncFaultInjectorClient,
+        effect_name: SlotMigrateEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        """Commands keep succeeding while slots migrate between nodes."""
+        logging.info(f"DB name: {db_name}")
+
+        client, cluster_endpoint_config = await self.setup_env(
+            fault_injector_client_oss_api, db_config
+        )
+
+        shards_count = db_config["shards_count"]
+        logging.info(f"Shards count: {shards_count}")
+
+        errors = asyncio.Queue()
+        if isinstance(fault_injector_client_oss_api, AsyncProxyServerFaultInjector):
+            execution_duration = 20
+        else:
+            execution_duration = 40
+
+        # Warm up the per-node connection pools with a single sequential pass over
+        # all shards before launching the concurrent load. The async client runs on
+        # one event loop, so a burst of concurrent cold connects to the (remote)
+        # cluster nodes would starve each other's connect-timeout budget and fail
+        # before any migration begins. Connecting sequentially gives each node an
+        # uncontended connect window; the concurrent tasks then reuse the pooled
+        # connections. (The sync test gets this for free via thread parallelism.)
+        logging.info("Warming up connection pools to all shards...")
+        warmup_keys = KeyGenerationHelpers.generate_keys_for_all_shards(
+            shards_count,
+            prefix=f"warmup_{effect_name}_{trigger}_key",
+        )
+        for key in warmup_keys:
+            await client.set(key, "value")
+            await client.get(key)
+
+        # Pre-generate each task's key set BEFORE launching the concurrent tasks.
+        # generate_keys_for_all_shards brute-forces CRC16 (~16k iterations/key) and
+        # is fully synchronous. Calling it inside each task would run that CPU work
+        # on the event loop right as the tasks start, stalling the single loop
+        # during the connection-establishment burst and causing spurious connect
+        # timeouts. (The sync test is immune: each worker is its own OS thread.)
+        task_names = [f"cmd_execution_{i}" for i in range(10)]
+        keys_by_task = {
+            name: KeyGenerationHelpers.generate_keys_for_all_shards(
+                shards_count,
+                prefix=f"{name}_{effect_name}_{trigger}_key",
+            )
+            for name in task_names
+        }
+
+        async def execute_commands(duration: int, task_name: str):
+            start = time.time()
+            executed_commands_count = 0
+            keys_for_all_shards = keys_by_task[task_name]
+            while time.time() - start < duration:
+                for key in keys_for_all_shards:
+                    try:
+                        await client.set(key, "value")
+                        await client.get(key)
+                        executed_commands_count += 2
+                    except Exception as e:
+                        logging.error(f"Error in task {task_name}: {e}")
+                        await errors.put(f"Command failed in task {task_name}: {e}")
+                await asyncio.sleep(0.001)
+            logging.debug(f"{task_name}: task ended")
+
+        tasks = [
+            asyncio.create_task(
+                execute_commands(execution_duration, name),
+                name=name,
+            )
+            for name in task_names
+        ]
+
+        logging.info("Waiting for tasks to start and have a few cycles executed ...")
+        await asyncio.sleep(3)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client_oss_api,
+                cluster_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        await asyncio.gather(*tasks)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        # Drain any in-flight topology-update tasks before consuming buffers.
+        await self._drain_maint_notification_tasks(client)
+
+        # Consume all node connection buffers to validate no notifications were
+        # left unconsumed.
+        logging.info(
+            "Consuming all buffers to validate no notifications were left unconsumed..."
+        )
+        # Snapshot the node list before iterating: the awaits in this loop
+        # (sleep + read_response) yield to the event loop, where reading a push
+        # notification can schedule a background topology-update task that
+        # mutates nodes_cache (set_nodes with remove_old=True), causing
+        # "dictionary changed size during iteration". Same reason the inner loop
+        # snapshots node._connections.
+        for node in list(client.nodes_manager.nodes_cache.values()):
+            for conn in list(node._connections):
+                if conn.is_connected:
+                    # Async can_read() is non-blocking (it only checks the buffer),
+                    # unlike the sync can_read(timeout=...). Give any in-flight push
+                    # data a moment to land before draining the buffer.
+                    await asyncio.sleep(0.2)
+                    try:
+                        while await conn.can_read():
+                            await conn.read_response(push_request=True)
+                    except RedisConnectionError:
+                        # remove/failover migrations close connections to the
+                        # removed/failed-over node server-side. async can_read()
+                        # reports True on EOF (it also flags a closed/dirty
+                        # connection, not just buffered data), so the drain enters
+                        # read_response() and hits "Connection closed by server".
+                        # A closed connection has nothing left to drain — this is
+                        # expected during the migration, not an unconsumed push.
+                        pass
+            logging.info(f"Consumed all buffers for node: {node.name}")
+        logging.info("All buffers consumed.")
 
         error_items = []
         while not errors.empty():

--- a/tests/test_asyncio/test_scenario/test_maint_notifications.py
+++ b/tests/test_asyncio/test_scenario/test_maint_notifications.py
@@ -1,0 +1,1197 @@
+"""Tests for Redis Enterprise maintenance push notifications — async standalone client."""
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import pytest
+import pytest_asyncio
+
+from redis.asyncio import Redis
+from redis.maint_notifications import (
+    EndpointType,
+    MaintenanceState,
+)
+from tests.test_asyncio.test_scenario.conftest import (
+    _get_async_client_maint_notifications,
+    get_async_standalone_client_maint_notifications,
+)
+from tests.test_asyncio.test_scenario.maint_notifications_helpers import (
+    AsyncClientValidations,
+)
+from tests.test_scenario.conftest import (
+    CLIENT_TIMEOUT,
+    RELAXED_TIMEOUT,
+    _FAULT_INJECTOR_STANDALONE_CLIENT,
+    use_mock_proxy,
+)
+from tests.test_asyncio.test_scenario.async_fault_injector_client import (
+    AsyncFaultInjectorClient,
+    AsyncProxyServerFaultInjector,
+)
+from tests.test_scenario.fault_injector_client import (
+    SlotMigrateEffects,
+    TopologyChangeStandaloneEffects,
+)
+from tests.test_scenario.maint_notifications_helpers import (
+    generate_params,
+    is_endpoint_configured_correctly,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S:%f",
+)
+
+logging.getLogger("redis.asyncio.maint_notifications").setLevel(logging.DEBUG)
+
+STANDALONE_MAINT_TIMEOUT = 60
+SLOT_SHUFFLE_TIMEOUT = 120
+
+DEFAULT_BIND_TTL = 15
+DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT = 1
+
+
+class TestAsyncPushNotificationsBase:
+    async def _get_all_connections_in_pool(self, client: Redis) -> List:
+        connections = []
+        async with client.connection_pool._get_pool_lock():
+            for conn in client.connection_pool._get_free_connections():
+                connections.append(conn)
+            for conn in client.connection_pool._get_in_use_connections():
+                connections.append(conn)
+        return connections
+
+    async def _validate_maintenance_state(
+        self, client: Redis, expected_matching_conns_count: int
+    ):
+        matching_conns_count = 0
+        connections = await self._get_all_connections_in_pool(client)
+
+        for conn in connections:
+            if (
+                conn.is_connected
+                and conn.socket_timeout == RELAXED_TIMEOUT
+                and conn.maintenance_state == MaintenanceState.MAINTENANCE
+            ):
+                matching_conns_count += 1
+        assert matching_conns_count == expected_matching_conns_count
+
+    async def _validate_moving_state(
+        self,
+        client: Redis,
+        configured_endpoint_type: EndpointType,
+        expected_matching_connected_conns_count: int,
+        expected_matching_disconnected_conns_count: int,
+        fault_injector_client: AsyncFaultInjectorClient,
+    ):
+        matching_connected_conns_count = 0
+        matching_disconnected_conns_count = 0
+        # No outer lock here: asyncio.Lock is non-reentrant and
+        # _get_all_connections_in_pool already holds the lock for its snapshot.
+        # Single-threaded event loop guarantees no interleaving after the await.
+        connections = await self._get_all_connections_in_pool(client)
+        for conn in connections:
+            endpoint_configured_correctly = is_endpoint_configured_correctly(
+                conn, configured_endpoint_type, fault_injector_client
+            )
+
+            if (
+                conn.is_connected
+                and conn.socket_timeout == RELAXED_TIMEOUT
+                and conn.maintenance_state == MaintenanceState.MOVING
+                and endpoint_configured_correctly
+            ):
+                matching_connected_conns_count += 1
+            elif (
+                not conn.is_connected
+                and conn.maintenance_state == MaintenanceState.MOVING
+                and conn.socket_timeout == RELAXED_TIMEOUT
+                and endpoint_configured_correctly
+            ):
+                matching_disconnected_conns_count += 1
+
+        assert matching_connected_conns_count == expected_matching_connected_conns_count
+        assert (
+            matching_disconnected_conns_count
+            == expected_matching_disconnected_conns_count
+        )
+
+    async def _validate_default_state(
+        self,
+        client: Redis,
+        expected_matching_conns_count: Union[int, Literal["all"]],
+        configured_timeout: float = CLIENT_TIMEOUT,
+    ):
+        matching_conns_count = 0
+        connections = await self._get_all_connections_in_pool(client)
+        logging.info(f"Validating {len(connections)} connections")
+
+        for conn in connections:
+            if not conn.is_connected:
+                if (
+                    conn.maintenance_state == MaintenanceState.NONE
+                    and conn.socket_timeout == configured_timeout
+                    and conn.host == getattr(conn, "orig_host_address", conn.host)
+                ):
+                    matching_conns_count += 1
+                else:
+                    logging.debug(
+                        f"Connection not matching default state: "
+                        f"maintenance_state={conn.maintenance_state}, "
+                        f"socket_timeout={conn.socket_timeout}, "
+                        f"host={conn.host}, "
+                        f"orig_host_address={getattr(conn, 'orig_host_address', None)}"
+                    )
+            elif (
+                conn.socket_timeout == configured_timeout
+                and conn.maintenance_state == MaintenanceState.NONE
+                and conn.host == getattr(conn, "orig_host_address", conn.host)
+            ):
+                matching_conns_count += 1
+            else:
+                logging.debug(
+                    f"Connection not matching default state: "
+                    f"maintenance_state={conn.maintenance_state}, "
+                    f"socket_timeout={conn.socket_timeout}, "
+                    f"host={conn.host}, "
+                    f"orig_host_address={getattr(conn, 'orig_host_address', None)}"
+                )
+
+        conn_kwargs = client.connection_pool.connection_kwargs
+        client_host = conn_kwargs.get("host", "unknown")
+        client_port = conn_kwargs.get("port", "unknown")
+
+        if expected_matching_conns_count == "all":
+            expected_matching_conns_count = len(connections)
+
+        assert matching_conns_count == expected_matching_conns_count, (
+            f"Default state validation failed. "
+            f"Client: host={client_host}, port={client_port}, "
+            f"configured_timeout={configured_timeout}. "
+            f"Expected {expected_matching_conns_count} matching connections, "
+            f"but found {matching_conns_count} out of {len(connections)} total connections."
+        )
+
+    async def _validate_default_notif_disabled_state(
+        self, client: Redis, expected_matching_conns_count: int
+    ):
+        matching_conns_count = 0
+        connections = await self._get_all_connections_in_pool(client)
+
+        for conn in connections:
+            if not conn.is_connected:
+                if (
+                    conn.maintenance_state == MaintenanceState.NONE
+                    and conn.socket_timeout == CLIENT_TIMEOUT
+                    and not hasattr(conn, "orig_host_address")
+                ):
+                    matching_conns_count += 1
+            elif (
+                conn.socket_timeout == CLIENT_TIMEOUT
+                and conn.maintenance_state == MaintenanceState.NONE
+                and not hasattr(conn, "orig_host_address")
+            ):
+                matching_conns_count += 1
+        assert matching_conns_count == expected_matching_conns_count
+
+    async def delete_prev_db(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        db_name: str,
+    ):
+        try:
+            logging.info(f"Deleting database if exists: {db_name}")
+            existing_db_id = await fault_injector_client.find_database_id_by_name(
+                db_name
+            )
+            if existing_db_id:
+                await fault_injector_client.delete_database(existing_db_id)
+                logging.info(f"Deleted database: {db_name}")
+            else:
+                logging.info(f"Database {db_name} does not exist.")
+        except Exception as e:
+            logging.error(f"Failed to delete database {db_name}: {e}")
+
+    async def create_db(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        bdb_config: Dict[str, Any],
+    ):
+        try:
+            logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
+            cluster_endpoint_config = await fault_injector_client.create_database(
+                bdb_config
+            )
+            return cluster_endpoint_config
+        except Exception as e:
+            pytest.fail(f"Failed to create database: {e}")
+
+    async def _trigger_effect(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        endpoints_config: Dict[str, Any],
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
+        trigger_name: Optional[str] = None,
+        target_node: Optional[str] = None,
+        empty_node: Optional[str] = None,
+        skip_end_notification: bool = False,
+        timeout: int = SLOT_SHUFFLE_TIMEOUT,
+    ):
+        action_id = await fault_injector_client.trigger_effect(
+            endpoint_config=endpoints_config,
+            effect_name=effect_name,
+            trigger_name=trigger_name,
+            source_node=target_node,
+            target_node=empty_node,
+            skip_end_notification=skip_end_notification,
+        )
+        result = await fault_injector_client.get_operation_result(
+            action_id,
+            timeout=timeout,
+        )
+        logging.debug(f"Action execution result: {result}")
+
+
+class TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase(
+    TestAsyncPushNotificationsBase
+):
+    async def setup_env(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        db_config: Dict[str, Any],
+        endpoint_type: Optional[EndpointType] = None,
+    ):
+        self._fault_injector = fault_injector_client
+        await self.delete_prev_db(fault_injector_client, db_config["name"])
+
+        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        self._bdb_name = db_config["name"]
+
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
+            else False
+        )
+
+        self._client = get_async_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
+            socket_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+            enable_maintenance_notifications=True,
+            endpoint_type=endpoint_type,
+            auth_ssl_client_certs=auth_ssl_client_certs,
+        )
+        return self._client, db_endpoint_config
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def setup_and_cleanup(self):
+        self.maintenance_ops_tasks = []
+        self._bdb_name = None
+        self._fault_injector = None
+        self._client: Redis | None = None
+
+        yield
+
+        logging.info("Starting cleanup...")
+
+        logging.info("Waiting for maintenance operation tasks to finish...")
+        if self.maintenance_ops_tasks:
+            await asyncio.gather(*self.maintenance_ops_tasks, return_exceptions=True)
+
+        if self._client is not None:
+            await self._client.aclose()
+
+        if self._bdb_name and self._fault_injector:
+            await self.delete_prev_db(self._fault_injector, self._bdb_name)
+
+        logging.info("Cleanup finished")
+
+
+class TestAsyncStandaloneClientPushNotificationsHandlingWithEffectTrigger(
+    TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP],
+        ),
+    )
+    async def test_notification_handling_during_data_movements_no_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        logging.info("Creating one connection in the pool.")
+        conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for opening push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn,
+        )
+
+        logging.info("Validating connection maintenance state...")
+        assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+        assert conn.socket_timeout == RELAXED_TIMEOUT
+
+        logging.info("Waiting for closing push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn,
+        )
+
+        logging.info("Validating connection default state is restored...")
+        assert conn.maintenance_state == MaintenanceState.NONE
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+
+        logging.info("Releasing connection back to the pool...")
+        await client.connection_pool.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    async def test_notification_handling_during_data_movements_with_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        conn = await client.connection_pool.get_connection()
+        await client.connection_pool.release(conn)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        logging.info("Validating connection migrating state...")
+        conn = await client.connection_pool.get_connection()
+        assert conn.maintenance_state == MaintenanceState.MAINTENANCE
+        assert conn.socket_timeout == RELAXED_TIMEOUT
+        await client.connection_pool.release(conn)
+
+        logging.info("Waiting for MIGRATED push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        logging.info("Validating connection states...")
+        conn = await client.connection_pool.get_connection()
+        assert conn.maintenance_state == MaintenanceState.NONE
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+        await client.connection_pool.release(conn)
+
+        logging.info("Waiting for MOVING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        logging.info("Validating connection states...")
+        conn = await client.connection_pool.get_connection()
+        assert conn.maintenance_state == MaintenanceState.MOVING
+        assert conn.socket_timeout == RELAXED_TIMEOUT
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(DEFAULT_BIND_TTL)
+
+        logging.info("Validating connection states...")
+        assert conn.maintenance_state == MaintenanceState.NONE
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+
+        await client.connection_pool.release(conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
+    )
+    async def test_timeout_handling_during_data_movements_with_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
+    ):
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        logging.info("Creating three connections in the pool.")
+        conns = []
+        for _ in range(3):
+            conns.append(await client.connection_pool.get_connection())
+        for conn in conns:
+            await client.connection_pool.release(conn)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=2,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        logging.info("Waiting for MIGRATED push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+
+        logging.info("Validating connection states after MIGRATED ...")
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        logging.info("Waiting for MOVING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        if endpoint_type == EndpointType.NONE:
+            logging.info(
+                "Waiting for moving ttl/2 to expire to validate proactive reconnection"
+            )
+            await asyncio.sleep(fault_injector_client.get_moving_ttl() / 2 + 1)
+
+        logging.info("Validating connections states...")
+        await self._validate_moving_state(
+            client,
+            endpoint_type,
+            expected_matching_connected_conns_count=0,
+            expected_matching_disconnected_conns_count=3,
+            fault_injector_client=fault_injector_client,
+        )
+        conn = await client.connection_pool.get_connection()
+        await self._validate_moving_state(
+            client,
+            endpoint_type,
+            expected_matching_connected_conns_count=1,
+            expected_matching_disconnected_conns_count=2,
+            fault_injector_client=fault_injector_client,
+        )
+        await client.connection_pool.release(conn)
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(DEFAULT_BIND_TTL)
+
+        logging.info("Validating connection states...")
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
+    )
+    async def test_connection_handling_during_data_movements_with_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
+    ):
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing with endpoint type: {endpoint_type}")
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info("Waiting for MIGRATED push notification ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        await client.connection_pool.release(first_conn)
+
+        logging.info("Waiting for MOVING push notifications on random connection ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        if endpoint_type == EndpointType.NONE:
+            logging.info(
+                "Waiting for moving ttl/2 to expire to validate proactive reconnection"
+            )
+            await asyncio.sleep(fault_injector_client.get_moving_ttl() / 2 + 1)
+
+        connections = []
+        for _ in range(3):
+            connections.append(await client.connection_pool.get_connection())
+        for conn in connections:
+            logging.debug(f"Releasing connection {conn}. {conn.maintenance_state}")
+            await client.connection_pool.release(conn)
+
+        logging.info("Validating connections states during MOVING ...")
+        await self._validate_moving_state(
+            client,
+            endpoint_type,
+            expected_matching_connected_conns_count=3,
+            expected_matching_disconnected_conns_count=0,
+            fault_injector_client=fault_injector_client,
+        )
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(fault_injector_client.get_moving_ttl())
+
+        logging.info("Validating connection states after MOVING has expired ...")
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    async def test_new_connections_receive_notifications_no_conn_drop(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for opening push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info(
+            "Creating second connection that should receive the opening notification as well."
+        )
+        second_conn = await client.connection_pool.get_connection()
+        await self._validate_maintenance_state(client, expected_matching_conns_count=2)
+
+        logging.info("Waiting for closing push notifications on both connections ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=second_conn,
+        )
+
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=2,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        await client.connection_pool.release(first_conn)
+        await client.connection_pool.release(second_conn)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    async def test_old_connection_shutdown_during_moving(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        endpoint_type = EndpointType.EXTERNAL_IP
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        conn = await client.connection_pool.get_connection()
+        await client.connection_pool.release(conn)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info("Waiting for MIGRATED push notification ...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=1,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        moving_event = asyncio.Event()
+        errors = asyncio.Queue()
+
+        async def execute_commands():
+            while not moving_event.is_set():
+                try:
+                    await client.set("key", "value")
+                    await client.get("key")
+                except Exception as e:
+                    await errors.put(
+                        f"Command failed in task {asyncio.current_task().get_name()}: {e}"
+                    )
+                await asyncio.sleep(0.001)
+
+        conn_to_check_moving = await client.connection_pool.get_connection()
+
+        threads_count = 10
+        tasks = [
+            asyncio.create_task(execute_commands(), name=f"cmd_task_{i}")
+            for i in range(threads_count)
+        ]
+
+        logging.info("Waiting for MOVING push notification ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn_to_check_moving,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        logging.info("Setting moving event...")
+        moving_event.set()
+        await client.connection_pool.release(conn_to_check_moving)
+
+        await asyncio.gather(*tasks)
+
+        logging.info("All command tasks finished. Validating connections states...")
+        connections = await self._get_all_connections_in_pool(client)
+        for conn in connections:
+            if conn.is_connected:
+                assert conn.get_resolved_ip() == conn.host
+                assert conn.maintenance_state == MaintenanceState.MOVING
+                assert conn.socket_timeout == RELAXED_TIMEOUT
+                if not isinstance(fault_injector_client, AsyncProxyServerFaultInjector):
+                    assert conn.host != conn.orig_host_address
+                assert not conn.should_reconnect()
+            else:
+                assert conn.maintenance_state == MaintenanceState.MOVING
+                assert conn.socket_timeout == RELAXED_TIMEOUT
+                if not isinstance(fault_injector_client, AsyncProxyServerFaultInjector):
+                    assert conn.host != conn.orig_host_address
+                assert not conn.should_reconnect()
+
+        error_items = []
+        while not errors.empty():
+            error_items.append(errors.get_nowait())
+        assert not error_items, f"Errors occurred in tasks: {error_items}"
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    async def test_new_connections_receive_moving(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        endpoint_type = EndpointType.EXTERNAL_IP
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        await self._validate_maintenance_state(client, expected_matching_conns_count=1)
+
+        logging.info("Waiting for MIGRATED push notifications ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+
+        logging.info("Waiting for MOVING push notifications on random connection ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+            expected_state=MaintenanceState.MOVING,
+        )
+
+        assert first_conn.is_connected, (
+            "Connection must be active after receiving MOVING notification"
+        )
+        old_address = first_conn.getpeername()
+        logging.info(f"The node address before bind: {old_address}")
+
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
+            else False
+        )
+
+        logging.info(
+            "Creating new client pointing at old address — "
+            "new connections should receive the moving notification..."
+        )
+        new_client = _get_async_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            endpoint_type=endpoint_type,
+            host_config=old_address,
+            socket_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+            auth_ssl_client_certs=auth_ssl_client_certs,
+        )
+
+        logging.info(
+            "Creating one connection in the new pool that should receive the moving notification."
+        )
+        new_client_conn = await new_client.connection_pool.get_connection()
+
+        logging.info("Validating connections states during MOVING ...")
+        await self._validate_moving_state(
+            new_client,
+            endpoint_type,
+            expected_matching_connected_conns_count=1,
+            expected_matching_disconnected_conns_count=0,
+            fault_injector_client=fault_injector_client,
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        await new_client.connection_pool.release(new_client_conn)
+        await new_client.aclose()
+
+        await client.connection_pool.release(first_conn)
+
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    async def test_disabled_handling_during_migrating_and_moving(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        logging.info(f"DB name: {db_name}")
+
+        self._fault_injector = fault_injector_client
+        await self.delete_prev_db(fault_injector_client, db_config["name"])
+        db_endpoint_config = await self.create_db(fault_injector_client, db_config)
+        self._bdb_name = db_config["name"]
+
+        logging.info("Creating client with disabled notifications.")
+        self._client = client = get_async_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
+            enable_maintenance_notifications=False,
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = await client.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        logging.info("Waiting for MIGRATING push notifications...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=first_conn
+        )
+
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=1
+        )
+
+        logging.info(
+            "Creating second connection — expect it not to receive MIGRATING either."
+        )
+        second_conn = await client.connection_pool.get_connection()
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=second_conn
+        )
+
+        logging.info(
+            "Validating connection states after MIGRATING for both connections ..."
+        )
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=2
+        )
+
+        logging.info("Waiting for MIGRATED push notifications on both connections ...")
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=first_conn
+        )
+        await AsyncClientValidations.wait_push_notification(
+            client, timeout=5, fail_on_timeout=False, connection=second_conn
+        )
+
+        await client.connection_pool.release(first_conn)
+        await client.connection_pool.release(second_conn)
+
+        logging.info("Waiting for MOVING push notifications on random connection ...")
+        await AsyncClientValidations.wait_push_notification(
+            client,
+            timeout=10,
+            fail_on_timeout=False,
+        )
+
+        connections = []
+        for _ in range(3):
+            connections.append(await client.connection_pool.get_connection())
+        for conn in connections:
+            await client.connection_pool.release(conn)
+
+        logging.info("Validating connections states during MOVING ...")
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=3
+        )
+
+        logging.info("Waiting for moving ttl to expire")
+        await asyncio.sleep(DEFAULT_BIND_TTL)
+
+        logging.info("Validating connection states after MOVING has expired ...")
+        await self._validate_default_notif_disabled_state(
+            client, expected_matching_conns_count=3
+        )
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+
+class TestAsyncStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
+    TestAsyncStandaloneClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [
+                TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP,
+                TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP,
+                TopologyChangeStandaloneEffects.CONN_DROP,
+                TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
+            ],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
+    )
+    async def test_command_execution_during_maintenance(
+        self,
+        fault_injector_client: AsyncFaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
+    ):
+        errors = asyncio.Queue()
+        if isinstance(fault_injector_client, AsyncProxyServerFaultInjector):
+            execution_duration = 20
+        else:
+            execution_duration = 60
+
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
+        client, db_endpoint_config = await self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
+        async def execute_commands(duration: int):
+            start = time.time()
+            while time.time() - start < duration:
+                try:
+                    await client.set("key", "value")
+                    await client.get("key")
+                except Exception as e:
+                    logging.error(
+                        f"Error in task {asyncio.current_task().get_name()}: {e}"
+                    )
+                    await errors.put(
+                        f"Command failed in task "
+                        f"{asyncio.current_task().get_name()}: {e}"
+                    )
+                await asyncio.sleep(0.001)
+            logging.debug(f"{asyncio.current_task().get_name()}: task ended")
+
+        tasks = [
+            asyncio.create_task(
+                execute_commands(execution_duration), name=f"cmd_task_{i}"
+            )
+            for i in range(10)
+        ]
+
+        logging.info("Waiting for tasks to start and have a few cycles executed ...")
+        await asyncio.sleep(3)
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_task = asyncio.create_task(
+            self._trigger_effect(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            )
+        )
+        self.maintenance_ops_tasks.append(trigger_task)
+
+        await asyncio.gather(*tasks)
+
+        await trigger_task
+        self.maintenance_ops_tasks.remove(trigger_task)
+
+        await self._validate_default_state(
+            client,
+            expected_matching_conns_count=10,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        error_items = []
+        while not errors.empty():
+            error_items.append(errors.get_nowait())
+        assert not error_items, f"Errors occurred in tasks: {error_items}"

--- a/tests/test_scenario/conftest.py
+++ b/tests/test_scenario/conftest.py
@@ -425,6 +425,7 @@ def get_cluster_client_maint_notifications(
     disable_retries: bool = False,
     auth_ssl_client_certs: bool = False,
     socket_timeout: Optional[float] = None,
+    socket_connect_timeout: Optional[float] = None,
 ):
     """Create Redis cluster client with maintenance notifications enabled."""
     # Get credentials from the configuration
@@ -476,8 +477,8 @@ def get_cluster_client_maint_notifications(
         port=port,
         socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
         socket_connect_timeout=CLIENT_TIMEOUT
-        if socket_timeout is None
-        else socket_timeout,
+        if socket_connect_timeout is None
+        else socket_connect_timeout,
         username=username,
         password=password,
         protocol=protocol,  # RESP3 required for push notifications

--- a/tests/test_scenario/conftest.py
+++ b/tests/test_scenario/conftest.py
@@ -55,6 +55,14 @@ _FAULT_INJECTOR_CLIENT_OSS_API = (
     else REFaultInjector(os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324"))
 )
 
+# Module-level singleton for fault injector client used in parametrize
+# This ensures we create only ONE instance that's shared between parametrize and fixture
+_FAULT_INJECTOR_STANDALONE_CLIENT = (
+    ProxyServerFaultInjector(oss_cluster=False)
+    if use_mock_proxy()
+    else REFaultInjector(os.getenv("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324"))
+)
+
 
 @pytest.fixture()
 def endpoint_name(request):
@@ -259,11 +267,6 @@ def _prepare_ssl_certificates(cert_chain: bool) -> dict:
     }
 
 
-@pytest.fixture()
-def client_maint_notifications(endpoints_config):
-    return _get_client_maint_notifications(endpoints_config)
-
-
 def _get_client_maint_notifications(
     endpoints_config,
     protocol: int = 3,
@@ -272,6 +275,7 @@ def _get_client_maint_notifications(
     enable_relaxed_timeout: bool = True,
     enable_proactive_reconnect: bool = True,
     disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
     socket_timeout: Optional[float] = None,
     host_config: Optional[str] = None,
 ):
@@ -313,6 +317,11 @@ def _get_client_maint_notifications(
     tls_enabled = True if parsed.scheme == "rediss" else False
     logging.info(f"TLS enabled: {tls_enabled}")
 
+    tls_kwargs = {"ssl": tls_enabled}
+    if tls_enabled:
+        ssl_config = _prepare_ssl_certificates(auth_ssl_client_certs)
+        tls_kwargs.update(ssl_config)
+
     # Create Redis client with maintenance notifications config
     # This will automatically create the MaintNotificationsPoolHandler
     client = Redis(
@@ -321,15 +330,87 @@ def _get_client_maint_notifications(
         socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
         username=username,
         password=password,
-        ssl=tls_enabled,
-        ssl_cert_reqs="none",
-        ssl_check_hostname=False,
         protocol=protocol,  # RESP3 required for push notifications
         maint_notifications_config=maintenance_config,
         retry=retry,
+        **tls_kwargs,
     )
     logging.info("Redis client created with maintenance notifications enabled")
     logging.info(f"Client uses Protocol: {client.connection_pool.get_protocol()}")
+
+    return client
+
+
+def get_standalone_client_maint_notifications(
+    endpoints_config,
+    protocol: int = 3,
+    enable_maintenance_notifications: bool = True,
+    endpoint_type: Optional[EndpointType] = None,
+    enable_relaxed_timeout: bool = True,
+    enable_proactive_reconnect: bool = True,
+    disable_retries: bool = False,
+    auth_ssl_client_certs: bool = False,
+    socket_timeout: Optional[float] = None,
+):
+    """Create Redis stanalone client with maintenance notifications enabled."""
+    # Get credentials from the configuration
+    username = endpoints_config.get("username")
+    password = endpoints_config.get("password")
+
+    # Parse host and port from endpoints URL
+    endpoints = endpoints_config.get("endpoints", [])
+    if not endpoints:
+        raise ValueError("No endpoints found in configuration")
+
+    parsed = urlparse(endpoints[0])
+    host = parsed.hostname
+    port = parsed.port
+
+    if not host:
+        raise ValueError(f"Could not parse host from endpoint URL: {endpoints[0]}")
+
+    logging.info(f"Connecting to Redis Enterprise: {host}:{port} with user: {username}")
+
+    if disable_retries:
+        retry = Retry(NoBackoff(), 0)
+    else:
+        retry = Retry(
+            backoff=ExponentialWithJitterBackoff(base=0.01, cap=1), retries=10
+        )
+
+    tls_enabled = True if parsed.scheme == "rediss" else False
+    logging.info(f"TLS enabled: {tls_enabled}")
+
+    tls_kwargs = {"ssl": tls_enabled}
+
+    if tls_enabled:
+        # Prepare SSL certificate configuration
+        ssl_config = _prepare_ssl_certificates(auth_ssl_client_certs)
+        tls_kwargs.update(ssl_config)
+
+    # Configure maintenance notifications
+    maintenance_config = MaintNotificationsConfig(
+        enabled=enable_maintenance_notifications,
+        proactive_reconnect=enable_proactive_reconnect,
+        relaxed_timeout=RELAXED_TIMEOUT if enable_relaxed_timeout else -1,
+        endpoint_type=endpoint_type,
+    )
+
+    # Create Redis cluster client with maintenance notifications config
+    client = Redis(
+        host=host,
+        port=port,
+        socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
+        username=username,
+        password=password,
+        protocol=protocol,  # RESP3 required for push notifications
+        maint_notifications_config=maintenance_config,
+        retry=retry,
+        **tls_kwargs,
+    )
+    logging.info(
+        "Redis standalone client created with maintenance notifications enabled"
+    )
 
     return client
 
@@ -394,6 +475,9 @@ def get_cluster_client_maint_notifications(
         host=host,
         port=port,
         socket_timeout=CLIENT_TIMEOUT if socket_timeout is None else socket_timeout,
+        socket_connect_timeout=CLIENT_TIMEOUT
+        if socket_timeout is None
+        else socket_timeout,
         username=username,
         password=password,
         protocol=protocol,  # RESP3 required for push notifications

--- a/tests/test_scenario/fault_injector_client.py
+++ b/tests/test_scenario/fault_injector_client.py
@@ -435,7 +435,16 @@ class REFaultInjector(FaultInjectorClient):
         return self.MOVING_TTL
 
 
-class ProxyServerFaultInjector(FaultInjectorClient):
+class MockProxyFaultInjector:
+    """Marker mixin for proxy-server-based fault injectors (sync and async).
+
+    Used to skip endpoint-type validation in tests — the mock proxy doesn't
+    distinguish endpoint types, so any isinstance check against this class
+    means "we're running against a local proxy, skip the check".
+    """
+
+
+class ProxyServerFaultInjector(MockProxyFaultInjector, FaultInjectorClient):
     """Fault injector client for proxy server setup."""
 
     NODE_PORT_1 = 15379

--- a/tests/test_scenario/fault_injector_client.py
+++ b/tests/test_scenario/fault_injector_client.py
@@ -1,19 +1,16 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 import json
 import logging
 import time
 import urllib.request
 import urllib.error
-from typing import Dict, Any, Optional, Tuple, Union
+from typing import Dict, Any, Optional, Union
 from enum import Enum
 
 import pytest
 
-from redis.cluster import ClusterNode
 from tests.maint_notifications.proxy_server_helpers import (
     ProxyInterceptorHelper,
-    RespTranslator,
     SlotsRange,
 )
 
@@ -42,6 +39,7 @@ class ActionType(str, Enum):
     EXECUTE_RLUTIL_COMMAND = "execute_rlutil_command"
     EXECUTE_RLADMIN_COMMAND = "execute_rladmin_command"
     SLOT_MIGRATE = "slot_migrate"
+    TOPOLOGY_CHANGE_STANDALONE = "topology_change_standalone"
 
 
 class SlotMigrateEffects(str, Enum):
@@ -49,6 +47,13 @@ class SlotMigrateEffects(str, Enum):
     REMOVE = "remove"
     ADD = "add"
     SLOT_SHUFFLE = "slot-shuffle"
+
+
+class TopologyChangeStandaloneEffects(str, Enum):
+    DATA_MOVEMENT_CONN_DROP = "data_movement_conn_drop"
+    DATA_MOVEMENT_NO_CONN_DROP = "data_movement_no_conn_drop"
+    CONN_DROP = "conn_drop"
+    DNS_RESOLUTION_CHANGE = "dns_resolution_change"
 
 
 class RestartDmcParams:
@@ -75,16 +80,6 @@ class ActionRequest:
             if isinstance(self.parameters, RestartDmcParams)
             else self.parameters,
         }
-
-
-@dataclass
-class NodeInfo:
-    node_id: str
-    role: str
-    internal_address: str
-    external_address: str
-    hostname: str
-    port: int
 
 
 class FaultInjectorClient(ABC):
@@ -119,48 +114,6 @@ class FaultInjectorClient(ABC):
         pass
 
     @abstractmethod
-    def find_target_node_and_empty_node(
-        self,
-        endpoint_config: Dict[str, Any],
-        force_cluster_info_refresh: bool = True,
-    ) -> Tuple[NodeInfo, NodeInfo]:
-        pass
-
-    @abstractmethod
-    def find_endpoint_for_bind(
-        self,
-        endpoint_name: str,
-        force_cluster_info_refresh: bool = True,
-    ) -> str:
-        pass
-
-    @abstractmethod
-    def execute_failover(
-        self,
-        endpoint_config: Dict[str, Any],
-        timeout: int = 60,
-    ) -> Dict[str, Any]:
-        pass
-
-    @abstractmethod
-    def execute_migrate(
-        self,
-        endpoint_config: Dict[str, Any],
-        target_node: str,
-        empty_node: str,
-        skip_end_notification: bool = False,
-    ) -> str:
-        pass
-
-    @abstractmethod
-    def execute_rebind(
-        self,
-        endpoint_config: Dict[str, Any],
-        endpoint_id: str,
-    ) -> str:
-        pass
-
-    @abstractmethod
     def get_moving_ttl(self) -> int:
         pass
 
@@ -172,10 +125,17 @@ class FaultInjectorClient(ABC):
         pass
 
     @abstractmethod
+    def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
     def trigger_effect(
         self,
         endpoint_config: Dict[str, Any],
-        effect_name: SlotMigrateEffects,
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
         trigger_name: Optional[str] = None,
         source_node: Optional[str] = None,
         target_node: Optional[str] = None,
@@ -214,10 +174,6 @@ class REFaultInjector(FaultInjectorClient):
                 error_body = json.loads(e.read().decode("utf-8"))
                 raise ValueError(f"Validation Error: {error_body}")
             raise
-
-    def list_actions(self) -> Dict[str, Any]:
-        """List all available actions"""
-        return self._make_request("GET", "/action")
 
     def trigger_action(self, action_request: ActionRequest) -> Dict[str, Any]:
         """Trigger a new action"""
@@ -405,285 +361,6 @@ class REFaultInjector(FaultInjectorClient):
 
         raise ValueError(f"Database {database_name} not found")
 
-    def find_target_node_and_empty_node(
-        self,
-        endpoint_config: Dict[str, Any],
-        force_cluster_info_refresh: bool = True,
-    ) -> Tuple[NodeInfo, NodeInfo]:
-        """Find the node with master shards and the node with no shards.
-
-        Returns:
-            tuple: (target_node, empty_node) where target_node has master shards
-                and empty_node has no shards
-        """
-        db_port = int(endpoint_config.get("port", 0))
-
-        if self._cluster_nodes_info is None or force_cluster_info_refresh:
-            self.get_cluster_nodes_info()
-
-        if not self._cluster_nodes_info:
-            raise ValueError("No cluster status output found")
-
-        # Parse the sections to find nodes with master shards and nodes with no shards
-        lines = self._cluster_nodes_info.split("\n")
-        shards_section_started = False
-        nodes_section_started = False
-
-        # Get all node IDs from CLUSTER NODES section
-        all_nodes = set()
-        all_nodes_details = {}
-        nodes_with_any_shards = set()  # Nodes with shards from ANY database
-        nodes_with_target_db_shards = set()  # Nodes with shards from target database
-        master_nodes = set()  # Master nodes for target database only
-
-        for line in lines:
-            line = line.strip()
-
-            # Start of CLUSTER NODES section
-            if line.startswith("CLUSTER NODES:"):
-                nodes_section_started = True
-                continue
-            elif line.startswith("DATABASES:"):
-                nodes_section_started = False
-                continue
-            elif nodes_section_started and line and not line.startswith("NODE:ID"):
-                # Parse node line: node:1  master 10.0.101.206 ... (ignore the role)
-                parts = line.split()
-                if len(parts) >= 1:
-                    node_id = parts[0].replace("*", "")  # Remove * prefix if present
-                    node_role = parts[1]
-                    node_internal_address = parts[2]
-                    node_external_address = parts[3]
-                    node_hostname = parts[4]
-
-                    node = NodeInfo(
-                        node_id.split(":")[1],
-                        node_role,
-                        node_internal_address,
-                        node_external_address,
-                        node_hostname,
-                        db_port,
-                    )
-                    all_nodes.add(node_id)
-                    all_nodes_details[node_id.split(":")[1]] = node
-
-            # Start of SHARDS section - only care about shard roles here
-            if line.startswith("SHARDS:"):
-                shards_section_started = True
-                continue
-            elif shards_section_started and line.startswith("DB:ID"):
-                continue
-            elif shards_section_started and line and not line.startswith("ENDPOINTS:"):
-                # Parse shard line: db:1  m-standard  redis:1  node:2  master  0-8191  1.4MB  OK
-                parts = line.split()
-                if len(parts) >= 5:
-                    db_id = parts[0]  # db:1, db:2, etc.
-                    node_id = parts[3]  # node:2
-                    shard_role = parts[4]  # master/slave - this is what matters
-
-                    # Track ALL nodes with shards (for finding truly empty nodes)
-                    nodes_with_any_shards.add(node_id)
-
-                    # Only track master nodes for the specific database we're testing
-                    bdb_id = endpoint_config.get("bdb_id")
-                    if db_id == f"db:{bdb_id}":
-                        nodes_with_target_db_shards.add(node_id)
-                        if shard_role == "master":
-                            master_nodes.add(node_id)
-            elif line.startswith("ENDPOINTS:") or not line:
-                shards_section_started = False
-
-        # Find empty node (node with no shards from ANY database)
-        nodes_with_no_shards_target_bdb = all_nodes - nodes_with_target_db_shards
-
-        logging.debug(f"All nodes: {all_nodes}")
-        logging.debug(f"Nodes with shards from any database: {nodes_with_any_shards}")
-        logging.debug(
-            f"Nodes with target database shards: {nodes_with_target_db_shards}"
-        )
-        logging.debug(f"Master nodes (target database only): {master_nodes}")
-        logging.debug(
-            f"Nodes with no shards from target database: {nodes_with_no_shards_target_bdb}"
-        )
-
-        if not nodes_with_no_shards_target_bdb:
-            raise ValueError("All nodes have shards from target database")
-
-        if not master_nodes:
-            raise ValueError("No nodes with master shards from target database found")
-
-        # Return the first available empty node and master node (numeric part only)
-        empty_node = next(iter(nodes_with_no_shards_target_bdb)).split(":")[
-            1
-        ]  # node:1 -> 1
-        target_node = next(iter(master_nodes)).split(":")[1]  # node:2 -> 2
-
-        return all_nodes_details[target_node], all_nodes_details[empty_node]
-
-    def find_endpoint_for_bind(
-        self,
-        endpoint_name: str,
-        force_cluster_info_refresh: bool = True,
-    ) -> str:
-        """Find the endpoint ID from cluster status.
-
-        Returns:
-            str: The endpoint ID (e.g., "1:1")
-        """
-        if self._cluster_nodes_info is None or force_cluster_info_refresh:
-            self.get_cluster_nodes_info()
-
-        if not self._cluster_nodes_info:
-            raise ValueError("No cluster status output found")
-
-        if not self._cluster_nodes_info:
-            raise ValueError("No cluster status output found")
-
-        # Parse the ENDPOINTS section to find endpoint ID
-        lines = self._cluster_nodes_info.split("\n")
-        endpoints_section_started = False
-
-        for line in lines:
-            line = line.strip()
-
-            # Start of ENDPOINTS section
-            if line.startswith("ENDPOINTS:"):
-                endpoints_section_started = True
-                continue
-            elif line.startswith("SHARDS:"):
-                break
-            elif endpoints_section_started and line and not line.startswith("DB:ID"):
-                # Parse endpoint line: db:1  m-standard  endpoint:1:1  node:2  single  No
-                parts = line.split()
-                if len(parts) >= 3 and parts[1] == endpoint_name:
-                    endpoint_full = parts[2]  # endpoint:1:1
-                    if endpoint_full.startswith("endpoint:"):
-                        endpoint_id = endpoint_full.replace("endpoint:", "")  # 1:1
-                        return endpoint_id
-
-        raise ValueError(f"No endpoint ID for {endpoint_name} found in cluster status")
-
-    def execute_failover(
-        self,
-        endpoint_config: Dict[str, Any],
-        timeout: int = 60,
-    ) -> Dict[str, Any]:
-        """Execute failover command and wait for completion."""
-
-        try:
-            # Refresh cluster info before getting the shard - we want to be sure
-            # that we have the current state
-            shard = self._get_first_master_shard(
-                endpoint_config,
-                force_cluster_info_refresh=True,
-            )
-            bdb_id = endpoint_config.get("bdb_id")
-            command = f"failover db db:{bdb_id} shard {shard}"
-
-            parameters = {
-                "bdb_id": bdb_id,
-                "rladmin_command": command,  # Just the command without "rladmin" prefix
-            }
-            logging.debug(f"Executing rladmin_command with parameter: {parameters}")
-
-            failover_action = ActionRequest(
-                action_type=ActionType.EXECUTE_RLADMIN_COMMAND,
-                parameters=parameters,
-            )
-            result = self.trigger_action(failover_action)
-
-            logging.debug(f"Failover command action result: {result}")
-
-            action_id = result.get("action_id")
-            if not action_id:
-                raise Exception(f"Failed to trigger failover action: {result}")
-
-            action_status_check_response = self.get_operation_result(
-                action_id, timeout=timeout
-            )
-            logging.info(
-                f"Completed failover execution: {action_status_check_response}"
-            )
-            return action_status_check_response
-
-        except Exception as e:
-            pytest.fail(f"Failed to execute failover: {e}")
-
-    def execute_migrate(
-        self,
-        endpoint_config: Dict[str, Any],
-        target_node: str,
-        empty_node: str,
-        skip_end_notification: bool = False,
-    ) -> str:
-        """Execute rladmin migrate command and wait for completion."""
-        command = f"migrate node {target_node} all_shards target_node {empty_node}"
-
-        # Get bdb_id from endpoint configuration
-        bdb_id = endpoint_config.get("bdb_id")
-
-        try:
-            # Correct parameter format for fault injector
-            parameters = {
-                "bdb_id": bdb_id,
-                "rladmin_command": command,  # Just the command without "rladmin" prefix
-            }
-
-            logging.debug(f"Executing rladmin_command with parameter: {parameters}")
-
-            action = ActionRequest(
-                action_type=ActionType.EXECUTE_RLADMIN_COMMAND, parameters=parameters
-            )
-            result = self.trigger_action(action)
-
-            logging.debug(f"Migrate command action result: {result}")
-
-            action_id = result.get("action_id")
-
-            if not action_id:
-                raise Exception(f"Failed to trigger migrate action: {result}")
-            return action_id
-        except Exception as e:
-            raise Exception(f"Failed to execute rladmin migrate: {e}")
-
-    def execute_rebind(
-        self,
-        endpoint_config: Dict[str, Any],
-        endpoint_id: str,
-    ) -> str:
-        """Execute rladmin bind endpoint command and wait for completion."""
-
-        endpoint_policy = endpoint_config["raw_endpoints"][0]["proxy_policy"]
-        logging.info(
-            f"Executing rladmin bind endpoint {endpoint_id} policy {endpoint_policy}"
-        )
-        command = f"bind endpoint {endpoint_id} policy {endpoint_policy}"
-
-        bdb_id = endpoint_config.get("bdb_id")
-
-        try:
-            parameters = {
-                "rladmin_command": command,  # Just the command without "rladmin" prefix
-                "bdb_id": bdb_id,
-            }
-
-            logging.info(f"Executing rladmin_command with parameter: {parameters}")
-            action = ActionRequest(
-                action_type=ActionType.EXECUTE_RLADMIN_COMMAND, parameters=parameters
-            )
-            result = self.trigger_action(action)
-            logging.info(
-                f"Migrate command {command} with parameters {parameters} trigger result: {result}"
-            )
-
-            action_id = result.get("action_id")
-
-            if not action_id:
-                raise Exception(f"Failed to trigger bind endpoint action: {result}")
-            return action_id
-        except Exception as e:
-            raise Exception(f"Failed to execute rladmin bind endpoint: {e}")
-
     def get_slot_migrate_triggers(
         self,
         effect_name: SlotMigrateEffects,
@@ -693,10 +370,20 @@ class REFaultInjector(FaultInjectorClient):
             "GET", f"/slot-migrate?effect={effect_name.value}&cluster_index=0"
         )
 
+    def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        """Get available triggers(trigger name + db example config) for a topology change for standalone client effect."""
+        return self._make_request(
+            "GET",
+            f"/topology-change-standalone?effect={effect_name.value}&cluster_index=0",
+        )
+
     def trigger_effect(
         self,
         endpoint_config: Dict[str, Any],
-        effect_name: SlotMigrateEffects,
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
         trigger_name: str,
         source_node: Optional[str] = None,
         target_node: Optional[str] = None,
@@ -721,11 +408,17 @@ class REFaultInjector(FaultInjectorClient):
             if target_node:
                 parameters["target_node"] = target_node
 
-            logging.debug(f"Executing slot migrate with parameters: {parameters}")
-
-            action = ActionRequest(
-                action_type=ActionType.SLOT_MIGRATE, parameters=parameters
+            action_type = (
+                ActionType.SLOT_MIGRATE
+                if isinstance(effect_name, SlotMigrateEffects)
+                else ActionType.TOPOLOGY_CHANGE_STANDALONE
             )
+
+            logging.debug(
+                f"Executing {action_type.value} with parameters: {parameters}"
+            )
+
+            action = ActionRequest(action_type=action_type, parameters=parameters)
             result = self.trigger_action(action)
 
             logging.debug(f"Trigger effect action result: {result}")
@@ -741,44 +434,6 @@ class REFaultInjector(FaultInjectorClient):
     def get_moving_ttl(self) -> int:
         return self.MOVING_TTL
 
-    def _get_first_master_shard(
-        self,
-        endpoint_config: Dict[str, Any],
-        force_cluster_info_refresh: bool = True,
-    ) -> str:
-        """Get the first master shard from the endpoint configuration."""
-        bdb_id = endpoint_config.get("bdb_id")
-
-        if self._cluster_nodes_info is None or force_cluster_info_refresh:
-            self.get_cluster_nodes_info()
-
-        if not self._cluster_nodes_info:
-            raise ValueError("No cluster status output found")
-
-        # Parse the SHARDS section to find the shard id covering slot 0
-        lines = self._cluster_nodes_info.split("\n")
-        shards_section_started = False
-
-        for line in lines:
-            line = line.strip()
-
-            # Start of SHARDS section
-            if line.startswith("SHARDS:"):
-                shards_section_started = True
-                continue
-            elif shards_section_started and line and not line.startswith("DB:ID"):
-                # Parse shard line: db:3 m-standard redis:3 node:3 master 0-8191 1.79MB OK
-                parts = line.split()
-                if (
-                    len(parts) >= 8
-                    and parts[0] == f"db:{bdb_id}"
-                    and parts[4] == "master"
-                    and parts[5].startswith("0-")
-                ):
-                    return parts[2].replace("redis:", "")  # redis:3 --> 3
-
-        raise ValueError("No master shard found")
-
 
 class ProxyServerFaultInjector(FaultInjectorClient):
     """Fault injector client for proxy server setup."""
@@ -786,12 +441,6 @@ class ProxyServerFaultInjector(FaultInjectorClient):
     NODE_PORT_1 = 15379
     NODE_PORT_2 = 15380
     NODE_PORT_3 = 15381
-
-    # Initial cluster node configuration for proxy-based tests
-    PROXY_CLUSTER_NODES = [
-        ClusterNode("127.0.0.1", NODE_PORT_1),
-        ClusterNode("127.0.0.1", NODE_PORT_2),
-    ]
 
     DEFAULT_CLUSTER_SLOTS = [
         SlotsRange("127.0.0.1", NODE_PORT_1, 0, 8191),
@@ -814,12 +463,6 @@ class ProxyServerFaultInjector(FaultInjectorClient):
         self.proxy_helper.set_cluster_slots(
             self.CLUSTER_SLOTS_INTERCEPTOR_NAME, self.DEFAULT_CLUSTER_SLOTS
         )
-
-        self.seq_id = 0
-
-    def _get_seq_id(self):
-        self.seq_id += 1
-        return self.seq_id
 
     def get_operation_result(
         self,
@@ -865,178 +508,6 @@ class ProxyServerFaultInjector(FaultInjectorClient):
     ) -> Optional[int]:
         return 1
 
-    def find_target_node_and_empty_node(
-        self,
-        endpoint_config: Dict[str, Any],
-        force_cluster_info_refresh: bool = True,
-    ) -> Tuple[NodeInfo, NodeInfo]:
-        target_node = NodeInfo(
-            "1", "master", "0.0.0.0", "127.0.0.1", "localhost", self.NODE_PORT_1
-        )
-        empty_node = NodeInfo(
-            "3", "master", "0.0.0.0", "127.0.0.1", "localhost", self.NODE_PORT_3
-        )
-        return target_node, empty_node
-
-    def find_endpoint_for_bind(
-        self,
-        endpoint_name: str,
-        force_cluster_info_refresh: bool = True,
-    ) -> str:
-        return "1:1"
-
-    def execute_failover(
-        self, endpoint_config: Dict[str, Any], timeout: int = 60
-    ) -> Dict[str, Any]:
-        """
-        Simulates a failover operation and waits for completion.
-        This method does not create or manage threads; if asynchronous execution is required,
-        it should be called from a separate thread by the caller.
-        This will always run for the same nodes - node 1 to node 3!
-        Assumes that the initial state is the DEFAULT_CLUSTER_SLOTS - shard 1 on node 1 and shard 2 on node 2.
-        In a real RE cluster, a replica would exist on another node, which is simulated here with node 3.
-        """
-
-        # send smigrating
-        if self.oss_cluster:
-            start_maint_notif = RespTranslator.oss_maint_notification_to_resp(
-                f"SMIGRATING {self._get_seq_id()} 0-8191"
-            )
-        else:
-            # send failing over
-            start_maint_notif = RespTranslator.re_cluster_maint_notification_to_resp(
-                f"FAILING_OVER {self._get_seq_id()} 2 [1]"
-            )
-
-        self.proxy_helper.send_notification(start_maint_notif)
-
-        # sleep to allow the client to receive the notification
-        time.sleep(self.SLEEP_TIME_BETWEEN_START_END_NOTIFICATIONS)
-
-        if self.oss_cluster:
-            # intercept cluster slots
-            self.proxy_helper.set_cluster_slots(
-                self.CLUSTER_SLOTS_INTERCEPTOR_NAME,
-                [
-                    SlotsRange("127.0.0.1", self.NODE_PORT_3, 0, 8191),
-                    SlotsRange("127.0.0.1", self.NODE_PORT_2, 8192, 16383),
-                ],
-            )
-            # send smigrated
-            end_maint_notif = RespTranslator.oss_maint_notification_to_resp(
-                f"SMIGRATED {self._get_seq_id()} 127.0.0.1:{self.NODE_PORT_3} 0-8191"
-            )
-        else:
-            # send failed over
-            end_maint_notif = RespTranslator.re_cluster_maint_notification_to_resp(
-                f"FAILED_OVER {self._get_seq_id()} [1]"
-            )
-        self.proxy_helper.send_notification(end_maint_notif)
-
-        return {"status": "done"}
-
-    def execute_migrate(
-        self,
-        endpoint_config: Dict[str, Any],
-        target_node: str,
-        empty_node: str,
-        skip_end_notification: bool = False,
-    ) -> str:
-        """
-        Simulate migrate command execution.
-        This method does not create or manage threads; it simulates the migration process synchronously.
-        If asynchronous execution is desired, the caller should run this method in a separate thread.
-        This will run always for the same nodes - node 1 to node 2!
-        Assuming that the initial state is the DEFAULT_CLUSTER_SLOTS - shard 1 on node 1 and shard 2 on node 2.
-
-        """
-
-        if self.oss_cluster:
-            # send smigrating
-            start_maint_notif = RespTranslator.oss_maint_notification_to_resp(
-                f"SMIGRATING {self._get_seq_id()} 0-200"
-            )
-        else:
-            # send migrating
-            start_maint_notif = RespTranslator.re_cluster_maint_notification_to_resp(
-                f"MIGRATING {self._get_seq_id()} 2 [1]"
-            )
-
-        self.proxy_helper.send_notification(start_maint_notif)
-
-        # sleep to allow the client to receive the notification
-        time.sleep(self.SLEEP_TIME_BETWEEN_START_END_NOTIFICATIONS)
-
-        if self.oss_cluster:
-            if not skip_end_notification:
-                # intercept cluster slots
-                self.proxy_helper.set_cluster_slots(
-                    self.CLUSTER_SLOTS_INTERCEPTOR_NAME,
-                    [
-                        SlotsRange("127.0.0.1", self.NODE_PORT_2, 0, 200),
-                        SlotsRange("127.0.0.1", self.NODE_PORT_1, 201, 8191),
-                        SlotsRange("127.0.0.1", self.NODE_PORT_2, 8192, 16383),
-                    ],
-                )
-                # send smigrated
-                end_maint_notif = RespTranslator.oss_maint_notification_to_resp(
-                    f"SMIGRATED {self._get_seq_id()} 127.0.0.1:{self.NODE_PORT_2} 0-200"
-                )
-                self.proxy_helper.send_notification(end_maint_notif)
-        else:
-            # send migrated
-            end_maint_notif = RespTranslator.re_cluster_maint_notification_to_resp(
-                f"MIGRATED {self._get_seq_id()} [1]"
-            )
-            self.proxy_helper.send_notification(end_maint_notif)
-
-        return "done"
-
-    def execute_rebind(self, endpoint_config: Dict[str, Any], endpoint_id: str) -> str:
-        """
-        Execute rladmin bind endpoint command and wait for completion.
-        This method simulates the actual bind process. It does not create or manage threads;
-        if you wish to run it in a separate thread, you must do so from the caller.
-        This will run always for the same nodes - node 1 to node 3!
-        Assuming that the initial state is the DEFAULT_CLUSTER_SLOTS - shard 1 on node 1
-        and shard 2 on node 2.
-
-        """
-        sleep_time = self.SLEEP_TIME_BETWEEN_START_END_NOTIFICATIONS
-        if self.oss_cluster:
-            # smigrating should be sent as part of the migrate flow
-            pass
-        else:
-            # send moving
-            sleep_time = self.MOVING_TTL
-            maint_start_notif = RespTranslator.re_cluster_maint_notification_to_resp(
-                f"MOVING {self._get_seq_id()} {sleep_time} 127.0.0.1:{self.NODE_PORT_3}"
-            )
-            self.proxy_helper.send_notification(maint_start_notif)
-
-        # sleep to allow the client to receive the notification
-        time.sleep(sleep_time)
-
-        if self.oss_cluster:
-            # intercept cluster slots
-            self.proxy_helper.set_cluster_slots(
-                self.CLUSTER_SLOTS_INTERCEPTOR_NAME,
-                [
-                    SlotsRange("127.0.0.1", self.NODE_PORT_3, 0, 8191),
-                    SlotsRange("127.0.0.1", self.NODE_PORT_2, 8192, 16383),
-                ],
-            )
-            # send smigrated
-            smigrated_node_1 = RespTranslator.oss_maint_notification_to_resp(
-                f"SMIGRATED {self._get_seq_id()} 127.0.0.1:{self.NODE_PORT_3} 0-8191"
-            )
-            self.proxy_helper.send_notification(smigrated_node_1)
-        else:
-            # TODO drop connections to node 1 to simulate that the node is removed
-            pass
-
-        return "done"
-
     def get_moving_ttl(self) -> int:
         return self.MOVING_TTL
 
@@ -1046,10 +517,16 @@ class ProxyServerFaultInjector(FaultInjectorClient):
     ) -> Dict[str, Any]:
         raise NotImplementedError("Not implemented for proxy server")
 
+    def get_topology_change_standalone_triggers(
+        self,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Not implemented for proxy server")
+
     def trigger_effect(
         self,
         endpoint_config: Dict[str, Any],
-        effect_name: SlotMigrateEffects,
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
         trigger_name: Optional[str] = None,
         source_node: Optional[str] = None,
         target_node: Optional[str] = None,

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -336,7 +336,7 @@ def generate_params(
                         ip_type = requirement["oss_cluster_api"]["ip_type"]
                         if ip_type == "internal":
                             continue
-                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
+                    db_name_pattern = dbconfig.get("name").rsplit("-", 2)[0]
                     dbconfig["name"] = db_name_pattern
 
                     if endpoint_types is not None:

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -1,16 +1,17 @@
 import binascii
 import logging
 import time
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Union
 import pytest
 from redis import RedisCluster
 
 from redis.client import Redis
 from redis.connection import Connection
+from redis.maint_notifications import MaintenanceState
 from tests.test_scenario.fault_injector_client import (
     FaultInjectorClient,
-    NodeInfo,
     SlotMigrateEffects,
+    TopologyChangeStandaloneEffects,
 )
 
 
@@ -48,6 +49,7 @@ class ClientValidations:
         timeout: float = 120,
         fail_on_timeout: bool = True,
         connection: Optional[Connection] = None,
+        expected_state: Optional[MaintenanceState] = None,
     ):
         """Wait for a push notification to be received."""
         start_time = time.time()  # returns the time in seconds
@@ -63,6 +65,16 @@ class ClientValidations:
         )
 
         try:
+            if (
+                expected_state is not None
+                and test_conn.maintenance_state == expected_state
+            ):
+                logging.debug(
+                    f"Connection already in expected state {expected_state}, "
+                    f"returning immediately"
+                )
+                return
+
             while time.time() - start_time < timeout:
                 try:
                     if test_conn.can_read(timeout=0.2):
@@ -73,7 +85,11 @@ class ClientValidations:
                         )
                         if test_conn.should_reconnect():
                             logging.debug("Connection is marked for reconnect")
-                        return
+                        if (
+                            expected_state is None
+                            or test_conn.maintenance_state == expected_state
+                        ):
+                            return
                 except Exception as e:
                     logging.error(f"Error reading push notification: {e}")
                     break
@@ -104,68 +120,6 @@ class ClusterOperations:
         )
 
     @staticmethod
-    def find_target_node_and_empty_node(
-        fault_injector: FaultInjectorClient,
-        endpoint_config: Dict[str, Any],
-        force_cluster_info_refresh: bool = True,
-    ) -> Tuple[NodeInfo, NodeInfo]:
-        """Find the node with master shards and the node with no shards.
-
-        Returns:
-            tuple: (target_node, empty_node) where target_node has master shards
-                   and empty_node has no shards
-        """
-        return fault_injector.find_target_node_and_empty_node(
-            endpoint_config, force_cluster_info_refresh
-        )
-
-    @staticmethod
-    def find_endpoint_for_bind(
-        fault_injector: FaultInjectorClient,
-        endpoint_name: str,
-        force_cluster_info_refresh: bool = True,
-    ) -> str:
-        """Find the endpoint ID from cluster status.
-
-        Returns:
-            str: The endpoint ID (e.g., "1:1")
-        """
-        return fault_injector.find_endpoint_for_bind(
-            endpoint_name, force_cluster_info_refresh
-        )
-
-    @staticmethod
-    def execute_failover(
-        fault_injector: FaultInjectorClient,
-        endpoint_config: Dict[str, Any],
-        timeout: int = 60,
-    ) -> Dict[str, Any]:
-        """Execute failover command and wait for completion."""
-        return fault_injector.execute_failover(endpoint_config, timeout)
-
-    @staticmethod
-    def execute_migrate(
-        fault_injector: FaultInjectorClient,
-        endpoint_config: Dict[str, Any],
-        target_node: str,
-        empty_node: str,
-        skip_end_notification: bool = False,
-    ) -> str:
-        """Execute rladmin migrate command and wait for completion."""
-        return fault_injector.execute_migrate(
-            endpoint_config, target_node, empty_node, skip_end_notification
-        )
-
-    @staticmethod
-    def execute_rebind(
-        fault_injector: FaultInjectorClient,
-        endpoint_config: Dict[str, Any],
-        endpoint_id: str,
-    ) -> str:
-        """Execute rladmin bind endpoint command and wait for completion."""
-        return fault_injector.execute_rebind(endpoint_config, endpoint_id)
-
-    @staticmethod
     def get_slot_migrate_triggers(
         fault_injector: FaultInjectorClient,
         effect_name: SlotMigrateEffects,
@@ -174,10 +128,21 @@ class ClusterOperations:
         return fault_injector.get_slot_migrate_triggers(effect_name)
 
     @staticmethod
+    def get_topology_change_standalone_triggers(
+        fault_injector: FaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+    ) -> Dict[str, Any]:
+        """
+        Get available triggers(trigger name + db example config) for a
+        topology change for standalone client effect.
+        """
+        return fault_injector.get_topology_change_standalone_triggers(effect_name)
+
+    @staticmethod
     def trigger_effect(
         fault_injector: FaultInjectorClient,
         endpoint_config: Dict[str, Any],
-        effect_name: SlotMigrateEffects,
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
         trigger_name: Optional[str] = None,
         source_node: Optional[str] = None,
         target_node: Optional[str] = None,

--- a/tests/test_scenario/maint_notifications_helpers.py
+++ b/tests/test_scenario/maint_notifications_helpers.py
@@ -7,9 +7,10 @@ from redis import RedisCluster
 
 from redis.client import Redis
 from redis.connection import Connection
-from redis.maint_notifications import MaintenanceState
+from redis.maint_notifications import EndpointType, MaintenanceState
 from tests.test_scenario.fault_injector_client import (
     FaultInjectorClient,
+    MockProxyFaultInjector,
     SlotMigrateEffects,
     TopologyChangeStandaloneEffects,
 )
@@ -252,3 +253,106 @@ class KeyGenerationHelpers:
                 keys.append(KeyGenerationHelpers.generate_key(slot_number, prefix))
 
         return keys
+
+
+def is_endpoint_configured_correctly(
+    conn,
+    configured_endpoint_type: EndpointType,
+    fault_injector_client,
+) -> bool:
+    """Return True if conn's host matches the expected endpoint type.
+
+    Always returns True for mock-proxy injectors — the proxy doesn't
+    distinguish endpoint types so there is nothing to validate.
+    """
+    if isinstance(fault_injector_client, MockProxyFaultInjector):
+        return True
+
+    if configured_endpoint_type == EndpointType.NONE:
+        if conn.host != conn.orig_host_address:
+            logging.debug(
+                f"Endpoint check failed: configured NONE but "
+                f"host={conn.host!r} != orig_host_address={conn.orig_host_address!r}"
+            )
+            return False
+        return True
+
+    if conn.host == conn.orig_host_address:
+        logging.debug(
+            f"Endpoint check failed: expected non-NONE endpoint type but "
+            f"host={conn.host!r} == orig_host_address={conn.orig_host_address!r}"
+        )
+        return False
+    actual_endpoint_type = conn.maint_notifications_config.get_endpoint_type(
+        conn.orig_host_address, conn
+    )
+    if configured_endpoint_type != actual_endpoint_type:
+        logging.debug(
+            f"Endpoint check failed: "
+            f"configured_endpoint_type={configured_endpoint_type!r} != "
+            f"actual_endpoint_type={actual_endpoint_type!r} for host={conn.host!r}"
+        )
+        return False
+    return True
+
+
+def generate_params(
+    fault_injector_client: FaultInjectorClient,
+    effect_names: list[SlotMigrateEffects | TopologyChangeStandaloneEffects],
+    skip_combinations: list[tuple[SlotMigrateEffects, str]] = [],
+    endpoint_types: Optional[list[EndpointType]] = None,
+):
+    """Build parametrize tuples for maint-notification scenario tests.
+
+    Returns a list of (effect_name, trigger, dbconfig, db_name) tuples, or
+    (effect_name, trigger, dbconfig, db_name, endpoint_type) when endpoint_types
+    is provided.
+    """
+    params = []
+    try:
+        logging.info(f"Extracting params for test with effect_names: {effect_names}")
+        for effect_name in effect_names:
+            if isinstance(effect_name, SlotMigrateEffects):
+                triggers_data = ClusterOperations.get_slot_migrate_triggers(
+                    fault_injector_client, effect_name
+                )
+            else:
+                triggers_data = (
+                    ClusterOperations.get_topology_change_standalone_triggers(
+                        fault_injector_client, effect_name
+                    )
+                )
+
+            for trigger_info in triggers_data["triggers"]:
+                trigger = trigger_info["name"]
+                if (effect_name, trigger) in skip_combinations:
+                    continue
+                if trigger == "maintenance_mode":
+                    continue
+                trigger_requirements = trigger_info["requirements"]
+                for requirement in trigger_requirements:
+                    dbconfig = requirement["dbconfig"]
+                    if requirement.get("oss_cluster_api"):
+                        ip_type = requirement["oss_cluster_api"]["ip_type"]
+                        if ip_type == "internal":
+                            continue
+                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
+                    dbconfig["name"] = db_name_pattern
+
+                    if endpoint_types is not None:
+                        for endpoint_type in endpoint_types:
+                            params.append(
+                                (
+                                    effect_name,
+                                    trigger,
+                                    dbconfig,
+                                    db_name_pattern,
+                                    endpoint_type,
+                                )
+                            )
+                    else:
+                        params.append((effect_name, trigger, dbconfig, db_name_pattern))
+    except Exception as e:
+        logging.error(f"Failed to extract params for test: {e}")
+
+    return params

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -16,22 +16,23 @@ from redis import Redis
 from redis.connection import ConnectionInterface
 from redis.maint_notifications import (
     EndpointType,
-    MaintNotificationsConfig,
     MaintenanceState,
 )
 from tests.test_scenario.conftest import (
+    _FAULT_INJECTOR_STANDALONE_CLIENT,
     CLIENT_TIMEOUT,
     RELAXED_TIMEOUT,
     _FAULT_INJECTOR_CLIENT_OSS_API,
     _get_client_maint_notifications,
     get_cluster_client_maint_notifications,
+    get_standalone_client_maint_notifications,
     use_mock_proxy,
 )
 from tests.test_scenario.fault_injector_client import (
     FaultInjectorClient,
-    NodeInfo,
     ProxyServerFaultInjector,
     SlotMigrateEffects,
+    TopologyChangeStandaloneEffects,
 )
 from tests.test_scenario.maint_notifications_helpers import (
     ClientValidations,
@@ -49,9 +50,8 @@ logging.basicConfig(
 logging.getLogger("redis.maint_notifications").setLevel(logging.DEBUG)
 logging.getLogger("redis.cluster").setLevel(logging.DEBUG)
 
-BIND_TIMEOUT = 60
-MIGRATE_TIMEOUT = 60
-FAILOVER_TIMEOUT = 15
+
+STANDALONE_MAINT_TIMEOUT = 60
 SMIGRATING_TIMEOUT = 20
 SMIGRATED_TIMEOUT = 40
 
@@ -68,11 +68,43 @@ class TestPushNotificationsBase:
     operations.
     """
 
+    def delete_prev_db(
+        self,
+        fault_injector_client: FaultInjectorClient,
+        db_name: str,
+    ):
+        try:
+            logging.info(f"Deleting database if exists: {db_name}")
+            existing_db_id = None
+            existing_db_id = ClusterOperations.find_database_id_by_name(
+                fault_injector_client, db_name
+            )
+
+            if existing_db_id:
+                fault_injector_client.delete_database(existing_db_id)
+                logging.info(f"Deleted database: {db_name}")
+            else:
+                logging.info(f"Database {db_name} does not exist.")
+        except Exception as e:
+            logging.error(f"Failed to delete database {db_name}: {e}")
+
+    def create_db(
+        self,
+        fault_injector_client: FaultInjectorClient,
+        bdb_config: Dict[str, Any],
+    ):
+        try:
+            logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
+            cluster_endpoint_config = fault_injector_client.create_database(bdb_config)
+            return cluster_endpoint_config
+        except Exception as e:
+            pytest.fail(f"Failed to create database: {e}")
+
     def _trigger_effect(
         self,
         fault_injector_client: FaultInjectorClient,
         endpoints_config: Dict[str, Any],
-        effect_name: SlotMigrateEffects,
+        effect_name: SlotMigrateEffects | TopologyChangeStandaloneEffects,
         trigger_name: Optional[str] = None,
         target_node: Optional[str] = None,
         empty_node: Optional[str] = None,
@@ -94,77 +126,6 @@ class TestPushNotificationsBase:
             timeout=timeout,
         )
         logging.debug(f"Action execution result: {trigger_effect_result}")
-
-    def _execute_failover(
-        self,
-        fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
-    ):
-        failover_result = ClusterOperations.execute_failover(
-            fault_injector_client, endpoints_config
-        )
-
-        logging.debug("Marking failover as executed")
-        self._failover_executed = True
-
-        logging.debug(f"Failover result: {failover_result}")
-
-    def _execute_migration(
-        self,
-        fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
-        target_node: str,
-        empty_node: str,
-        skip_end_notification: bool = False,
-    ):
-        migrate_action_id = ClusterOperations.execute_migrate(
-            fault_injector=fault_injector_client,
-            endpoint_config=endpoints_config,
-            target_node=target_node,
-            empty_node=empty_node,
-            skip_end_notification=skip_end_notification,
-        )
-
-        migrate_result = fault_injector_client.get_operation_result(
-            migrate_action_id, timeout=MIGRATE_TIMEOUT
-        )
-        logging.debug(f"Migration result: {migrate_result}")
-
-    def _execute_bind(
-        self,
-        fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
-        endpoint_id: str,
-    ):
-        bind_action_id = ClusterOperations.execute_rebind(
-            fault_injector_client, endpoints_config, endpoint_id
-        )
-
-        bind_result = fault_injector_client.get_operation_result(
-            bind_action_id, timeout=BIND_TIMEOUT
-        )
-        logging.debug(f"Bind result: {bind_result}")
-
-    def _execute_migrate_bind_flow(
-        self,
-        fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
-        target_node: str,
-        empty_node: str,
-        endpoint_id: str,
-    ):
-        self._execute_migration(
-            fault_injector_client=fault_injector_client,
-            endpoints_config=endpoints_config,
-            target_node=target_node,
-            empty_node=empty_node,
-            skip_end_notification=True,
-        )
-        self._execute_bind(
-            fault_injector_client=fault_injector_client,
-            endpoints_config=endpoints_config,
-            endpoint_id=endpoint_id,
-        )
 
     def _get_all_connections_in_pool(self, client: Redis) -> List[ConnectionInterface]:
         connections = []
@@ -191,6 +152,43 @@ class TestPushNotificationsBase:
                 matching_conns_count += 1
         assert matching_conns_count == expected_matching_conns_count
 
+    def _is_endpoint_configured_correctly(
+        self,
+        conn,
+        configured_endpoint_type: EndpointType,
+        fault_injector_client: FaultInjectorClient,
+    ) -> bool:
+        if isinstance(fault_injector_client, ProxyServerFaultInjector):
+            return True  # skip endpoint type validation when using proxy server
+
+        if configured_endpoint_type == EndpointType.NONE:
+            if conn.host != conn.orig_host_address:
+                logging.debug(
+                    f"Endpoint check failed: configured NONE but "
+                    f"host={conn.host!r} != orig_host_address={conn.orig_host_address!r}"
+                )
+                return False
+            return True
+
+        # configured_endpoint_type != EndpointType.NONE
+        if conn.host == conn.orig_host_address:
+            logging.debug(
+                f"Endpoint check failed: expected non-NONE endpoint type but "
+                f"host={conn.host!r} == orig_host_address={conn.orig_host_address!r}"
+            )
+            return False
+        actual_endpoint_type = conn.maint_notifications_config.get_endpoint_type(
+            conn.orig_host_address, conn
+        )
+        if configured_endpoint_type != actual_endpoint_type:
+            logging.debug(
+                f"Endpoint check failed: "
+                f"configured_endpoint_type={configured_endpoint_type!r} != "
+                f"actual_endpoint_type={actual_endpoint_type!r} for host={conn.host!r}"
+            )
+            return False
+        return True
+
     def _validate_moving_state(
         self,
         client: Redis,
@@ -205,24 +203,8 @@ class TestPushNotificationsBase:
         with client.connection_pool._lock:
             connections = self._get_all_connections_in_pool(client)
             for conn in connections:
-                endpoint_configured_correctly = bool(
-                    (
-                        configured_endpoint_type == EndpointType.NONE
-                        and conn.host == conn.orig_host_address
-                    )
-                    or (
-                        configured_endpoint_type != EndpointType.NONE
-                        and conn.host != conn.orig_host_address
-                        and (
-                            configured_endpoint_type
-                            == MaintNotificationsConfig().get_endpoint_type(
-                                conn.host, conn
-                            )
-                        )
-                    )
-                    or isinstance(
-                        fault_injector_client, ProxyServerFaultInjector
-                    )  # we should not validate the endpoint type when using proxy server
+                endpoint_configured_correctly = self._is_endpoint_configured_correctly(
+                    conn, configured_endpoint_type, fault_injector_client
                 )
 
                 if (
@@ -330,145 +312,251 @@ class TestPushNotificationsBase:
         assert matching_conns_count == expected_matching_conns_count
 
 
-class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
+def generate_params(
+    fault_injector_client: FaultInjectorClient,
+    effect_names: list[SlotMigrateEffects | TopologyChangeStandaloneEffects],
+    skip_combinations: list[tuple[SlotMigrateEffects, str]] = [],
+    endpoint_types: Optional[list[EndpointType]] = None,
+):
+    # params should produce list of tuples: (effect_name, trigger_name, bdb_config, bdb_name)
+    # when endpoint_types is provided, each tuple is expanded to include an endpoint_type,
+    # producing: (effect_name, trigger_name, bdb_config, bdb_name, endpoint_type)
+    params = []
+    try:
+        logging.info(f"Extracting params for test with effect_names: {effect_names}")
+        for effect_name in effect_names:
+            if isinstance(effect_name, SlotMigrateEffects):
+                triggers_data = ClusterOperations.get_slot_migrate_triggers(
+                    fault_injector_client, effect_name
+                )
+            else:
+                triggers_data = (
+                    ClusterOperations.get_topology_change_standalone_triggers(
+                        fault_injector_client, effect_name
+                    )
+                )
+
+            for trigger_info in triggers_data["triggers"]:
+                trigger = trigger_info["name"]
+                if (effect_name, trigger) in skip_combinations:
+                    continue
+                if trigger == "maintenance_mode":
+                    continue
+                trigger_requirements = trigger_info["requirements"]
+                for requirement in trigger_requirements:
+                    dbconfig = requirement["dbconfig"]
+                    if requirement.get("oss_cluster_api"):
+                        ip_type = requirement["oss_cluster_api"]["ip_type"]
+                        if ip_type == "internal":
+                            continue
+                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
+                    dbconfig["name"] = (
+                        db_name_pattern  # this will ensure dbs will be deleted
+                    )
+
+                    if endpoint_types is not None:
+                        for endpoint_type in endpoint_types:
+                            params.append(
+                                (
+                                    effect_name,
+                                    trigger,
+                                    dbconfig,
+                                    db_name_pattern,
+                                    endpoint_type,
+                                )
+                            )
+                    else:
+                        params.append((effect_name, trigger, dbconfig, db_name_pattern))
+    except Exception as e:
+        logging.error(f"Failed to extract params for test: {e}")
+
+    return params
+
+
+class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
+    TestPushNotificationsBase
+):
+    def setup_env(
+        self,
+        fault_injector_client: FaultInjectorClient,
+        db_config: Dict[str, Any],
+        endpoint_type: EndpointType | None = None,
+    ):
+        self.delete_prev_db(fault_injector_client, db_config["name"])
+
+        db_endpoint_config = self.create_db(fault_injector_client, db_config)
+
+        self._bdb_name = db_config["name"]
+        socket_timeout = DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            else False
+        )
+
+        standalone_client_maint_notifications = (
+            get_standalone_client_maint_notifications(
+                endpoints_config=db_endpoint_config,
+                disable_retries=True,
+                socket_timeout=socket_timeout,
+                enable_maintenance_notifications=True,
+                endpoint_type=endpoint_type,
+                auth_ssl_client_certs=auth_ssl_client_certs,
+            )
+        )
+        return standalone_client_maint_notifications, db_endpoint_config
+
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(
         self,
-        client_maint_notifications: Redis,
-        fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
-        endpoint_name: str,
     ):
-        # Initialize cleanup flags first to ensure they exist even if setup fails
-        self._failover_executed = False
-        self.endpoint_id = None
-
-        try:
-            target_node, empty_node = ClusterOperations.find_target_node_and_empty_node(
-                fault_injector_client, endpoints_config
-            )
-            logging.info(f"Using target_node: {target_node}, empty_node: {empty_node}")
-        except Exception as e:
-            pytest.fail(f"Failed to find target and empty nodes: {e}")
-
-        try:
-            self.endpoint_id = ClusterOperations.find_endpoint_for_bind(
-                fault_injector_client,
-                endpoint_name,
-                force_cluster_info_refresh=False,
-            )
-            logging.info(f"Using endpoint: {self.endpoint_id}")
-        except Exception as e:
-            pytest.fail(f"Failed to find endpoint for bind operation: {e}")
-
-        # Ensure setup completed successfully
-        if not target_node or not empty_node:
-            pytest.fail("Setup failed: target_node or empty_node not available")
-        if not self.endpoint_id:
-            pytest.fail("Setup failed: endpoint_id not available")
-
-        self.target_node: NodeInfo = target_node
-        self.empty_node: NodeInfo = empty_node
+        self.maintenance_ops_threads = []
+        self._bdb_name = None
 
         # Yield control to the test
         yield
 
         # Cleanup code - this will run even if the test fails
         logging.info("Starting cleanup...")
-        try:
-            client_maint_notifications.close()
-        except Exception as e:
-            logging.error(f"Failed to close client: {e}")
+        if self._bdb_name:
+            self.delete_prev_db(_FAULT_INJECTOR_STANDALONE_CLIENT, self._bdb_name)
 
-        # Only attempt cleanup if we have the necessary attributes and they were executed
-        if (
-            not isinstance(fault_injector_client, ProxyServerFaultInjector)
-            and self._failover_executed
-        ):
-            try:
-                self._execute_failover(fault_injector_client, endpoints_config)
-                logging.info("Failover cleanup completed")
-            except Exception as e:
-                logging.error(f"Failed to revert failover: {e}")
+        logging.info("Waiting for maintenance operations threads to finish...")
+        for thread in self.maintenance_ops_threads:
+            thread.join()
 
         logging.info("Cleanup finished")
 
+
+class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
+    TestStanaloneClientPushNotificationsWithEffectTriggerBase
+):
     @pytest.mark.timeout(300)  # 5 minutes timeout for this test
-    def test_receive_failing_over_and_failed_over_push_notification(
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP],
+        ),
+    )
+    def test_notification_handling_during_data_movements_no_conn_drop(
         self,
-        client_maint_notifications: Redis,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
     ):
         """
-        Test the push notifications are received when executing cluster operations.
+        Test the push notifications are received when executing cluster operations
+        that don't lead to dropping connections.
 
         """
+        logging.info(f"DB name: {db_name}")
+
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config
+        )
+
         logging.info("Creating one connection in the pool.")
         conn = client_maint_notifications.connection_pool.get_connection()
 
-        logging.info("Executing failover command...")
-        failover_thread = Thread(
-            target=self._execute_failover,
-            name="failover_thread",
-            args=(fault_injector_client, endpoints_config),
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
+            args=(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            ),
         )
-        failover_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
-        logging.info("Waiting for FAILING_OVER push notifications...")
+        logging.info("Waiting for opening push notifications...")
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=FAILOVER_TIMEOUT, connection=conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn,
         )
 
         logging.info("Validating connection maintenance state...")
         assert conn.maintenance_state == MaintenanceState.MAINTENANCE
         assert conn._sock.gettimeout() == RELAXED_TIMEOUT
 
-        logging.info("Waiting for FAILED_OVER push notifications...")
+        logging.info("Waiting for closing push notifications...")
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=FAILOVER_TIMEOUT, connection=conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=conn,
         )
 
         logging.info("Validating connection default states is restored...")
         assert conn.maintenance_state == MaintenanceState.NONE
-        assert conn._sock.gettimeout() == CLIENT_TIMEOUT
+        assert conn._sock.gettimeout() == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
 
         logging.info("Releasing connection back to the pool...")
         client_maint_notifications.connection_pool.release(conn)
 
-        failover_thread.join()
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
 
     @pytest.mark.timeout(300)  # 5 minutes timeout for this test
-    def test_receive_migrating_and_moving_push_notification(
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    def test_notification_handling_during_data_movements_with_conn_drop(
         self,
-        client_maint_notifications: Redis,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
     ):
         """
-        Test the push notifications are received when executing cluster operations.
+        Test the push notifications are received when executing cluster operations
+        that lead to dropping connections.
 
         """
+        logging.info(f"DB name: {db_name}")
+
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config
+        )
+
         # create one connection and release it back to the pool
         conn = client_maint_notifications.connection_pool.get_connection()
         client_maint_notifications.connection_pool.release(conn)
 
-        logging.info("Executing rladmin migrate command...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         logging.info("Waiting for MIGRATING push notifications...")
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=MIGRATE_TIMEOUT
+            client_maint_notifications, timeout=STANDALONE_MAINT_TIMEOUT
         )
 
         logging.info("Validating connection migrating state...")
@@ -479,29 +567,21 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
 
         logging.info("Waiting for MIGRATED push notifications...")
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=MIGRATE_TIMEOUT
+            client_maint_notifications, timeout=STANDALONE_MAINT_TIMEOUT
         )
 
         logging.info("Validating connection states...")
         conn = client_maint_notifications.connection_pool.get_connection()
         assert conn.maintenance_state == MaintenanceState.NONE
-        assert conn._sock.gettimeout() == CLIENT_TIMEOUT
+        assert conn._sock.gettimeout() == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
         client_maint_notifications.connection_pool.release(conn)
 
-        migrate_thread.join()
-
-        logging.info("Executing rladmin bind endpoint command...")
-
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
-        )
-        bind_thread.start()
-
         logging.info("Waiting for MOVING push notifications...")
+        # There might be multiple migrations, so we wait until we receive a moving notification
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=BIND_TIMEOUT
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
         )
 
         logging.info("Validating connection states...")
@@ -510,84 +590,100 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         assert conn._sock.gettimeout() == RELAXED_TIMEOUT
 
         logging.info("Waiting for moving ttl to expire")
-        time.sleep(BIND_TIMEOUT)
+        time.sleep(DEFAULT_BIND_TTL)
 
         logging.info("Validating connection states...")
         assert conn.maintenance_state == MaintenanceState.NONE
-        assert conn.socket_timeout == CLIENT_TIMEOUT
-        assert conn._sock.gettimeout() == CLIENT_TIMEOUT
-        client_maint_notifications.connection_pool.release(conn)
-        bind_thread.join()
+        assert conn.socket_timeout == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
+        assert conn._sock.gettimeout() == DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout
+        client_maint_notifications.connection_pool.release(conn)
+
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
     @pytest.mark.parametrize(
-        "endpoint_type",
-        [
-            EndpointType.EXTERNAL_FQDN,
-            EndpointType.EXTERNAL_IP,
-            EndpointType.NONE,
-        ],
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
     )
-    def test_timeout_handling_during_migrating_and_moving(
+    def test_timeout_handling_during_data_movements_with_conn_drop(
         self,
-        endpoint_type: EndpointType,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
     ):
         """
-        Test the push notifications are received when executing cluster operations.
+        Test the push notifications are received when executing cluster operations
+        that lead to dropping connections.
 
         """
+        logging.info(f"DB name: {db_name}")
         logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
-        client = _get_client_maint_notifications(
-            endpoints_config=endpoints_config, endpoint_type=endpoint_type
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
         )
 
         # Create three connections in the pool
         logging.info("Creating three connections in the pool.")
         conns = []
         for _ in range(3):
-            conns.append(client.connection_pool.get_connection())
+            conns.append(client_maint_notifications.connection_pool.get_connection())
         # Release the connections
         for conn in conns:
-            client.connection_pool.release(conn)
+            client_maint_notifications.connection_pool.release(conn)
 
-        logging.info("Executing rladmin migrate command...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         logging.info("Waiting for MIGRATING push notifications...")
         # this will consume the notification in one of the connections
-        ClientValidations.wait_push_notification(client, timeout=MIGRATE_TIMEOUT)
+        ClientValidations.wait_push_notification(
+            client_maint_notifications, timeout=STANDALONE_MAINT_TIMEOUT
+        )
 
-        self._validate_maintenance_state(client, expected_matching_conns_count=1)
-        self._validate_default_state(client, expected_matching_conns_count=2)
+        self._validate_maintenance_state(
+            client_maint_notifications, expected_matching_conns_count=1
+        )
+        self._validate_default_state(
+            client_maint_notifications,
+            expected_matching_conns_count=2,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
 
         logging.info("Waiting for MIGRATED push notifications...")
-        ClientValidations.wait_push_notification(client, timeout=MIGRATE_TIMEOUT)
+        ClientValidations.wait_push_notification(
+            client_maint_notifications, timeout=STANDALONE_MAINT_TIMEOUT
+        )
 
         logging.info("Validating connection states after MIGRATED ...")
-        self._validate_default_state(client, expected_matching_conns_count=3)
-
-        migrate_thread.join()
-
-        logging.info("Executing rladmin bind endpoint command...")
-
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
+        self._validate_default_state(
+            client_maint_notifications,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
         )
-        bind_thread.start()
 
         logging.info("Waiting for MOVING push notifications...")
         # this will consume the notification in one of the connections
@@ -595,7 +691,11 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         # the consumed connection will be disconnected during
         # releasing it back to the pool and as a result we will have
         # 3 disconnected connections in the pool
-        ClientValidations.wait_push_notification(client, timeout=BIND_TIMEOUT)
+        ClientValidations.wait_push_notification(
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
 
         if endpoint_type == EndpointType.NONE:
             logging.info(
@@ -605,7 +705,7 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
 
         logging.info("Validating connections states...")
         self._validate_moving_state(
-            client,
+            client_maint_notifications,
             endpoint_type,
             expected_matching_connected_conns_count=0,
             expected_matching_disconnected_conns_count=3,
@@ -615,84 +715,103 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         # either to the address provided in the moving notification or to the original address
         # depending on the configured endpoint type
         # with this call we test if we are able to connect to the new address
-        conn = client.connection_pool.get_connection()
+        conn = client_maint_notifications.connection_pool.get_connection()
         self._validate_moving_state(
-            client,
+            client_maint_notifications,
             endpoint_type,
             expected_matching_connected_conns_count=1,
             expected_matching_disconnected_conns_count=2,
             fault_injector_client=fault_injector_client,
         )
-        client.connection_pool.release(conn)
+        client_maint_notifications.connection_pool.release(conn)
 
         logging.info("Waiting for moving ttl to expire")
-        time.sleep(BIND_TIMEOUT)
+        time.sleep(DEFAULT_BIND_TTL)
 
         logging.info("Validating connection states...")
-        self._validate_default_state(client, expected_matching_conns_count=3)
-        bind_thread.join()
+        self._validate_default_state(
+            client_maint_notifications,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
     @pytest.mark.parametrize(
-        "endpoint_type",
-        [
-            EndpointType.EXTERNAL_FQDN,
-            EndpointType.EXTERNAL_IP,
-            EndpointType.NONE,
-        ],
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
     )
-    def test_connection_handling_during_moving(
+    def test_connection_handling_during_data_movements_with_conn_drop(
         self,
-        endpoint_type: EndpointType,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+        endpoint_type: EndpointType,
     ):
-        logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
-        client = _get_client_maint_notifications(
-            endpoints_config=endpoints_config, endpoint_type=endpoint_type
+        """
+        Test the push notifications are received when executing cluster operations
+        that lead to dropping connections.
+        This test validates that the connection is reconnected to the new address
+        after the moving notification is received.
+        This test also validates that newly created connections will also be
+        reconnected to the new address.
+
+        """
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing with endpoint type: {endpoint_type}")
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
         )
 
         logging.info("Creating one connection in the pool.")
-        first_conn = client.connection_pool.get_connection()
+        first_conn = client_maint_notifications.connection_pool.get_connection()
 
-        logging.info("Executing rladmin migrate command...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         logging.info("Waiting for MIGRATING push notifications...")
         # this will consume the notification in the provided connection
         ClientValidations.wait_push_notification(
-            client, timeout=MIGRATE_TIMEOUT, connection=first_conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
         )
 
-        self._validate_maintenance_state(client, expected_matching_conns_count=1)
+        self._validate_maintenance_state(
+            client_maint_notifications, expected_matching_conns_count=1
+        )
 
         logging.info("Waiting for MIGRATED push notification ...")
         ClientValidations.wait_push_notification(
-            client, timeout=MIGRATE_TIMEOUT, connection=first_conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
         )
 
-        client.connection_pool.release(first_conn)
-
-        migrate_thread.join()
-
-        logging.info("Executing rladmin bind endpoint command...")
-
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
-        )
-        bind_thread.start()
+        client_maint_notifications.connection_pool.release(first_conn)
 
         logging.info("Waiting for MOVING push notifications on random connection ...")
         # this will consume the notification in one of the connections
@@ -700,7 +819,11 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         # the consumed connection will be disconnected during
         # releasing it back to the pool and as a result we will have
         # 3 disconnected connections in the pool
-        ClientValidations.wait_push_notification(client, timeout=BIND_TIMEOUT)
+        ClientValidations.wait_push_notification(
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            expected_state=MaintenanceState.MOVING,
+        )
 
         if endpoint_type == EndpointType.NONE:
             logging.info(
@@ -708,13 +831,14 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
             )
             time.sleep(fault_injector_client.get_moving_ttl() / 2)
 
-        # validate that new connections will also receive the moving notification
         connections = []
         for _ in range(3):
-            connections.append(client.connection_pool.get_connection())
+            connections.append(
+                client_maint_notifications.connection_pool.get_connection()
+            )
         for conn in connections:
             logging.debug(f"Releasing connection {conn}. {conn.maintenance_state}")
-            client.connection_pool.release(conn)
+            client_maint_notifications.connection_pool.release(conn)
 
         logging.info("Validating connections states during MOVING ...")
         # during get_connection() the existing connection will be reconnected
@@ -723,7 +847,7 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         # with this call we test if we are able to connect to the new address
         # new connection should also be marked as moving
         self._validate_moving_state(
-            client,
+            client_maint_notifications,
             endpoint_type,
             expected_matching_connected_conns_count=3,
             expected_matching_disconnected_conns_count=0,
@@ -734,49 +858,178 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         time.sleep(fault_injector_client.get_moving_ttl())
 
         logging.info("Validating connection states after MOVING has expired ...")
-        self._validate_default_state(client, expected_matching_conns_count=3)
-        bind_thread.join()
+        self._validate_default_state(
+            client_maint_notifications,
+            expected_matching_conns_count=3,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
+    def test_new_connections_receive_notifications_no_conn_drop(
+        self,
+        fault_injector_client: FaultInjectorClient,
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
+    ):
+        """
+        Test the push notifications are received when executing cluster operations
+        that lead to dropping connections.
+
+        """
+        logging.info(f"DB name: {db_name}")
+
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config
+        )
+
+        logging.info("Creating one connection in the pool.")
+        first_conn = client_maint_notifications.connection_pool.get_connection()
+
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
+            args=(
+                fault_injector_client,
+                db_endpoint_config,
+                effect_name,
+                trigger,
+            ),
+        )
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
+
+        logging.info("Waiting for opening push notifications...")
+        # this will consume the notification in the provided connection
+        ClientValidations.wait_push_notification(
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+        self._validate_maintenance_state(
+            client_maint_notifications, expected_matching_conns_count=1
+        )
+
+        # validate that new connections will also receive the opening notification
+        # it should be received as part of the client connection setup flow
+        logging.info(
+            "Creating second connection that should receive the opening notification as well."
+        )
+        second_connection = client_maint_notifications.connection_pool.get_connection()
+        self._validate_maintenance_state(
+            client_maint_notifications, expected_matching_conns_count=2
+        )
+
+        logging.info("Waiting for closing push notifications on both connections ...")
+        ClientValidations.wait_push_notification(
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+        )
+        ClientValidations.wait_push_notification(
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=second_connection,
+        )
+
+        self._validate_default_state(
+            client_maint_notifications,
+            expected_matching_conns_count=2,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
+
+        client_maint_notifications.connection_pool.release(first_conn)
+        client_maint_notifications.connection_pool.release(second_connection)
+
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
+    @pytest.mark.skipif(
+        use_mock_proxy(),
+        reason="Mock proxy doesn't support sending notifications to new connections.",
+    )
     def test_old_connection_shutdown_during_moving(
         self,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
     ):
+        """
+        Test the push notifications are received when executing cluster operations
+        that lead to dropping connections.
+
+        """
+        logging.info(f"DB name: {db_name}")
+
         # it is better to use ip for this test - enables validation that
         # the connection is disconnected from the original address
         # and connected to the new address
         endpoint_type = EndpointType.EXTERNAL_IP
         logging.info("Testing old connection shutdown during MOVING")
-        client = _get_client_maint_notifications(
-            endpoints_config=endpoints_config, endpoint_type=endpoint_type
+
+        client, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
         )
 
         # create one connection and release it back to the pool
         conn = client.connection_pool.get_connection()
         client.connection_pool.release(conn)
 
-        logging.info("Starting migration ...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         logging.info("Waiting for MIGRATING push notifications...")
-        ClientValidations.wait_push_notification(client, timeout=MIGRATE_TIMEOUT)
+        ClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
         self._validate_maintenance_state(client, expected_matching_conns_count=1)
 
         logging.info("Waiting for MIGRATED push notification ...")
-        ClientValidations.wait_push_notification(client, timeout=MIGRATE_TIMEOUT)
-        self._validate_default_state(client, expected_matching_conns_count=1)
-        migrate_thread.join()
+        ClientValidations.wait_push_notification(
+            client, timeout=STANDALONE_MAINT_TIMEOUT
+        )
+        self._validate_default_state(
+            client,
+            expected_matching_conns_count=1,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+        )
 
         moving_event = threading.Event()
 
@@ -799,14 +1052,6 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         # for it because it has already received and processed it
         conn_to_check_moving = client.connection_pool.get_connection()
 
-        logging.info("Starting rebind...")
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
-        )
-        bind_thread.start()
-
         errors = Queue()
         threads_count = 10
         futures = []
@@ -825,7 +1070,10 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
             # this will consume the notification in one of the connections
             # and will handle the states of the rest
             ClientValidations.wait_push_notification(
-                client, timeout=BIND_TIMEOUT, connection=conn_to_check_moving
+                client,
+                timeout=STANDALONE_MAINT_TIMEOUT,
+                connection=conn_to_check_moving,
+                expected_state=MaintenanceState.MOVING,
             )
             # set the event to stop the command execution threads
             logging.info("Setting moving event...")
@@ -862,79 +1110,106 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         # validate no errors were raised in the command execution threads
         assert errors.empty(), f"Errors occurred in threads: {errors.queue}"
 
-        logging.info("Waiting for moving ttl to expire")
-        bind_thread.join()
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
 
     @pytest.mark.timeout(300)  # 5 minutes timeout
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
     @pytest.mark.skipif(
         use_mock_proxy(),
         reason="Mock proxy doesn't support sending notifications to new connections.",
     )
     def test_new_connections_receive_moving(
         self,
-        client_maint_notifications: Redis,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
     ):
+        logging.info(f"DB name: {db_name}")
+
+        endpoint_type = EndpointType.EXTERNAL_IP
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
+        )
+
         logging.info("Creating one connection in the pool.")
         first_conn = client_maint_notifications.connection_pool.get_connection()
 
-        logging.info("Executing rladmin migrate command...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         logging.info("Waiting for MIGRATING push notifications...")
         # this will consume the notification in the provided connection
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=MIGRATE_TIMEOUT, connection=first_conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
         )
 
         self._validate_maintenance_state(
             client_maint_notifications, expected_matching_conns_count=1
         )
 
-        logging.info("Waiting for MIGRATED push notifications on both connections ...")
+        logging.info("Waiting for MIGRATED push notifications ...")
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=MIGRATE_TIMEOUT, connection=first_conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
         )
-
-        migrate_thread.join()
-
-        logging.info("Executing rladmin bind endpoint command...")
-
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
-        )
-        bind_thread.start()
 
         logging.info("Waiting for MOVING push notifications on random connection ...")
         ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=BIND_TIMEOUT, connection=first_conn
+            client_maint_notifications,
+            timeout=STANDALONE_MAINT_TIMEOUT,
+            connection=first_conn,
+            expected_state=MaintenanceState.MOVING,
         )
 
+        assert first_conn._sock is not None, (
+            "Connection must be active after receiving MOVING notification"
+        )
         old_address = first_conn._sock.getpeername()[0]
         logging.info(f"The node address before bind: {old_address}")
         logging.info(
             "Creating new client to connect to the same node - new connections to this node should receive the moving notification..."
         )
 
-        endpoint_type = EndpointType.EXTERNAL_IP
+        auth_ssl_client_certs_config_info = db_config.get(
+            "authentication_ssl_client_certs", None
+        )
+        auth_ssl_client_certs = (
+            True
+            if auth_ssl_client_certs_config_info
+            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            else False
+        )
+
         # create new client with new pool that should also receive the moving notification
         new_client = _get_client_maint_notifications(
-            endpoints_config=endpoints_config,
+            endpoints_config=db_endpoint_config,
             endpoint_type=endpoint_type,
             host_config=old_address,
+            socket_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
+            auth_ssl_client_certs=auth_ssl_client_certs,
         )
 
         # the moving notification will be consumed as
@@ -954,111 +1229,59 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
             fault_injector_client=fault_injector_client,
         )
 
-        logging.info("Waiting for moving thread to be completed ...")
-        bind_thread.join()
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
 
         new_client.connection_pool.release(new_client_conn)
         new_client.close()
 
         client_maint_notifications.connection_pool.release(first_conn)
 
-    @pytest.mark.timeout(300)  # 5 minutes timeout
-    @pytest.mark.skipif(
-        use_mock_proxy(),
-        reason="Mock proxy doesn't support sending notifications to new connections.",
-    )
-    def test_new_connections_receive_migrating(
-        self,
-        client_maint_notifications: Redis,
-        fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
-    ):
-        logging.info("Creating one connection in the pool.")
-        first_conn = client_maint_notifications.connection_pool.get_connection()
-
-        logging.info("Executing rladmin migrate command...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
-            args=(
-                fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
-            ),
-        )
-        migrate_thread.start()
-
-        logging.info("Waiting for MIGRATING push notifications...")
-        # this will consume the notification in the provided connection
-        ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=MIGRATE_TIMEOUT, connection=first_conn
-        )
-
-        self._validate_maintenance_state(
-            client_maint_notifications, expected_matching_conns_count=1
-        )
-
-        # validate that new connections will also receive the migrating notification
-        # it should be received as part of the client connection setup flow
-        logging.info(
-            "Creating second connection that should receive the migrating notification as well."
-        )
-        second_connection = client_maint_notifications.connection_pool.get_connection()
-        self._validate_maintenance_state(
-            client_maint_notifications, expected_matching_conns_count=2
-        )
-
-        logging.info("Waiting for MIGRATED push notifications on both connections ...")
-        ClientValidations.wait_push_notification(
-            client_maint_notifications, timeout=MIGRATE_TIMEOUT, connection=first_conn
-        )
-        ClientValidations.wait_push_notification(
-            client_maint_notifications,
-            timeout=MIGRATE_TIMEOUT,
-            connection=second_connection,
-        )
-
-        migrate_thread.join()
-        logging.info("Executing rladmin bind endpoint command for cleanup...")
-
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
-        )
-        bind_thread.start()
-        bind_thread.join()
-        client_maint_notifications.connection_pool.release(first_conn)
-        client_maint_notifications.connection_pool.release(second_connection)
-
     @pytest.mark.timeout(300)
+    @pytest.mark.parametrize(
+        "effect_name, trigger, db_config, db_name",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP],
+        ),
+    )
     def test_disabled_handling_during_migrating_and_moving(
         self,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
     ):
+        logging.info(f"DB name: {db_name}")
+
+        self.delete_prev_db(fault_injector_client, db_config["name"])
+        db_endpoint_config = self.create_db(fault_injector_client, db_config)
+        self._bdb_name = db_config["name"]
+
         logging.info("Creating client with disabled notifications.")
-        client = _get_client_maint_notifications(
-            endpoints_config=endpoints_config,
+        client = get_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
             enable_maintenance_notifications=False,
         )
 
         logging.info("Creating one connection in the pool.")
         first_conn = client.connection_pool.get_connection()
 
-        logging.info("Executing rladmin migrate command...")
-        migrate_thread = Thread(
-            target=self._execute_migration,
-            name="migrate_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         logging.info("Waiting for MIGRATING push notifications...")
         # this will consume the notification in the provided connection if it arrives
@@ -1070,7 +1293,7 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
             client, expected_matching_conns_count=1
         )
 
-        # validate that new connections will also receive the moving notification
+        # validate that new connections will also not receive the migrating notification
         logging.info(
             "Creating second connection in the pool"
             " and expect it not to receive the migrating as well."
@@ -1099,17 +1322,6 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         client.connection_pool.release(first_conn)
         client.connection_pool.release(second_connection)
 
-        migrate_thread.join()
-
-        logging.info("Executing rladmin bind endpoint command...")
-
-        bind_thread = Thread(
-            target=self._execute_bind,
-            name="bind_thread",
-            args=(fault_injector_client, endpoints_config, self.endpoint_id),
-        )
-        bind_thread.start()
-
         logging.info("Waiting for MOVING push notifications on random connection ...")
         # this will consume the notification if it arrives in one of the connections
         # and will handle the states of the rest
@@ -1122,7 +1334,7 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
             fail_on_timeout=False,
         )
 
-        # validate that new connections will also receive the moving notification
+        # validate that new connections will also not receive the moving notification
         connections = []
         for _ in range(3):
             connections.append(client.connection_pool.get_connection())
@@ -1141,21 +1353,39 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         self._validate_default_notif_disabled_state(
             client, expected_matching_conns_count=3
         )
-        bind_thread.join()
 
-    @pytest.mark.timeout(300)
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
+
+
+class TestStandaloneClientCommandsExecutionWithPushNotificationsWithEffectTrigger(
+    TestStanaloneClientPushNotificationsWithEffectTriggerBase
+):
+    @pytest.mark.timeout(300)  # 5 minutes timeout for this test
     @pytest.mark.parametrize(
-        "endpoint_type",
-        [
-            EndpointType.EXTERNAL_FQDN,
-            EndpointType.EXTERNAL_IP,
-            EndpointType.NONE,
-        ],
+        "effect_name, trigger, db_config, db_name, endpoint_type",
+        generate_params(
+            _FAULT_INJECTOR_STANDALONE_CLIENT,
+            [
+                TopologyChangeStandaloneEffects.DATA_MOVEMENT_NO_CONN_DROP,
+                TopologyChangeStandaloneEffects.DATA_MOVEMENT_CONN_DROP,
+                TopologyChangeStandaloneEffects.CONN_DROP,
+                TopologyChangeStandaloneEffects.DNS_RESOLUTION_CHANGE,
+            ],
+            endpoint_types=[
+                EndpointType.EXTERNAL_FQDN,
+                EndpointType.EXTERNAL_IP,
+                EndpointType.NONE,
+            ],
+        ),
     )
-    def test_command_execution_during_migrating_and_moving(
+    def test_command_execution_during_maintenance(
         self,
         fault_injector_client: FaultInjectorClient,
-        endpoints_config: Dict[str, Any],
+        effect_name: TopologyChangeStandaloneEffects,
+        trigger: str,
+        db_config: dict[str, Any],
+        db_name: str,
         endpoint_type: EndpointType,
     ):
         """
@@ -1170,24 +1400,20 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         if isinstance(fault_injector_client, ProxyServerFaultInjector):
             execution_duration = 20
         else:
-            execution_duration = 180
+            execution_duration = 60
 
-        socket_timeout = DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT
-
-        client = _get_client_maint_notifications(
-            endpoints_config=endpoints_config,
-            endpoint_type=endpoint_type,
-            disable_retries=True,
-            socket_timeout=socket_timeout,
-            enable_maintenance_notifications=True,
+        logging.info(f"DB name: {db_name}")
+        logging.info(f"Testing timeout handling for endpoint type: {endpoint_type}")
+        client_maint_notifications, db_endpoint_config = self.setup_env(
+            fault_injector_client, db_config, endpoint_type=endpoint_type
         )
 
         def execute_commands(duration: int, errors: Queue):
             start = time.time()
             while time.time() - start < duration:
                 try:
-                    client.set("key", "value")
-                    client.get("key")
+                    client_maint_notifications.set("key", "value")
+                    client_maint_notifications.get("key")
                 except Exception as e:
                     logging.error(
                         f"Error in thread {threading.current_thread().name}: {e}"
@@ -1213,107 +1439,39 @@ class TestStandaloneClientPushNotifications(TestPushNotificationsBase):
         logging.info("Waiting for threads to start and have a few cycles executed ...")
         time.sleep(3)
 
-        migrate_and_bind_thread = Thread(
-            target=self._execute_migrate_bind_flow,
-            name="migrate_and_bind_thread",
+        logging.info("Executing FI command that triggers the desired effect...")
+        trigger_effect_thread = Thread(
+            target=self._trigger_effect,
+            name="trigger_effect_thread",
             args=(
                 fault_injector_client,
-                endpoints_config,
-                self.target_node.node_id,
-                self.empty_node.node_id,
-                self.endpoint_id,
+                db_endpoint_config,
+                effect_name,
+                trigger,
             ),
         )
-        migrate_and_bind_thread.start()
+        self.maintenance_ops_threads.append(trigger_effect_thread)
+        trigger_effect_thread.start()
 
         for thread in threads:
             thread.join()
 
-        migrate_and_bind_thread.join()
+        trigger_effect_thread.join()
+        self.maintenance_ops_threads.remove(trigger_effect_thread)
 
         # validate connections settings
         self._validate_default_state(
-            client, expected_matching_conns_count=10, configured_timeout=socket_timeout
+            client_maint_notifications,
+            expected_matching_conns_count=10,
+            configured_timeout=DEFAULT_STANDALONE_CLIENT_SOCKET_TIMEOUT,
         )
 
         assert errors.empty(), f"Errors occurred in threads: {errors.queue}"
 
 
-def generate_params(
-    fault_injector_client: FaultInjectorClient,
-    effect_names: list[SlotMigrateEffects],
-    skip_combinations: list[tuple[SlotMigrateEffects, str]] = [],
-):
-    # params should produce list of tuples: (effect_name, trigger_name, bdb_config, bdb_name)
-    params = []
-    try:
-        logging.info(f"Extracting params for test with effect_names: {effect_names}")
-        for effect_name in effect_names:
-            triggers_data = ClusterOperations.get_slot_migrate_triggers(
-                fault_injector_client, effect_name
-            )
-
-            for trigger_info in triggers_data["triggers"]:
-                trigger = trigger_info["name"]
-                if (effect_name, trigger) in skip_combinations:
-                    continue
-                if trigger == "maintenance_mode":
-                    continue
-                trigger_requirements = trigger_info["requirements"]
-                for requirement in trigger_requirements:
-                    dbconfig = requirement["dbconfig"]
-                    ip_type = requirement["oss_cluster_api"]["ip_type"]
-                    if ip_type == "internal":
-                        continue
-                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
-                    dbconfig["name"] = (
-                        db_name_pattern  # this will ensure dbs will be deleted
-                    )
-
-                    params.append((effect_name, trigger, dbconfig, db_name_pattern))
-    except Exception as e:
-        logging.error(f"Failed to extract params for test: {e}")
-
-    return params
-
-
 class TestClusterClientPushNotificationsWithEffectTriggerBase(
     TestPushNotificationsBase
 ):
-    def delete_prev_db(
-        self,
-        fault_injector_client_oss_api: FaultInjectorClient,
-        db_name: str,
-    ):
-        try:
-            logging.info(f"Deleting database if exists: {db_name}")
-            existing_db_id = None
-            existing_db_id = ClusterOperations.find_database_id_by_name(
-                fault_injector_client_oss_api, db_name
-            )
-
-            if existing_db_id:
-                fault_injector_client_oss_api.delete_database(existing_db_id)
-                logging.info(f"Deleted database: {db_name}")
-            else:
-                logging.info(f"Database {db_name} does not exist.")
-        except Exception as e:
-            logging.error(f"Failed to delete database {db_name}: {e}")
-
-    def create_db(
-        self,
-        fault_injector_client_oss_api: FaultInjectorClient,
-        bdb_config: Dict[str, Any],
-    ):
-        try:
-            logging.info(f"Creating database: \n{json.dumps(bdb_config, indent=2)}")
-            cluster_endpoint_config = fault_injector_client_oss_api.create_database(
-                bdb_config
-            )
-            return cluster_endpoint_config
-        except Exception as e:
-            pytest.fail(f"Failed to create database: {e}")
-
     def setup_env(
         self,
         fault_injector_client_oss_api: FaultInjectorClient,

--- a/tests/test_scenario/test_maint_notifications.py
+++ b/tests/test_scenario/test_maint_notifications.py
@@ -38,6 +38,8 @@ from tests.test_scenario.maint_notifications_helpers import (
     ClientValidations,
     ClusterOperations,
     KeyGenerationHelpers,
+    generate_params,
+    is_endpoint_configured_correctly,
 )
 
 logging.basicConfig(
@@ -152,43 +154,6 @@ class TestPushNotificationsBase:
                 matching_conns_count += 1
         assert matching_conns_count == expected_matching_conns_count
 
-    def _is_endpoint_configured_correctly(
-        self,
-        conn,
-        configured_endpoint_type: EndpointType,
-        fault_injector_client: FaultInjectorClient,
-    ) -> bool:
-        if isinstance(fault_injector_client, ProxyServerFaultInjector):
-            return True  # skip endpoint type validation when using proxy server
-
-        if configured_endpoint_type == EndpointType.NONE:
-            if conn.host != conn.orig_host_address:
-                logging.debug(
-                    f"Endpoint check failed: configured NONE but "
-                    f"host={conn.host!r} != orig_host_address={conn.orig_host_address!r}"
-                )
-                return False
-            return True
-
-        # configured_endpoint_type != EndpointType.NONE
-        if conn.host == conn.orig_host_address:
-            logging.debug(
-                f"Endpoint check failed: expected non-NONE endpoint type but "
-                f"host={conn.host!r} == orig_host_address={conn.orig_host_address!r}"
-            )
-            return False
-        actual_endpoint_type = conn.maint_notifications_config.get_endpoint_type(
-            conn.orig_host_address, conn
-        )
-        if configured_endpoint_type != actual_endpoint_type:
-            logging.debug(
-                f"Endpoint check failed: "
-                f"configured_endpoint_type={configured_endpoint_type!r} != "
-                f"actual_endpoint_type={actual_endpoint_type!r} for host={conn.host!r}"
-            )
-            return False
-        return True
-
     def _validate_moving_state(
         self,
         client: Redis,
@@ -203,7 +168,7 @@ class TestPushNotificationsBase:
         with client.connection_pool._lock:
             connections = self._get_all_connections_in_pool(client)
             for conn in connections:
-                endpoint_configured_correctly = self._is_endpoint_configured_correctly(
+                endpoint_configured_correctly = is_endpoint_configured_correctly(
                     conn, configured_endpoint_type, fault_injector_client
                 )
 
@@ -312,67 +277,6 @@ class TestPushNotificationsBase:
         assert matching_conns_count == expected_matching_conns_count
 
 
-def generate_params(
-    fault_injector_client: FaultInjectorClient,
-    effect_names: list[SlotMigrateEffects | TopologyChangeStandaloneEffects],
-    skip_combinations: list[tuple[SlotMigrateEffects, str]] = [],
-    endpoint_types: Optional[list[EndpointType]] = None,
-):
-    # params should produce list of tuples: (effect_name, trigger_name, bdb_config, bdb_name)
-    # when endpoint_types is provided, each tuple is expanded to include an endpoint_type,
-    # producing: (effect_name, trigger_name, bdb_config, bdb_name, endpoint_type)
-    params = []
-    try:
-        logging.info(f"Extracting params for test with effect_names: {effect_names}")
-        for effect_name in effect_names:
-            if isinstance(effect_name, SlotMigrateEffects):
-                triggers_data = ClusterOperations.get_slot_migrate_triggers(
-                    fault_injector_client, effect_name
-                )
-            else:
-                triggers_data = (
-                    ClusterOperations.get_topology_change_standalone_triggers(
-                        fault_injector_client, effect_name
-                    )
-                )
-
-            for trigger_info in triggers_data["triggers"]:
-                trigger = trigger_info["name"]
-                if (effect_name, trigger) in skip_combinations:
-                    continue
-                if trigger == "maintenance_mode":
-                    continue
-                trigger_requirements = trigger_info["requirements"]
-                for requirement in trigger_requirements:
-                    dbconfig = requirement["dbconfig"]
-                    if requirement.get("oss_cluster_api"):
-                        ip_type = requirement["oss_cluster_api"]["ip_type"]
-                        if ip_type == "internal":
-                            continue
-                    db_name_pattern = dbconfig.get("name").rsplit("-", 1)[0]
-                    dbconfig["name"] = (
-                        db_name_pattern  # this will ensure dbs will be deleted
-                    )
-
-                    if endpoint_types is not None:
-                        for endpoint_type in endpoint_types:
-                            params.append(
-                                (
-                                    effect_name,
-                                    trigger,
-                                    dbconfig,
-                                    db_name_pattern,
-                                    endpoint_type,
-                                )
-                            )
-                    else:
-                        params.append((effect_name, trigger, dbconfig, db_name_pattern))
-    except Exception as e:
-        logging.error(f"Failed to extract params for test: {e}")
-
-    return params
-
-
 class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
     TestPushNotificationsBase
 ):
@@ -396,21 +300,19 @@ class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
-        standalone_client_maint_notifications = (
-            get_standalone_client_maint_notifications(
-                endpoints_config=db_endpoint_config,
-                disable_retries=True,
-                socket_timeout=socket_timeout,
-                enable_maintenance_notifications=True,
-                endpoint_type=endpoint_type,
-                auth_ssl_client_certs=auth_ssl_client_certs,
-            )
+        self._client = get_standalone_client_maint_notifications(
+            endpoints_config=db_endpoint_config,
+            disable_retries=True,
+            socket_timeout=socket_timeout,
+            enable_maintenance_notifications=True,
+            endpoint_type=endpoint_type,
+            auth_ssl_client_certs=auth_ssl_client_certs,
         )
-        return standalone_client_maint_notifications, db_endpoint_config
+        return self._client, db_endpoint_config
 
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(
@@ -418,18 +320,23 @@ class TestStanaloneClientPushNotificationsWithEffectTriggerBase(
     ):
         self.maintenance_ops_threads = []
         self._bdb_name = None
+        self._client = None
 
         # Yield control to the test
         yield
 
         # Cleanup code - this will run even if the test fails
         logging.info("Starting cleanup...")
-        if self._bdb_name:
-            self.delete_prev_db(_FAULT_INJECTOR_STANDALONE_CLIENT, self._bdb_name)
+
+        if self._client is not None:
+            self._client.close()
 
         logging.info("Waiting for maintenance operations threads to finish...")
         for thread in self.maintenance_ops_threads:
             thread.join()
+
+        if self._bdb_name:
+            self.delete_prev_db(_FAULT_INJECTOR_STANDALONE_CLIENT, self._bdb_name)
 
         logging.info("Cleanup finished")
 
@@ -1199,7 +1106,7 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
@@ -1260,7 +1167,8 @@ class TestStandaloneClientPushNotificationsHandlingWithEffectTrigger(
         self._bdb_name = db_config["name"]
 
         logging.info("Creating client with disabled notifications.")
-        client = get_standalone_client_maint_notifications(
+        # self._client for teardown cleanup; local `client` used in the rest of this method.
+        self._client = client = get_standalone_client_maint_notifications(
             endpoints_config=db_endpoint_config,
             disable_retries=True,
             enable_maintenance_notifications=False,
@@ -1485,6 +1393,7 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
 
         self._bdb_name = db_config["name"]
         socket_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
+        socket_connect_timeout = DEFAULT_OSS_API_CLIENT_SOCKET_TIMEOUT
 
         auth_ssl_client_certs_config_info = db_config.get(
             "authentication_ssl_client_certs", None
@@ -1493,18 +1402,19 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
         auth_ssl_client_certs = (
             True
             if auth_ssl_client_certs_config_info
-            and auth_ssl_client_certs_config_info[0]["client_cert"] is not None
+            and auth_ssl_client_certs_config_info[0].get("client_cert") is not None
             else False
         )
 
-        cluster_client_maint_notifications = get_cluster_client_maint_notifications(
+        self._client = get_cluster_client_maint_notifications(
             endpoints_config=cluster_endpoint_config,
             disable_retries=True,
             socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
             enable_maintenance_notifications=True,
             auth_ssl_client_certs=auth_ssl_client_certs,
         )
-        return cluster_client_maint_notifications, cluster_endpoint_config
+        return self._client, cluster_endpoint_config
 
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(
@@ -1512,18 +1422,23 @@ class TestClusterClientPushNotificationsWithEffectTriggerBase(
     ):
         self.maintenance_ops_threads = []
         self._bdb_name = None
+        self._client = None
 
         # Yield control to the test
         yield
 
         # Cleanup code - this will run even if the test fails
         logging.info("Starting cleanup...")
-        if self._bdb_name:
-            self.delete_prev_db(_FAULT_INJECTOR_CLIENT_OSS_API, self._bdb_name)
+
+        if self._client is not None:
+            self._client.close()
 
         logging.info("Waiting for maintenance operations threads to finish...")
         for thread in self.maintenance_ops_threads:
             thread.join()
+
+        if self._bdb_name:
+            self.delete_prev_db(_FAULT_INJECTOR_CLIENT_OSS_API, self._bdb_name)
 
         logging.info("Cleanup finished")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 from redis.utils import (
     DEFAULT_RESP_VERSION,
+    SENTINEL,
     check_protocol_version,
     compare_versions,
     deprecated_function,
@@ -52,6 +53,11 @@ class TestCheckProtocolVersion:
         assert check_protocol_version(None, DEFAULT_RESP_VERSION) is True
         other = 2 if DEFAULT_RESP_VERSION == 3 else 3
         assert check_protocol_version(None, other) is False
+
+    def test_sentinel_resolves_to_default(self):
+        assert check_protocol_version(SENTINEL, DEFAULT_RESP_VERSION) is True
+        other = 2 if DEFAULT_RESP_VERSION == 3 else 3
+        assert check_protocol_version(SENTINEL, other) is False
 
     @pytest.mark.parametrize("protocol", [3, "3"])
     def test_resp3_matches(self, protocol):


### PR DESCRIPTION
## Change summary

This pull request adds full asynchronous support for Redis maintenance
notifications (the "SCH" push-notification flow) across both the standalone and
cluster clients, bringing the async stack to parity with the existing sync
implementation. Until now maintenance notifications — node migrating/migrated,
failing-over/failed-over, and the OSS-cluster moving/moved events used to relax
timeouts and proactively reconnect during planned maintenance — were only handled
by the synchronous client. This branch mirrors that behavior under
`redis/asyncio/` and hardens the shared logic that both stacks now rely on.

The core of the change is a new `redis/asyncio/maint_notifications.py`
that mirrors the sync module's handlers, config, and notification
types, plus substantial additions to `redis/asyncio/connection.py`,
`redis/asyncio/client.py`, and `redis/asyncio/cluster.py` to wire the pool,
connection, and OSS-cluster handlers into the async connection lifecycle
(including cancelling scheduled maintenance tasks on `aclose`). On the sync side,
`redis/maint_notifications.py` and `redis/connection.py` were refactored so the
abstractions are shared cleanly: the parser hooks now go through a new
`_get_push_notifications_parser()` guard that raises unless a RESP3/hiredis
parser is present, `parser` type hints were widened to `BaseParser`, and OSS
cluster mode and pool-handler mode are now treated as mutually exclusive when a
pool is created with the default RESP3 "auto" config (the pool handler is cleared
so a connection is never configured with both). The `set_tmp_settings`
sentinel for relaxed timeout changed from `None` to `-1` so that "leave
unchanged" is distinguishable from "reset to 0".

Two correctness fixes ride along. IPv6 endpoints are now parsed with
`rsplit(":", 1)` in `redis/_parsers/base.py` so `host:port` splitting no longer
breaks on colon-bearing IPv6 literals, and dead code for the OSS maintenance
path was removed (#4175). The "connection has unexpected data" guards in
`ConnectionPool`/`BlockingConnectionPool` now skip the `can_read()` check when
caching or maintenance notifications are enabled, since push frames legitimately
sit on the socket in those modes. RESP2/RESP3 branch checks were also normalized
to `check_protocol_version(..., 3)` for consistency.

Backward-compatibility and parity notes: the public API is preserved — the
changes are additive on the async side and internal-refactor/bug-fix on the sync
side. The RESP3-requirement validation for cluster maintenance config was
consolidated into `RedisCluster.__init__` (the mixin now trusts it has already
been validated), and it now also checks `config.enabled` rather than merely the
config's presence. Sync/async parity is satisfied: every runtime change under
`redis/` has its mirror under `redis/asyncio/`, and the test suites were updated
on both sides.

## Test coverage

Extensive tests were added and reworked on both stacks. New async unit/handling
suites cover standalone and cluster maintenance-notification handling
(`tests/test_asyncio/test_maint_notifications_handling.py`,
`test_async_maint_notifications_handling.py`,
`test_async_cluster_maint_notifications_handling.py`), plus connection and
connection-pool additions in `tests/test_asyncio/`, and a new async fault-injector
client and scenario suite under `tests/test_asyncio/test_scenario/`. The sync and
async standalone scenario tests were migrated to an effects-based action model
(#4126), with shared `maint_notifications_helpers.py` on both sides, and the sync
fault-injector client was slimmed down accordingly. The suites exercise the
migrating/failing-over/OSS-moving start and completion events, relaxed-timeout
application, proactive reconnect, and the IPv6 endpoint-parsing edge case across
sync and async.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to connection lifecycle, pool locking, and cluster topology refresh on maintenance events; incorrect handling could cause stale routes, reconnect storms, or missed push frames during planned failover.
> 
> **Overview**
> Adds **async parity** with the sync client for RESP3 maintenance push notifications (MOVING, migrating/migrated, OSS SMIGRATED, relaxed timeouts, proactive reconnect).
> 
> New `redis/asyncio/maint_notifications.py` implements pool, connection, and OSS-cluster handlers with `asyncio` tasks, locks, and scheduled TTL cleanup. Async **client**, **cluster**, **connection**, and **connection pool** gain `maint_notifications_config`, mixins that wire parsers and `CLIENT MAINT_NOTIFICATIONS`, connect-time handshake, and pool APIs (`apply_moving_notification`, atomic MOVING cleanup). **BlockingConnectionPool** can serialize get/release with maintenance mutations via `_in_maintenance`.
> 
> **Shared fixes/refactors:** IPv6 endpoints use `rsplit(":", 1)` when parsing MOVING/SMIGRATED addresses; `can_read()` “dirty connection” checks are skipped when maintenance (or cache) is enabled; OSS cluster vs pool handlers are mutually exclusive; relaxed-timeout “unchanged” sentinel is `-1`; helpers extracted in `redis/maint_notifications.py`. Sync client uses `connection_pool.close()` on shutdown; async uses `aclose()` and reconnects single-connection clients after maintenance-driven `should_reconnect()`.
> 
> `aiohttp` added to dev requirements for async scenario tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74977e40ea051e127ffe02691c2ecef50f1b5f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->