### PR TITLE
feat: add COLLECT reducer support to search aggregations

### DIFF
--- a/redis/commands/search/reducers.py
+++ b/redis/commands/search/reducers.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Iterable, Union
 
 from .aggregation import Asc, Desc, Reducer, SortDirection
 
@@ -202,26 +202,25 @@ class collect(Reducer):
 
     def __init__(
         self,
-        fields: Union[str, list[str]] = "*",
+        fields: str | Iterable[str] = "*",
         distinct: bool = False,
-        sort_by: Union[str, Asc, Desc, list[Union[str, Asc, Desc]], None] = None,
-        limit: Union[tuple[int, int], None] = None,
+        sort_by: Asc | Desc | Iterable[Asc | Desc] | None = None,
+        limit: tuple[int, int] | None = None,
     ) -> None:
         """
         ### Parameters
 
         - **fields**: The fields to project from each collected row. Either the
             literal ``"*"`` (project every field present in the pipeline at this
-            stage) or a field name / list of field names. Names are normalized
-            to a single leading ``@`` on the wire; output map keys are the bare
-            names.
+            stage) or a field name / iterable of field names. Names are
+            normalized to a single leading ``@`` on the wire; output map keys
+            are the bare names.
         - **distinct**: When ``True``, emit ``DISTINCT`` to deduplicate entries
             with identical projected fields. Forward-compatible: this option is
             not yet implemented by the server and currently produces a server
             error when sent.
-        - **sort_by**: One field name, an ``Asc``/``Desc`` instance, or a list
-            of them, used to order the collected entries within each group.
-            Bare names default to ascending order.
+        - **sort_by**: An ``Asc``/``Desc`` instance or an iterable of them, used
+            to order the collected entries within each group.
         - **limit**: An ``(offset, count)`` pair. Returns at most ``count``
             entries per group after skipping ``offset``. With ``sort_by`` this
             acts as a top-N selection.
@@ -232,18 +231,11 @@ class collect(Reducer):
         if fields == "*":
             args += ["FIELDS", "*"]
         else:
-            if isinstance(fields, str):
-                if not fields.strip():
-                    raise ValueError(
-                        "collect fields must be '*' or a non-empty list of names"
-                    )
-                names = [fields]
-            else:
-                names = list(fields)
-                if not names:
-                    raise ValueError(
-                        "collect fields must be '*' or a non-empty list of names"
-                    )
+            names = [fields] if isinstance(fields, str) else list(fields)
+            if not names or any(not n.strip() for n in names):
+                raise ValueError(
+                    "collect fields must be '*' or a non-empty list of names"
+                )
             names = [_ensure_at_prefix(n) for n in names]
             args += ["FIELDS", str(len(names))] + names
 
@@ -253,15 +245,10 @@ class collect(Reducer):
 
         # SORTBY (optional)
         if sort_by is not None:
-            sort_fields = (
-                [sort_by] if isinstance(sort_by, (str, Asc, Desc)) else sort_by
-            )
+            sort_fields = [sort_by] if isinstance(sort_by, (Asc, Desc)) else sort_by
             sort_args: list[str] = []
             for f in sort_fields:
-                if isinstance(f, (Asc, Desc)):
-                    sort_args += [_ensure_at_prefix(f.field), f.DIRSTRING]
-                else:
-                    sort_args += [_ensure_at_prefix(f)]
+                sort_args += [_ensure_at_prefix(f.field), f.DIRSTRING]
             if not sort_args:
                 raise ValueError("collect sort_by must contain at least one field")
             args += ["SORTBY", str(len(sort_args))] + sort_args

--- a/redis/commands/search/reducers.py
+++ b/redis/commands/search/reducers.py
@@ -3,6 +3,11 @@ from typing import Union
 from .aggregation import Asc, Desc, Reducer, SortDirection
 
 
+def _ensure_at_prefix(name: str) -> str:
+    """Return ``name`` with a single leading ``@`` prefix."""
+    return name if name.startswith("@") else "@" + name
+
+
 class FieldOnlyReducer(Reducer):
     """See https://redis.io/docs/interact/search-and-query/search/aggregations/"""
 
@@ -180,3 +185,90 @@ class random_sample(Reducer):
         args = [field, str(size)]
         super().__init__(*args)
         self._field = field
