### PR TITLE
feat: add exclude_empty (EXCLUDEEMPTY) option to TS.MRANGE and TS.MREVRANGE

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.8.0'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.10:custom-28772936538-debian
+    8.10:unstable-29211243717-debian
 
 jobs:
   dependency-audit:

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -1392,6 +1392,7 @@ class TimeSeriesCommands:
         latest: bool | None,
         bucket_timestamp: str | None,
         empty: bool | None,
+        exclude_empty: bool | None,
     ):
         """Create TS.MRANGE and TS.MREVRANGE arguments."""
         if (
@@ -1402,6 +1403,8 @@ class TimeSeriesCommands:
             raise DataError(
                 "GROUPBY is not allowed when multiple aggregators are specified"
             )
+        if exclude_empty and groupby is not None:
+            raise DataError("EXCLUDEEMPTY is not allowed with GROUPBY")
         params: list[EncodableT] = [from_time, to_time]
         self._append_latest(params, latest)
         self._append_filer_by_ts(params, filter_by_ts)
@@ -1412,6 +1415,7 @@ class TimeSeriesCommands:
         self._append_aggregation(params, aggregation_type, bucket_size_msec)
         self._append_bucket_timestamp(params, bucket_timestamp)
         self._append_empty(params, empty)
+        self._append_exclude_empty(params, exclude_empty)
         params.extend(["FILTER"])
         params += filters
         self._append_groupby_reduce(params, groupby, reduce)
@@ -1437,6 +1441,7 @@ class TimeSeriesCommands:
         latest: bool | None = False,
         bucket_timestamp: str | None = None,
         empty: bool | None = False,
+        exclude_empty: bool | None = False,
     ) -> TimeSeriesMRangeResponse: ...
 
     @overload
@@ -1459,6 +1464,7 @@ class TimeSeriesCommands:
         latest: bool | None = False,
         bucket_timestamp: str | None = None,
         empty: bool | None = False,
+        exclude_empty: bool | None = False,
     ) -> Awaitable[TimeSeriesMRangeResponse]: ...
 
     def mrange(
@@ -1480,6 +1486,7 @@ class TimeSeriesCommands:
         latest: bool | None = False,
         bucket_timestamp: str | None = None,
         empty: bool | None = False,
+        exclude_empty: bool | None = False,
     ) -> TimeSeriesMRangeResponse | Awaitable[TimeSeriesMRangeResponse]:
         """
         Query a range across multiple time-series by filters in forward direction.
@@ -1536,6 +1543,9 @@ class TimeSeriesCommands:
                 `+`, `high`, `~`, `mid`].
             empty:
                 Reports aggregations for empty buckets.
+            exclude_empty:
+                Omit matching series whose reported samples array is empty for the
+                queried range and options. Must not be combined with `groupby`.
         """
         params = self.__mrange_params(
             aggregation_type,
@@ -1555,6 +1565,7 @@ class TimeSeriesCommands:
             latest,
             bucket_timestamp,
             empty,
+            exclude_empty,
         )
 
         return self.execute_command(
@@ -1581,6 +1592,7 @@ class TimeSeriesCommands:
         latest: bool | None = False,
         bucket_timestamp: str | None = None,
         empty: bool | None = False,
+        exclude_empty: bool | None = False,
     ) -> TimeSeriesMRangeResponse: ...
 
     @overload
@@ -1603,6 +1615,7 @@ class TimeSeriesCommands:
         latest: bool | None = False,
         bucket_timestamp: str | None = None,
         empty: bool | None = False,
