### PR TITLE
fix: Restore NEVER_DECODE option for FT.SEARCH with protocol=3

### DIFF
--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -111,11 +111,13 @@ class SearchCommands:
             SYNDUMP_CMD: self._parse_syndump,
         }
         # Explicit ``protocol=3`` + ``legacy_responses=True`` keeps the
-        # pre-existing native RESP3 surface.  The only registered callback
-        # is for experimental HYBRID, which normalizes the native shape.
-        # FT.PROFILE stays on the old direct ``_parse_results`` special
-        # case and is not registered as a response callback.
+        # pre-existing native RESP3 surface.  SEARCH and HYBRID both use
+        # ``NEVER_DECODE`` (their results may contain binary field values),
+        # so their native callbacks decode only the structural keys and keep
+        # field values as bytes.  FT.PROFILE stays on the old direct
+        # ``_parse_results`` special case and is not registered as a callback.
         self._RESP3_MODULE_CALLBACKS = {
+            SEARCH_CMD: self._parse_search_resp3_native,
             HYBRID_CMD: self._parse_hybrid_search_resp3_native,
         }
         # ``protocol=None`` + ``legacy_responses=True`` (the v8 default):
@@ -480,6 +482,45 @@ class SearchCommands:
             with_scores=getattr(query, "_with_scores", False),
             field_encodings=getattr(query, "_return_fields_decode_as", None),
         )
+
+    def _parse_search_resp3_native(self, res, **kwargs):
+        """Normalise the RESP3 FT.SEARCH map while preserving its native shape.
+
+        ``protocol=3`` + ``legacy_responses=True`` keeps the RESP3 dict
+        surface.  FT.SEARCH uses ``NEVER_DECODE`` (its results may contain
+        binary field values such as vector embeddings), so the wire hands
+        back raw bytes.  Decode the structural keys and the field values here
+        instead of at the wire: text values are decoded leniently while
+        binary fields flagged via ``return_field(..., decode_field=False)``
+        are preserved as raw bytes.  This keeps the previously decoded native
+        surface intact and no longer crashes on non-UTF-8 field data.
+        """
+        if not isinstance(res, dict):
+            return res
+        query = kwargs.get("query")
+        field_encodings = getattr(query, "_return_fields_decode_as", None)
+        res = {str_if_bytes(k): v for k, v in res.items()}
+        if "results" in res:
+            results = []
+            for item in res["results"]:
+                if not isinstance(item, dict):
+                    results.append(item)
+                    continue
+                item = {str_if_bytes(k): v for k, v in item.items()}
+                if "id" in item:
+                    item["id"] = str_if_bytes(item["id"])
+                extra = item.get("extra_attributes")
+                if isinstance(extra, dict):
+                    decoded = {}
+                    for k, v in extra.items():
+                        k = str_if_bytes(k)
+                        decoded[k] = decode_field_value(v, k, field_encodings)
+                    item["extra_attributes"] = decoded
+                results.append(item)
+            res["results"] = results
+        if "warning" in res:
+            res["warning"] = [str_if_bytes(w) for w in res["warning"]]
+        return res
 
     def _parse_aggregate_resp3(self, res, **kwargs):
         """Parse RESP3 FT.AGGREGATE response into an AggregateResult object."""
@@ -1267,9 +1308,10 @@ class SearchCommands:
         args, query = self._mk_query_args(query, query_params=query_params)
         st = time.monotonic()
 
-        options = {}
-        if not check_protocol_version(get_protocol_version(self.client), 3):
-            options[NEVER_DECODE] = True
+        # FT.SEARCH results may contain binary field values (e.g. vector
+        # embeddings), so always request raw bytes from the wire and let the
+        # search-layer parsers decode per-field.  Mirrors ``hybrid_search``.
+        options = {NEVER_DECODE: True}
         if isinstance(self, Pipeline):
             options["query"] = query
             options["duration"] = 0
@@ -1771,9 +1813,10 @@ class AsyncSearchCommands(SearchCommands):
         args, query = self._mk_query_args(query, query_params=query_params)
         st = time.monotonic()
 
-        options = {}
-        if not check_protocol_version(get_protocol_version(self.client), 3):
-            options[NEVER_DECODE] = True
+        # FT.SEARCH results may contain binary field values (e.g. vector
+        # embeddings), so always request raw bytes from the wire and let the
+        # search-layer parsers decode per-field.  Mirrors ``hybrid_search``.
+        options = {NEVER_DECODE: True}
         if isinstance(self, Pipeline):
             options["query"] = query
             options["duration"] = 0

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -43,7 +43,6 @@ from tests.conftest import (
     expects_unified_shape,
     get_protocol_version,
     skip_if_redis_enterprise,
-    skip_if_resp_version,
     skip_if_server_version_gte,
     skip_if_server_version_lt,
     skip_ifmodversion_lt,
@@ -1278,7 +1277,6 @@ class TestBaseSearchFunctionality(AsyncSearchTestsBase):
             await decoded_r.config_set("search-on-timeout", original)
 
     @pytest.mark.redismod
-    @skip_if_resp_version(3)
     async def test_binary_and_text_fields(self, decoded_r: redis.Redis):
         fake_vec = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
 
@@ -1313,23 +1311,27 @@ class TestBaseSearchFunctionality(AsyncSearchTestsBase):
             .return_field("first_name")
         )
         result = await decoded_r.ft(index_name).search(query=query, query_params={})
