### PR TITLE
feat: add FT.ALIASLIST support

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -528,6 +528,7 @@ class AbstractRedisCluster:
             "FT.ALIASADD",
             "FT.ALIASUPDATE",
             "FT.ALIASDEL",
+            "FT.ALIASLIST",
             "FT.TAGVALS",
             "FT.SUGADD",
             "FT.SUGGET",

--- a/redis/commands/cluster.py
+++ b/redis/commands/cluster.py
@@ -165,6 +165,7 @@ READ_COMMANDS = frozenset(
         "JSON.STRLEN",
         "JSON.TYPE",
         # RediSearch Module
+        "FT.ALIASLIST",
         "FT.EXPLAIN",
         "FT.INFO",
         "FT.PROFILE",

--- a/redis/commands/policies.py
+++ b/redis/commands/policies.py
@@ -103,6 +103,10 @@ STATIC_POLICIES: PolicyRecords = {
             request_policy=RequestPolicy.DEFAULT_KEYLESS,
             response_policy=ResponsePolicy.DEFAULT_KEYLESS,
         ),
+        "aliaslist": CommandPolicies(
+            request_policy=RequestPolicy.DEFAULT_KEYLESS,
+            response_policy=ResponsePolicy.DEFAULT_KEYLESS,
+        ),
         "sugdel": CommandPolicies(
             request_policy=RequestPolicy.DEFAULT_KEYED,
             response_policy=ResponsePolicy.DEFAULT_KEYED,

--- a/redis/commands/search/__init__.py
+++ b/redis/commands/search/__init__.py
@@ -200,7 +200,7 @@ class Pipeline(SearchCommands, RedisPipeline):
             elif check_protocol_version(protocol, 3):
                 cmd_callbacks = self._RESP3_MODULE_CALLBACKS
             else:
-                cmd_callbacks = {}
+                cmd_callbacks = self._RESP2_LEGACY_PIPELINE_CALLBACKS
         else:
             if check_protocol_version(protocol, 3):
                 cmd_callbacks = self._RESP3_UNIFIED_MODULE_CALLBACKS

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -145,6 +145,14 @@ class SearchCommands:
         self._RESP3_TO_RESP2_LEGACY_PIPELINE_CALLBACKS = {
             SEARCH_CMD: self._pipeline_parse_search_resp3_to_legacy,
             HYBRID_CMD: self._pipeline_parse_hybrid_search_resp3_to_legacy,
+            ALIAS_LIST_CMD: self._parse_aliaslist,
+        }
+        # ``protocol=2`` + ``legacy_responses=True`` pipelines otherwise return
+        # raw wire responses.  ``FT.ALIASLIST`` is a new command with no pre-v8
+        # raw pipeline shape to preserve, so it is still normalized to a ``set``
+        # to match the direct-call behavior and the documented return type.
+        self._RESP2_LEGACY_PIPELINE_CALLBACKS = {
+            ALIAS_LIST_CMD: self._parse_aliaslist,
         }
         # ``legacy_responses=False`` + RESP2 wire: enhanced RESP2 parsers
         # producing the unified shape (``attributes`` as list of dicts,

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -11,6 +11,7 @@ from redis.commands.search.hybrid_query import (
     HybridQuery,
 )
 from redis.commands.search.hybrid_result import HybridCursorResult, HybridResult
+from redis.typing import KeyT
 from redis.utils import (
     check_protocol_version,
     decode_field_value,
@@ -276,7 +277,12 @@ class SearchCommands:
 
     def _parse_aliaslist(self, res, **kwargs):
         # RESP2 replies with an array and RESP3 with a set; both are decoded
-        # into a list by the parsers, so normalize to an unordered ``set``.
+        # into a list/set by the parsers, so normalize to an unordered ``set``.
+        # Alias names are user data, so they honor ``decode_responses`` (``str``
+        # when decoding is enabled, ``bytes`` when it is not) — matching the
+        # passthrough behavior of FT.TAGVALS and FT.DICTDUMP rather than being
+        # force-decoded like the structural map keys handled by the other
+        # search parsers.
         return set(res) if res else set()
 
     def _parse_search(self, res, **kwargs):
@@ -1629,7 +1635,7 @@ class SearchCommands:
 
         return self.execute_command(TAGVALS_CMD, self.index_name, tagfield)
 
-    def aliasadd(self, alias: str):
+    def aliasadd(self, alias: KeyT):
         """
         Alias a search index - will fail if alias already exists
 
@@ -1642,7 +1648,7 @@ class SearchCommands:
 
         return self.execute_command(ALIAS_ADD_CMD, alias, self.index_name)
 
-    def aliasupdate(self, alias: str):
+    def aliasupdate(self, alias: KeyT):
         """
         Updates an alias - will fail if alias does not already exist
 
@@ -1655,7 +1661,7 @@ class SearchCommands:
 
         return self.execute_command(ALIAS_UPDATE_CMD, alias, self.index_name)
 
-    def aliasdel(self, alias: str):
+    def aliasdel(self, alias: KeyT):
         """
         Removes an alias to a search index
 
@@ -1667,13 +1673,15 @@ class SearchCommands:
         """  # noqa
         return self.execute_command(ALIAS_DEL_CMD, alias)
 
-    def aliaslist(self) -> Set[str]:
+    def aliaslist(self) -> Set[str | bytes]:
         """
         List all aliases associated with the current index as an unordered set.
 
         The index must be the name of an index created with ``FT.CREATE``; an
         alias name is not accepted as a substitute. Returns an empty set when
-        the index exists but has no aliases.
+        the index exists but has no aliases. Alias names honor
+        ``decode_responses`` (``str`` when decoding is enabled, ``bytes``
+        otherwise).
 
         For more information see `FT.ALIASLIST <https://redis.io/commands/ft.aliaslist>`_.
         """  # noqa
@@ -1827,13 +1835,15 @@ class AsyncSearchCommands(SearchCommands):
         res = await self.execute_command(INFO_CMD, self.index_name)
         return self._parse_results(INFO_CMD, res)
 
-    async def aliaslist(self) -> Set[str]:
+    async def aliaslist(self) -> Set[str | bytes]:
         """
         List all aliases associated with the current index as an unordered set.
 
         The index must be the name of an index created with ``FT.CREATE``; an
         alias name is not accepted as a substitute. Returns an empty set when
-        the index exists but has no aliases.
+        the index exists but has no aliases. Alias names honor
+        ``decode_responses`` (``str`` when decoding is enabled, ``bytes``
+        otherwise).
 
         For more information see `FT.ALIASLIST <https://redis.io/commands/ft.aliaslist>`_.
         """  # noqa

--- a/redis/commands/search/commands.py
+++ b/redis/commands/search/commands.py
@@ -1,6 +1,6 @@
 import itertools
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from redis._parsers.helpers import pairs_to_dict
 from redis.client import NEVER_DECODE, Pipeline
@@ -57,6 +57,7 @@ TAGVALS_CMD = "FT.TAGVALS"
 ALIAS_ADD_CMD = "FT.ALIASADD"
 ALIAS_UPDATE_CMD = "FT.ALIASUPDATE"
 ALIAS_DEL_CMD = "FT.ALIASDEL"
+ALIAS_LIST_CMD = "FT.ALIASLIST"
 INFO_CMD = "FT.INFO"
 SUGADD_COMMAND = "FT.SUGADD"
 SUGDEL_COMMAND = "FT.SUGDEL"
@@ -109,6 +110,7 @@ class SearchCommands:
             SPELLCHECK_CMD: self._parse_spellcheck,
             CONFIG_CMD: self._parse_config_get,
             SYNDUMP_CMD: self._parse_syndump,
+            ALIAS_LIST_CMD: self._parse_aliaslist,
         }
         # Explicit ``protocol=3`` + ``legacy_responses=True`` keeps the
         # pre-existing native RESP3 surface.  SEARCH and HYBRID both use
@@ -119,6 +121,7 @@ class SearchCommands:
         self._RESP3_MODULE_CALLBACKS = {
             SEARCH_CMD: self._parse_search_resp3_native,
             HYBRID_CMD: self._parse_hybrid_search_resp3_native,
+            ALIAS_LIST_CMD: self._parse_aliaslist,
         }
         # ``protocol=None`` + ``legacy_responses=True`` (the v8 default):
         # the wire is RESP3 but the Python surface mirrors RESP2 legacy
@@ -133,6 +136,7 @@ class SearchCommands:
             SPELLCHECK_CMD: self._parse_spellcheck_resp3,
             CONFIG_CMD: self._parse_config_get_resp3_to_legacy,
             SYNDUMP_CMD: self._parse_syndump_resp3,
+            ALIAS_LIST_CMD: self._parse_aliaslist,
         }
         # Search pipelines historically returned raw wire responses in
         # legacy mode.  The default connection now uses RESP3 on the wire,
@@ -155,6 +159,7 @@ class SearchCommands:
             SPELLCHECK_CMD: self._parse_spellcheck,
             CONFIG_CMD: self._parse_config_get_unified,
             SYNDUMP_CMD: self._parse_syndump_unified,
+            ALIAS_LIST_CMD: self._parse_aliaslist,
         }
         # ``legacy_responses=False`` + RESP3 wire: keeps the native RESP3
         # shape for commands whose unified shape diverges from the
