### PR TITLE
Fix Sentinel pool capacity loss after failover

### DIFF
--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3301,10 +3301,11 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
             else:
                 # Pool doesn't own this connection, do not add it back
                 # to the pool.
-                # The created connections count should not be changed,
-                # because the connection was not created by the pool.
                 # Still need to decrement USED since it was counted in get_connection()
                 connection.disconnect()
+                # Subclasses can reject a connection created by this pool.
+                if connection.pid == self.pid:
+                    self._created_connections -= 1
                 record_connection_count(
                     pool_name="unknown_pool",
                     connection_state=ConnectionState.USED,

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3303,7 +3303,10 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
                 # to the pool.
                 # Still need to decrement USED since it was counted in get_connection()
                 connection.disconnect()
-                # Subclasses can reject a connection created by this pool.
+                # Subclasses such as SentinelConnectionPool can override
+                # owns_connection() with a comparison different from local PID
+                # ownership. When such a subclass rejects a connection, also require
+                # connection.pid == self.pid before reclaiming its slot.
                 if connection.pid == self.pid:
                     self._created_connections -= 1
                 record_connection_count(

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,3 +1,4 @@
+import os
 import socket
 from unittest import mock
 
@@ -257,6 +258,46 @@ def test_slave_round_robin(cluster, sentinel, master_ip):
     assert next(rotator) == (master_ip, 6379)
     with pytest.raises(SlaveNotFoundError):
         next(rotator)
+
+
+@pytest.mark.onlynoncluster
+def test_master_failover_reclaims_discarded_connection_slot():
+    master_a = ("master-a", 6379)
+    master_b = ("master-b", 6379)
+
+    class FakeConnection:
+        def __init__(self, **kwargs):
+            self.host, self.port = master_a
+            self.pid = os.getpid()
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+        def can_read(self, timeout=0):
+            return False
+
+        def should_reconnect(self):
+            return False
+
+    pool = SentinelConnectionPool(
+        "mymaster",
+        mock.MagicMock(),
+        connection_class=FakeConnection,
+        max_connections=2,
+    )
+    pool.proxy.master_address = master_a
+
+    for _ in range(pool.max_connections):
+        connection = pool.get_connection()
+        pool.proxy.master_address = master_b
+        pool.release(connection)
+        pool.proxy.master_address = master_a
+
+    assert pool._created_connections == 0
+    pool.get_connection()
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -260,6 +260,7 @@ def test_slave_round_robin(cluster, sentinel, master_ip):
         next(rotator)
 
 
+@pytest.mark.fixed_client
 @pytest.mark.onlynoncluster
 def test_master_failover_reclaims_discarded_connection_slot():
     master_a = ("master-a", 6379)


### PR DESCRIPTION
### Description of change

Fixes #4187. During a Sentinel master failover, the sync pool can reject an in-flight connection it originally created, but releasing it did not restore `_created_connections`, permanently consuming capacity. The pool now reclaims that slot only for connections created in its current process, and the regression test fails before the fix and passes after it.

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)? (Pending upstream CI.)
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (Not applicable; no API change.)
- [x] Is there an example added to the examples folder (if applicable)? (Not applicable.)

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to sync `ConnectionPool.release()` for the non-owned-connection path; guarded by PID check to avoid incorrect decrements after fork.
> 
> **Overview**
> Fixes **permanent connection pool shrink** after Sentinel master failover (#4187). When `SentinelConnectionPool` rejects a connection on `release()` because it no longer points at the current master, the pool now decrements `_created_connections` (guarded by `connection.pid == self.pid`) so the slot is not lost forever.
> 
> Adds **`test_master_failover_reclaims_discarded_connection_slot`**, which simulates failover between two master addresses and asserts the pool can still allocate connections after repeated get/release cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72581ec6974b3df32eca473e2d24042a57ee7698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->