+
+
+class collect(Reducer):
+    """
+    Gathers the rows of each ``GROUPBY`` group, projects a chosen set of
+    fields from every row, optionally deduplicates, sorts, and limits them,
+    and returns them as an array of per-entry maps under the reducer alias.
+
+    ``COLLECT`` is a preview feature gated behind
+    ``search-enable-unstable-features``. See
+    `FT.AGGREGATE <https://redis.io/commands/ft.aggregate>`_.
+    """
+
+    NAME = "COLLECT"
+
+    def __init__(
+        self,
+        fields: Union[str, list[str]] = "*",
+        distinct: bool = False,
+        sort_by: Union[str, Asc, Desc, list[Union[str, Asc, Desc]], None] = None,
+        limit: Union[tuple[int, int], None] = None,
+    ) -> None:
+        """
+        ### Parameters
+
+        - **fields**: The fields to project from each collected row. Either the
+            literal ``"*"`` (project every field present in the pipeline at this
+            stage) or a field name / list of field names. Names are normalized
+            to a single leading ``@`` on the wire; output map keys are the bare
+            names.
+        - **distinct**: When ``True``, emit ``DISTINCT`` to deduplicate entries
+            with identical projected fields. Forward-compatible: this option is
+            not yet implemented by the server and currently produces a server
+            error when sent.
+        - **sort_by**: One field name, an ``Asc``/``Desc`` instance, or a list
+            of them, used to order the collected entries within each group.
+            Bare names default to ascending order.
+        - **limit**: An ``(offset, count)`` pair. Returns at most ``count``
+            entries per group after skipping ``offset``. With ``sort_by`` this
+            acts as a top-N selection.
+        """
+        args: list[str] = []
+
+        # FIELDS (required)
+        if fields == "*":
+            args += ["FIELDS", "*"]
+        else:
+            if isinstance(fields, str):
+                if not fields.strip():
+                    raise ValueError(
+                        "collect fields must be '*' or a non-empty list of names"
+                    )
+                names = [fields]
+            else:
+                names = list(fields)
+                if not names:
+                    raise ValueError(
+                        "collect fields must be '*' or a non-empty list of names"
+                    )
+            names = [_ensure_at_prefix(n) for n in names]
+            args += ["FIELDS", str(len(names))] + names
+
+        # DISTINCT (optional)
+        if distinct:
+            args += ["DISTINCT"]
+
+        # SORTBY (optional)
+        if sort_by is not None:
+            sort_fields = (
+                [sort_by] if isinstance(sort_by, (str, Asc, Desc)) else sort_by
+            )
+            sort_args: list[str] = []
+            for f in sort_fields:
+                if isinstance(f, (Asc, Desc)):
+                    sort_args += [_ensure_at_prefix(f.field), f.DIRSTRING]
+                else:
+                    sort_args += [_ensure_at_prefix(f)]
+            if not sort_args:
+                raise ValueError("collect sort_by must contain at least one field")
+            args += ["SORTBY", str(len(sort_args))] + sort_args
+
+        # LIMIT (optional)
+        if limit is not None:
+            offset, count = limit
+            args += ["LIMIT", str(offset), str(count)]
+
+        super().__init__(*args)

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -1695,10 +1695,17 @@ def collect_groups(client, res, alias, group_field="color"):
 
 
 class TestAggregations(AsyncSearchTestsBase):
