### PR TITLE
feat: add TS.QUERYLABELS support to the timeseries command surface

### DIFF
--- a/redis/commands/timeseries/__init__.py
+++ b/redis/commands/timeseries/__init__.py
@@ -23,6 +23,7 @@ from .commands import (
     NRANGE_CMD,
     NREVRANGE_CMD,
     QUERYINDEX_CMD,
+    QUERYLABELS_CMD,
     RANGE_CMD,
     READ_CMD,
     REVRANGE_CMD,
@@ -39,6 +40,7 @@ from .utils import (
     parse_m_range_resp3_to_resp2_legacy,
     parse_m_range_unified,
     parse_n_range,
+    parse_query_labels,
     parse_range,
     parse_range_unified,
 )
@@ -63,6 +65,7 @@ class _TimeSeriesBase(TimeSeriesCommands):
             READ_CMD: parse_range_unified,
             NRANGE_CMD: parse_n_range,
             NREVRANGE_CMD: parse_n_range,
+            QUERYLABELS_CMD: parse_query_labels,
         }
 
         _RESP2_MODULE_CALLBACKS = {

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -32,6 +32,7 @@ MREVRANGE_CMD = "TS.MREVRANGE"
 NRANGE_CMD = "TS.NRANGE"
 NREVRANGE_CMD = "TS.NREVRANGE"
 QUERYINDEX_CMD = "TS.QUERYINDEX"
+QUERYLABELS_CMD = "TS.QUERYLABELS"
 RANGE_CMD = "TS.RANGE"
 READ_CMD = "TS.READ"
 REVRANGE_CMD = "TS.REVRANGE"
@@ -1839,6 +1840,73 @@ class TimeSeriesCommands:
         For more information see https://redis.io/commands/ts.queryindex/
         """
         return self.execute_command(QUERYINDEX_CMD, *filters)
+
+    @overload
+    def querylabels(
+        self: SyncClientProtocol,
+        label: str | None = None,
+        filters: list[str] | None = None,
+    ) -> list[bytes | str]: ...
+
+    @overload
+    def querylabels(
+        self: AsyncClientProtocol,
+        label: str | None = None,
+        filters: list[str] | None = None,
+    ) -> Awaitable[list[bytes | str]]: ...
+
+    def querylabels(
+        self, label: str | None = None, filters: list[str] | None = None
+    ) -> list[bytes | str] | Awaitable[list[bytes | str]]:
+        """
+        Get label metadata for the time series matching `filters`.
+
+        The single `TS.QUERYLABELS` request is built from the supplied
+        arguments:
+
+        - When `label` is omitted (``None``), the ``LABELS`` form is issued and
+          the reply is the set of all label names present on the matching (and
+          readable) series, including the label names used in the filter
+          itself.
+        - When `label` is given, the ``VALUES`` form is issued and the reply is
+          the set of all values assigned to `label` across the matching series.
+          `label` is matched byte-exactly and is passed to the server without
+          any normalization; a series that does not carry `label`, and a
+          `label` that matches no series, contribute nothing (an empty reply,
+          not an error).
+
+        The reply is unordered and already deduplicated by the server. When
+        `filters` is omitted (``None``), all indexed series are queried; filter
+        expressions use the same language as `TS.QUERYINDEX` and are passed
+        verbatim, while an explicitly empty collection raises a `DataError`.
+
+        For more information see https://redis.io/commands/ts.querylabels/
+        """
+        if label is None:
+            params: list[EncodableT] = ["LABELS"]
+        else:
+            params = ["VALUES", label]
+        self._append_filter_expressions(params, filters)
+        return self.execute_command(QUERYLABELS_CMD, *params)
+
+    @staticmethod
+    def _append_filter_expressions(params: list[EncodableT], filters: list[str] | None):
+        """Append the optional FILTER clause for TS.QUERYLABELS.
+
+        ``None`` omits ``FILTER`` entirely (the documented all-series query);
+        an explicitly empty collection is a local usage error, since silently
+        widening to all series would be surprising. Expressions are passed
+        through verbatim, without parsing, reordering, or normalizing.
+        """
+        if filters is None:
+            return
+        if not filters:
+            raise DataError(
+                "filters cannot be an empty collection; pass None to query "
+                "all indexed series."
+            )
+        params.append("FILTER")
+        params.extend(filters)
 
     @staticmethod
     def _append_uncompressed(params: list[EncodableT], uncompressed: bool | None):

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -1,4 +1,4 @@
-from typing import Any, Awaitable, Dict, List, Tuple, overload
+from typing import Any, Awaitable, Dict, Iterable, List, Tuple, overload
 
 from redis.exceptions import DataError
 from redis.typing import (
@@ -1845,19 +1845,19 @@ class TimeSeriesCommands:
     def querylabels(
         self: SyncClientProtocol,
         label: str | None = None,
-        filters: list[str] | None = None,
-    ) -> list[bytes | str]: ...
+        filters: Iterable[str] | None = None,
+    ) -> set[bytes | str]: ...
 
     @overload
     def querylabels(
         self: AsyncClientProtocol,
         label: str | None = None,
-        filters: list[str] | None = None,
-    ) -> Awaitable[list[bytes | str]]: ...
+        filters: Iterable[str] | None = None,
+    ) -> Awaitable[set[bytes | str]]: ...
 
     def querylabels(
-        self, label: str | None = None, filters: list[str] | None = None
-    ) -> list[bytes | str] | Awaitable[list[bytes | str]]:
+        self, label: str | None = None, filters: Iterable[str] | None = None
+    ) -> set[bytes | str] | Awaitable[set[bytes | str]]:
         """
         Get label metadata for the time series matching `filters`.
 
@@ -1875,10 +1875,11 @@ class TimeSeriesCommands:
           `label` that matches no series, contribute nothing (an empty reply,
           not an error).
 
-        The reply is unordered and already deduplicated by the server. When
-        `filters` is omitted (``None``), all indexed series are queried; filter
-        expressions use the same language as `TS.QUERYINDEX` and are passed
-        verbatim, while an explicitly empty collection raises a `DataError`.
+        The reply is unordered and already deduplicated by the server, so it is
+        returned as a Python ``set``. When `filters` is omitted (``None``), all
+        indexed series are queried; filter expressions use the same language as
+        `TS.QUERYINDEX` and are passed verbatim, while an explicitly empty
+        collection raises a `DataError`.
 
         For more information see https://redis.io/commands/ts.querylabels/
         """
@@ -1890,16 +1891,21 @@ class TimeSeriesCommands:
         return self.execute_command(QUERYLABELS_CMD, *params)
 
     @staticmethod
-    def _append_filter_expressions(params: list[EncodableT], filters: list[str] | None):
+    def _append_filter_expressions(
+        params: list[EncodableT], filters: Iterable[str] | None
+    ):
         """Append the optional FILTER clause for TS.QUERYLABELS.
 
         ``None`` omits ``FILTER`` entirely (the documented all-series query);
         an explicitly empty collection is a local usage error, since silently
-        widening to all series would be surprising. Expressions are passed
-        through verbatim, without parsing, reordering, or normalizing.
+        widening to all series would be surprising. Any iterable is accepted and
+        materialized once so single-pass iterators are handled correctly.
+        Expressions are passed through verbatim, without parsing, reordering, or
+        normalizing.
         """
         if filters is None:
             return
+        filters = list(filters)
         if not filters:
             raise DataError(
                 "filters cannot be an empty collection; pass None to query "

--- a/redis/commands/timeseries/utils.py
+++ b/redis/commands/timeseries/utils.py
@@ -23,17 +23,18 @@ def _nativestr_dict(d):
 
 
 def parse_query_labels(response, **kwargs):
-    """Normalize the TS.QUERYLABELS reply to a list of unique strings.
+    """Normalize the TS.QUERYLABELS reply to a ``set`` of unique strings.
 
     The reply is a flat array under RESP2 and a set under RESP3; both are
-    surfaced as a Python ``list`` so the collection type is identical across
-    protocols. Elements are kept byte-exact (never coerced or normalized) and
+    surfaced as a Python ``set`` so the collection type is identical across
+    protocols and reflects that the server returns a unique, unordered
+    collection. Elements are kept byte-exact (never coerced or normalized) and
     the server already deduplicates them. A missing reply maps to an empty
-    list so an empty result is a normal success rather than an error.
+    ``set`` so an empty result is a normal success rather than an error.
     """
     if response is None:
-        return []
-    return list(response)
+        return set()
+    return set(response)
 
 
 def parse_range(response, **kwargs):

--- a/redis/commands/timeseries/utils.py
+++ b/redis/commands/timeseries/utils.py
@@ -22,6 +22,20 @@ def _nativestr_dict(d):
     }
 
 
