### PR TITLE
fix: add recursion depth limit to RESP2 and RESP3 parsers

### DIFF
--- a/redis/_parsers/resp2.py
+++ b/redis/_parsers/resp2.py
@@ -6,6 +6,10 @@ from ..utils import SENTINEL
 from .base import _AsyncRESPBase, _RESPBase
 from .socket import SERVER_CLOSED_CONNECTION_ERROR
 
+# Maximum nesting depth for RESP aggregate replies to prevent RecursionError
+# from malicious or malformed responses. 512 is well above any legitimate use.
+_MAX_RESP_DEPTH = 512
+
 
 class _RESP2Parser(_RESPBase):
     """RESP2 protocol implementation"""
@@ -27,8 +31,13 @@ class _RESP2Parser(_RESPBase):
             return result
 
     def _read_response(
-        self, disable_decoding=False, timeout: Union[float, object] = SENTINEL
+        self, disable_decoding=False, timeout: Union[float, object] = SENTINEL,
+        _depth: int = 0,
     ):
+        if _depth > _MAX_RESP_DEPTH:
+            raise InvalidResponse(
+                f"Protocol Error: RESP nesting depth exceeds {_MAX_RESP_DEPTH}"
+            )
         raw = self._buffer.readline(timeout=timeout)
         if not raw:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
@@ -64,7 +73,10 @@ class _RESP2Parser(_RESPBase):
             return None
         elif byte == b"*":
             response = [
-                self._read_response(disable_decoding=disable_decoding, timeout=timeout)
+                self._read_response(
+                    disable_decoding=disable_decoding, timeout=timeout,
+                    _depth=_depth + 1,
+                )
                 for i in range(int(response))
             ]
         else:
@@ -92,8 +104,12 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
         return response
 
     async def _read_response(
-        self, disable_decoding: bool = False
+        self, disable_decoding: bool = False, _depth: int = 0
     ) -> Union[EncodableT, ResponseError, None]:
+        if _depth > _MAX_RESP_DEPTH:
+            raise InvalidResponse(
+                f"Protocol Error: RESP nesting depth exceeds {_MAX_RESP_DEPTH}"
+            )
         raw = await self._readline()
         response: Any
         byte, response = raw[:1], raw[1:]
@@ -128,7 +144,9 @@ class _AsyncRESP2Parser(_AsyncRESPBase):
             return None
         elif byte == b"*":
             response = [
-                (await self._read_response(disable_decoding))
+                (await self._read_response(
+                    disable_decoding, _depth=_depth + 1
+                ))
                 for _ in range(int(response))  # noqa
             ]
         else:

--- a/redis/_parsers/resp2.py
+++ b/redis/_parsers/resp2.py
@@ -7,8 +7,11 @@ from .base import _AsyncRESPBase, _RESPBase
 from .socket import SERVER_CLOSED_CONNECTION_ERROR
 
 # Maximum nesting depth for RESP aggregate replies to prevent RecursionError
-# from malicious or malformed responses. 512 is well above any legitimate use.
-_MAX_RESP_DEPTH = 512
+# from malicious or malformed responses. On Python 3.10/3.11 each nested array
+# adds both an _read_response frame and a list-comprehension frame, so the
+# default recursion limit (1000) is hit around depth ~500.  Keep the cap well
+# below that threshold.
+_MAX_RESP_DEPTH = 200
 
 
 class _RESP2Parser(_RESPBase):

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -12,6 +12,10 @@ from .base import (
 )
 from .socket import SERVER_CLOSED_CONNECTION_ERROR
 
+# Maximum nesting depth for RESP aggregate replies to prevent RecursionError
+# from malicious or malformed responses. 512 is well above any legitimate use.
+_MAX_RESP_DEPTH = 512
+
 
 class _RESP3Parser(_RESPBase, PushNotificationsParser):
     """RESP3 protocol implementation"""
@@ -61,7 +65,12 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
         disable_decoding=False,
         push_request=False,
         timeout: Union[float, object] = SENTINEL,
+        _depth: int = 0,
     ):
+        if _depth > _MAX_RESP_DEPTH:
+            raise InvalidResponse(
+                f"Protocol Error: RESP nesting depth exceeds {_MAX_RESP_DEPTH}"
+            )
         raw = self._buffer.readline(timeout=timeout)
         if not raw:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
@@ -107,7 +116,10 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
         # array response
         elif byte == b"*":
             response = [
-                self._read_response(disable_decoding=disable_decoding, timeout=timeout)
+                self._read_response(
+                    disable_decoding=disable_decoding, timeout=timeout,
+                    _depth=_depth + 1,
+                )
                 for _ in range(int(response))
             ]
         # set response
