### PR TITLE
Decode ACL LOG string values on the default RESP3 legacy callback

### DIFF
--- a/redis/_parsers/helpers.py
+++ b/redis/_parsers/helpers.py
@@ -1341,7 +1341,7 @@ def parse_acl_log_resp3_to_resp2_legacy(response, **options):
     data = []
     for log in response:
         if isinstance(log, dict):
-            log_data = {str_if_bytes(k): v for k, v in log.items()}
+            log_data = {str_if_bytes(k): str_if_bytes(v) for k, v in log.items()}
         else:
             log_data = pairs_to_dict(log, True, True)
         client_info = log_data.get("client-info", "")

--- a/tests/test_parsers/test_helpers.py
+++ b/tests/test_parsers/test_helpers.py
@@ -1,6 +1,8 @@
 import pytest
 
 from redis._parsers.helpers import (
+    parse_acl_log,
+    parse_acl_log_resp3_to_resp2_legacy,
     parse_client_list,
     parse_command,
     parse_info,
@@ -143,3 +145,56 @@ def test_parse_sentinel_masters_resp3_returns_master_dict():
     assert masters["redis-py-test"]["flags"] == {"master"}
     assert masters["redis-py-test"]["is_master"] is True
     assert masters["redis-py-test"]["is_sdown"] is False
+
+
+@pytest.mark.fixed_client
+def test_parse_acl_log_resp3_legacy_decodes_string_values():
+    # On a RESP3 connection with the default legacy_responses=True, each ACL
+    # LOG entry arrives as a map. The scalar string fields (reason, context,
+    # object, username) are bulk strings and must be decoded to ``str`` so the
+    # result matches what parse_acl_log() produces from a RESP2 connection.
+    client_info = b"id=3 addr=127.0.0.1:52654 name= age=0 user=someuser"
+    resp3_entry = {
+        b"count": 1,
+        b"reason": b"auth",
+        b"context": b"toplevel",
+        b"object": b"AUTH",
+        b"username": b"someuser",
+        b"age-seconds": b"8.038",
+        b"client-info": client_info,
+        b"entry-id": 0,
+        b"timestamp-created": 1700000000000,
+        b"timestamp-last-updated": 1700000000000,
+    }
+
+    parsed = parse_acl_log_resp3_to_resp2_legacy([resp3_entry])[0]
+
+    assert parsed["reason"] == "auth"
+    assert parsed["context"] == "toplevel"
+    assert parsed["object"] == "AUTH"
+    assert parsed["username"] == "someuser"
+
+    # Must match the RESP2-wire legacy shape exactly (the default-config promise).
+    resp2_entry = [
+        b"count",
+        1,
+        b"reason",
+        b"auth",
+        b"context",
+        b"toplevel",
+        b"object",
+        b"AUTH",
+        b"username",
+        b"someuser",
+        b"age-seconds",
+        b"8.038",
+        b"client-info",
+        client_info,
+        b"entry-id",
+        0,
+        b"timestamp-created",
+        1700000000000,
+        b"timestamp-last-updated",
+        1700000000000,
+    ]
+    assert parse_acl_log([resp2_entry]) == [parsed]


### PR DESCRIPTION
`parse_acl_log_resp3_to_resp2_legacy` decodes the ACL LOG entry's map **keys** but leaves the string **values** as bytes, so the default client returns bytes where the RESP2 client returns `str`:

```python
Redis(protocol=2).acl_log()   # {'reason': 'auth', 'context': 'toplevel', 'object': 'AUTH', 'username': 'someuser', ...}
Redis().acl_log()             # {'reason': b'auth', 'context': b'toplevel', 'object': b'AUTH', 'username': b'someuser', ...}
```

`Redis()` defaults to the RESP3 wire with `legacy_responses=True` (`get_response_callbacks(None, True)`), and the server sends each ACL LOG entry as a map on RESP3, so `parse_acl_log_resp3_to_resp2_legacy` always runs. Its documented contract (the legacy/unified split added in #4052) is to match the RESP2 legacy shape — but four bulk-string fields (`reason`, `context`, `object`, `username`) come back as `bytes`.

**Root cause** (`redis/_parsers/helpers.py`): the map branch does `{str_if_bytes(k): v for ...}` — keys only. The base RESP2 callback uses `pairs_to_dict(log, True, True)` (decode keys **and** values) and the sibling `parse_acl_log_resp3_unified` also decodes values; this branch is the one that doesn't.

**Fix** (1 line): decode the values too, mirroring the siblings. Non-string values (the integer `count`/`entry-id`/timestamps) pass through `str_if_bytes` unchanged; `age-seconds`/`client-info` are overwritten afterward exactly as before.

```python
-            log_data = {str_if_bytes(k): v for k, v in log.items()}
+            log_data = {str_if_bytes(k): str_if_bytes(v) for k, v in log.items()}
```

**Verification** (re-runnable from the diff): added `test_parse_acl_log_resp3_legacy_decodes_string_values` in `tests/test_parsers/test_helpers.py` (pure unit test, no server) — it builds the RESP3 map entry, asserts the four fields decode to `str`, and asserts the result equals `parse_acl_log` on the equivalent RESP2 flat list. It fails on the current tree (`assert b'auth' == 'auth'`) and passes with the fix. `pytest tests/test_parsers/` → 10 passed; `ruff check`/`ruff format --check` clean. `helpers.py` is shared by the sync and async stacks, so the single change covers both.

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line parser fix in shared helpers with a focused unit test; no auth or wire-protocol behavior beyond ACL LOG response shaping.
> 
> **Overview**
> Fixes a **RESP3 + `legacy_responses=True`** mismatch for **`ACL LOG`**: map entries were decoded on keys only, so fields like `reason`, `context`, `object`, and `username` stayed as `bytes` instead of matching RESP2’s `str` shape.
> 
> `parse_acl_log_resp3_to_resp2_legacy` now runs **`str_if_bytes` on values** in the RESP3 map branch (same idea as `pairs_to_dict(..., decode_string_values=True)` on RESP2). Post-processing for `client-info` and `age-seconds` is unchanged.
> 
> Adds **`test_parse_acl_log_resp3_legacy_decodes_string_values`** to assert those fields are `str` and that the parsed entry equals `parse_acl_log` on the equivalent RESP2 wire list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5f5af9f8f21a89056422e4e4bf429988b0315d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->