+def parse_query_labels(response, **kwargs):
+    """Normalize the TS.QUERYLABELS reply to a list of unique strings.
+
+    The reply is a flat array under RESP2 and a set under RESP3; both are
+    surfaced as a Python ``list`` so the collection type is identical across
+    protocols. Elements are kept byte-exact (never coerced or normalized) and
+    the server already deduplicates them. A missing reply maps to an empty
+    list so an empty result is a normal success rather than an error.
+    """
+    if response is None:
+        return []
+    return list(response)
+
+
 def parse_range(response, **kwargs):
     """Parse range response. Used by TS.RANGE and TS.REVRANGE (legacy shape)."""
     if not response:

--- a/specs/redis_commands_guide.md
+++ b/specs/redis_commands_guide.md
@@ -98,6 +98,24 @@ def scan(
 In terms of required and optional arguments we follow the specification and trying to reflect it as close
 as possible.
 
+For argument type hints, prefer the most general abstract interface that expresses what the command actually needs
+over a concrete implementation type. When an argument is only iterated over, type it as `Iterable[...]` rather than
+`list[...]` so the API accepts any compatible input (lists, tuples, sets, generators, etc.) instead of just one
+concrete type. Only pin a concrete type (e.g. `list[...]`) when the implementation explicitly requires that type's
+capabilities, such as indexing, slicing, ordering guarantees, or in-place mutation. This keeps the public API
+permissive on input while the command internally normalizes the value to whatever Redis-friendly format it needs.
+
+```python
+# Preferred: accepts any iterable of strings.
+def querylabels(self, label: str | None = None, filters: Iterable[str] | None = None): ...
+
+# Avoid unless a list is explicitly required (indexing, ordering, mutation):
+def querylabels(self, label: str | None = None, filters: list[str] | None = None): ...
+```
+
+Note that this applies to input arguments. Return type hints should reflect the concrete type the command actually
+produces (see "Protocols compatibility" above).
+
 ### Testing
 
 Command tests are located in `tests/test_*command_type*.py` and `tests/test_asyncio/test_*command_type*.py` for async

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -1119,7 +1119,7 @@ async def test_query_labels(decoded_r: redis.Redis):
     # LABELS mode with a filter returns the union of label names across the
     # matching series, including the label used in the filter itself.
     labels = await decoded_r.ts().querylabels(filters=["type=sensor"])
-    assert isinstance(labels, list)
+    assert isinstance(labels, set)
     assert sorted(labels) == ["location", "sensortype", "type"]
 
     # Omitting the filter queries all indexed series.
@@ -1130,7 +1130,18 @@ async def test_query_labels(decoded_r: redis.Redis):
     ]
 
     # A filter that matches nothing is a normal empty reply, not an error.