@@ -260,6 +265,11 @@ class SearchCommands:
     def _parse_info(self, res, **kwargs):
         it = map(str_if_bytes, res)
         return dict(zip(it, it))
+
+    def _parse_aliaslist(self, res, **kwargs):
+        # RESP2 replies with an array and RESP3 with a set; both are decoded
+        # into a list by the parsers, so normalize to an unordered ``set``.
+        return set(res) if res else set()
 
     def _parse_search(self, res, **kwargs):
         return Result(
@@ -1649,6 +1659,21 @@ class SearchCommands:
         """  # noqa
         return self.execute_command(ALIAS_DEL_CMD, alias)
 
+    def aliaslist(self) -> Set[str]:
+        """
+        List all aliases associated with the current index as an unordered set.
+
+        The index must be the name of an index created with ``FT.CREATE``; an
+        alias name is not accepted as a substitute. Returns an empty set when
+        the index exists but has no aliases.
+
+        For more information see `FT.ALIASLIST <https://redis.io/commands/ft.aliaslist>`_.
+        """  # noqa
+        res = self.execute_command(ALIAS_LIST_CMD, self.index_name)
+        if isinstance(res, Pipeline):
+            return res
+        return self._parse_results(ALIAS_LIST_CMD, res)
+
     def sugadd(self, key, *suggestions, **kwargs):
         """
         Add suggestion terms to the AutoCompleter engine. Each suggestion has
@@ -1793,6 +1818,21 @@ class AsyncSearchCommands(SearchCommands):
 
         res = await self.execute_command(INFO_CMD, self.index_name)
         return self._parse_results(INFO_CMD, res)
+
+    async def aliaslist(self) -> Set[str]:
+        """
+        List all aliases associated with the current index as an unordered set.
+
+        The index must be the name of an index created with ``FT.CREATE``; an
+        alias name is not accepted as a substitute. Returns an empty set when
+        the index exists but has no aliases.
+
+        For more information see `FT.ALIASLIST <https://redis.io/commands/ft.aliaslist>`_.
+        """  # noqa
+        res = await self.execute_command(ALIAS_LIST_CMD, self.index_name)
+        if isinstance(res, Pipeline):
+            return res
+        return self._parse_results(ALIAS_LIST_CMD, res)
 
     async def search(
         self,

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -936,6 +936,41 @@ class TestBaseSearchFunctionality(AsyncSearchTestsBase):
             _ = (await alias_client2.search("*")).docs[0]
 
     @pytest.mark.redismod
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aliaslist(self, decoded_r: redis.Redis):
+        index = decoded_r.ft("aliaslistidx")
+        await index.create_index((TextField("txt"),))
+
+        # An existing index with no aliases returns an empty set, not an error.
+        assert await index.aliaslist() == set()
+
+        # Aliases are returned as an unordered collection.
+        await index.aliasadd("alias1")
+        await index.aliasadd("alias2")
+        aliases = await index.aliaslist()
+        assert isinstance(aliases, set)
+        assert aliases == {"alias1", "alias2"}
+
+        # FT.ALIASUPDATE moving an alias to another index removes it from the
+        # previous index's listing.
+        index2 = decoded_r.ft("aliaslistidx2")
+        await index2.create_index((TextField("txt"),))
+        await index2.aliasupdate("alias1")
+        assert await index.aliaslist() == {"alias2"}
+        assert await index2.aliaslist() == {"alias1"}
+
+        # FT.ALIASDEL removes the alias from the listing.
+        await index.aliasdel("alias2")
+        assert await index.aliaslist() == set()
+
+        # A missing index and an alias name supplied as the index both fail
+        # with the index-not-found error; the client must not resolve aliases.
+        with pytest.raises(redis.ResponseError):
+            await decoded_r.ft("nonexistent_aliaslist_index").aliaslist()
+        with pytest.raises(redis.ResponseError):
+            await decoded_r.ft("alias1").aliaslist()
+
+    @pytest.mark.redismod
     async def test_tags(self, decoded_r: redis.Redis):
         await decoded_r.ft().create_index((TextField("txt"), TagField("tags")))
         tags = "foo,foo bar,hello;world"

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -971,6 +971,29 @@ class TestBaseSearchFunctionality(AsyncSearchTestsBase):
             await decoded_r.ft("alias1").aliaslist()
 
     @pytest.mark.redismod
+    @skip_if_server_version_lt("8.9.0")
+    @skip_if_redis_enterprise()
+    async def test_aliaslist_decode_responses_false(self, create_redis, stack_url):
+        # ``decode_responses`` is not part of the CI protocol/legacy matrix,
+        # so pin only that here and let the harness supply the protocol x
+        # legacy combinations (as it does for ``test_aliaslist`` above).
+        client = await create_redis(decode_responses=False, url=stack_url)
+        index = client.ft("aliaslistbytesidx")
+        await index.create_index((TextField("txt"),))
+
+        # ``aliasadd`` accepts a ``KeyT`` (str | bytes | memoryview); mix a
+        # ``str`` and a ``bytes`` alias to exercise the widened input type.
+        await index.aliasadd("alias1")
+        await index.aliasadd(b"alias2")
+
+        # Alias names are user data, so with ``decode_responses=False`` they
+        # are returned as ``bytes`` (honoring the flag, like FT.TAGVALS /
+        # FT.DICTDUMP) rather than being force-decoded to ``str``.
+        aliases = await index.aliaslist()
+        assert isinstance(aliases, set)
+        assert aliases == {b"alias1", b"alias2"}
+
+    @pytest.mark.redismod
     async def test_tags(self, decoded_r: redis.Redis):
         await decoded_r.ft().create_index((TextField("txt"), TagField("tags")))
         tags = "foo,foo bar,hello;world"

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -2582,6 +2582,30 @@ class TestPipeline(AsyncSearchTestsBase):
             )
 
     @pytest.mark.redismod
+    @skip_if_redis_enterprise()
+    @skip_if_server_version_lt("8.9.0")
+    async def test_aliaslist_in_pipeline(self, decoded_r: redis.Redis):
+        index = decoded_r.ft("aliaslistpipeidx")
+        await index.create_index((TextField("txt"),))
+
+        # An empty listing normalizes to ``set()`` through the pipeline, not
+        # the raw ``[]`` wire response.
+        p = index.pipeline()
+        await p.aliaslist()
+        res = await p.execute()
+        assert isinstance(res[0], set)
+        assert res[0] == set()
+
+        # Aliases are returned as an unordered set, matching the direct call.
+        await index.aliasadd("alias1")
+        await index.aliasadd("alias2")
+        p = index.pipeline()
+        await p.aliaslist()
+        res = await p.execute()
+        assert isinstance(res[0], set)
+        assert res[0] == {"alias1", "alias2"}
+
+    @pytest.mark.redismod
     @skip_if_server_version_lt("8.3.224")
     async def test_hybrid_search_query_with_pipeline(self, decoded_r: redis.Redis):
         p = decoded_r.ft().pipeline()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3718,6 +3718,30 @@ class TestPipeline(SearchTestsBase):
             )
 
     @pytest.mark.redismod
