### PR TITLE
test: add FT.SEARCH server-timeout coverage for return and fail policies

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 build
 build==1.2.2.post1 ; platform_python_implementation == "PyPy"
-click==8.0.4
+click==8.3.3
 invoke==2.2.0
 packaging>=20.4
 packaging==24.2 ; platform_python_implementation == "PyPy"

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -41,6 +41,7 @@ from tests.conftest import (
     expects_resp2_shape,
     expects_resp3_shape,
     expects_unified_shape,
+    get_protocol_version,
     skip_if_redis_enterprise,
     skip_if_resp_version,
     skip_if_server_version_gte,
@@ -173,6 +174,9 @@ class AsyncSearchTestsBase:
 
 
 class TestBaseSearchFunctionality(AsyncSearchTestsBase):
+    _SEARCH_TIMEOUT_DIM = 8192
+    _SEARCH_TIMEOUT_DOCS = 1500
+
     @pytest.mark.redismod
     async def test_client(self, decoded_r: redis.Redis):
         num_docs = 500
@@ -1172,6 +1176,106 @@ class TestBaseSearchFunctionality(AsyncSearchTestsBase):
         q2 = Query("foo").timeout("not_a_number")
         with pytest.raises(redis.ResponseError):
             await decoded_r.ft().search(q2)
+
+    async def _create_search_timeout_index(self, decoded_r: redis.Redis):
+        await decoded_r.ft().create_index(
+            (
+                TextField("description"),
+                VectorField(
+                    "embedding",
+                    "FLAT",
+                    {
+                        "TYPE": "FLOAT32",
+                        "DIM": self._SEARCH_TIMEOUT_DIM,
+                        "DISTANCE_METRIC": "L2",
+                    },
+                ),
+            ),
+            definition=IndexDefinition(prefix=["search-timeout-item:"]),
+        )
+        await AsyncSearchTestsBase.waitForIndex(decoded_r, "idx")
+
+    async def _add_data_for_search_timeout(self, decoded_r: redis.Redis):
+        vectors = [
+            np.full(self._SEARCH_TIMEOUT_DIM, value, dtype=np.float32).tobytes()
+            for value in (0.1, 0.2, 0.3, 0.4, 0.5)
+        ]
+        pipeline = decoded_r.pipeline()
+        batch_size = 250
+        for i in range(self._SEARCH_TIMEOUT_DOCS):
+            pipeline.hset(
+                f"search-timeout-item:{i}",
+                mapping={
+                    "description": "red shoes",
+                    "embedding": vectors[i % len(vectors)],
+                },
+            )
+            if (i + 1) % batch_size == 0:
+                await pipeline.execute()
+                pipeline = decoded_r.pipeline()
+        await pipeline.execute()
+
+    @pytest.mark.redismod
+    @pytest.mark.timeout(60)
+    async def test_search_query_with_timeout(self, decoded_r: redis.Redis):
+        await self._create_search_timeout_index(decoded_r)
+        await self._add_data_for_search_timeout(decoded_r)
+
+        query_vector = np.full(
+            self._SEARCH_TIMEOUT_DIM, 0.25, dtype=np.float32
+        ).tobytes()
+        query = Query(f"*=>[KNN {self._SEARCH_TIMEOUT_DOCS} @embedding $vec]").timeout(
+            1
+        )
+        res = await decoded_r.ft().search(query, query_params={"vec": query_vector})
+
+        if expects_resp3_shape(decoded_r):
+            warnings = res.get("warning", [])
+            total = res["total_results"]
+        else:
+            warnings = res.warnings
+            total = res.total
+
+        # A timed-out search still returns a well-formed (partial) result.
+        assert isinstance(total, int) and total >= 0
+
+        if int(get_protocol_version(decoded_r)) == 3:
+            # Only the RESP3 wire carries the server timeout warning.
+            assert any(
+                "Timeout limit was reached" in safe_str(warning) for warning in warnings
+            )
+        else:
+            # The RESP2 wire does not carry the warning field on FT.SEARCH.
+            assert warnings == []
+
+    @pytest.mark.redismod
+    @pytest.mark.timeout(60)
+    @skip_if_server_version_lt("8.9.0")
+    async def test_search_query_with_timeout_fail_policy(self, decoded_r: redis.Redis):
+        await self._create_search_timeout_index(decoded_r)
+        await self._add_data_for_search_timeout(decoded_r)
+
+        query_vector = np.full(
+            self._SEARCH_TIMEOUT_DIM, 0.25, dtype=np.float32
+        ).tobytes()
+        query = Query(f"*=>[KNN {self._SEARCH_TIMEOUT_DOCS} @embedding $vec]").timeout(
+            1
+        )
+
+        # ``search-on-timeout`` controls whether a timed-out query returns the
+        # partial results collected so far (``return``, the default) or fails
+        # the command (``fail``).  Capture the original value so it is always
+        # restored, even if the assertion below raises.
+        config = await decoded_r.config_get("search-on-timeout")
+        original = config["search-on-timeout"]
+        try:
+            assert await decoded_r.config_set("search-on-timeout", "fail")
+            # With the ``fail`` policy the server aborts the timed-out search
+            # instead of returning partial results.
+            with pytest.raises(redis.ResponseError):
+                await decoded_r.ft().search(query, query_params={"vec": query_vector})
+        finally:
+            await decoded_r.config_set("search-on-timeout", original)
 
     @pytest.mark.redismod
     @skip_if_resp_version(3)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -50,6 +50,7 @@ from .conftest import (
     expects_resp2_shape,
     expects_resp3_shape,
     expects_unified_shape,
+    get_protocol_version,
     skip_if_redis_enterprise,
     skip_if_resp_version,
     skip_if_server_version_gte,
@@ -197,6 +198,9 @@ class SearchTestsBase:
 
 
 class TestBaseSearchFunctionality(SearchTestsBase):
+    _SEARCH_TIMEOUT_DIM = 8192
+    _SEARCH_TIMEOUT_DOCS = 1500
+
     @pytest.mark.redismod
     def test_client(self, client):
         num_docs = 500
@@ -1515,6 +1519,105 @@ class TestBaseSearchFunctionality(SearchTestsBase):
         q2 = Query("foo").timeout("not_a_number")
         with pytest.raises(redis.ResponseError):
             r.ft().search(q2)
+
+    def _create_search_timeout_index(self, client):
+        client.ft().create_index(
+            (
+                TextField("description"),
+                VectorField(
+                    "embedding",
+                    "FLAT",
+                    {
+                        "TYPE": "FLOAT32",
+                        "DIM": self._SEARCH_TIMEOUT_DIM,
+                        "DISTANCE_METRIC": "L2",
+                    },
+                ),
+            ),
+            definition=IndexDefinition(prefix=["search-timeout-item:"]),
+        )
+        SearchTestsBase.waitForIndex(client, "idx")
+
+    def _add_data_for_search_timeout(self, client):
+        vectors = [
+            np.full(self._SEARCH_TIMEOUT_DIM, value, dtype=np.float32).tobytes()
+            for value in (0.1, 0.2, 0.3, 0.4, 0.5)
+        ]
+        pipeline = client.pipeline()
+        batch_size = 250
+        for i in range(self._SEARCH_TIMEOUT_DOCS):
+            pipeline.hset(
+                f"search-timeout-item:{i}",
+                mapping={
+                    "description": "red shoes",
+                    "embedding": vectors[i % len(vectors)],
+                },
+            )
+            if (i + 1) % batch_size == 0:
+                pipeline.execute()
+                pipeline = client.pipeline()
+        pipeline.execute()
+
+    @pytest.mark.redismod
+    @pytest.mark.timeout(60)
+    def test_search_query_with_timeout(self, client):
+        self._create_search_timeout_index(client)
+        self._add_data_for_search_timeout(client)
+
+        query_vector = np.full(
+            self._SEARCH_TIMEOUT_DIM, 0.25, dtype=np.float32
+        ).tobytes()
+        query = Query(f"*=>[KNN {self._SEARCH_TIMEOUT_DOCS} @embedding $vec]").timeout(
+            1
+        )
+        res = client.ft().search(query, query_params={"vec": query_vector})
+
+        if expects_resp3_shape(client):
+            warnings = res.get("warning", [])
+            total = res["total_results"]
+        else:
+            warnings = res.warnings
+            total = res.total
+
+        # A timed-out search still returns a well-formed (partial) result.
+        assert isinstance(total, int) and total >= 0
+
+        if int(get_protocol_version(client)) == 3:
+            # Only the RESP3 wire carries the server timeout warning.
+            assert any(
+                "Timeout limit was reached" in safe_str(warning) for warning in warnings
+            )
+        else:
+            # The RESP2 wire does not carry the warning field on FT.SEARCH.
+            assert warnings == []
+
+    @pytest.mark.redismod
+    @pytest.mark.timeout(60)
+    @skip_if_server_version_lt("8.9.0")
+    def test_search_query_with_timeout_fail_policy(self, client):
+        self._create_search_timeout_index(client)
+        self._add_data_for_search_timeout(client)
+
+        query_vector = np.full(
+            self._SEARCH_TIMEOUT_DIM, 0.25, dtype=np.float32
+        ).tobytes()
+        query = Query(f"*=>[KNN {self._SEARCH_TIMEOUT_DOCS} @embedding $vec]").timeout(
+            1
+        )
+
+        # ``search-on-timeout`` controls whether a timed-out query returns the
+        # partial results collected so far (``return``, the default) or fails
+        # the command (``fail``).  Capture the original value so it is always
+        # restored, even if the assertion below raises.
+        original = client.config_get("search-on-timeout")["search-on-timeout"]
+        try:
+            assert client.config_set("search-on-timeout", "fail")
+            # With the ``fail`` policy the server aborts the timed-out search
+            # instead of returning partial results.
+            with pytest.raises(redis.ResponseError):
+                client.ft().search(query, query_params={"vec": query_vector})
+        finally:
+            client.config_set("search-on-timeout", original)
 
     @pytest.mark.redismod
     @skip_if_server_version_lt("7.2.0")


### PR DESCRIPTION
## Change summary

This pull request adds integration test coverage for `FT.SEARCH` server-side
timeout behaviour, which was previously untested end-to-end — the existing
`test_query_timeout` only checked argument encoding and the error for a
non-numeric timeout, never triggering a real timeout or inspecting the result.
The new tests mirror the existing `test_hybrid_search_query_with_timeout` pattern
for the plain search command.

Two tests are added to `TestBaseSearchFunctionality` in both `tests/test_search.py`
and `tests/test_asyncio/test_search.py`, backed by two small private helpers
(`_create_search_timeout_index` / `_add_data_for_search_timeout`) and class
constants (`_SEARCH_TIMEOUT_DIM = 8192`, `_SEARCH_TIMEOUT_DOCS = 1500`). The
helpers build a large FLAT vector index and bulk-load 1500 documents so a
`KNN 1500` query with `Query(...).timeout(1)` (1 ms) reliably exceeds the limit.

- `test_search_query_with_timeout` exercises the default `return` policy: the
  server returns partial results plus a timeout warning. Assertions are shape-
  and wire-aware — under `expects_resp3_shape` the raw RESP3 dict is read
  (`res["total_results"]`, `res.get("warning", [])`), otherwise the `Result`
  object (`res.total`, `res.warnings`). The `"Timeout limit was reached"` warning
  is only carried on the RESP3 wire, so it is asserted when
  `int(get_protocol_version(...)) == 3` (the `int()` normalizes a pinned
  `--protocol=3`, which arrives as the string `"3"`) and asserted empty on the
  RESP2 wire.
- `test_search_query_with_timeout_fail_policy` sets the new `search-on-timeout`
  policy to `fail` via native `config_set` (FT.CONFIG is removed at 7.9.0+) and
  asserts the timed-out search raises `redis.ResponseError`. It captures the
  original config value and restores it in a `finally` block so global server
  state is always reverted, and is guarded by `@skip_if_server_version_lt("8.9.0")`
  since that is the first server exposing the policy.

This is a tests-only change with no runtime or public-API impact, and the sync
and async stacks are kept fully in parity. A new `get_protocol_version` import is
added to both test modules' `conftest` import blocks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only plus a dev dependency pin bump; no production code or client API changes.
> 
> **Overview**
> Adds **end-to-end integration tests** for `FT.SEARCH` when `Query(...).timeout()` actually fires on the server, complementing the existing tests that only check query argument encoding.
> 
> In both sync and async `TestBaseSearchFunctionality`, new helpers build a large FLAT vector index (8192-dim, 1500 docs) and run a heavy `KNN` query with a **1 ms** timeout so the server reliably hits the limit. **`test_search_query_with_timeout`** checks the default **`return`** behavior: partial results with a valid total, and the `"Timeout limit was reached"` warning **only on RESP3** (via `get_protocol_version`). **`test_search_query_with_timeout_fail_policy`** (Redis **≥ 8.9.0**) temporarily sets `search-on-timeout` to **`fail`** with `config_set` and expects `ResponseError`, restoring the prior value in `finally`.
> 
> Also bumps **`click`** in `dev_requirements.txt` from 8.0.4 to 8.3.3. No library or public API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c7c65f8e74b043bb8db9ee59c79be93536c9e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->