+        exclude_empty: bool | None = False,
     ) -> Awaitable[TimeSeriesMRangeResponse]: ...
 
     def mrevrange(
@@ -1624,6 +1637,7 @@ class TimeSeriesCommands:
         latest: bool | None = False,
         bucket_timestamp: str | None = None,
         empty: bool | None = False,
+        exclude_empty: bool | None = False,
     ) -> TimeSeriesMRangeResponse | Awaitable[TimeSeriesMRangeResponse]:
         """
         Query a range across multiple time-series by filters in reverse direction.
@@ -1680,6 +1694,9 @@ class TimeSeriesCommands:
                 `+`, `high`, `~`, `mid`].
             empty:
                 Reports aggregations for empty buckets.
+            exclude_empty:
+                Omit matching series whose reported samples array is empty for the
+                queried range and options. Must not be combined with `groupby`.
         """
         params = self.__mrange_params(
             aggregation_type,
@@ -1699,6 +1716,7 @@ class TimeSeriesCommands:
             latest,
             bucket_timestamp,
             empty,
+            exclude_empty,
         )
 
         return self.execute_command(
@@ -2009,6 +2027,12 @@ class TimeSeriesCommands:
         """Append EMPTY property to params."""
         if empty:
             params.append("EMPTY")
+
+    @staticmethod
+    def _append_exclude_empty(params: list[EncodableT], exclude_empty: bool | None):
+        """Append EXCLUDEEMPTY property to params."""
+        if exclude_empty:
+            params.append("EXCLUDEEMPTY")
 
     @staticmethod
     def _append_insertion_filters(

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -515,6 +515,130 @@ async def test_multi_range(decoded_r: redis.Redis):
         assert {"Test": "This", "team": "ny"} == res[KEY1][0]
 
 
+def _mrange_returned_keys(decoded_r, res):
+    """Return the set of series key names in a TS.MRANGE/MREVRANGE reply,
+    normalizing the RESP2 (list of single-key dicts) and RESP3/unified
+    (dict keyed by name) shapes."""
+    if expects_resp2_shape(decoded_r):
+        return {next(iter(entry)) for entry in res}
+    return set(res.keys())
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_mrange_exclude_empty(decoded_r: redis.Redis):
+    await decoded_r.ts().create("s", labels={"sensor": "1", "type": "demo"})
+    await decoded_r.ts().create("t", labels={"sensor": "1", "type": "demo"})
+    await decoded_r.ts().create("u", labels={"sensor": "1", "type": "demo"})
+    await decoded_r.ts().madd(
+        [
+            ("s", 100, 100),
+            ("t", 100, 100),
+            ("s", 200, 200),
+            ("t", 300, 300),
+            ("s", 400, 400),
+            ("t", 400, 400),
+            ("u", 2000, 2000),
+        ]
+    )
+
+    # Without EXCLUDEEMPTY, "u" matches the filter but has no samples in range.
+    res = await decoded_r.ts().mrange("-", 500, filters=["sensor=1"])
+    assert {"s", "t", "u"} == _mrange_returned_keys(decoded_r, res)
+
+    # With EXCLUDEEMPTY, "u" is omitted from the top-level reply.
+    res = await decoded_r.ts().mrange(
+        "-", 500, filters=["sensor=1"], exclude_empty=True
+    )
+    assert {"s", "t"} == _mrange_returned_keys(decoded_r, res)
+
+    # Composing with WITHLABELS should not change the exclusion behavior.
+    res = await decoded_r.ts().mrange(
+        "-", 500, filters=["sensor=1"], with_labels=True, exclude_empty=True
+    )
+    assert {"s", "t"} == _mrange_returned_keys(decoded_r, res)
+
+    # Composing with AGGREGATION should still omit the empty series.
+    res = await decoded_r.ts().mrange(
+        "-",
+        500,
+        filters=["sensor=1"],
+        aggregation_type="min",
+        bucket_size_msec=100,
+        exclude_empty=True,
+    )
+    assert {"s", "t"} == _mrange_returned_keys(decoded_r, res)
+
+    # When every matching series is empty, no series is reported (an empty
+    # top-level reply; shape is [] in RESP2 and {} in RESP3).
+    res = await decoded_r.ts().mrange(1, 50, filters=["sensor=1"], exclude_empty=True)
+    assert 0 == len(res)
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_mrevrange_exclude_empty(decoded_r: redis.Redis):
+    await decoded_r.ts().create("s", labels={"sensor": "1", "type": "demo"})
+    await decoded_r.ts().create("t", labels={"sensor": "1", "type": "demo"})
+    await decoded_r.ts().create("u", labels={"sensor": "1", "type": "demo"})
+    await decoded_r.ts().madd(
+        [
+            ("s", 100, 100),
+            ("t", 100, 100),
+            ("s", 200, 200),
+            ("t", 300, 300),
+            ("s", 400, 400),
+            ("t", 400, 400),
+            ("u", 2000, 2000),
+        ]
+    )
+
+    res = await decoded_r.ts().mrevrange("-", 500, filters=["sensor=1"])
+    assert {"s", "t", "u"} == _mrange_returned_keys(decoded_r, res)
+
+    res = await decoded_r.ts().mrevrange(
+        "-", 500, filters=["sensor=1"], exclude_empty=True
+    )
+    assert {"s", "t"} == _mrange_returned_keys(decoded_r, res)
+
+    # All matching series empty -> empty top-level reply ([] in RESP2, {} in RESP3).
+    res = await decoded_r.ts().mrevrange(
+        1, 50, filters=["sensor=1"], exclude_empty=True
+    )
+    assert 0 == len(res)
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+async def test_mrange_exclude_empty_with_groupby_raises(decoded_r: redis.Redis):
+    # EXCLUDEEMPTY is mutually exclusive with GROUPBY. This is validated
+    # client-side, so it does not require server support.
+    with pytest.raises(
+        redis.DataError, match="EXCLUDEEMPTY is not allowed with GROUPBY"
+    ):
+        await decoded_r.ts().mrange(
+            "-",
+            500,
+            filters=["sensor=1"],
+            groupby="type",
+            reduce="max",
+            exclude_empty=True,
+        )
+    with pytest.raises(
+        redis.DataError, match="EXCLUDEEMPTY is not allowed with GROUPBY"
+    ):
+        await decoded_r.ts().mrevrange(
+            "-",
+            500,
+            filters=["sensor=1"],
+            groupby="type",
+            reduce="max",
+            exclude_empty=True,
+        )
+
+
 @pytest.mark.onlynoncluster
 @pytest.mark.redismod
 @skip_ifmodversion_lt("1.10.0", "timeseries")

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -686,6 +686,124 @@ def test_mrange(client):
         assert {"Test": "This", "team": "ny"} == res["1"][0]
 
 
+def _mrange_returned_keys(client, res):
+    """Return the set of series key names in a TS.MRANGE/MREVRANGE reply,
+    normalizing the RESP2 (list of single-key dicts) and RESP3/unified
+    (dict keyed by name) shapes."""
+    if expects_resp2_shape(client):
+        return {next(iter(entry)) for entry in res}
+    return set(res.keys())
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_mrange_exclude_empty(client):
+    client.ts().create("s", labels={"sensor": "1", "type": "demo"})
+    client.ts().create("t", labels={"sensor": "1", "type": "demo"})
+    client.ts().create("u", labels={"sensor": "1", "type": "demo"})
+    client.ts().madd(
+        [
+            ("s", 100, 100),
+            ("t", 100, 100),
+            ("s", 200, 200),
+            ("t", 300, 300),
+            ("s", 400, 400),
+            ("t", 400, 400),
+            ("u", 2000, 2000),
+        ]
+    )
+
+    # Without EXCLUDEEMPTY, "u" matches the filter but has no samples in range.
+    res = client.ts().mrange("-", 500, filters=["sensor=1"])
+    assert {"s", "t", "u"} == _mrange_returned_keys(client, res)
+
+    # With EXCLUDEEMPTY, "u" is omitted from the top-level reply.
+    res = client.ts().mrange("-", 500, filters=["sensor=1"], exclude_empty=True)
+    assert {"s", "t"} == _mrange_returned_keys(client, res)
+
+    # Composing with WITHLABELS should not change the exclusion behavior.
+    res = client.ts().mrange(
+        "-", 500, filters=["sensor=1"], with_labels=True, exclude_empty=True
+    )
+    assert {"s", "t"} == _mrange_returned_keys(client, res)
+
+    # Composing with AGGREGATION should still omit the empty series.
+    res = client.ts().mrange(
+        "-",
+        500,
+        filters=["sensor=1"],
+        aggregation_type="min",
+        bucket_size_msec=100,
+        exclude_empty=True,
+    )
+    assert {"s", "t"} == _mrange_returned_keys(client, res)
+
+    # When every matching series is empty, no series is reported (an empty
+    # top-level reply; shape is [] in RESP2 and {} in RESP3).
+    res = client.ts().mrange(1, 50, filters=["sensor=1"], exclude_empty=True)
+    assert 0 == len(res)
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+def test_mrevrange_exclude_empty(client):
+    client.ts().create("s", labels={"sensor": "1", "type": "demo"})
+    client.ts().create("t", labels={"sensor": "1", "type": "demo"})
+    client.ts().create("u", labels={"sensor": "1", "type": "demo"})
+    client.ts().madd(
+        [
+            ("s", 100, 100),
+            ("t", 100, 100),
+            ("s", 200, 200),
+            ("t", 300, 300),
+            ("s", 400, 400),
+            ("t", 400, 400),
+            ("u", 2000, 2000),
+        ]
+    )
+
+    res = client.ts().mrevrange("-", 500, filters=["sensor=1"])
+    assert {"s", "t", "u"} == _mrange_returned_keys(client, res)
+
+    res = client.ts().mrevrange("-", 500, filters=["sensor=1"], exclude_empty=True)
+    assert {"s", "t"} == _mrange_returned_keys(client, res)
+
+    # All matching series empty -> empty top-level reply ([] in RESP2, {} in RESP3).
+    res = client.ts().mrevrange(1, 50, filters=["sensor=1"], exclude_empty=True)
+    assert 0 == len(res)
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+def test_mrange_exclude_empty_with_groupby_raises(client):
+    # EXCLUDEEMPTY is mutually exclusive with GROUPBY. This is validated
+    # client-side, so it does not require server support.
+    with pytest.raises(
+        redis.DataError, match="EXCLUDEEMPTY is not allowed with GROUPBY"
+    ):
+        client.ts().mrange(
+            "-",
+            500,
+            filters=["sensor=1"],
+            groupby="type",
+            reduce="max",
+            exclude_empty=True,
+        )
+    with pytest.raises(
+        redis.DataError, match="EXCLUDEEMPTY is not allowed with GROUPBY"
+    ):
+        client.ts().mrevrange(
+            "-",
+            500,
+            filters=["sensor=1"],
+            groupby="type",
+            reduce="max",
+            exclude_empty=True,
+        )
+
+
 @pytest.mark.onlynoncluster
 @pytest.mark.redismod
 @skip_ifmodversion_lt("1.10.0", "timeseries")


### PR DESCRIPTION

## Change summary

This pull request adds support for the `EXCLUDEEMPTY` option to the `TS.MRANGE`
and `TS.MREVRANGE` time-series commands via a new `exclude_empty` keyword
argument on `mrange()` and `mrevrange()`. When set, matching series whose
reported samples array is empty for the queried range and options are omitted
from the top-level reply, letting callers filter out series that match the
label filters but contribute no data in the requested window.

The change is implemented entirely in `redis/commands/timeseries/commands.py`.
A new `exclude_empty` parameter is threaded through the private
`__mrange_params` builder and all four public overloads (sync and async, for
both `mrange` and `mrevrange`), defaulting to `False` to preserve current
behavior. A small `_append_exclude_empty` static helper appends the
`EXCLUDEEMPTY` token, mirroring the existing `_append_empty` helper. Docstrings
for both commands document the new option and its constraint. Because
`TimeSeriesCommands` is shared by the sync and async clients, this single mixin
change covers both stacks, so sync/async parity is maintained.

`EXCLUDEEMPTY` is mutually exclusive with `GROUPBY`, so the builder raises
`DataError("EXCLUDEEMPTY is not allowed with GROUPBY")` when both are supplied;
this is validated client-side and does not require server support. The new
argument is keyword-only in practice and additive with a `False` default, so
there is no backward-compatibility impact on existing callers or return types.
The CI integration workflow is also updated to point the `8.10` custom Redis
image at the `unstable-29211243717-debian` build, which provides the server-side
support this option depends on.

## Test coverage

New tests are added to both `tests/test_timeseries.py` and
`tests/test_asyncio/test_timeseries.py`. `test_mrange_exclude_empty` and
`test_mrevrange_exclude_empty` verify that a series matching the filter but
empty in range is included without the option and omitted with `exclude_empty=True`,
and that the behavior composes correctly with `WITHLABELS` and `AGGREGATION`,
and yields an empty top-level reply when all matching series are empty.
A shared `_mrange_returned_keys` helper normalizes the RESP2 (list of single-key dicts)
and RESP3/unified (dict keyed by name) reply shapes so the assertions hold under both protocols.

`test_mrange_exclude_empty_with_groupby_raises` exercises the client-side
validation, asserting that combining `exclude_empty=True` with `groupby`/`reduce`
raises `DataError` for both `mrange` and `mrevrange`; it needs no server support
and is therefore not version-gated.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API with default off; risk is mainly callers on older Redis without EXCLUDEEMPTY support when they opt in.
> 
> **Overview**
> Adds **`exclude_empty`** on **`mrange()`** and **`mrevrange()`**, mapping to the server **`EXCLUDEEMPTY`** flag so label-matched series with no samples in the requested window are dropped from the reply. Default **`False`** keeps prior behavior.
> 
> Client-side **`DataError`** is raised when **`exclude_empty`** is combined with **`groupby`**. Sync/async tests cover exclusion, composition with labels/aggregation, and the GROUPBY guard; CI points the **8.10** matrix image at an unstable build that implements the server option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b7aad6b28c77a369b10ba468cc8220d86984b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->