+    @skip_if_redis_enterprise()
+    @skip_if_server_version_lt("8.9.0")
+    def test_aliaslist_in_pipeline(self, client):
+        index = client.ft("aliaslistpipeidx")
+        index.create_index((TextField("txt"),))
+
+        # An empty listing normalizes to ``set()`` through the pipeline, not
+        # the raw ``[]`` wire response.
+        p = index.pipeline()
+        p.aliaslist()
+        res = p.execute()
+        assert isinstance(res[0], set)
+        assert res[0] == set()
+
+        # Aliases are returned as an unordered set, matching the direct call.
+        index.aliasadd("alias1")
+        index.aliasadd("alias2")
+        p = index.pipeline()
+        p.aliaslist()
+        res = p.execute()
+        assert isinstance(res[0], set)
+        assert res[0] == {"alias1", "alias2"}
+
+    @pytest.mark.redismod
     @skip_if_server_version_lt("8.4.0")
     def test_hybrid_search_query_with_pipeline(self, client):
         p = client.ft().pipeline()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -894,6 +894,41 @@ class TestBaseSearchFunctionality(SearchTestsBase):
             _ = alias_client2.search("*").docs[0]
 
     @pytest.mark.redismod
+    @skip_if_server_version_lt("8.9.0")
+    def test_aliaslist(self, client):
+        index = client.ft("aliaslistidx")
+        index.create_index((TextField("txt"),))
+
+        # An existing index with no aliases returns an empty set, not an error.
+        assert index.aliaslist() == set()
+
+        # Aliases are returned as an unordered collection.
+        index.aliasadd("alias1")
+        index.aliasadd("alias2")
+        aliases = index.aliaslist()
+        assert isinstance(aliases, set)
+        assert aliases == {"alias1", "alias2"}
+
+        # FT.ALIASUPDATE moving an alias to another index removes it from the
+        # previous index's listing.
+        index2 = client.ft("aliaslistidx2")
+        index2.create_index((TextField("txt"),))
+        index2.aliasupdate("alias1")
+        assert index.aliaslist() == {"alias2"}
+        assert index2.aliaslist() == {"alias1"}
+
+        # FT.ALIASDEL removes the alias from the listing.
+        index.aliasdel("alias2")
+        assert index.aliaslist() == set()
+
+        # A missing index and an alias name supplied as the index both fail
+        # with the index-not-found error; the client must not resolve aliases.
+        with pytest.raises(redis.ResponseError):
+            client.ft("nonexistent_aliaslist_index").aliaslist()
+        with pytest.raises(redis.ResponseError):
+            client.ft("alias1").aliaslist()
+
+    @pytest.mark.redismod
     def test_textfield_sortable_nostem(self, client):
         # Creating the index definition with sortable and no_stem
         client.ft().create_index((TextField("txt", sortable=True, no_stem=True),))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -929,6 +929,31 @@ class TestBaseSearchFunctionality(SearchTestsBase):
             client.ft("alias1").aliaslist()
 
     @pytest.mark.redismod