-    async def _setup_collect_index(self, client):
-        """Enable the preview feature and index the shared fruit documents."""
-        await client.config_set("search-enable-unstable-features", "yes")
-        await client.ft().create_index(
+    @pytest_asyncio.fixture
+    async def collect_index(self, decoded_r):
+        """Enable the preview feature and index the shared fruit documents.
+
+        Restores ``search-enable-unstable-features`` to its original value on
+        teardown so the preview flag does not leak into other tests.
+        """
+        config = await decoded_r.config_get("search-enable-unstable-features")
+        original = config["search-enable-unstable-features"]
+        await decoded_r.config_set("search-enable-unstable-features", "yes")
+        await decoded_r.ft().create_index(
             (
                 TextField("color"),
                 TextField("name"),
@@ -1707,8 +1714,10 @@ class TestAggregations(AsyncSearchTestsBase):
             )
         )
         for key, mapping in COLLECT_FRUITS.items():
-            await client.hset(key, mapping=mapping)
-        await self.waitForIndex(client, "idx")
+            await decoded_r.hset(key, mapping=mapping)
+        await self.waitForIndex(decoded_r, "idx")
+        yield
+        await decoded_r.config_set("search-enable-unstable-features", original)
 
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
@@ -2026,10 +2035,10 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_sortby(self, decoded_r: redis.Redis):
+    async def test_aggregations_collect_sortby(
+        self, decoded_r: redis.Redis, collect_index
+    ):
         # COLLECT projects the named fields per group, ordered by SORTBY.
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2058,16 +2067,18 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_sortby_ascending(self, decoded_r: redis.Redis):
-        # Bare sort names default to ascending order.
-        await self._setup_collect_index(decoded_r)
-
+    async def test_aggregations_collect_sortby_ascending(
+        self, decoded_r: redis.Redis, collect_index
+    ):
+        # An ``Asc`` directive orders the collected entries in ascending order.
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
             .group_by(
                 "@color",
-                reducers.collect(["@name"], sort_by="@sweetness").alias("fruits"),
+                reducers.collect(
+                    ["@name"], sort_by=[aggregations.Asc("@sweetness")]
+                ).alias("fruits"),
             )
         )
         groups = collect_groups(
@@ -2084,10 +2095,10 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_limit_top_n(self, decoded_r: redis.Redis):
+    async def test_aggregations_collect_limit_top_n(
+        self, decoded_r: redis.Redis, collect_index
+    ):
         # SORTBY + LIMIT is a bounded top-N selection with an offset.
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2113,11 +2124,9 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
     async def test_aggregations_collect_multiple_sort_keys(
-        self, decoded_r: redis.Redis
+        self, decoded_r: redis.Redis, collect_index
     ):
         # Multiple sort keys are applied left to right.
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2149,10 +2158,10 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_sparse_projection(self, decoded_r: redis.Redis):
+    async def test_aggregations_collect_sparse_projection(
+        self, decoded_r: redis.Redis, collect_index
+    ):
         # A field absent from a row is omitted from that entry (not NULL).
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2182,16 +2191,18 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_key_field(self, decoded_r: redis.Redis):
+    async def test_aggregations_collect_key_field(
+        self, decoded_r: redis.Redis, collect_index
+    ):
         # ``@__key`` can be projected when carried into the pipeline via LOAD.
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("@__key", "@name")
             .group_by(
                 "@color",
-                reducers.collect(["@name", "@__key"], sort_by="@name").alias("fruits"),
+                reducers.collect(
+                    ["@name", "@__key"], sort_by=[aggregations.Asc("@name")]
+                ).alias("fruits"),
             )
         )
         groups = collect_groups(
@@ -2211,10 +2222,10 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_fields_all(self, decoded_r: redis.Redis):
+    async def test_aggregations_collect_fields_all(
+        self, decoded_r: redis.Redis, collect_index
+    ):
         # FIELDS * is stage-local: after GROUPBY only the group key is present.
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2229,27 +2240,33 @@ class TestAggregations(AsyncSearchTestsBase):
         assert all(entry == {"color": "red"} for entry in groups["red"])
         assert all(entry == {"color": "yellow"} for entry in groups["yellow"])
 
-    @pytest.mark.parametrize("bad_fields", [[], (), "", "   "])
+    @pytest.mark.parametrize(
+        "bad_fields",
+        [[], (), "", "   ", ["   "], ["name", ""], ["name", "   "]],
+    )
     def test_aggregations_collect_invalid_fields(self, bad_fields):
         # Empty or blank field selectors are local API misuse and are rejected
-        # client-side with a ValueError before any command is sent.
+        # client-side with a ValueError before any command is sent. A blank
+        # entry anywhere in the list is rejected too, not just an empty list.
         with pytest.raises(ValueError):
             reducers.collect(bad_fields)
 
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    async def test_aggregations_collect_single_str_field(self, decoded_r: redis.Redis):
+    async def test_aggregations_collect_single_str_field(
+        self, decoded_r: redis.Redis, collect_index
+    ):
         # A single field may be passed as a bare string; the client wraps it as
         # a one-field projection.
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
             .group_by(
                 "@color",
-                reducers.collect("@name", sort_by="@sweetness").alias("fruits"),
+                reducers.collect(
+                    "@name", sort_by=[aggregations.Asc("@sweetness")]
+                ).alias("fruits"),
             )
         )
         groups = collect_groups(
@@ -2267,12 +2284,10 @@ class TestAggregations(AsyncSearchTestsBase):
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
     async def test_aggregations_collect_field_names_without_prefix(
-        self, decoded_r: redis.Redis
+        self, decoded_r: redis.Redis, collect_index
     ):
         # Field and sort names may be supplied without a leading "@"; the client
         # normalizes them on the wire (the server requires the prefix).
-        await self._setup_collect_index(decoded_r)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -1541,7 +1541,71 @@ class TestConfig(AsyncSearchTestsBase):
         assert "100" == res["timeout"]
 
 
+# Documents shared by the COLLECT reducer tests. Some fruits deliberately omit
+# ``origin`` so the sparse-projection behavior can be exercised.
+COLLECT_FRUITS = {
+    "fruit:apple": {"color": "red", "name": "apple", "sweetness": 4, "origin": "usa"},
+    "fruit:strawberry": {"color": "red", "name": "strawberry", "sweetness": 3},
+    "fruit:cherry": {
+        "color": "red",
+        "name": "cherry",
+        "sweetness": 5,
+        "origin": "turkey",
+    },
+    "fruit:banana": {
+        "color": "yellow",
+        "name": "banana",
+        "sweetness": 4,
+        "origin": "ecuador",
+    },
+    "fruit:lemon": {"color": "yellow", "name": "lemon", "sweetness": 2},
+}
+
+
+def collect_entry_to_dict(entry):
+    """Normalize a single COLLECT entry to a dict.
+
+    RESP3 entries are maps already; RESP2 entries are flat
+    ``[key, value, key, value, ...]`` arrays.
+    """
+    if isinstance(entry, dict):
+        return entry
+    return {entry[i]: entry[i + 1] for i in range(0, len(entry), 2)}
+
+
+def collect_groups(client, res, alias, group_field="color"):
+    """Return ``{group_value: [entry_dict, ...]}`` from an FT.AGGREGATE COLLECT
+    result across all response shapes.
+
+    ``legacy_resp3`` returns a dict of results; the other shapes return an
+    ``AggregateResult`` whose rows are flat ``[key, value, ...]`` lists.
+    """
+    if expects_resp3_shape(client):
+        rows = [result["extra_attributes"] for result in res["results"]]
+    else:
+        rows = [{row[i]: row[i + 1] for i in range(0, len(row), 2)} for row in res.rows]
+    return {
+        attrs[group_field]: [collect_entry_to_dict(e) for e in attrs[alias]]
+        for attrs in rows
+    }
+
+
 class TestAggregations(AsyncSearchTestsBase):
+    async def _setup_collect_index(self, client):
+        """Enable the preview feature and index the shared fruit documents."""
+        await client.config_set("search-enable-unstable-features", "yes")
+        await client.ft().create_index(
+            (
+                TextField("color"),
+                TextField("name"),
+                NumericField("sweetness"),
+                TextField("origin"),
+            )
+        )
+        for key, mapping in COLLECT_FRUITS.items():
+            await client.hset(key, mapping=mapping)
+        await self.waitForIndex(client, "idx")
+
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     async def test_aggregations_groupby(self, decoded_r: redis.Redis):
@@ -1854,6 +1918,281 @@ class TestAggregations(AsyncSearchTestsBase):
                     "RedisAI",
                     "RedisJson",
                 ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_sortby(self, decoded_r: redis.Redis):
+        # COLLECT projects the named fields per group, ordered by SORTBY.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name", "@sweetness"],
+                    sort_by=[aggregations.Desc("@sweetness")],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert groups["red"] == [
+            {"name": "cherry", "sweetness": "5"},
+            {"name": "apple", "sweetness": "4"},
+            {"name": "strawberry", "sweetness": "3"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "sweetness": "4"},
+            {"name": "lemon", "sweetness": "2"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_sortby_ascending(self, decoded_r: redis.Redis):
+        # Bare sort names default to ascending order.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(["@name"], sort_by="@sweetness").alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert groups["red"] == [
+            {"name": "strawberry"},
+            {"name": "apple"},
+            {"name": "cherry"},
+        ]
+        assert groups["yellow"] == [{"name": "lemon"}, {"name": "banana"}]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_limit_top_n(self, decoded_r: redis.Redis):
+        # SORTBY + LIMIT is a bounded top-N selection with an offset.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name"],
+                    sort_by=[aggregations.Desc("@sweetness")],
+                    limit=(1, 1),
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        # red desc: cherry, apple, strawberry -> skip 1, take 1 -> apple
+        assert groups["red"] == [{"name": "apple"}]
+        # yellow desc: banana, lemon -> skip 1, take 1 -> lemon
+        assert groups["yellow"] == [{"name": "lemon"}]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_multiple_sort_keys(
+        self, decoded_r: redis.Redis
+    ):
+        # Multiple sort keys are applied left to right.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name", "@sweetness"],
+                    sort_by=[
+                        aggregations.Desc("@sweetness"),
+                        aggregations.Asc("@name"),
+                    ],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert groups["red"] == [
+            {"name": "cherry", "sweetness": "5"},
+            {"name": "apple", "sweetness": "4"},
+            {"name": "strawberry", "sweetness": "3"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "sweetness": "4"},
+            {"name": "lemon", "sweetness": "2"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_sparse_projection(self, decoded_r: redis.Redis):
+        # A field absent from a row is omitted from that entry (not NULL).
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name", "@origin"],
+                    sort_by=[aggregations.Desc("@sweetness")],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        # strawberry and lemon have no ``origin`` -> the key is omitted.
+        assert groups["red"] == [
+            {"name": "cherry", "origin": "turkey"},
+            {"name": "apple", "origin": "usa"},
+            {"name": "strawberry"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "origin": "ecuador"},
+            {"name": "lemon"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_key_field(self, decoded_r: redis.Redis):
+        # ``@__key`` can be projected when carried into the pipeline via LOAD.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("@__key", "@name")
+            .group_by(
+                "@color",
+                reducers.collect(["@name", "@__key"], sort_by="@name").alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert groups["red"] == [
+            {"name": "apple", "__key": "fruit:apple"},
+            {"name": "cherry", "__key": "fruit:cherry"},
+            {"name": "strawberry", "__key": "fruit:strawberry"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "__key": "fruit:banana"},
+            {"name": "lemon", "__key": "fruit:lemon"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_fields_all(self, decoded_r: redis.Redis):
+        # FIELDS * is stage-local: after GROUPBY only the group key is present.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by("@color", reducers.collect("*").alias("fruits"))
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert len(groups["red"]) == 3
+        assert len(groups["yellow"]) == 2
+        assert all(entry == {"color": "red"} for entry in groups["red"])
+        assert all(entry == {"color": "yellow"} for entry in groups["yellow"])
+
+    @pytest.mark.parametrize("bad_fields", [[], (), "", "   "])
+    def test_aggregations_collect_invalid_fields(self, bad_fields):
+        # Empty or blank field selectors are local API misuse and are rejected
+        # client-side with a ValueError before any command is sent.
+        with pytest.raises(ValueError):
+            reducers.collect(bad_fields)
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_single_str_field(self, decoded_r: redis.Redis):
+        # A single field may be passed as a bare string; the client wraps it as
+        # a one-field projection.
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect("@name", sort_by="@sweetness").alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert groups["red"] == [
+            {"name": "strawberry"},
+            {"name": "apple"},
+            {"name": "cherry"},
+        ]
+        assert groups["yellow"] == [{"name": "lemon"}, {"name": "banana"}]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aggregations_collect_field_names_without_prefix(
+        self, decoded_r: redis.Redis
+    ):
+        # Field and sort names may be supplied without a leading "@"; the client
+        # normalizes them on the wire (the server requires the prefix).
+        await self._setup_collect_index(decoded_r)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["name", "sweetness"],
+                    sort_by=[aggregations.Desc("sweetness")],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(
+            decoded_r, await decoded_r.ft().aggregate(req), "fruits"
+        )
+
+        assert groups["red"] == [
+            {"name": "cherry", "sweetness": "5"},
+            {"name": "apple", "sweetness": "4"},
+            {"name": "strawberry", "sweetness": "3"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "sweetness": "4"},
+            {"name": "lemon", "sweetness": "2"},
+        ]
 
     @pytest.mark.redismod
     async def test_aggregations_sort_by_and_limit(self, decoded_r: redis.Redis):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2097,7 +2097,71 @@ class TestConfig(SearchTestsBase):
         assert "Syntax error" in str(err.value)
 
 
+# Documents shared by the COLLECT reducer tests. Some fruits deliberately omit
+# ``origin`` so the sparse-projection behavior can be exercised.
+COLLECT_FRUITS = {
+    "fruit:apple": {"color": "red", "name": "apple", "sweetness": 4, "origin": "usa"},
+    "fruit:strawberry": {"color": "red", "name": "strawberry", "sweetness": 3},
+    "fruit:cherry": {
+        "color": "red",
+        "name": "cherry",
+        "sweetness": 5,
+        "origin": "turkey",
+    },
+    "fruit:banana": {
+        "color": "yellow",
+        "name": "banana",
+        "sweetness": 4,
+        "origin": "ecuador",
+    },
+    "fruit:lemon": {"color": "yellow", "name": "lemon", "sweetness": 2},
+}
+
+
+def collect_entry_to_dict(entry):
+    """Normalize a single COLLECT entry to a dict.
+
+    RESP3 entries are maps already; RESP2 entries are flat
+    ``[key, value, key, value, ...]`` arrays.
+    """
+    if isinstance(entry, dict):
+        return entry
+    return {entry[i]: entry[i + 1] for i in range(0, len(entry), 2)}
+
+
+def collect_groups(client, res, alias, group_field="color"):
+    """Return ``{group_value: [entry_dict, ...]}`` from an FT.AGGREGATE COLLECT
+    result across all response shapes.
+
+    ``legacy_resp3`` returns a dict of results; the other shapes return an
+    ``AggregateResult`` whose rows are flat ``[key, value, ...]`` lists.
+    """
+    if expects_resp3_shape(client):
+        rows = [result["extra_attributes"] for result in res["results"]]
+    else:
+        rows = [{row[i]: row[i + 1] for i in range(0, len(row), 2)} for row in res.rows]
+    return {
+        attrs[group_field]: [collect_entry_to_dict(e) for e in attrs[alias]]
+        for attrs in rows
+    }
+
+
 class TestAggregations(SearchTestsBase):
+    def _setup_collect_index(self, client):
+        """Enable the preview feature and index the shared fruit documents."""
+        client.config_set("search-enable-unstable-features", "yes")
+        client.ft().create_index(
+            (
+                TextField("color"),
+                TextField("name"),
+                NumericField("sweetness"),
+                TextField("origin"),
+            )
+        )
+        for key, mapping in COLLECT_FRUITS.items():
+            client.hset(key, mapping=mapping)
+        self.waitForIndex(client, "idx")
+
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     def test_aggregations_groupby(self, client):
@@ -2354,6 +2418,259 @@ class TestAggregations(SearchTestsBase):
                 "RedisAI",
                 "RedisJson",
             ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_sortby(self, client):
+        # COLLECT projects the named fields per group, ordered by SORTBY.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name", "@sweetness"],
+                    sort_by=[aggregations.Desc("@sweetness")],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert groups["red"] == [
+            {"name": "cherry", "sweetness": "5"},
+            {"name": "apple", "sweetness": "4"},
+            {"name": "strawberry", "sweetness": "3"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "sweetness": "4"},
+            {"name": "lemon", "sweetness": "2"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_sortby_ascending(self, client):
+        # Bare sort names default to ascending order.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(["@name"], sort_by="@sweetness").alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert groups["red"] == [
+            {"name": "strawberry"},
+            {"name": "apple"},
+            {"name": "cherry"},
+        ]
+        assert groups["yellow"] == [{"name": "lemon"}, {"name": "banana"}]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_limit_top_n(self, client):
+        # SORTBY + LIMIT is a bounded top-N selection with an offset.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name"],
+                    sort_by=[aggregations.Desc("@sweetness")],
+                    limit=(1, 1),
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        # red desc: cherry, apple, strawberry -> skip 1, take 1 -> apple
+        assert groups["red"] == [{"name": "apple"}]
+        # yellow desc: banana, lemon -> skip 1, take 1 -> lemon
+        assert groups["yellow"] == [{"name": "lemon"}]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_multiple_sort_keys(self, client):
+        # Multiple sort keys are applied left to right.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name", "@sweetness"],
+                    sort_by=[
+                        aggregations.Desc("@sweetness"),
+                        aggregations.Asc("@name"),
+                    ],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert groups["red"] == [
+            {"name": "cherry", "sweetness": "5"},
+            {"name": "apple", "sweetness": "4"},
+            {"name": "strawberry", "sweetness": "3"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "sweetness": "4"},
+            {"name": "lemon", "sweetness": "2"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_sparse_projection(self, client):
+        # A field absent from a row is omitted from that entry (not NULL).
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["@name", "@origin"],
+                    sort_by=[aggregations.Desc("@sweetness")],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        # strawberry and lemon have no ``origin`` -> the key is omitted.
+        assert groups["red"] == [
+            {"name": "cherry", "origin": "turkey"},
+            {"name": "apple", "origin": "usa"},
+            {"name": "strawberry"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "origin": "ecuador"},
+            {"name": "lemon"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_key_field(self, client):
+        # ``@__key`` can be projected when carried into the pipeline via LOAD.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("@__key", "@name")
+            .group_by(
+                "@color",
+                reducers.collect(["@name", "@__key"], sort_by="@name").alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert groups["red"] == [
+            {"name": "apple", "__key": "fruit:apple"},
+            {"name": "cherry", "__key": "fruit:cherry"},
+            {"name": "strawberry", "__key": "fruit:strawberry"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "__key": "fruit:banana"},
+            {"name": "lemon", "__key": "fruit:lemon"},
+        ]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_fields_all(self, client):
+        # FIELDS * is stage-local: after GROUPBY only the group key is present.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by("@color", reducers.collect("*").alias("fruits"))
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert len(groups["red"]) == 3
+        assert len(groups["yellow"]) == 2
+        assert all(entry == {"color": "red"} for entry in groups["red"])
+        assert all(entry == {"color": "yellow"} for entry in groups["yellow"])
+
+    @pytest.mark.parametrize("bad_fields", [[], (), "", "   "])
+    def test_aggregations_collect_invalid_fields(self, bad_fields):
+        # Empty or blank field selectors are local API misuse and are rejected
+        # client-side with a ValueError before any command is sent.
+        with pytest.raises(ValueError):
+            reducers.collect(bad_fields)
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_single_str_field(self, client):
+        # A single field may be passed as a bare string; the client wraps it as
+        # a one-field projection.
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect("@name", sort_by="@sweetness").alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert groups["red"] == [
+            {"name": "strawberry"},
+            {"name": "apple"},
+            {"name": "cherry"},
+        ]
+        assert groups["yellow"] == [{"name": "lemon"}, {"name": "banana"}]
+
+    @pytest.mark.redismod
+    @pytest.mark.onlynoncluster
+    @skip_if_server_version_lt("8.9.0")
+    def test_aggregations_collect_field_names_without_prefix(self, client):
+        # Field and sort names may be supplied without a leading "@"; the client
+        # normalizes them on the wire (the server requires the prefix).
+        self._setup_collect_index(client)
+
+        req = (
+            aggregations.AggregateRequest("*")
+            .load("*")
+            .group_by(
+                "@color",
+                reducers.collect(
+                    ["name", "sweetness"],
+                    sort_by=[aggregations.Desc("sweetness")],
+                ).alias("fruits"),
+            )
+        )
+        groups = collect_groups(client, client.ft().aggregate(req), "fruits")
+
+        assert groups["red"] == [
+            {"name": "cherry", "sweetness": "5"},
+            {"name": "apple", "sweetness": "4"},
+            {"name": "strawberry", "sweetness": "3"},
+        ]
+        assert groups["yellow"] == [
+            {"name": "banana", "sweetness": "4"},
+            {"name": "lemon", "sweetness": "2"},
+        ]
 
     @pytest.mark.redismod
     def test_aggregations_sort_by_and_limit(self, client):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2250,8 +2250,15 @@ def collect_groups(client, res, alias, group_field="color"):
 
 
 class TestAggregations(SearchTestsBase):
-    def _setup_collect_index(self, client):
-        """Enable the preview feature and index the shared fruit documents."""
+    @pytest.fixture
+    def collect_index(self, client):
+        """Enable the preview feature and index the shared fruit documents.
+
+        Restores ``search-enable-unstable-features`` to its original value on
+        teardown so the preview flag does not leak into other tests.
+        """
+        config = client.config_get("search-enable-unstable-features")
+        original = config["search-enable-unstable-features"]
         client.config_set("search-enable-unstable-features", "yes")
         client.ft().create_index(
             (
@@ -2264,6 +2271,8 @@ class TestAggregations(SearchTestsBase):
         for key, mapping in COLLECT_FRUITS.items():
             client.hset(key, mapping=mapping)
         self.waitForIndex(client, "idx")
+        yield
+        client.config_set("search-enable-unstable-features", original)
 
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
@@ -2525,10 +2534,8 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_sortby(self, client):
+    def test_aggregations_collect_sortby(self, client, collect_index):
         # COLLECT projects the named fields per group, ordered by SORTBY.
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2555,16 +2562,16 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_sortby_ascending(self, client):
-        # Bare sort names default to ascending order.
-        self._setup_collect_index(client)
-
+    def test_aggregations_collect_sortby_ascending(self, client, collect_index):
+        # An ``Asc`` directive orders the collected entries in ascending order.
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
             .group_by(
                 "@color",
-                reducers.collect(["@name"], sort_by="@sweetness").alias("fruits"),
+                reducers.collect(
+                    ["@name"], sort_by=[aggregations.Asc("@sweetness")]
+                ).alias("fruits"),
             )
         )
         groups = collect_groups(client, client.ft().aggregate(req), "fruits")
@@ -2579,10 +2586,8 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_limit_top_n(self, client):
+    def test_aggregations_collect_limit_top_n(self, client, collect_index):
         # SORTBY + LIMIT is a bounded top-N selection with an offset.
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2605,10 +2610,8 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_multiple_sort_keys(self, client):
+    def test_aggregations_collect_multiple_sort_keys(self, client, collect_index):
         # Multiple sort keys are applied left to right.
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2638,10 +2641,8 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_sparse_projection(self, client):
+    def test_aggregations_collect_sparse_projection(self, client, collect_index):
         # A field absent from a row is omitted from that entry (not NULL).
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2669,16 +2670,16 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_key_field(self, client):
+    def test_aggregations_collect_key_field(self, client, collect_index):
         # ``@__key`` can be projected when carried into the pipeline via LOAD.
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("@__key", "@name")
             .group_by(
                 "@color",
-                reducers.collect(["@name", "@__key"], sort_by="@name").alias("fruits"),
+                reducers.collect(
+                    ["@name", "@__key"], sort_by=[aggregations.Asc("@name")]
+                ).alias("fruits"),
             )
         )
         groups = collect_groups(client, client.ft().aggregate(req), "fruits")
@@ -2696,10 +2697,8 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_fields_all(self, client):
+    def test_aggregations_collect_fields_all(self, client, collect_index):
         # FIELDS * is stage-local: after GROUPBY only the group key is present.
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
@@ -2712,27 +2711,31 @@ class TestAggregations(SearchTestsBase):
         assert all(entry == {"color": "red"} for entry in groups["red"])
         assert all(entry == {"color": "yellow"} for entry in groups["yellow"])
 
-    @pytest.mark.parametrize("bad_fields", [[], (), "", "   "])
+    @pytest.mark.parametrize(
+        "bad_fields",
+        [[], (), "", "   ", ["   "], ["name", ""], ["name", "   "]],
+    )
     def test_aggregations_collect_invalid_fields(self, bad_fields):
         # Empty or blank field selectors are local API misuse and are rejected
-        # client-side with a ValueError before any command is sent.
+        # client-side with a ValueError before any command is sent. A blank
+        # entry anywhere in the list is rejected too, not just an empty list.
         with pytest.raises(ValueError):
             reducers.collect(bad_fields)
 
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_single_str_field(self, client):
+    def test_aggregations_collect_single_str_field(self, client, collect_index):
         # A single field may be passed as a bare string; the client wraps it as
         # a one-field projection.
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")
             .group_by(
                 "@color",
-                reducers.collect("@name", sort_by="@sweetness").alias("fruits"),
+                reducers.collect(
+                    "@name", sort_by=[aggregations.Asc("@sweetness")]
+                ).alias("fruits"),
             )
         )
         groups = collect_groups(client, client.ft().aggregate(req), "fruits")
@@ -2747,11 +2750,11 @@ class TestAggregations(SearchTestsBase):
     @pytest.mark.redismod
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("8.9.0")
-    def test_aggregations_collect_field_names_without_prefix(self, client):
+    def test_aggregations_collect_field_names_without_prefix(
+        self, client, collect_index
+    ):
         # Field and sort names may be supplied without a leading "@"; the client
         # normalizes them on the wire (the server requires the prefix).
-        self._setup_collect_index(client)
-
         req = (
             aggregations.AggregateRequest("*")
             .load("*")


### PR DESCRIPTION
## Change summary

This pull request adds support for the `COLLECT` aggregation reducer to the
search-and-query command surface. `COLLECT` gathers the rows of each `GROUPBY`
group, projects a chosen set of fields from every row, and returns them as an
array of per-entry maps under the reducer alias, with optional deduplication,
sorting, and limiting. It is a preview feature gated behind the server's
`search-enable-unstable-features` flag. The change is purely additive: a new
`collect` reducer class alongside the existing reducers, with no modification to
any existing reducer or public signature.

The implementation lives entirely in `redis/commands/search/reducers.py`. A new
`collect(Reducer)` class builds the `FT.AGGREGATE ... REDUCE COLLECT` argument
vector from four constructor options: `fields` (either the literal `"*"` or a
name / list of names), `distinct`, `sort_by` (a name, an `Asc`/`Desc` instance,
or a list of them), and `limit` as an `(offset, count)` pair. A small module-level
helper, `_ensure_at_prefix`, normalizes every field and sort key to a single
leading `@` on the wire so callers may pass bare names or `@`-prefixed names
interchangeably. Empty or blank field specifications raise `ValueError` early
rather than emitting a malformed command.

A few edge cases are handled explicitly: `sort_by` accepts a single value or a
list and coerces bare names to ascending order via `Asc`/`Desc`; the `FIELDS`
and `SORTBY` clauses emit their argument counts as the wire protocol requires;
and `distinct` is wired through as a forward-compatible `DISTINCT` token even
though the server does not yet implement it (documented in the docstring as
currently producing a server error). Reducers are shared between the sync and
async stacks — both import the same `redis/commands/search/reducers.py` — so
there is no separate async runtime mirror to update; sync/async parity here is
about test coverage, which is provided on both sides. There is no
backward-compatibility or public-API risk, since nothing existing changes.

## Test coverage

New tests are added in both `tests/test_search.py` and
`tests/test_asyncio/test_search.py`, kept in lockstep, with shared helpers
(`collect_entry_to_dict`, `collect_groups`) and a common `_setup_collect_index`
fixture. They exercise the full option matrix against a live index: descending
and ascending `sort_by`, `limit` as top-N selection, multiple sort keys, sparse
projection where some fields are absent from rows, projecting a key field,
`FIELDS *` (project-all), single-string-field projection, and passing field
names with and without the `@` prefix to confirm normalization.

Argument-validation behavior is covered by a parametrized
`test_aggregations_collect_invalid_fields` (sync and async) asserting `ValueError`
for empty/blank field inputs, which needs no server connection. The integration
tests rely on the `COLLECT` preview feature and therefore require a server with


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive search aggregation API and tests only; no changes to existing reducers or command paths. Preview feature is opt-in via server config and Redis 8.9+ in tests.
> 
> **Overview**
> Adds client support for the preview **COLLECT** `FT.AGGREGATE` reducer so grouped pipelines can return per-row field maps as an array under a reducer alias.
> 
> In `reducers.py`, a new `collect` class builds the `REDUCE COLLECT` wire args from `fields` (`*` or named projections), optional `distinct`, `sort_by` (`Asc`/`Desc`), and `limit` `(offset, count)`. **`_ensure_at_prefix`** normalizes field and sort keys to a single `@` on the wire; empty or blank field specs raise **`ValueError`** before the command is sent. **`distinct`** is emitted for forward compatibility but is documented as not yet supported server-side.
> 
> Sync and async integration tests share fruit fixtures, a `collect_index` fixture that toggles **`search-enable-unstable-features`**, and helpers that normalize COLLECT results across RESP2/RESP3. Coverage includes sort direction, top-N limits, sparse projection, `@__key`, `FIELDS *`, and client-side validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5e0fc09f59e3f404c2ca4505b441503add87ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->