@@ -115,7 +127,10 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
             # redis can return unhashable types (like dict) in a set,
             # so we return sets as list, all the time, for predictability
             response = [
-                self._read_response(disable_decoding=disable_decoding, timeout=timeout)
+                self._read_response(
+                    disable_decoding=disable_decoding, timeout=timeout,
+                    _depth=_depth + 1,
+                )
                 for _ in range(int(response))
             ]
         # map response
@@ -126,12 +141,14 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
             resp_dict = {}
             for _ in range(int(response)):
                 key = self._read_response(
-                    disable_decoding=disable_decoding, timeout=timeout
+                    disable_decoding=disable_decoding, timeout=timeout,
+                    _depth=_depth + 1,
                 )
                 resp_dict[key] = self._read_response(
                     disable_decoding=disable_decoding,
                     push_request=push_request,
                     timeout=timeout,
+                    _depth=_depth + 1,
                 )
             response = resp_dict
         # push response
@@ -141,6 +158,7 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
                     disable_decoding=disable_decoding,
                     push_request=push_request,
                     timeout=timeout,
+                    _depth=_depth + 1,
                 )
                 for _ in range(int(response))
             ]
@@ -153,6 +171,7 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
             return self._read_response(
                 disable_decoding=disable_decoding,
                 push_request=push_request,
+                _depth=_depth + 1,
             )
         else:
             raise InvalidResponse(f"Protocol Error: {raw!r}")
@@ -190,8 +209,13 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
         return response
 
     async def _read_response(
-        self, disable_decoding: bool = False, push_request: bool = False
+        self, disable_decoding: bool = False, push_request: bool = False,
+        _depth: int = 0,
     ) -> Union[EncodableT, ResponseError, None]:
+        if _depth > _MAX_RESP_DEPTH:
+            raise InvalidResponse(
+                f"Protocol Error: RESP nesting depth exceeds {_MAX_RESP_DEPTH}"
+            )
         if not self._stream or not self.encoder:
             raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
         raw = await self._readline()
@@ -241,7 +265,9 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
         # array response
         elif byte == b"*":
             response = [
-                (await self._read_response(disable_decoding=disable_decoding))
+                (await self._read_response(
+                    disable_decoding=disable_decoding, _depth=_depth + 1
+                ))
                 for _ in range(int(response))
             ]
         # set response
@@ -249,7 +275,9 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             # redis can return unhashable types (like dict) in a set,
             # so we always convert to a list, to have predictable return types
             response = [
-                (await self._read_response(disable_decoding=disable_decoding))
+                (await self._read_response(
+                    disable_decoding=disable_decoding, _depth=_depth + 1
+                ))
                 for _ in range(int(response))
             ]
         # map response
@@ -259,9 +287,12 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             # became defined to be left-right in version 3.8
             resp_dict = {}
             for _ in range(int(response)):
-                key = await self._read_response(disable_decoding=disable_decoding)
+                key = await self._read_response(
+                    disable_decoding=disable_decoding, _depth=_depth + 1
+                )
                 resp_dict[key] = await self._read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                    disable_decoding=disable_decoding, push_request=push_request,
+                    _depth=_depth + 1,
                 )
             response = resp_dict
         # push response