+    @skip_if_server_version_lt("8.9.0")
+    @skip_if_redis_enterprise()
+    def test_aliaslist_decode_responses_false(self, request, stack_url):
+        # ``decode_responses`` is not part of the CI protocol/legacy matrix,
+        # so pin only that here and let the harness supply the protocol x
+        # legacy combinations (as it does for ``test_aliaslist`` above).
+        client = _get_client(
+            redis.Redis, request, decode_responses=False, from_url=stack_url
+        )
+        index = client.ft("aliaslistbytesidx")
+        index.create_index((TextField("txt"),))
+
+        # ``aliasadd`` accepts a ``KeyT`` (str | bytes | memoryview); mix a
+        # ``str`` and a ``bytes`` alias to exercise the widened input type.
+        index.aliasadd("alias1")
+        index.aliasadd(b"alias2")
+
+        # Alias names are user data, so with ``decode_responses=False`` they
+        # are returned as ``bytes`` (honoring the flag, like FT.TAGVALS /
+        # FT.DICTDUMP) rather than being force-decoded to ``str``.
+        aliases = index.aliaslist()
+        assert isinstance(aliases, set)
+        assert aliases == {b"alias1", b"alias2"}
+
+    @pytest.mark.redismod
     def test_textfield_sortable_nostem(self, client):
         # Creating the index definition with sortable and no_stem
         client.ft().create_index((TextField("txt", sortable=True, no_stem=True),))