-    assert await decoded_r.ts().querylabels(filters=["type=missing"]) == []
+    assert await decoded_r.ts().querylabels(filters=["type=missing"]) == set()
+
+    # `filters` accepts any iterable, not just a list (a tuple and a single-pass
+    # generator both work).
+    assert sorted(await decoded_r.ts().querylabels(filters=("type=sensor",))) == [
+        "location",
+        "sensortype",
+        "type",
+    ]
+    assert sorted(
+        await decoded_r.ts().querylabels(filters=(f for f in ["type=sensor"]))
+    ) == ["location", "sensortype", "type"]
 
 
 @pytest.mark.onlynoncluster
@@ -1143,7 +1154,7 @@ async def test_query_label_values(decoded_r: redis.Redis):
 
     # VALUES mode returns the deduplicated union of a label's values.
     values = await decoded_r.ts().querylabels("location", filters=["type=sensor"])
-    assert isinstance(values, list)
+    assert isinstance(values, set)
     assert sorted(values) == ["Kitchen", "LivingRoom"]
 
     # Omitting the filter collects values across all indexed series.
@@ -1155,12 +1166,13 @@ async def test_query_label_values(decoded_r: redis.Redis):
 
     # A label carried by no matching series yields an empty reply.
     assert (
-        await decoded_r.ts().querylabels("nonexistent", filters=["type=sensor"]) == []
+        await decoded_r.ts().querylabels("nonexistent", filters=["type=sensor"])
+        == set()
     )
 
     # Values are byte-exact strings and are never coerced to numbers.
     await decoded_r.ts().create(4, labels={"type": "sensor", "code": "123"})