-        docs = result.docs
 
-        if len(docs) == 0:
-            hash_content = await decoded_r.hget(f"{index_name}:1", "first_name")
-        assert len(docs) > 0, (
-            f"Returned search results are empty. Result: {result}; Hash: {hash_content}"
-        )
+        if expects_resp3_shape(decoded_r):
+            # protocol=3 + legacy_responses=True returns the native RESP3 dict;
+            # text fields are decoded while the binary field is kept as bytes.
+            results = result["results"]
+            assert len(results) > 0, f"Returned search results are empty: {result}"
+            attributes = results[0]["extra_attributes"]
+        else:
+            docs = result.docs
+            assert len(docs) > 0, f"Returned search results are empty: {result}"
+            attributes = docs[0]
 
         decoded_vec_from_search_results = np.frombuffer(
-            docs[0]["vector_emb"], dtype=np.float32
+            attributes["vector_emb"], dtype=np.float32
         )
 
         assert np.array_equal(decoded_vec_from_search_results, fake_vec), (
             "The vectors are not equal"
         )
 
-        assert docs[0]["first_name"] == mixed_data["first_name"], (
+        assert attributes["first_name"] == mixed_data["first_name"], (
             "The text field is not decoded correctly"
         )
 
@@ -3930,7 +3932,7 @@ class TestHybridSearch(AsyncSearchTestsBase):
             warnings = res["warnings"]
             assert res["execution_time"] > 0
 
-        assert any(
+        all_match = all(
             safe_str(warning)
             in {
                 "Timeout limit was reached (VSIM)",
@@ -3938,6 +3940,8 @@ class TestHybridSearch(AsyncSearchTestsBase):
             }
             for warning in warnings
         )
+
+        assert all_match, f"Not all warnings are matching expected values: {warnings}"
 
     @pytest.mark.redismod
     @skip_if_server_version_lt("8.3.224")

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -3932,6 +3932,8 @@ class TestHybridSearch(AsyncSearchTestsBase):
             warnings = res["warnings"]
             assert res["execution_time"] > 0
 
+        assert warnings, f"Expected timeout warnings but none were returned: {warnings}"
+
         all_match = all(
             safe_str(warning)
             in {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5943,6 +5943,8 @@ class TestHybridSearch(SearchTestsBase):
             warnings = res["warnings"]
             assert res["execution_time"] > 0
 
+        assert warnings, f"Expected timeout warnings but none were returned: {warnings}"
+
         all_match = all(
             safe_str(warning)
             in {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -52,7 +52,6 @@ from .conftest import (
     expects_unified_shape,
     get_protocol_version,
     skip_if_redis_enterprise,
-    skip_if_resp_version,
     skip_if_server_version_gte,
     skip_if_server_version_lt,
     skip_ifmodversion_lt,
@@ -1355,7 +1354,6 @@ class TestBaseSearchFunctionality(SearchTestsBase):
             assert "telmatosaurus" == total["results"][0]["extra_attributes"]["txt"]
 
     @pytest.mark.redismod
-    @skip_if_resp_version(3)
     def test_binary_and_text_fields(self, client):
         fake_vec = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
 
@@ -1390,16 +1388,28 @@ class TestBaseSearchFunctionality(SearchTestsBase):
             .return_field("vector_emb", decode_field=False)
             .return_field("first_name")
         )
-        docs = client.ft(index_name).search(query=query, query_params={}).docs
+        result = client.ft(index_name).search(query=query, query_params={})
+
+        if expects_resp3_shape(client):
+            # protocol=3 + legacy_responses=True returns the native RESP3 dict;
+            # text fields are decoded while the binary field is kept as bytes.
+            results = result["results"]
+            assert len(results) > 0, f"Returned search results are empty: {result}"
+            attributes = results[0]["extra_attributes"]
+        else:
+            docs = result.docs
+            assert len(docs) > 0, f"Returned search results are empty: {result}"
+            attributes = docs[0]
+
         decoded_vec_from_search_results = np.frombuffer(
-            docs[0]["vector_emb"], dtype=np.float32
+            attributes["vector_emb"], dtype=np.float32
         )
 
         assert np.array_equal(decoded_vec_from_search_results, fake_vec), (
             "The vectors are not equal"
         )
 
-        assert docs[0]["first_name"] == mixed_data["first_name"], (
+        assert attributes["first_name"] == mixed_data["first_name"], (
             "The text field is not decoded correctly"
         )
 
@@ -5933,7 +5943,7 @@ class TestHybridSearch(SearchTestsBase):
             warnings = res["warnings"]
             assert res["execution_time"] > 0
 
-        assert any(
+        all_match = all(
             safe_str(warning)
             in {
                 "Timeout limit was reached (VSIM)",
@@ -5941,6 +5951,7 @@ class TestHybridSearch(SearchTestsBase):
             }
             for warning in warnings
         )
+        assert all_match, f"Not all warning are matching the pattern: {warnings}"
 
     @pytest.mark.redismod
     @skip_if_server_version_lt("8.3.224")


### PR DESCRIPTION
## Change summary

This pull request fixes a regression introduced by #4052 in how `FT.SEARCH`
requests and decodes results under RESP3. Before #4052, `search()` always set
`options[NEVER_DECODE] = True`, so the wire returned raw bytes and the search layer
was responsible for decoding. #4052 (default protocol → RESP3, with legacy response
shapes preserved) wrapped that line in `if not check_protocol_version(..., 3)`,
which meant that under `protocol=3` the wire decoded the entire reply as UTF-8. Any
binary field value returned via `return_field(..., decode_field=False)` — for
example a vector embedding — then raised a decode error instead of coming back as
bytes, and the behavior diverged from `hybrid_search`, which already always requests
raw bytes and decodes in the search layer.

The fix restores the pre-#4052 contract and moves decoding fully into the search
layer. `search()` and its async mirror `AsyncSearchCommands.search()` again set
`options[NEVER_DECODE] = True` unconditionally, and a new
`_parse_search_resp3_native` callback is registered for `SEARCH_CMD` in
`_RESP3_MODULE_CALLBACKS`. That callback preserves the native RESP3 dict shape for
`protocol=3` + `legacy_responses=True`: it decodes the structural keys (`results`,
`id`, `extra_attributes` keys, `warning`) with `str_if_bytes`, decodes text field
values leniently via the existing `decode_field_value` helper (keyed off the query's
`_return_fields_decode_as`), and keeps fields flagged `decode_field=False` as raw
bytes. Non-dict replies pass through unchanged.

- Runtime: `redis/commands/search/commands.py` — new `_parse_search_resp3_native`,
  `SEARCH_CMD` registered as a RESP3 native callback, and unconditional `NEVER_DECODE`
  in both the sync and async `search()`.
- Backward-compatibility: this restores correct behavior that #4052 broke — under
  `protocol=3` + `legacy_responses=True`, `FT.SEARCH` now returns the native RESP3
  dict with per-field decoding (binary fields as bytes) instead of crashing on
  non-UTF-8 data. The default (`protocol=None`) response shape is unchanged, and the
  sync/async stacks stay in lockstep.

## Test coverage

`test_binary_and_text_fields` (sync `tests/test_search.py` and async
`tests/test_asyncio/test_search.py`) drops its `@skip_if_resp_version(3)` guard so it
now exercises RESP3, and branches on `expects_resp3_shape(...)`: for the native RESP3
dict it reads `result["results"][0]["extra_attributes"]`, otherwise the legacy
`result.docs[0]`. In both shapes it asserts the binary `vector_emb` round-trips as
bytes (via `np.frombuffer`) and the text `first_name` field decodes correctly — the
exact mixed binary/text case that regressed under #4052.

The hybrid-search warning checks in both files were also tightened from `any(...)`
to `all(...)` with an explanatory failure message, so every returned warning must
match the expected set rather than just one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RediSearch response parsing for all FT.SEARCH calls across protocols, but behavior aligns with the pre-regression contract and hybrid_search; risk is mainly around subtle RESP3 vs legacy shape differences.
> 
> **Overview**
> Fixes a **RESP3 regression** where `FT.SEARCH` stopped requesting raw wire bytes, so the client tried to UTF-8-decode the whole reply and **crashed on binary fields** (e.g. vector embeddings from `return_field(..., decode_field=False)`).
> 
> **`search()`** (sync and async) again always passes **`NEVER_DECODE: True`**, matching **`hybrid_search`**. For **`protocol=3`** + **`legacy_responses=True`**, a new **`_parse_search_resp3_native`** callback is registered so the native RESP3 dict is kept while structural keys are decoded and **`extra_attributes`** are handled per-field via **`decode_field_value`** (text decoded, binary left as bytes).
> 
> Tests: **`test_binary_and_text_fields`** now runs on RESP3 and asserts both response shapes; hybrid timeout warning checks require **all** warnings to match the expected set, not just one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ceb5a0de980a4b7cb9bc92a5206a1cf621a1de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->