### PR TITLE
fix: use list() to copy dict items before iteration in PubSub.run()

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1641,10 +1641,10 @@ class PubSub:
             >>> task.cancel()
             >>> await task
         """
-        for channel, handler in self.channels.items():
+        for channel, handler in list(self.channels.items()):
             if handler is None:
                 raise PubSubError(f"Channel: '{channel}' has no handler registered")
-        for pattern, handler in self.patterns.items():
+        for pattern, handler in list(self.patterns.items()):
             if handler is None:
                 raise PubSubError(f"Pattern: '{pattern}' has no handler registered")
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -1608,13 +1608,13 @@ class PubSub:
         pubsub=None,
         sharded_pubsub: bool = False,
     ) -> "PubSubWorkerThread":
-        for channel, handler in self.channels.items():
+        for channel, handler in list(self.channels.items()):
             if handler is None:
                 raise PubSubError(f"Channel: '{channel}' has no handler registered")
-        for pattern, handler in self.patterns.items():
+        for pattern, handler in list(self.patterns.items()):
             if handler is None:
                 raise PubSubError(f"Pattern: '{pattern}' has no handler registered")
-        for s_channel, handler in self.shard_channels.items():
+        for s_channel, handler in list(self.shard_channels.items()):
             if handler is None:
                 raise PubSubError(
                     f"Shard Channel: '{s_channel}' has no handler registered"


### PR DESCRIPTION
## WHAT
Guard `self.channels` and `self.patterns` with `list()` before iteration in `PubSub.run()` and `run_in_thread()` validation loops.

## WHY
If `handle_message()` calls `self.channels.pop()` (or `self.patterns.pop()`) during the startup validation loop, the live dict view mutates mid-iteration, causing `RuntimeError: dictionary changed size during iteration`.

This is a real bug, though separate from #3748 (which is an asyncio heap race in `loop.call_at()` — see review discussion).

## HOW
Wrap `.items()` calls with `list()` to snapshot the dict before iterating.

## RISK
Only iteration source changes. Subscription semantics and message ordering unchanged. No allocation in hot path — validation runs once at startup.

## VERIFY
Existing PubSub tests pass.

## NOTE
This is a preventive fix for dict-mutation-during-iteration. It does not fix the asyncio `_scheduled` heap race reported in #3748.