### PR TITLE
fix: add missing type annotations to LockError and RedisClusterException

### DIFF
--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -110,7 +110,9 @@ class LockError(RedisError, ValueError):
     # NOTE: For backwards compatibility, this class derives from ValueError.
     # This was originally chosen to behave like threading.Lock.
 
-    def __init__(self, message=None, lock_name=None):
+    def __init__(
+        self, message: str | None = None, lock_name: str | None = None
+    ) -> None:
         super().__init__(message)
         self.message = message
         self.lock_name = lock_name
@@ -144,7 +146,7 @@ class RedisClusterException(Exception):
     Base exception for the RedisCluster client
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args: object) -> None:
         super().__init__(*args)
         self.error_type = ExceptionType.SERVER
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,45 @@
+from redis.exceptions import (
+    CrossSlotTransactionError,
+    InvalidPipelineStack,
+    LockError,
+    LockNotOwnedError,
+    RedisClusterException,
+    SlotNotCoveredError,
+)
+
+
+class TestLockError:
+    def test_defaults(self):
+        err = LockError()
+        assert err.message is None
+        assert err.lock_name is None
+        assert err.args == (None,)
+
+    def test_with_message_and_lock_name(self):
+        err = LockError("lock is not owned", "my-lock")
+        assert err.message == "lock is not owned"
+        assert err.lock_name == "my-lock"
+        assert err.args == ("lock is not owned",)
+
+    def test_is_value_error(self):
+        assert isinstance(LockError(), ValueError)
+
+    def test_lock_not_owned_error_inherits_lock_error(self):
+        err = LockNotOwnedError("not owned", "my-lock")
+        assert isinstance(err, LockError)
+        assert err.message == "not owned"
+        assert err.lock_name == "my-lock"
+
+
+class TestRedisClusterException:
+    def test_sets_error_type_and_args(self):
+        err = RedisClusterException("boom")
+        assert err.args == ("boom",)
+        assert repr(err) == "server:RedisClusterException"
+
+    def test_subclasses_construct(self):
+        assert SlotNotCoveredError("no node covers slot").args == (
+            "no node covers slot",
+        )
+        assert CrossSlotTransactionError("cross slot").args == ("cross slot",)
+        assert InvalidPipelineStack("bad stack").args == ("bad stack",)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from redis.exceptions import (
     CrossSlotTransactionError,
     InvalidPipelineStack,
@@ -6,6 +8,8 @@ from redis.exceptions import (
     RedisClusterException,
     SlotNotCoveredError,
 )
+
+pytestmark = pytest.mark.fixed_client
 
 
 class TestLockError:


### PR DESCRIPTION
## Summary
- `LockError.__init__` and `RedisClusterException.__init__` had zero type annotations, even though the package ships `py.typed`. Consumers running mypy with `disallow-untyped-calls` (or `--strict`) hit `error: Call to untyped function ... [no-untyped-call]` when constructing these (or their subclasses).
- Annotated both constructors to match the pattern already used elsewhere in `redis/exceptions.py` (e.g. `RedisError.__init__`).
- This transitively fixes the same gap for subclasses that inherit these constructors without overriding them: `LockNotOwnedError`, `SlotNotCoveredError`, `CrossSlotTransactionError`, and `InvalidPipelineStack`.
- `ChildDeadlockedError` and `IncorrectPolicyType` (also mentioned in the issue) subclass `Exception` directly with no override, and `BaseException.__init__` is already fully typed in typeshed — no change needed there.
- Pure annotation addition: no parameters added/removed/renamed, no default values changed, no runtime behavior change.

Fixes #4192

## Test plan
- [x] Added `tests/test_exceptions.py` covering construction and attribute behavior of `LockError`, `LockNotOwnedError`, `RedisClusterException`, `SlotNotCoveredError`, `CrossSlotTransactionError`, and `InvalidPipelineStack` (all pass).
- [x] `ruff check` / `ruff format --check` pass on the changed files.
- [x] `vulture redis/exceptions.py whitelist.py --min-confidence 80` shows no new findings (one pre-existing, unrelated finding on `TryAgainError`).
- [x] Verified with `mypy --disallow-untyped-calls`: 13 pre-existing, unrelated errors (implicit-Optional on `status_code` params) present before and after this change — same count, confirming no new errors introduced and the two touched constructors are no longer reported as untyped calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes to exception constructors plus new unit tests; no call-site or runtime logic changes.
> 
> **Overview**
> Adds explicit type hints to **`LockError.__init__`** (`message` / `lock_name` as optional `str`, `-> None`) and **`RedisClusterException.__init__`** (`*args: object`, `-> None`) so strict mypy consumers no longer hit untyped-call errors when constructing these exceptions or subclasses that reuse those constructors.
> 
> Introduces **`tests/test_exceptions.py`** to lock in construction, `message` / `lock_name` / `args`, `ValueError` inheritance for `LockError`, and `repr` / subclass behavior for cluster-related exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2fa90a7051965321928a89b1387ffddbbdaa4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->