### PR TITLE
fix: add close()/aclose() to Sentinel to release sentinel client pools

### DIFF
--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -269,11 +269,19 @@ class Sentinel(AsyncSentinelCommands):
         Close all sentinel clients created by this Sentinel and their
         connection pools.
 
+        Each client is closed independently: if one raises, the remaining
+        clients are still closed and the first error is re-raised afterwards.
+
         Clients returned by ``master_for``/``slave_for`` are owned by the
         caller and are not closed here.
         """
-        for sentinel in self.sentinels:
-            await sentinel.aclose()
+        resp = await asyncio.gather(
+            *(sentinel.aclose() for sentinel in self.sentinels),
+            return_exceptions=True,
+        )
+        exc = next((r for r in resp if isinstance(r, BaseException)), None)
+        if exc:
+            raise exc
 
     async def __aenter__(self) -> "Sentinel":
         return self

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -264,6 +264,23 @@ class Sentinel(AsyncSentinelCommands):
             f"(sentinels=[{','.join(sentinel_addresses)}])>"
         )
 
+    async def aclose(self) -> None:
+        """
+        Close all sentinel clients created by this Sentinel and their
+        connection pools.
+
+        Clients returned by ``master_for``/``slave_for`` are owned by the
+        caller and are not closed here.
+        """
+        for sentinel in self.sentinels:
+            await sentinel.aclose()
+
+    async def __aenter__(self) -> "Sentinel":
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        await self.aclose()
+
     def check_master_state(self, state: dict, service_name: str) -> bool:
         if not state["is_master"] or state["is_sdown"] or state["is_odown"]:
             return False

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -294,6 +294,23 @@ class Sentinel(SentinelCommands):
             f"(sentinels=[{','.join(sentinel_addresses)}])>"
         )
 
+    def close(self) -> None:
+        """
+        Close all sentinel clients created by this Sentinel and their
+        connection pools.
+
+        Clients returned by ``master_for``/``slave_for`` are owned by the
+        caller and are not closed here.
+        """
+        for sentinel in self.sentinels:
+            sentinel.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def check_master_state(self, state, service_name):
         if not state["is_master"] or state["is_sdown"] or state["is_odown"]:
             return False

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -299,11 +299,21 @@ class Sentinel(SentinelCommands):
         Close all sentinel clients created by this Sentinel and their
         connection pools.
 
+        Each client is closed independently: if one raises, the remaining
+        clients are still closed and the first error is re-raised afterwards.
+
         Clients returned by ``master_for``/``slave_for`` are owned by the
         caller and are not closed here.
         """
+        exc = None
         for sentinel in self.sentinels:
-            sentinel.close()
+            try:
+                sentinel.close()
+            except Exception as e:
+                if exc is None:
+                    exc = e
+        if exc:
+            raise exc
 
     def __enter__(self):
         return self

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -333,6 +333,30 @@ async def test_aclose(cluster, sentinel):
         s.aclose.assert_awaited_once()
 
 
+@pytest.mark.onlynoncluster
+async def test_aclose_error_still_closes_remaining_clients(cluster, sentinel):
+    sentinel.sentinels = [mock.AsyncMock() for _ in range(3)]
+    sentinel.sentinels[0].aclose.side_effect = Exception("sentinel down")
+
+    with pytest.raises(Exception, match="sentinel down"):
+        await sentinel.aclose()
+
+    # the failing client must not prevent closing the others
+    for s in sentinel.sentinels:
+        s.aclose.assert_awaited_once()
+
+
+@pytest.mark.onlynoncluster
+async def test_aclose_idempotent(cluster, sentinel):
+    sentinel.sentinels = [mock.AsyncMock() for _ in range(2)]
+
+    await sentinel.aclose()
+    await sentinel.aclose()
+
+    for s in sentinel.sentinels:
+        assert s.aclose.await_count == 2
+
+
 # Tests against real sentinel instances
 @pytest.mark.onlynoncluster
 async def test_get_sentinels(deployed_sentinel):

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -321,6 +321,18 @@ async def test_repr_correctly_represents_connection_object(sentinel):
     )
 
 