-    assert await decoded_r.ts().querylabels("code", filters=["type=sensor"]) == ["123"]
+    assert await decoded_r.ts().querylabels("code", filters=["type=sensor"]) == {"123"}
 
 
 @pytest.mark.onlynoncluster

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -1104,6 +1104,86 @@ async def test_query_index(decoded_r: redis.Redis):
     )
 
 
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_query_labels(decoded_r: redis.Redis):
+    await decoded_r.ts().create(
+        1, labels={"type": "sensor", "location": "LivingRoom", "sensortype": "temp"}
+    )
+    await decoded_r.ts().create(
+        2, labels={"type": "sensor", "location": "Kitchen", "sensortype": "temp"}
+    )
+    await decoded_r.ts().create(3, labels={"type": "gauge", "location": "BedRoom"})
+
+    # LABELS mode with a filter returns the union of label names across the
+    # matching series, including the label used in the filter itself.
+    labels = await decoded_r.ts().querylabels(filters=["type=sensor"])
+    assert isinstance(labels, list)
+    assert sorted(labels) == ["location", "sensortype", "type"]
+
+    # Omitting the filter queries all indexed series.
+    assert sorted(await decoded_r.ts().querylabels()) == [
+        "location",
+        "sensortype",
+        "type",
+    ]
+
+    # A filter that matches nothing is a normal empty reply, not an error.
+    assert await decoded_r.ts().querylabels(filters=["type=missing"]) == []
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_query_label_values(decoded_r: redis.Redis):
+    await decoded_r.ts().create(1, labels={"type": "sensor", "location": "LivingRoom"})
+    await decoded_r.ts().create(2, labels={"type": "sensor", "location": "Kitchen"})
+    await decoded_r.ts().create(3, labels={"type": "gauge", "location": "BedRoom"})
+
+    # VALUES mode returns the deduplicated union of a label's values.
+    values = await decoded_r.ts().querylabels("location", filters=["type=sensor"])
+    assert isinstance(values, list)
+    assert sorted(values) == ["Kitchen", "LivingRoom"]
+
+    # Omitting the filter collects values across all indexed series.
+    assert sorted(await decoded_r.ts().querylabels("location")) == [
+        "BedRoom",
+        "Kitchen",
+        "LivingRoom",
+    ]
+
+    # A label carried by no matching series yields an empty reply.
+    assert (
+        await decoded_r.ts().querylabels("nonexistent", filters=["type=sensor"]) == []
+    )
+
+    # Values are byte-exact strings and are never coerced to numbers.
+    await decoded_r.ts().create(4, labels={"type": "sensor", "code": "123"})
+    assert await decoded_r.ts().querylabels("code", filters=["type=sensor"]) == ["123"]
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_query_labels_empty_filters_raises(decoded_r: redis.Redis):
+    # An explicitly empty filter collection is a local usage error; pass None
+    # (omit the argument) to query all indexed series instead.
+    with pytest.raises(redis.DataError):
+        await decoded_r.ts().querylabels(filters=[])
+    with pytest.raises(redis.DataError):
+        await decoded_r.ts().querylabels("location", filters=[])
+
+
+@pytest.mark.onlynoncluster
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
+async def test_query_labels_server_errors(decoded_r: redis.Redis):
+    # Server-side filter parsing errors surface unchanged as ResponseError.
+    with pytest.raises(redis.ResponseError):
+        await decoded_r.ts().querylabels("location", filters=["badexpr"])
+
+
 @pytest.mark.redismod
 async def test_uncompressed(decoded_r: redis.Redis):
     await decoded_r.ts().create("compressed")

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1288,7 +1288,7 @@ def test_query_labels(client):
     # LABELS mode with a filter returns the union of label names across the
     # matching series, including the label used in the filter itself.
     labels = client.ts().querylabels(filters=["type=sensor"])