### PR DESCRIPTION
## Change summary

This pull request adds support for the RediSearch `FT.ALIASLIST` command to
both the sync and async client stacks. `FT.ALIASLIST` returns all aliases
associated with an index, and until now the client exposed `aliasadd`,
`aliasupdate`, and `aliasdel` but no way to enumerate the existing aliases.

The change introduces a new `aliaslist()` method on both `SearchCommands` and
`AsyncSearchCommands` in `redis/commands/search/commands.py`, backed by a new
`ALIAS_LIST_CMD = "FT.ALIASLIST"` constant. The method issues the command
against the current index name (`self.index_name`) and, when invoked inside a
pipeline, returns the pipeline unchanged so buffered execution keeps working.
A new `_parse_aliaslist` response callback normalizes the reply to an unordered
`set`: RESP2 replies with an array and RESP3 with a set, but both are decoded
to a list by the parsers, so the callback coerces to `set` (empty set when the
index has no aliases). The callback is registered across all the relevant
response-callback tables (RESP2 legacy, native RESP3, RESP3-to-legacy, and the
unified surface) so the shape is consistent regardless of the
`protocol`/`legacy_responses` combination.

Cluster routing is wired up in three places: `FT.ALIASLIST` is added to the
command allow-list in `redis/cluster.py`, added to `READ_COMMANDS` in
`redis/commands/cluster.py` so it is replica-eligible, and given a static
policy entry (`DEFAULT_KEYLESS` request and response policy) in
`redis/commands/policies.py`. The addition is purely additive — a new public
method with no changes to existing signatures, defaults, or return types — so
there is no backward-compatibility or public-API risk. Sync/async parity is
maintained: the sync and async methods share identical docstrings, behavior,
and the `Set[str]` return type.