+@pytest.mark.onlynoncluster
+async def test_aclose(cluster, sentinel):
+    sentinel.sentinels = [mock.AsyncMock() for _ in range(2)]
+
+    async with sentinel as entered:
+        assert entered is sentinel
+
+    # exiting the context closes every sentinel client and its pool
+    for s in sentinel.sentinels:
+        s.aclose.assert_awaited_once()
+
+
 # Tests against real sentinel instances
 @pytest.mark.onlynoncluster
 async def test_get_sentinels(deployed_sentinel):

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -303,6 +303,18 @@ def test_auto_close_pool(cluster, sentinel, method_name):
     pool.disconnect()
 
 
+@pytest.mark.onlynoncluster
+def test_close(cluster, sentinel):
+    sentinel.sentinels = [mock.Mock() for _ in range(2)]
+
+    with sentinel as entered:
+        assert entered is sentinel
+
+    # exiting the context closes every sentinel client and its pool
+    for s in sentinel.sentinels:
+        s.close.assert_called_once()
+
+
 # Tests against real sentinel instances
 @pytest.mark.onlynoncluster
 def test_get_sentinels(deployed_sentinel):

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -315,6 +315,30 @@ def test_close(cluster, sentinel):
         s.close.assert_called_once()
 
 
+@pytest.mark.onlynoncluster
+def test_close_error_still_closes_remaining_clients(cluster, sentinel):
+    sentinel.sentinels = [mock.Mock() for _ in range(3)]
+    sentinel.sentinels[0].close.side_effect = Exception("sentinel down")
+
+    with pytest.raises(Exception, match="sentinel down"):
+        sentinel.close()
+
+    # the failing client must not prevent closing the others
+    for s in sentinel.sentinels:
+        s.close.assert_called_once()
+
+
+@pytest.mark.onlynoncluster
+def test_close_idempotent(cluster, sentinel):
+    sentinel.sentinels = [mock.Mock() for _ in range(2)]
+
+    sentinel.close()
+    sentinel.close()
+
+    for s in sentinel.sentinels:
+        assert s.close.call_count == 2
+
+
 # Tests against real sentinel instances
 @pytest.mark.onlynoncluster
 def test_get_sentinels(deployed_sentinel):


### PR DESCRIPTION
### Description of change

`Sentinel` (both sync and async) builds a `Redis` client per sentinel node in `__init__` (`self.sentinels`), each with its own connection pool, but exposes no way to close them. Letting a `Sentinel` go out of scope leaves those pools open — which surfaces as `Exception ignored in <AbstractConnection.__del__>` warnings on GC (e.g. under `IsolatedAsyncioTestCase`) and gives tests / shutdown paths no clean teardown. The only workaround today is to reach into `sentinel.sentinels` and close each one by hand.

This adds `close()` (sync) / `aclose()` (async), plus context-manager support, which close every sentinel client and its pool — mirroring the `Redis` client API:

```python
with Sentinel([("localhost", 26379)]) as sentinel:
    master = sentinel.master_for("mymaster")
    ...
```

Clients returned by `master_for`/`slave_for` are owned by the caller and are left untouched.

### Pull Request check-list

  - [x] Do tests and lints pass with this change?
  - [x] Do the CI tests pass with this change?
  - [x] Is the new or changed code fully tested?
  - [ ] Is a documentation update included?
  - [ ] Is there an example added to the examples folder?

Fixes redis/redis-py#3201


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lifecycle API with bounded behavior; no changes to discovery, failover, or command execution paths.
> 
> **Overview**
> **`Sentinel` now has explicit teardown** for the per-node `Redis` clients it creates in `self.sentinels`, which previously had no public shutdown path and could leak pools (e.g. GC warnings in async tests).
> 
> Sync **`close()`** and async **`aclose()`** shut down every internal sentinel client and its pool. If one close fails, the rest still run and the first error is re-raised afterward. **`master_for` / `slave_for` clients are not closed**—callers still own those.
> 
> **Context manager support** (`with Sentinel(...)` / `async with Sentinel(...)`) calls `close()` / `aclose()` on exit, aligned with the main `Redis` client API.
> 
> Tests cover context-manager teardown, error propagation with full close attempts, and calling close twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30616fab405ed2952a6c100438637e734476cbe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->