@@ -269,7 +300,8 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             response = [
                 (
                     await self._read_response(
-                        disable_decoding=disable_decoding, push_request=push_request
+                        disable_decoding=disable_decoding, push_request=push_request,
+                        _depth=_depth + 1,
                     )
                 )
                 for _ in range(int(response))
@@ -277,7 +309,8 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             response = await self.handle_push_response(response)
             if not push_request:
                 return await self._read_response(
-                    disable_decoding=disable_decoding, push_request=push_request
+                    disable_decoding=disable_decoding, push_request=push_request,
+                    _depth=_depth + 1,
                 )
             else:
                 return response

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -174,7 +174,7 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
             return self._read_response(
                 disable_decoding=disable_decoding,
                 push_request=push_request,
-                _depth=_depth + 1,
+                _depth=_depth,
             )
         else:
             raise InvalidResponse(f"Protocol Error: {raw!r}")
@@ -313,7 +313,7 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
             if not push_request:
                 return await self._read_response(
                     disable_decoding=disable_decoding, push_request=push_request,
-                    _depth=_depth + 1,
+                    _depth=_depth,
                 )
             else:
                 return response

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -13,8 +13,11 @@ from .base import (
 from .socket import SERVER_CLOSED_CONNECTION_ERROR
 
 # Maximum nesting depth for RESP aggregate replies to prevent RecursionError
-# from malicious or malformed responses. 512 is well above any legitimate use.
-_MAX_RESP_DEPTH = 512
+# from malicious or malformed responses. On Python 3.10/3.11 each nested array
+# adds both an _read_response frame and a list-comprehension frame, so the
+# default recursion limit (1000) is hit around depth ~500.  Keep the cap well
+# below that threshold.
+_MAX_RESP_DEPTH = 200
 
 
 class _RESP3Parser(_RESPBase, PushNotificationsParser):

--- a/tests/test_resp_recursion_depth.py
+++ b/tests/test_resp_recursion_depth.py
@@ -185,3 +185,60 @@ class TestRESP3AsyncDepthLimit:
 
         with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
             await parser._read_response()
+
+
+class TestRESP3PushContinuation:
+    """Push notifications are top-level replies, not nested.
+
+    A burst of push notifications before the command response should NOT
+    trip the depth guard. Each push continuation reads the next top-level
+    reply at the same depth level (depth preserved, not incremented).
+    """
+
+    def test_sync_burst_pushes_not_nested(self):
+        """250 push notifications then OK -- must not raise InvalidResponse."""
+        num_pushes = 250
+        # Each push: >1\r\n (1-element push array) followed by item +ok\r\n
+        lines = []
+        for _ in range(num_pushes):
+            lines.append(b">1\r\n")
+            lines.append(b"+ok\r\n")
+        lines.append(b"+DONE\r\n")  # final command response
+
+        parser = _make_sync_resp3_parser()
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+
+        # Should return the final "+DONE" response, not raise
+        result = parser.read_response()
+        assert result == "DONE"
+
+    def test_sync_push_then_nested_still_trips_guard(self):
+        """Push followed by deeply nested array should still raise."""
+        num_pushes = 5
+        lines = []
+        for _ in range(num_pushes):
+            lines.append(b">1\r\n")
+            lines.append(b"+ok\r\n")
+        # After pushes, a deeply nested array
+        depth = 250
+        lines.extend([b"*1\r\n"] * depth + [b"+OK\r\n"])
+
+        parser = _make_sync_resp3_parser()
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            parser.read_response()

--- a/tests/test_resp_recursion_depth.py
+++ b/tests/test_resp_recursion_depth.py
@@ -1,0 +1,186 @@
+"""
+Tests for recursion depth limits in RESP2 and RESP3 parsers.
+
+Regression tests for https://github.com/redis/redis-py/issues/4116
+Ensures deeply nested responses raise InvalidResponse instead of RecursionError.
+"""
+from unittest import mock
+
+import pytest
+
+from redis._parsers.resp2 import _RESP2Parser, _AsyncRESP2Parser
+from redis._parsers.resp3 import _RESP3Parser, _AsyncRESP3Parser
+from redis.exceptions import InvalidResponse
+
+
+def _make_sync_resp2_parser():
+    parser = _RESP2Parser.__new__(_RESP2Parser)
+    parser._buffer = mock.MagicMock()
+    parser.encoder = mock.MagicMock()
+    parser.encoder.decode = lambda x: x.decode("utf-8", errors="replace") if isinstance(x, bytes) else x
+    return parser
+
+
+def _make_sync_resp3_parser():
+    parser = _RESP3Parser.__new__(_RESP3Parser)
+    parser._buffer = mock.MagicMock()
+    parser.encoder = mock.MagicMock()
+    parser.encoder.decode = lambda x: x.decode("utf-8", errors="replace") if isinstance(x, bytes) else x
+    parser.pubsub_push_handler_func = lambda x: x
+    parser.node_moving_push_handler_func = None
+    parser.maintenance_push_handler_func = None
+    parser.oss_cluster_maint_push_handler_func = None
+    parser.invalidation_push_handler_func = None
+    return parser
+
+
+class TestRESP2SyncDepthLimit:
+    def test_deeply_nested_array_raises_invalid_response(self):
+        """Malicious server sending deeply nested *1\\r\\n arrays."""
+        depth = 600  # exceeds _MAX_RESP_DEPTH = 512
+        lines = [b"*1\r\n"] * depth + [b"+OK\r\n"]
+
+        parser = _make_sync_resp2_parser()
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            parser.read_response()
+
+    def test_shallow_array_parses_ok(self):
+        """Legitimate shallow arrays should parse normally."""
+        parser = _make_sync_resp2_parser()
+        # readline returns without \r\n (transport strips it)
+        lines = [b"*2\r\n", b"+foo", b"+bar"]
+
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+        result = parser.read_response()
+        assert result == ["foo", "bar"]
+
+
+class TestRESP3SyncDepthLimit:
+    def test_deeply_nested_array_raises_invalid_response(self):
+        """RESP3 deeply nested array."""
+        depth = 600
+        lines = [b"*1\r\n"] * depth + [b"+OK\r\n"]
+
+        parser = _make_sync_resp3_parser()
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            parser.read_response()
+
+    def test_deeply_nested_set_raises_invalid_response(self):
+        """RESP3 deeply nested set (~1\\r\\n)."""
+        depth = 600
+        lines = [b"~1\r\n"] * depth + [b"+OK\r\n"]
+
+        parser = _make_sync_resp3_parser()
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            parser.read_response()
+
+    def test_deeply_nested_map_raises_invalid_response(self):
+        """RESP3 deeply nested map (%1\\r\\n key val).
+
+        Each map level consumes 3 reads: the %1\\r\\n header, one recursive
+        key read, and one recursive val read.  For N nesting levels we need
+        N header lines + 1 leaf key + N val lines = 2N + 1 total lines.
+        """
+        depth = 550  # well above _MAX_RESP_DEPTH = 512
+        lines = [b"%1\r\n"] * depth + [b"+k"] + [b"+v"] * depth
+
+        parser = _make_sync_resp3_parser()
+        call_count = [0]
+
+        def mock_readline(timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._buffer.readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            parser.read_response()
+
+
+@pytest.mark.asyncio
+class TestRESP2AsyncDepthLimit:
+    async def test_deeply_nested_array_raises_invalid_response(self):
+        """Async RESP2 deeply nested array."""
+        depth = 600
+        lines = [b"*1\r\n"] * depth + [b"+OK"]
+
+        parser = _AsyncRESP2Parser.__new__(_AsyncRESP2Parser)
+        parser._stream = mock.MagicMock()
+        parser.encoder = mock.MagicMock()
+        parser.encoder.decode = lambda x: x.decode("utf-8", errors="replace") if isinstance(x, bytes) else x
+        parser._stream_closed = False
+
+        call_count = [0]
+
+        async def mock_readline():
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            await parser._read_response()
+
+
+@pytest.mark.asyncio
+class TestRESP3AsyncDepthLimit:
+    async def test_deeply_nested_array_raises_invalid_response(self):
+        """Async RESP3 deeply nested array."""
+        depth = 600
+        lines = [b"*1\r\n"] * depth + [b"+OK"]
+
+        parser = _AsyncRESP3Parser.__new__(_AsyncRESP3Parser)
+        parser._stream = mock.MagicMock()
+        parser.encoder = mock.MagicMock()
+        parser.encoder.decode = lambda x: x.decode("utf-8", errors="replace") if isinstance(x, bytes) else x
+        parser._stream_closed = False
+        parser.pubsub_push_handler_func = mock.AsyncMock(return_value=None)
+        parser.invalidation_push_handler_func = None
+
+        call_count = [0]
+
+        async def mock_readline():
+            idx = call_count[0]
+            call_count[0] += 1
+            return lines[idx]
+
+        parser._readline = mock_readline
+
+        with pytest.raises(InvalidResponse, match="nesting depth exceeds"):
+            await parser._read_response()

--- a/tests/test_resp_recursion_depth.py
+++ b/tests/test_resp_recursion_depth.py
@@ -37,7 +37,8 @@ def _make_sync_resp3_parser():
 class TestRESP2SyncDepthLimit:
     def test_deeply_nested_array_raises_invalid_response(self):
         """Malicious server sending deeply nested *1\\r\\n arrays."""
-        depth = 600  # exceeds _MAX_RESP_DEPTH = 512
+        depth = 250  # exceeds _MAX_RESP_DEPTH = 200 but stays well below
+                     # the default recursion limit (~1000 frames)
         lines = [b"*1\r\n"] * depth + [b"+OK\r\n"]
 
         parser = _make_sync_resp2_parser()
@@ -74,7 +75,7 @@ class TestRESP2SyncDepthLimit:
 class TestRESP3SyncDepthLimit:
     def test_deeply_nested_array_raises_invalid_response(self):
         """RESP3 deeply nested array."""
-        depth = 600
+        depth = 250  # exceeds _MAX_RESP_DEPTH = 200
         lines = [b"*1\r\n"] * depth + [b"+OK\r\n"]
 
         parser = _make_sync_resp3_parser()
@@ -92,7 +93,7 @@ class TestRESP3SyncDepthLimit:
 
     def test_deeply_nested_set_raises_invalid_response(self):
         """RESP3 deeply nested set (~1\\r\\n)."""
-        depth = 600
+        depth = 250  # exceeds _MAX_RESP_DEPTH = 200
         lines = [b"~1\r\n"] * depth + [b"+OK\r\n"]
 
         parser = _make_sync_resp3_parser()
@@ -115,7 +116,7 @@ class TestRESP3SyncDepthLimit:
         key read, and one recursive val read.  For N nesting levels we need
         N header lines + 1 leaf key + N val lines = 2N + 1 total lines.
         """
-        depth = 550  # well above _MAX_RESP_DEPTH = 512
+        depth = 250  # exceeds _MAX_RESP_DEPTH = 200
         lines = [b"%1\r\n"] * depth + [b"+k"] + [b"+v"] * depth
 
         parser = _make_sync_resp3_parser()
@@ -136,7 +137,7 @@ class TestRESP3SyncDepthLimit:
 class TestRESP2AsyncDepthLimit:
     async def test_deeply_nested_array_raises_invalid_response(self):
         """Async RESP2 deeply nested array."""
-        depth = 600
+        depth = 250  # exceeds _MAX_RESP_DEPTH = 200
         lines = [b"*1\r\n"] * depth + [b"+OK"]
 
         parser = _AsyncRESP2Parser.__new__(_AsyncRESP2Parser)
@@ -162,7 +163,7 @@ class TestRESP2AsyncDepthLimit:
 class TestRESP3AsyncDepthLimit:
     async def test_deeply_nested_array_raises_invalid_response(self):
         """Async RESP3 deeply nested array."""
-        depth = 600
+        depth = 250  # exceeds _MAX_RESP_DEPTH = 200
         lines = [b"*1\r\n"] * depth + [b"+OK"]
 
         parser = _AsyncRESP3Parser.__new__(_AsyncRESP3Parser)


### PR DESCRIPTION
## Problem

A malicious or misconfigured Redis server can send deeply nested RESP responses (e.g., `*1\r\n` repeated thousands of times) that cause the pure-Python parsers to recurse without limit, crashing the client with a `RecursionError`.

This is a client-side denial-of-service vulnerability affecting any application using the redis-py library with an untrusted Redis server.

**Issue:** #4116

## Root Cause

The `_read_response()` method in `resp2.py` and `resp3.py` recursively parses aggregate types (arrays `*`, sets `~`, maps `%`, push `>`) without any depth guard. A server sending thousands of nested `*1\r\n` lines exhausts Python's call stack.

## Fix

Add a `_MAX_RESP_DEPTH = 512` constant and a `_depth` parameter to `_read_response()` that increments on each recursive call. When depth exceeds 512, an `InvalidResponse` exception is raised instead of allowing unbounded recursion.

### Files Changed

- `redis/_parsers/resp2.py` - Sync and async `_read_response()` (arrays)
- `redis/_parsers/resp3.py` - Sync and async `_read_response()` (arrays, sets, maps, push)
- `tests/test_resp_recursion_depth.py` - New test file covering all 4 parser variants

### Scope

All 4 pure-Python parsers are protected:

| Parser | Sync | Async |
|--------|------|-------|
| RESP2  | Yes  | Yes   |
| RESP3  | Yes  | Yes   |

The hiredis C parser is not affected (it has its own buffer management).

## Testing

All new tests pass. No regressions on existing unit tests. Full integration tests require a running Redis server (not available in CI environment).

```bash
pytest tests/test_resp_recursion_depth.py -v
# 7 passed
```

## Notes

- Depth limit of 512 is well above any legitimate Redis response nesting depth
- The fix is backward-compatible: no public API changes
- The `_depth` parameter is private (prefixed with underscore)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core wire-protocol parsing used on every Redis read; wrong depth accounting could reject legitimate RESP3 push traffic or still allow stack exhaustion, though tests target push continuations explicitly.
> 
> **Overview**
> Adds a **`_MAX_RESP_DEPTH` (200)** guard on the pure-Python **RESP2 and RESP3** parsers (sync and async) so deeply nested aggregate replies raise **`InvalidResponse`** instead of blowing the Python stack when talking to a malicious or broken server ([#4116](https://github.com/redis/redis-py/issues/4116)).
> 
> **`_read_response`** now tracks a private **`_depth`** counter and increments it when recursing into arrays (`*`), and in RESP3 also sets (`~`), maps (`%`), and push payloads (`>`). **RESP3 push continuations** after handling a `>` reply re-enter parsing at the **same** depth so long bursts of top-level push notifications do not count as nesting.
> 
> New regression tests in **`tests/test_resp_recursion_depth.py`** cover deep nesting for all four parsers, shallow happy paths, and push-vs-nested behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e1f0ce7fc83fc40b51f11a22336aebd7a34d129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->