### PR TITLE
test: add VectorField RERANK serialization tests for sync and async search

### DIFF
--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -2619,6 +2619,40 @@ class TestPipeline(AsyncSearchTestsBase):
 
 class TestSearchWithVamana(AsyncSearchTestsBase):
     # SVS-VAMANA Async Tests
+    @pytest.mark.fixed_client
+    def test_vector_field_rerank(self):
+        # Pure serialization check: VectorField builds the FT.CREATE args with
+        # no server round-trip, so this test needs no Redis and is not gated.
+        # RERANK is a boolean key-value attribute for HNSW vector fields on
+        # disk-backed (Flex / Auto-Tiering) deployments, where it is mandatory.
+        # It toggles the exact FP32 rerank pass over the approximate candidates
+        # returned by the on-disk graph traversal. It flows through the generic
+        # ``attributes`` dict as the string "TRUE"/"FALSE" (a bare flag is
+        # rejected by the server, and Python bools are rejected by the client
+        # encoder), and the attribute-count token accounts for the extra pair.
+        # Field construction has no I/O, so this mirrors the sync serialization
+        # test and is not an async test.
+        field = VectorField(
+            "v",
+            "HNSW",
+            {"TYPE": "FLOAT32", "DIM": 128, "DISTANCE_METRIC": "L2", "RERANK": "TRUE"},
+        )
+        assert field.args[0] == "VECTOR"
+        assert field.args[1] == "HNSW"
+        assert field.args[2] == 8  # 4 attribute pairs -> 8 tokens
+        assert "RERANK" in field.args
+        assert "TRUE" in field.args
+
+        # MS2 also accepts RERANK FALSE (opt out of the rerank pass).
+        field = VectorField(
+            "v",
+            "HNSW",
+            {"TYPE": "FLOAT32", "DIM": 128, "DISTANCE_METRIC": "L2", "RERANK": "FALSE"},
+        )
+        assert field.args[2] == 8
+        assert "RERANK" in field.args
+        assert "FALSE" in field.args
+
     @pytest.mark.redismod
     @skip_if_server_version_lt("8.1.224")
     async def test_async_svs_vamana_basic_functionality(self, decoded_r: redis.Redis):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3419,6 +3419,38 @@ class TestDifferentFieldTypesSearch(SearchTestsBase):
         with pytest.raises(Exception):
             r.ft().create_index((VectorField("v", "SORT", {}),))
 
+    @pytest.mark.fixed_client
+    def test_vector_field_rerank(self):
+        # Pure serialization check: VectorField builds the FT.CREATE args with
+        # no server round-trip, so this test needs no Redis and is not gated.
+        # RERANK is a boolean key-value attribute for HNSW vector fields on
+        # disk-backed (Flex / Auto-Tiering) deployments, where it is mandatory.
+        # It toggles the exact FP32 rerank pass over the approximate candidates
+        # returned by the on-disk graph traversal. It flows through the generic
+        # ``attributes`` dict as the string "TRUE"/"FALSE" (a bare flag is
+        # rejected by the server, and Python bools are rejected by the client
+        # encoder), and the attribute-count token accounts for the extra pair.
+        field = VectorField(
+            "v",
+            "HNSW",
+            {"TYPE": "FLOAT32", "DIM": 128, "DISTANCE_METRIC": "L2", "RERANK": "TRUE"},
+        )
+        assert field.args[0] == "VECTOR"
+        assert field.args[1] == "HNSW"
+        assert field.args[2] == 8  # 4 attribute pairs -> 8 tokens
+        assert "RERANK" in field.args
+        assert "TRUE" in field.args
+
+        # MS2 also accepts RERANK FALSE (opt out of the rerank pass).
+        field = VectorField(
+            "v",
+            "HNSW",
+            {"TYPE": "FLOAT32", "DIM": 128, "DISTANCE_METRIC": "L2", "RERANK": "FALSE"},
+        )
+        assert field.args[2] == 8
+        assert "RERANK" in field.args
+        assert "FALSE" in field.args
+
     @pytest.mark.redismod
     @skip_ifmodversion_lt("2.4.3", "search")
     def test_text_params(self, client):


### PR DESCRIPTION

## Change summary

This pull request adds serialization coverage for the `RERANK` attribute on
`VectorField`, which had no dedicated test. `RERANK` is a boolean key-value
attribute for HNSW vector fields on disk-backed (Flex / Auto-Tiering)
deployments; the tests verify it flows through the `attributes` dict as the
string `"TRUE"`/`"FALSE"` and produces a well-formed `FT.CREATE` argument vector.

Changes are test-only (`tests/test_search.py`, `tests/test_asyncio/test_search.py`),
so there is no runtime, public-API, or wire-protocol impact. The tests are pure
serialization checks marked `fixed_client` and need no Redis server; the async
copy is intentionally a plain (non-`async`) `def`. Sync/async parity is preserved.

## Test coverage

Adds a mirrored `test_vector_field_rerank` in both suites. Each constructs a
`VectorField("v", "HNSW", {...})` with `RERANK` set to `"TRUE"` and `"FALSE"`,
then asserts the type/algorithm tokens, the attribute-count token (4 pairs → 8),
and that `RERANK` and its value appear in `field.args`. No product code changed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new unit tests with no production code, API, or protocol impact.
> 
> **Overview**
> Adds mirrored **`test_vector_field_rerank`** coverage in sync and async search suites for the HNSW **`RERANK`** index attribute (disk-backed Flex / Auto-Tiering), which had no dedicated test before.
> 
> Each test is marked **`fixed_client`** and only inspects **`VectorField(...).args`**—no Redis server—asserting **`VECTOR`/`HNSW`**, the attribute-count token (4 pairs → 8), and that **`RERANK`** appears with **`"TRUE"`** or **`"FALSE"`** from the attributes dict. **No library or runtime code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b25af2bee776f29c8d1da65fe8bf300be7eb18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->