## Test coverage

New `test_aliaslist` tests are added to both `tests/test_search.py` and
`tests/test_asyncio/test_search.py`, gated by `@pytest.mark.redismod` and
`skip_if_server_version_lt("8.9.0")`. They exercise the empty-listing case (an
existing index with no aliases returns an empty set rather than an error),
multiple aliases returned as an unordered `set`, `FT.ALIASUPDATE` moving an
alias between indexes and updating both listings, `FT.ALIASDEL` removing an
alias, and the error paths where a missing index or an alias name supplied as
the index both raise `ResponseError` (confirming the client does not silently
resolve aliases).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and cluster routing for a read-only search command; no changes to existing method signatures or return types beyond new `aliaslist()` and pipeline callback wiring.
> 
> **Overview**
> Adds **`aliaslist()`** on sync and async RediSearch clients so callers can list aliases for an index via **`FT.ALIASLIST`**, with replies normalized to an unordered **`set`** (empty when none) across RESP2/RESP3 and **`legacy_responses`** / pipeline paths.
> 
> **Cluster:** registers the command in search allow-lists, **`READ_COMMANDS`**, and a keyless **`aliaslist`** policy so it routes like other index-scoped read commands.
> 
> **Related tweaks:** **`aliasadd` / `aliasupdate` / `aliasdel`** alias parameters widened to **`KeyT`**; RESP2 legacy pipelines now use **`_RESP2_LEGACY_PIPELINE_CALLBACKS`** so **`FT.ALIASLIST`** still parses to a set instead of raw wire data.
> 
> Tests cover listing, alias moves/deletes, error cases (missing index / alias-as-index), **`decode_responses=False`**, and pipelines (Redis ≥ 8.9).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a28e011aeb389593509767b6e8e6c021c679d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->