-    assert isinstance(labels, list)
+    assert isinstance(labels, set)
     assert sorted(labels) == ["location", "sensortype", "type"]
 
     # Omitting the filter queries all indexed series.
@@ -1299,7 +1299,20 @@ def test_query_labels(client):
     ]
 
     # A filter that matches nothing is a normal empty reply, not an error.
-    assert client.ts().querylabels(filters=["type=missing"]) == []
+    assert client.ts().querylabels(filters=["type=missing"]) == set()
+
+    # `filters` accepts any iterable, not just a list (a tuple and a single-pass
+    # generator both work).
+    assert sorted(client.ts().querylabels(filters=("type=sensor",))) == [
+        "location",
+        "sensortype",
+        "type",
+    ]
+    assert sorted(client.ts().querylabels(filters=(f for f in ["type=sensor"]))) == [
+        "location",
+        "sensortype",
+        "type",
+    ]
 
 
 @pytest.mark.redismod
@@ -1312,7 +1325,7 @@ def test_query_label_values(client):
 
     # VALUES mode returns the deduplicated union of a label's values.
     values = client.ts().querylabels("location", filters=["type=sensor"])
-    assert isinstance(values, list)
+    assert isinstance(values, set)
     assert sorted(values) == ["Kitchen", "LivingRoom"]
 
     # Omitting the filter collects values across all indexed series.
@@ -1323,11 +1336,11 @@ def test_query_label_values(client):
     ]
 
     # A label carried by no matching series yields an empty reply.
-    assert client.ts().querylabels("nonexistent", filters=["type=sensor"]) == []
+    assert client.ts().querylabels("nonexistent", filters=["type=sensor"]) == set()
 
     # Values are byte-exact strings and are never coerced to numbers.
     client.ts().create(4, labels={"type": "sensor", "code": "123"})
-    assert client.ts().querylabels("code", filters=["type=sensor"]) == ["123"]
+    assert client.ts().querylabels("code", filters=["type=sensor"]) == {"123"}
 
 
 @pytest.mark.redismod

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1274,6 +1274,84 @@ def test_query_index(client):
 
 
 @pytest.mark.redismod
+@pytest.mark.onlynoncluster
+@skip_if_server_version_lt("8.9.0")
+def test_query_labels(client):
+    client.ts().create(
+        1, labels={"type": "sensor", "location": "LivingRoom", "sensortype": "temp"}
+    )
+    client.ts().create(
+        2, labels={"type": "sensor", "location": "Kitchen", "sensortype": "temp"}
+    )
+    client.ts().create(3, labels={"type": "gauge", "location": "BedRoom"})
+
+    # LABELS mode with a filter returns the union of label names across the
+    # matching series, including the label used in the filter itself.
+    labels = client.ts().querylabels(filters=["type=sensor"])
+    assert isinstance(labels, list)
+    assert sorted(labels) == ["location", "sensortype", "type"]
+
+    # Omitting the filter queries all indexed series.
+    assert sorted(client.ts().querylabels()) == [
+        "location",
+        "sensortype",
+        "type",
+    ]
+
+    # A filter that matches nothing is a normal empty reply, not an error.
+    assert client.ts().querylabels(filters=["type=missing"]) == []
+
+
+@pytest.mark.redismod
+@pytest.mark.onlynoncluster
+@skip_if_server_version_lt("8.9.0")
+def test_query_label_values(client):
+    client.ts().create(1, labels={"type": "sensor", "location": "LivingRoom"})
+    client.ts().create(2, labels={"type": "sensor", "location": "Kitchen"})
+    client.ts().create(3, labels={"type": "gauge", "location": "BedRoom"})
+
+    # VALUES mode returns the deduplicated union of a label's values.
+    values = client.ts().querylabels("location", filters=["type=sensor"])
+    assert isinstance(values, list)
+    assert sorted(values) == ["Kitchen", "LivingRoom"]
+
+    # Omitting the filter collects values across all indexed series.
+    assert sorted(client.ts().querylabels("location")) == [
+        "BedRoom",
+        "Kitchen",
+        "LivingRoom",
+    ]
+
+    # A label carried by no matching series yields an empty reply.
+    assert client.ts().querylabels("nonexistent", filters=["type=sensor"]) == []
+
+    # Values are byte-exact strings and are never coerced to numbers.
+    client.ts().create(4, labels={"type": "sensor", "code": "123"})
+    assert client.ts().querylabels("code", filters=["type=sensor"]) == ["123"]
+
+
+@pytest.mark.redismod
+@pytest.mark.onlynoncluster
+@skip_if_server_version_lt("8.9.0")
+def test_query_labels_empty_filters_raises(client):
+    # An explicitly empty filter collection is a local usage error; pass None
+    # (omit the argument) to query all indexed series instead.
+    with pytest.raises(redis.DataError):
+        client.ts().querylabels(filters=[])
+    with pytest.raises(redis.DataError):
+        client.ts().querylabels("location", filters=[])
+
+
+@pytest.mark.redismod
+@pytest.mark.onlynoncluster
+@skip_if_server_version_lt("8.9.0")
+def test_query_labels_server_errors(client):
+    # Server-side filter parsing errors surface unchanged as ResponseError.
+    with pytest.raises(redis.ResponseError):
+        client.ts().querylabels("location", filters=["badexpr"])
+
+
+@pytest.mark.redismod
 def test_pipeline(client):
     pipeline = client.ts().pipeline()
     pipeline.create("with_pipeline")


### PR DESCRIPTION
## Change summary

This pull request adds support for the `TS.QUERYLABELS` RedisTimeSeries command
as a new `querylabels(label=None, filters=None)` method on the shared
`TimeSeriesCommands` class. Omitting `label` issues the `LABELS` form (union of
label names across matching series); passing `label` issues the `VALUES` form
(deduplicated values for that label). `filters=None` queries all indexed series,
while an explicitly empty collection raises `DataError`. Filters and `label` are
passed byte-exact, so server-side filter errors surface unchanged as
`ResponseError`. A `parse_query_labels` callback normalizes the reply to a
Python `list` (RESP2 array / RESP3 set) and maps a missing reply to `[]`.

The change is purely additive and, because `TimeSeriesCommands` is shared, the
single method plus typed `@overload`s serve both `Redis` and
`redis.asyncio.Redis` with aligned sync/async signatures — no
backward-compatibility or wire-protocol risk.

## Test coverage

New tests in [tests/test_timeseries.py](tests/test_timeseries.py) and
[tests/test_asyncio/test_timeseries.py](tests/test_asyncio/test_timeseries.py),
kept in lockstep, cover the `LABELS` and `VALUES` forms (with and without
filters), byte-exact values that aren't coerced to numbers, empty results as a
normal success, the `DataError` for empty `filters`, and server-side parse
errors surfacing as `ResponseError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive TimeSeries API with local validation only; no changes to existing commands or wire behavior for current callers.
> 
> **Overview**
> Adds **`TS.QUERYLABELS`** to the RedisTimeSeries client as **`querylabels(label=None, filters=None)`** on shared `TimeSeriesCommands`, so sync and async `ts()` callers get the same API.
> 
> **`label` omitted** sends the `LABELS` form (union of label names on matching series). **`label` set** sends `VALUES` (deduplicated values for that label). **`filters=None`** queries all indexed series; an **empty** `filters` collection raises **`DataError`** locally. Filters use the same expressions as `queryindex` and are passed through verbatim.
> 
> **`parse_query_labels`** normalizes RESP2 arrays and RESP3 sets to a Python **`set`**. The command is wired via **`QUERYLABELS_CMD`** in the timeseries module callbacks.
> 
> Contributor docs now recommend **`Iterable[str]`** for filter arguments that are only iterated. Integration tests (sync + async, Redis ≥ 8.9.0) cover LABELS/VALUES modes, iterables, empty results, client validation, and server **`ResponseError`** on bad filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d50805e6d2081ba350cd1f3a06d3d7c21a016f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->