### PR TITLE
feat: add client-side HIMPORT fieldset support for standalone and cluster clients

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -122,11 +122,14 @@ docstrings
 eg
 enums
 exc
+fieldset
+fieldsets
 firsttimersonly
 fo
 formatter
 genindex
 gmail
+himport
 hiredis
 http
 idx
@@ -162,6 +165,7 @@ parsers
 performant
 pmessage
 png
+positionally
 pre
 psubscribe
 pubsub

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.8.0'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.10:custom-29557896054-debian
+    8.10:8.10-rc2
 
 jobs:
   dependency-audit:

--- a/README.md
+++ b/README.md
@@ -221,6 +221,61 @@ This is useful when:
 
 For the complete failover configuration options and examples, see the [Multi-database client docs](https://redis.readthedocs.io/en/latest/multi_database.html).
 
+### Bulk hash ingestion (HIMPORT)
+
+Redis 8.10 adds the `HIMPORT` command family for loading many hashes that share
+the same set of field names: register the field names once with `himport_prepare`,
+then create each hash by sending only its values. Keys written this way are regular
+hashes — every hash command works on them.
+
+``` python
+r.himport_prepare("users", ["name", "email", "age"])
+r.himport_set("user:1", "users", ["alice", "alice@example.com", "25"])
+r.himport_set("user:2", "users", ["bob", "bob@example.com", "30"])
+r.himport_discard("users")  # => 1
+```
+
+Values pair positionally with the prepared fields. Hash enumeration order
+(`HGETALL`, `HKEYS`) is not guaranteed to match the prepare order.
+
+**Fieldsets are connection state.** A prepared fieldset lives in the server-side
+session of the physical connection that prepared it: it is invisible to other
+connections and destroyed by a disconnect or `RESET`. redis-py handles this for you —
+`himport_prepare` records the fieldset in a client-level registry, and the `PREPARE`
+is applied lazily on whatever pooled connection serves each `himport_set` (and
+re-applied automatically after a reconnect, `RESET`, or Sentinel/cluster failover).
+You declare each fieldset once per client with `himport_prepare`; there is no
+constructor argument for it.
+
+For the highest ingestion throughput, send the `PREPARE` and its `SET`s in one
+pipeline — a single batch always executes on one connection:
+
+``` python
+with r.pipeline(transaction=False) as pipe:
+    pipe.himport_prepare("users", ["name", "email", "age"])
+    for uid, row in rows:
+        pipe.himport_set(f"user:{uid}", "users", row)
+    pipe.execute()
+```
+
+The automatic re-prepare applies to direct calls only, not to commands inside
+`pipeline`/`transaction` blocks: a batched `himport_set` relies on the single
+pre-flight `PREPARE` in that batch.
+
+With `RedisCluster`, `himport_prepare` / `himport_discard` / `himport_discard_all`
+fan out to every master node and return a single aggregated reply, matching the
+standalone API; `himport_set` routes by the key's hash slot. With Sentinel, call
+`himport_prepare` on the long-lived client returned by `master_for(...)`; the fieldset
+survives failover automatically. HIMPORT is not supported on the multi-database
+(Active-Active) client.
+
+The async client mirrors this exactly:
+
+``` python
+await r.himport_prepare("users", ["name", "email", "age"])
+await r.himport_set("user:1", "users", ["alice", "alice@example.com", "25"])
+```
+
 ---------------------------------------------
 
 ### Author

--- a/README.md
+++ b/README.md
@@ -263,8 +263,13 @@ The automatic re-prepare applies to direct calls only, not to commands inside
 pre-flight `PREPARE` in that batch.
 
 With `RedisCluster`, `himport_prepare` / `himport_discard` / `himport_discard_all`
-fan out to every master node and return a single aggregated reply, matching the
-standalone API; `himport_set` routes by the key's hash slot. With Sentinel, call
+update the client's shared, cluster-wide registry and return immediately — like the
+standalone API, they perform no server I/O of their own. The server-side `PREPARE`
+(and, after a discard, `DISCARD`) is applied lazily on each node's connection the
+next time it serves an `himport_set`, and re-applied after reconnects or failover;
+`himport_set` itself routes by the key's hash slot. A discard is therefore not
+removed from every server session at once: each connection drops the fieldset on its
+next `himport_set` (or on disconnect). With Sentinel, call
 `himport_prepare` on the long-lived client returned by `master_for(...)`; the fieldset
 survives failover automatically. HIMPORT is not supported on the multi-database
 (Active-Active) client.

--- a/redis/_himport_exec.py
+++ b/redis/_himport_exec.py
@@ -220,3 +220,62 @@ def prepare_pipeline(node, conn, command_arg_lists):
         conn._himport_prepared[fs.name] = fs.version
     if first_error is not None:
         raise first_error
+
+
+def pipeline_prepares(node, conn, command_arg_lists):
+    """Return the fieldsets that must be PREPAREd on ``conn`` for this batch.
+
+    Like :func:`prepare_pipeline`, but does **not** send the PREPAREs: the caller
+    folds them into the same packed write as the queued commands (see the pipeline
+    executors), so the first pipeline use of a fieldset on a fresh or reconnected
+    connection stays a single round trip instead of a separate PREPARE exchange
+    followed by the batch. Deferred-discard reconciliation is still performed here,
+    but it only touches the socket when discards are actually pending (rare); the
+    common warm-up cost -- the first-use PREPARE -- is what gets folded. Returns an
+    empty list when the batch references no not-yet-prepared registered fieldset,
+    or when ``conn`` carries no real HIMPORT registry.
+    """
+    registry = getattr(conn, "himport_registry", None)
+    if not isinstance(registry, HImportRegistry):
+        return []
+    reconcile_discards(node, conn)
+    to_prepare = []
+    seen = set()
+    for args in command_arg_lists:
+        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+            continue
+        fieldset_name = args[2]
+        if fieldset_name in seen:
+            continue
+        seen.add(fieldset_name)
+        fieldset = registry.get(fieldset_name)
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            to_prepare.append(fieldset)
+    return to_prepare
+
+
+def prepare_wire_commands(fieldsets):
+    """The leading ``HIMPORT PREPARE`` wire commands the caller folds into a batch."""
+    return [himport_prepare_command(fs.name, fs.fields) for fs in fieldsets]
+
+
+def drain_pipeline_prepares(node, conn, fieldsets):
+    """Drain the ``len(fieldsets)`` leading PREPARE replies of a folded pipeline
+    write, marking each fieldset prepared on success.
+
+    Returns the first ``ResponseError`` (or ``None``). The caller must still drain
+    the queued command replies and only then surface this error: every reply on
+    the wire has to be read before raising, or the pooled socket desyncs.
+    """
+    first_error = None
+    for fs in fieldsets:
+        try:
+            node.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            first_error = first_error or e
+            continue
+        conn._himport_prepared[fs.name] = fs.version
+    return first_error

--- a/redis/_himport_exec.py
+++ b/redis/_himport_exec.py
@@ -1,0 +1,222 @@
+"""Shared HIMPORT wire-execution helpers for the synchronous clients.
+
+The PREPARE / SET / DISCARD packed-write drain loops, per-connection version
+bookkeeping, and ``NoSuchFieldsetError`` re-prepare-and-retry are identical for
+the standalone (:class:`redis.Redis`) and cluster (:class:`redis.RedisCluster`)
+sync clients, differing only in (a) which object provides ``parse_response`` and
+(b) the cluster-only ASK-redirect handling. These functions take that object as
+``node`` and an ``asking`` flag (``False`` -- and a no-op -- for standalone), so
+both clients share one implementation instead of copy-pasting the logic. The
+per-class ``_himport_*`` methods are thin delegators to these functions.
+
+The async mirror lives in :mod:`redis.asyncio._himport_exec`; the two are kept
+separate on purpose (the project maintains parallel sync/async stacks by hand).
+"""
+
+from redis.exceptions import NoSuchFieldsetError, ResponseError
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+    HImportRegistry,
+    himport_discard_command,
+    himport_prepare_command,
+    himport_set_command,
+)
+
+
+def reconcile_discards(node, conn):
+    """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
+
+    Runs at most once per registry mutation: the connection records the registry
+    ``revision`` it last reconciled against, so unchanged registries are a no-op.
+    ``node`` supplies ``parse_response`` (the standalone client itself, or the
+    owning node's client in cluster mode).
+    """
+    registry = conn.himport_registry
+    if registry is None or conn._himport_reconciled_revision == registry.revision:
+        return
+    # Snapshot the revision *before* computing ``stale`` so the value stamped at
+    # the end is never newer than the registry state ``stale`` reflects. A
+    # concurrent ``himport_discard`` (thread-shared sync client) that lands after
+    # this point only leaves the connection marked behind the live revision, so
+    # the next reconcile re-runs and catches it. Re-reading ``registry.revision``
+    # at the end instead would stamp a discard this connection never sent.
+    reconciled_to = registry.revision
+    stale = registry.names_to_discard(list(conn._himport_prepared))
+    if stale:
+        conn.send_packed_command(
+            conn.pack_commands([himport_discard_command(n) for n in stale])
+        )
+        # One reply per packed DISCARD must be read regardless of a per-command
+        # ResponseError, otherwise the unread replies desync the pooled socket.
+        # Drain every reply, then surface the first error (ConnectionError is not
+        # caught: it tears the socket down, so no desync is possible).
+        first_error = None
+        for n in stale:
+            try:
+                node.parse_response(conn, HIMPORT_DISCARD)
+            except ResponseError as e:
+                first_error = first_error or e
+            conn._himport_prepared.pop(n, None)
+        if first_error is not None:
+            raise first_error
+    conn._himport_reconciled_revision = reconciled_to
+
+
+def prepare_and_set(node, conn, key, fieldset_name, values, fieldset, asking=False):
+    """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write).
+
+    When ``asking`` is set (an ASK-redirected cluster SET) the batch becomes
+    ``[PREPARE, ASKING, SET]`` so the per-command ASKING allowance falls
+    immediately before the SET -- the only slot-scoped command. PREPARE is a
+    connection-session command the ASKING flag does not gate, so placing it
+    before ASKING is safe. Every reply is drained even on a per-command error so
+    the packed replies never desync the pooled socket.
+    """
+    commands = [himport_prepare_command(fieldset_name, fieldset.fields)]
+    if asking:
+        commands.append(("ASKING",))
+    commands.append(himport_set_command(key, fieldset_name, values))
+    conn.send_packed_command(conn.pack_commands(commands))
+    prep_error = ask_error = set_error = None
+    set_resp = None
+    try:
+        node.parse_response(conn, HIMPORT_PREPARE)
+    except ResponseError as e:
+        prep_error = e
+    if asking:
+        try:
+            node.parse_response(conn, "ASKING")
+        except ResponseError as e:
+            ask_error = e
+    try:
+        set_resp = node.parse_response(conn, HIMPORT_SET)
+    except ResponseError as e:
+        set_error = e
+
+    if prep_error:
+        raise prep_error  # PREPARE failure is the root cause
+    else:
+        conn._himport_prepared[fieldset_name] = fieldset.version
+
+    if ask_error:
+        raise ask_error
+    if set_error:
+        raise set_error
+    return set_resp
+
+
+def execute_set(node, conn, key, fieldset_name, values, asking=False):
+    """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
+
+    Reconciles deferred discards, lazily bundles PREPARE with the SET on first
+    use of a fieldset, and recovers once from a mid-connection fieldset loss
+    (``NoSuchFieldsetError``) by re-PREPARE-and-retry. When ``asking`` is set the
+    ASKING allowance is folded into the SET's own packed write so it immediately
+    precedes the (slot-scoped) SET; the session setup runs first, since those are
+    connection-session commands the flag does not gate.
+    """
+    reconcile_discards(node, conn)
+
+    registry = conn.himport_registry
+    fieldset = registry.get(fieldset_name) if registry is not None else None
+    # Lazy PREPARE bundled with SET on first use of this fieldset.
+    if (
+        fieldset is not None
+        and conn._himport_prepared.get(fieldset_name) != fieldset.version
+    ):
+        return prepare_and_set(
+            node, conn, key, fieldset_name, values, fieldset, asking=asking
+        )
+
+    # Believed already prepared (or an unregistered fieldset): bare SET, with
+    # ASKING packed immediately before it when this is an ASK redirect.
+    if asking:
+        conn.send_packed_command(
+            conn.pack_commands(
+                [("ASKING",), himport_set_command(key, fieldset_name, values)]
+            )
+        )
+        try:
+            node.parse_response(conn, "ASKING")
+        except ResponseError as ask_error:
+            # ASKING and SET were one packed write, so the SET reply is still
+            # queued. Drain it before surfacing the ASKING error, otherwise the
+            # connection returns to the pool with an unread reply and desyncs the
+            # next borrower.
+            try:
+                node.parse_response(conn, HIMPORT_SET)
+            except ResponseError:
+                pass
+            raise ask_error
+    else:
+        conn.send_command(*himport_set_command(key, fieldset_name, values))
+    try:
+        return node.parse_response(conn, HIMPORT_SET)
+    except NoSuchFieldsetError:
+        # Server dropped the fieldset mid-connection without dropping the socket
+        # (e.g. RESET / maxmemory-clients eviction): re-PREPARE on this healthy
+        # connection and retry the SET once rather than reconnecting. Only for
+        # registry-backed fieldsets; manual/unregistered usage propagates.
+        if fieldset is None:
+            raise
+        conn._himport_prepared.pop(fieldset_name, None)
+        return prepare_and_set(
+            node, conn, key, fieldset_name, values, fieldset, asking=asking
+        )
+
+
+def prepare_pipeline(node, conn, command_arg_lists):
+    """Pre-flight ``conn`` for a pipeline batch containing ``HIMPORT SET``s.
+
+    The packed pipeline write bypasses the per-command lazy-PREPARE path, so the
+    fieldsets referenced by the buffered SETs must be PREPAREd on ``conn`` first.
+    Reconciles deferred discards, then PREPAREs every distinct registered fieldset
+    the batch references that this connection has not already prepared, in one
+    packed write. ``command_arg_lists`` is the batch's per-command positional-arg
+    sequences (the caller extracts them from its own command representation).
+    No-op when the batch has no registry-backed ``HIMPORT SET``.
+    """
+    # A pipeline may run on a connection type that never carries real HIMPORT
+    # state (e.g. mocked test doubles); only proceed for a real config.
+    registry = getattr(conn, "himport_registry", None)
+    if not isinstance(registry, HImportRegistry):
+        return
+    reconcile_discards(node, conn)
+    to_prepare = []
+    seen = set()
+    for args in command_arg_lists:
+        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+            continue
+        fieldset_name = args[2]
+        if fieldset_name in seen:
+            continue
+        seen.add(fieldset_name)
+        fieldset = registry.get(fieldset_name)
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            to_prepare.append(fieldset)
+    if not to_prepare:
+        return
+    conn.send_packed_command(
+        conn.pack_commands(
+            [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
+        )
+    )
+    # One reply per packed PREPARE must be read regardless of a per-command
+    # ResponseError, otherwise the unread replies desync the socket before the
+    # buffered batch is even sent. Drain every reply (marking only the ones that
+    # succeeded), then surface the first error as the root cause.
+    first_error = None
+    for fs in to_prepare:
+        try:
+            node.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            first_error = first_error or e
+            continue
+        conn._himport_prepared[fs.name] = fs.version
+    if first_error is not None:
+        raise first_error

--- a/redis/_himport_exec.py
+++ b/redis/_himport_exec.py
@@ -22,6 +22,7 @@ from redis.himport import (
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
+    is_himport_set_command,
 )
 
 
@@ -187,7 +188,7 @@ def prepare_pipeline(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
             continue
         fieldset_name = args[2]
         if fieldset_name in seen:
@@ -242,7 +243,7 @@ def pipeline_prepares(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
             continue
         fieldset_name = args[2]
         if fieldset_name in seen:

--- a/redis/_himport_exec.py
+++ b/redis/_himport_exec.py
@@ -22,7 +22,7 @@ from redis.himport import (
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
-    is_himport_set_command,
+    parse_himport_set_args,
 )
 
 
@@ -188,9 +188,10 @@ def prepare_pipeline(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
+        parsed = parse_himport_set_args(args)
+        if parsed is None:
             continue
-        fieldset_name = args[2]
+        fieldset_name = parsed[1]
         if fieldset_name in seen:
             continue
         seen.add(fieldset_name)
@@ -243,9 +244,10 @@ def pipeline_prepares(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
+        parsed = parse_himport_set_args(args)
+        if parsed is None:
             continue
-        fieldset_name = args[2]
+        fieldset_name = parsed[1]
         if fieldset_name in seen:
             continue
         seen.add(fieldset_name)

--- a/redis/_himport_exec.py
+++ b/redis/_himport_exec.py
@@ -179,47 +179,17 @@ def prepare_pipeline(node, conn, command_arg_lists):
     sequences (the caller extracts them from its own command representation).
     No-op when the batch has no registry-backed ``HIMPORT SET``.
     """
-    # A pipeline may run on a connection type that never carries real HIMPORT
-    # state (e.g. mocked test doubles); only proceed for a real config.
-    registry = getattr(conn, "himport_registry", None)
-    if not isinstance(registry, HImportRegistry):
-        return
-    reconcile_discards(node, conn)
-    to_prepare = []
-    seen = set()
-    for args in command_arg_lists:
-        parsed = parse_himport_set_args(args)
-        if parsed is None:
-            continue
-        fieldset_name = parsed[1]
-        if fieldset_name in seen:
-            continue
-        seen.add(fieldset_name)
-        fieldset = registry.get(fieldset_name)
-        if (
-            fieldset is not None
-            and conn._himport_prepared.get(fieldset_name) != fieldset.version
-        ):
-            to_prepare.append(fieldset)
+    # Selection (registry check, deferred-discard reconcile, scan/dedup/version)
+    # is shared with pipeline_prepares. This path differs only in that it sends the
+    # PREPAREs as their own packed exchange -- rather than folding them into a
+    # queued write -- then drains their replies and raises the first error.
+    to_prepare = pipeline_prepares(node, conn, command_arg_lists)
     if not to_prepare:
         return
-    conn.send_packed_command(
-        conn.pack_commands(
-            [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
-        )
-    )
-    # One reply per packed PREPARE must be read regardless of a per-command
-    # ResponseError, otherwise the unread replies desync the socket before the
-    # buffered batch is even sent. Drain every reply (marking only the ones that
-    # succeeded), then surface the first error as the root cause.
-    first_error = None
-    for fs in to_prepare:
-        try:
-            node.parse_response(conn, HIMPORT_PREPARE)
-        except ResponseError as e:
-            first_error = first_error or e
-            continue
-        conn._himport_prepared[fs.name] = fs.version
+    conn.send_packed_command(conn.pack_commands(prepare_wire_commands(to_prepare)))
+    # Every reply must be drained even on a per-command error, or the unread
+    # replies desync the socket before the buffered batch is sent; then raise.
+    first_error = drain_pipeline_prepares(node, conn, to_prepare)
     if first_error is not None:
         raise first_error
 

--- a/redis/_parsers/base.py
+++ b/redis/_parsers/base.py
@@ -30,6 +30,7 @@ from ..exceptions import (
     MovedError,
     NoPermissionError,
     NoScriptError,
+    NoSuchFieldsetError,
     OutOfMemoryError,
     ReadOnlyError,
     ResponseError,
@@ -61,6 +62,13 @@ EXTERNAL_AUTH_PROVIDER_ERROR = {
     "problem with LDAP service": ExternalAuthProviderError,
 }
 
+# HIMPORT SET referencing a fieldset the connection has not prepared. The server
+# reply is a fixed message with no fieldset name appended (verified against the
+# server: always exactly ``ERR no such fieldset``), so an exact match is correct.
+NO_SUCH_FIELDSET_ERROR = {
+    "no such fieldset": NoSuchFieldsetError,
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -83,6 +91,7 @@ class BaseParser(ABC):
             MODULE_UNLOAD_NOT_POSSIBLE_ERROR: ModuleError,
             **NO_AUTH_SET_ERROR,
             **EXTERNAL_AUTH_PROVIDER_ERROR,
+            **NO_SUCH_FIELDSET_ERROR,
         },
         "OOM": OutOfMemoryError,
         "WRONGPASS": AuthenticationError,

--- a/redis/_parsers/response_callbacks.py
+++ b/redis/_parsers/response_callbacks.py
@@ -26,6 +26,12 @@ protocol-specific overlay. Callers wrap the returned dict in
 
 from typing import Any, Callable, Optional
 
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_DISCARDALL,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+)
 from redis.utils import str_if_bytes
 
 from .helpers import (
@@ -182,6 +188,10 @@ _RedisCallbacks = {
     "FUNCTION FLUSH": bool_ok,
     "FUNCTION RESTORE": bool_ok,
     "GEODIST": float_or_none,
+    HIMPORT_PREPARE: bool_ok,
+    HIMPORT_SET: bool_ok,
+    HIMPORT_DISCARD: int,
+    HIMPORT_DISCARDALL: int,
     "HSCAN": parse_hscan,
     "INFO": parse_info,
     "LASTSAVE": timestamp_to_datetime,

--- a/redis/asyncio/_himport_exec.py
+++ b/redis/asyncio/_himport_exec.py
@@ -1,0 +1,226 @@
+"""Shared HIMPORT wire-execution helpers for the asynchronous clients.
+
+Async mirror of :mod:`redis._himport_exec`. The PREPARE / SET / DISCARD
+packed-write drain loops, per-connection version bookkeeping, and
+``NoSuchFieldsetError`` re-prepare-and-retry are identical for the standalone
+(:class:`redis.asyncio.Redis`) and cluster (async ``ClusterNode``) clients,
+differing only in (a) which object provides ``parse_response`` and (b) the
+cluster-only ASK-redirect handling. These coroutines take that object as
+``node`` and an ``asking`` flag (``False`` -- and a no-op -- for standalone), so
+both clients share one implementation. The per-class ``_himport_*`` methods are
+thin delegators to these coroutines.
+
+The sync version lives in :mod:`redis._himport_exec`; the two are kept separate
+on purpose (the project maintains parallel sync/async stacks by hand).
+"""
+
+from redis.exceptions import NoSuchFieldsetError, ResponseError
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+    HImportRegistry,
+    himport_discard_command,
+    himport_prepare_command,
+    himport_set_command,
+)
+
+
+async def reconcile_discards(node, conn):
+    """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
+
+    Runs at most once per registry mutation: the connection records the registry
+    ``revision`` it last reconciled against, so unchanged registries are a no-op.
+    ``node`` supplies ``parse_response`` (the standalone client itself, or the
+    owning ``ClusterNode`` in cluster mode).
+    """
+    registry = conn.himport_registry
+    if registry is None or conn._himport_reconciled_revision == registry.revision:
+        return
+    # Snapshot the revision *before* computing ``stale`` so the value stamped at
+    # the end is never newer than the registry state ``stale`` reflects. A
+    # concurrent ``himport_discard`` (or another task while this awaits the
+    # DISCARD replies) that lands after this point only leaves the connection
+    # marked behind the live revision, so the next reconcile re-runs and catches
+    # it. Re-reading ``registry.revision`` at the end instead would stamp a
+    # discard this connection never sent.
+    reconciled_to = registry.revision
+    stale = registry.names_to_discard(list(conn._himport_prepared))
+    if stale:
+        await conn.send_packed_command(
+            conn.pack_commands([himport_discard_command(n) for n in stale])
+        )
+        # One reply per packed DISCARD must be read regardless of a per-command
+        # ResponseError, otherwise the unread replies desync the pooled socket.
+        # Drain every reply, then surface the first error (ConnectionError is not
+        # caught: it tears the socket down, so no desync is possible).
+        first_error = None
+        for n in stale:
+            try:
+                await node.parse_response(conn, HIMPORT_DISCARD)
+            except ResponseError as e:
+                first_error = first_error or e
+            conn._himport_prepared.pop(n, None)
+        if first_error is not None:
+            raise first_error
+    conn._himport_reconciled_revision = reconciled_to
+
+
+async def prepare_and_set(
+    node, conn, key, fieldset_name, values, fieldset, asking=False
+):
+    """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write).
+
+    When ``asking`` is set (an ASK-redirected cluster SET) the batch becomes
+    ``[PREPARE, ASKING, SET]`` so the per-command ASKING allowance falls
+    immediately before the SET -- the only slot-scoped command. PREPARE is a
+    connection-session command the ASKING flag does not gate, so placing it
+    before ASKING is safe. Every reply is drained even on a per-command error so
+    the packed replies never desync the pooled socket.
+    """
+    commands = [himport_prepare_command(fieldset_name, fieldset.fields)]
+    if asking:
+        commands.append(("ASKING",))
+    commands.append(himport_set_command(key, fieldset_name, values))
+    await conn.send_packed_command(conn.pack_commands(commands))
+    prep_error = ask_error = set_error = None
+    set_resp = None
+    try:
+        await node.parse_response(conn, HIMPORT_PREPARE)
+    except ResponseError as e:
+        prep_error = e
+    if asking:
+        try:
+            await node.parse_response(conn, "ASKING")
+        except ResponseError as e:
+            ask_error = e
+    try:
+        set_resp = await node.parse_response(conn, HIMPORT_SET)
+    except ResponseError as e:
+        set_error = e
+
+    if prep_error:
+        raise prep_error  # PREPARE failure is the root cause
+    else:
+        conn._himport_prepared[fieldset_name] = fieldset.version
+
+    if ask_error:
+        raise ask_error
+    if set_error:
+        raise set_error
+    return set_resp
+
+
+async def execute_set(node, conn, key, fieldset_name, values, asking=False):
+    """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
+
+    Reconciles deferred discards, lazily bundles PREPARE with the SET on first
+    use of a fieldset, and recovers once from a mid-connection fieldset loss
+    (``NoSuchFieldsetError``) by re-PREPARE-and-retry. When ``asking`` is set the
+    ASKING allowance is folded into the SET's own packed write so it immediately
+    precedes the (slot-scoped) SET; the session setup runs first, since those are
+    connection-session commands the flag does not gate.
+    """
+    await reconcile_discards(node, conn)
+
+    registry = conn.himport_registry
+    fieldset = registry.get(fieldset_name) if registry is not None else None
+    # Lazy PREPARE bundled with SET on first use of this fieldset.
+    if (
+        fieldset is not None
+        and conn._himport_prepared.get(fieldset_name) != fieldset.version
+    ):
+        return await prepare_and_set(
+            node, conn, key, fieldset_name, values, fieldset, asking=asking
+        )
+
+    # Believed already prepared (or an unregistered fieldset): bare SET, with
+    # ASKING packed immediately before it when this is an ASK redirect.
+    if asking:
+        await conn.send_packed_command(
+            conn.pack_commands(
+                [("ASKING",), himport_set_command(key, fieldset_name, values)]
+            )
+        )
+        try:
+            await node.parse_response(conn, "ASKING")
+        except ResponseError as ask_error:
+            # ASKING and SET were one packed write, so the SET reply is still
+            # queued. Drain it before surfacing the ASKING error, otherwise the
+            # connection returns to the pool with an unread reply and desyncs the
+            # next borrower.
+            try:
+                await node.parse_response(conn, HIMPORT_SET)
+            except ResponseError:
+                pass
+            raise ask_error
+    else:
+        await conn.send_command(*himport_set_command(key, fieldset_name, values))
+    try:
+        return await node.parse_response(conn, HIMPORT_SET)
+    except NoSuchFieldsetError:
+        # Server dropped the fieldset mid-connection without dropping the socket
+        # (e.g. RESET / maxmemory-clients eviction): re-PREPARE on this healthy
+        # connection and retry the SET once rather than reconnecting. Only for
+        # registry-backed fieldsets; manual/unregistered usage propagates.
+        if fieldset is None:
+            raise
+        conn._himport_prepared.pop(fieldset_name, None)
+        return await prepare_and_set(
+            node, conn, key, fieldset_name, values, fieldset, asking=asking
+        )
+
+
+async def prepare_pipeline(node, conn, command_arg_lists):
+    """Pre-flight ``conn`` for a pipeline batch containing ``HIMPORT SET``s.
+
+    The packed pipeline write bypasses the per-command lazy-PREPARE path, so the
+    fieldsets referenced by the buffered SETs must be PREPAREd on ``conn`` first.
+    Reconciles deferred discards, then PREPAREs every distinct registered fieldset
+    the batch references that this connection has not already prepared, in one
+    packed write. ``command_arg_lists`` is the batch's per-command positional-arg
+    sequences (the caller extracts them from its own command representation).
+    No-op when the batch has no registry-backed ``HIMPORT SET``.
+    """
+    # A pipeline may run on a connection type that never carries real HIMPORT
+    # state (e.g. mocked test doubles); only proceed for a real config.
+    registry = getattr(conn, "himport_registry", None)
+    if not isinstance(registry, HImportRegistry):
+        return
+    await reconcile_discards(node, conn)
+    to_prepare = []
+    seen = set()
+    for args in command_arg_lists:
+        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+            continue
+        fieldset_name = args[2]
+        if fieldset_name in seen:
+            continue
+        seen.add(fieldset_name)
+        fieldset = registry.get(fieldset_name)
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            to_prepare.append(fieldset)
+    if not to_prepare:
+        return
+    await conn.send_packed_command(
+        conn.pack_commands(
+            [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
+        )
+    )
+    # One reply per packed PREPARE must be read regardless of a per-command
+    # ResponseError, otherwise the unread replies desync the socket before the
+    # buffered batch is even sent. Drain every reply (marking only the ones that
+    # succeeded), then surface the first error as the root cause.
+    first_error = None
+    for fs in to_prepare:
+        try:
+            await node.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            first_error = first_error or e
+            continue
+        conn._himport_prepared[fs.name] = fs.version
+    if first_error is not None:
+        raise first_error

--- a/redis/asyncio/_himport_exec.py
+++ b/redis/asyncio/_himport_exec.py
@@ -183,47 +183,19 @@ async def prepare_pipeline(node, conn, command_arg_lists):
     sequences (the caller extracts them from its own command representation).
     No-op when the batch has no registry-backed ``HIMPORT SET``.
     """
-    # A pipeline may run on a connection type that never carries real HIMPORT
-    # state (e.g. mocked test doubles); only proceed for a real config.
-    registry = getattr(conn, "himport_registry", None)
-    if not isinstance(registry, HImportRegistry):
-        return
-    await reconcile_discards(node, conn)
-    to_prepare = []
-    seen = set()
-    for args in command_arg_lists:
-        parsed = parse_himport_set_args(args)
-        if parsed is None:
-            continue
-        fieldset_name = parsed[1]
-        if fieldset_name in seen:
-            continue
-        seen.add(fieldset_name)
-        fieldset = registry.get(fieldset_name)
-        if (
-            fieldset is not None
-            and conn._himport_prepared.get(fieldset_name) != fieldset.version
-        ):
-            to_prepare.append(fieldset)
+    # Selection (registry check, deferred-discard reconcile, scan/dedup/version)
+    # is shared with pipeline_prepares. This path differs only in that it sends the
+    # PREPAREs as their own packed exchange -- rather than folding them into a
+    # queued write -- then drains their replies and raises the first error.
+    to_prepare = await pipeline_prepares(node, conn, command_arg_lists)
     if not to_prepare:
         return
     await conn.send_packed_command(
-        conn.pack_commands(
-            [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
-        )
+        conn.pack_commands(prepare_wire_commands(to_prepare))
     )
-    # One reply per packed PREPARE must be read regardless of a per-command
-    # ResponseError, otherwise the unread replies desync the socket before the
-    # buffered batch is even sent. Drain every reply (marking only the ones that
-    # succeeded), then surface the first error as the root cause.
-    first_error = None
-    for fs in to_prepare:
-        try:
-            await node.parse_response(conn, HIMPORT_PREPARE)
-        except ResponseError as e:
-            first_error = first_error or e
-            continue
-        conn._himport_prepared[fs.name] = fs.version
+    # Every reply must be drained even on a per-command error, or the unread
+    # replies desync the socket before the buffered batch is sent; then raise.
+    first_error = await drain_pipeline_prepares(node, conn, to_prepare)
     if first_error is not None:
         raise first_error
 

--- a/redis/asyncio/_himport_exec.py
+++ b/redis/asyncio/_himport_exec.py
@@ -224,3 +224,62 @@ async def prepare_pipeline(node, conn, command_arg_lists):
         conn._himport_prepared[fs.name] = fs.version
     if first_error is not None:
         raise first_error
+
+
+async def pipeline_prepares(node, conn, command_arg_lists):
+    """Return the fieldsets that must be PREPAREd on ``conn`` for this batch.
+
+    Like :func:`prepare_pipeline`, but does **not** send the PREPAREs: the caller
+    folds them into the same packed write as the queued commands (see the pipeline
+    executors), so the first pipeline use of a fieldset on a fresh or reconnected
+    connection stays a single round trip instead of a separate PREPARE exchange
+    followed by the batch. Deferred-discard reconciliation is still performed here,
+    but it only touches the socket when discards are actually pending (rare); the
+    common warm-up cost -- the first-use PREPARE -- is what gets folded. Returns an
+    empty list when the batch references no not-yet-prepared registered fieldset,
+    or when ``conn`` carries no real HIMPORT registry.
+    """
+    registry = getattr(conn, "himport_registry", None)
+    if not isinstance(registry, HImportRegistry):
+        return []
+    await reconcile_discards(node, conn)
+    to_prepare = []
+    seen = set()
+    for args in command_arg_lists:
+        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+            continue
+        fieldset_name = args[2]
+        if fieldset_name in seen:
+            continue
+        seen.add(fieldset_name)
+        fieldset = registry.get(fieldset_name)
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            to_prepare.append(fieldset)
+    return to_prepare
+
+
+def prepare_wire_commands(fieldsets):
+    """The leading ``HIMPORT PREPARE`` wire commands the caller folds into a batch."""
+    return [himport_prepare_command(fs.name, fs.fields) for fs in fieldsets]
+
+
+async def drain_pipeline_prepares(node, conn, fieldsets):
+    """Drain the ``len(fieldsets)`` leading PREPARE replies of a folded pipeline
+    write, marking each fieldset prepared on success.
+
+    Returns the first ``ResponseError`` (or ``None``). The caller must still drain
+    the queued command replies and only then surface this error: every reply on
+    the wire has to be read before raising, or the pooled socket desyncs.
+    """
+    first_error = None
+    for fs in fieldsets:
+        try:
+            await node.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            first_error = first_error or e
+            continue
+        conn._himport_prepared[fs.name] = fs.version
+    return first_error

--- a/redis/asyncio/_himport_exec.py
+++ b/redis/asyncio/_himport_exec.py
@@ -23,7 +23,7 @@ from redis.himport import (
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
-    is_himport_set_command,
+    parse_himport_set_args,
 )
 
 
@@ -192,9 +192,10 @@ async def prepare_pipeline(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
+        parsed = parse_himport_set_args(args)
+        if parsed is None:
             continue
-        fieldset_name = args[2]
+        fieldset_name = parsed[1]
         if fieldset_name in seen:
             continue
         seen.add(fieldset_name)
@@ -247,9 +248,10 @@ async def pipeline_prepares(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
+        parsed = parse_himport_set_args(args)
+        if parsed is None:
             continue
-        fieldset_name = args[2]
+        fieldset_name = parsed[1]
         if fieldset_name in seen:
             continue
         seen.add(fieldset_name)

--- a/redis/asyncio/_himport_exec.py
+++ b/redis/asyncio/_himport_exec.py
@@ -23,6 +23,7 @@ from redis.himport import (
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
+    is_himport_set_command,
 )
 
 
@@ -191,7 +192,7 @@ async def prepare_pipeline(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
             continue
         fieldset_name = args[2]
         if fieldset_name in seen:
@@ -246,7 +247,7 @@ async def pipeline_prepares(node, conn, command_arg_lists):
     to_prepare = []
     seen = set()
     for args in command_arg_lists:
-        if not args or args[0] != HIMPORT_SET or len(args) < 3:
+        if not args or not is_himport_set_command(args[0]) or len(args) < 3:
             continue
         fieldset_name = args[2]
         if fieldset_name in seen:

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -86,7 +86,7 @@ from redis.himport import (
     HIMPORT_DISCARD,
     HIMPORT_PREPARE,
     HIMPORT_SET,
-    HImportConfig,
+    HImportRegistry,
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
@@ -372,7 +372,7 @@ class Redis(
         himport_schemas:
             optional mapping of `fieldset_name -> ordered field names` to register
             as HIMPORT fieldsets at construction time - see `redis.himport` for
-            details. The pool owns the resulting `HImportConfig`, so this argument
+            details. The pool owns the resulting `HImportRegistry`, so this argument
             is ignored when connection_pool is provided: to preconfigure schemas
             with a caller-supplied pool, pass `himport_schemas` to the pool itself
             (e.g. `ConnectionPool(..., himport_schemas=...)`).
@@ -489,7 +489,7 @@ class Redis(
                         "maint_notifications_config": maint_notifications_config,
                     }
                 )
-            # The pool builds the HImportConfig from the schemas (see
+            # The pool builds the HImportRegistry from the schemas (see
             # ConnectionPool.__init__) and owns it; the client never holds a mutable
             # reference, so the registry is mutated only via the HIMPORT command methods.
             if himport_schemas is not None:
@@ -569,12 +569,12 @@ class Redis(
         return self.connection_pool.connection_kwargs
 
     @property
-    def himport_config(self) -> HImportConfig:
+    def himport_registry(self) -> HImportRegistry:
         """The client's HIMPORT fieldset registry (empty if none was declared).
 
         Read-only: the registry is mutated only through the HIMPORT command methods.
         """
-        return self.connection_pool.himport_config
+        return self.connection_pool.himport_registry
 
     def get_retry(self) -> Optional[Retry]:
         return self.get_connection_kwargs().get("retry")
@@ -889,13 +889,22 @@ class Redis(
     async def _himport_reconcile_discards(self, conn):
         """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
 
-        Runs at most once per registry mutation: the connection records the config
+        Runs at most once per registry mutation: the connection records the registry
         ``revision`` it last reconciled against, so unchanged registries are a no-op.
         """
-        cfg = conn.himport_config
-        if cfg is None or conn._himport_reconciled_revision == cfg.revision:
+        registry = conn.himport_registry
+        if registry is None or conn._himport_reconciled_revision == registry.revision:
             return
-        stale = cfg.names_to_discard(list(conn._himport_prepared))
+        # Snapshot the revision *before* computing ``stale`` so the value stamped at
+        # the end is never newer than the registry state ``stale`` reflects. A
+        # concurrent ``himport_discard`` (thread-shared sync client, or another task
+        # while this awaits the DISCARD replies) that lands after this point only
+        # leaves the connection marked behind the live revision, so the next
+        # reconcile re-runs and catches it. Re-reading ``registry.revision`` at the
+        # end instead would stamp a discard this connection never sent, leaving the
+        # server session carrying a supposedly-discarded fieldset.
+        reconciled_to = registry.revision
+        stale = registry.names_to_discard(list(conn._himport_prepared))
         if stale:
             await conn.send_packed_command(
                 conn.pack_commands([himport_discard_command(n) for n in stale])
@@ -913,7 +922,7 @@ class Redis(
                 conn._himport_prepared.pop(n, None)
             if first_error is not None:
                 raise first_error
-        conn._himport_reconciled_revision = cfg.revision
+        conn._himport_reconciled_revision = reconciled_to
 
     async def _himport_prepare_and_set(
         self, conn, key, fieldset_name, values, fieldset
@@ -960,8 +969,8 @@ class Redis(
         """
         await self._himport_reconcile_discards(conn)
 
-        cfg = conn.himport_config
-        fieldset = cfg.get(fieldset_name) if cfg is not None else None
+        registry = conn.himport_registry
+        fieldset = registry.get(fieldset_name) if registry is not None else None
         # Lazy PREPARE bundled with SET on first use of this fieldset.
         if (
             fieldset is not None
@@ -1119,7 +1128,7 @@ class Redis(
     ) -> bool:
         """Declare an HIMPORT fieldset for use by :meth:`himport_set`."""
         await self.initialize()
-        fieldset = self.himport_config.prepare(fieldset_name, fields)
+        fieldset = self.himport_registry.prepare(fieldset_name, fields)
         conn = self.connection
         if self.single_connection_client and conn is not None and conn.is_connected:
             await self.himport_prepare_internal(fieldset_name, fieldset.fields)
@@ -1129,25 +1138,25 @@ class Redis(
     async def himport_discard(self, fieldset_name: str) -> int:
         """Remove a runtime fieldset. Raises ``DataError`` for init-declared ones."""
         await self.initialize()
-        removed = self.himport_config.discard(fieldset_name)
+        removed = self.himport_registry.discard(fieldset_name)
         conn = self.connection
         if self.single_connection_client and conn is not None and conn.is_connected:
             if removed:
                 await self.himport_discard_internal(fieldset_name)
             conn._himport_prepared.pop(fieldset_name, None)
-            conn._himport_reconciled_revision = self.himport_config.revision
+            conn._himport_reconciled_revision = self.himport_registry.revision
         return 1 if removed else 0
 
     async def himport_discard_all(self) -> int:
         """Remove all runtime fieldsets. Raises ``DataError`` if any init one exists."""
         await self.initialize()
-        count = self.himport_config.discard_all()
+        count = self.himport_registry.discard_all()
         conn = self.connection
         if self.single_connection_client and conn is not None and conn.is_connected:
             if count:
                 await self.himport_discard_all_internal()
             conn._himport_prepared.clear()
-            conn._himport_reconciled_revision = self.himport_config.revision
+            conn._himport_reconciled_revision = self.himport_registry.revision
         return count
 
 
@@ -2129,8 +2138,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
         """
         # A pipeline may run on a connection type that never carries real HIMPORT
         # state (e.g. mocked test doubles); only proceed for a real config.
-        cfg = getattr(conn, "himport_config", None)
-        if not isinstance(cfg, HImportConfig):
+        registry = getattr(conn, "himport_registry", None)
+        if not isinstance(registry, HImportRegistry):
             return
         await self._himport_reconcile_discards(conn)
         to_prepare = []
@@ -2142,7 +2151,7 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
             if fieldset_name in seen:
                 continue
             seen.add(fieldset_name)
-            fieldset = cfg.get(fieldset_name)
+            fieldset = registry.get(fieldset_name)
             if (
                 fieldset is not None
                 and conn._himport_prepared.get(fieldset_name) != fieldset.version

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -1122,7 +1122,7 @@ class Redis(
         fieldset = self.himport_config.prepare(fieldset_name, fields)
         conn = self.connection
         if self.single_connection_client and conn is not None and conn.is_connected:
-            await self.himport_prepare_internal(fieldset_name, fields)
+            await self.himport_prepare_internal(fieldset_name, fieldset.fields)
             conn._himport_prepared[fieldset_name] = fieldset.version
         return True
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -325,7 +325,6 @@ class Redis(
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
         maint_notifications_config: MaintNotificationsConfig | None = None,
-        himport_schemas: Mapping[str, Iterable[str]] | None = None,
     ):
         """
         Initialize a new Redis client.
@@ -369,13 +368,6 @@ class Redis(
             will be enabled by default (logic is included in the connection pool
             initialization).
             Argument is ignored when connection_pool is provided.
-        himport_schemas:
-            optional mapping of `fieldset_name -> ordered field names` to register
-            as HIMPORT fieldsets at construction time - see `redis.himport` for
-            details. The pool owns the resulting `HImportRegistry`, so this argument
-            is ignored when connection_pool is provided: to preconfigure schemas
-            with a caller-supplied pool, pass `himport_schemas` to the pool itself
-            (e.g. `ConnectionPool(..., himport_schemas=...)`).
         """
         kwargs: Dict[str, Any]
         if event_dispatcher is None:
@@ -489,11 +481,6 @@ class Redis(
                         "maint_notifications_config": maint_notifications_config,
                     }
                 )
-            # The pool builds the HImportRegistry from the schemas (see
-            # ConnectionPool.__init__) and owns it; the client never holds a mutable
-            # reference, so the registry is mutated only via the HIMPORT command methods.
-            if himport_schemas is not None:
-                kwargs.update({"himport_schemas": himport_schemas})
             # This arg only used if no pool is passed in
             self.auto_close_connection_pool = auto_close_connection_pool
             connection_pool = ConnectionPool(**kwargs)
@@ -1136,7 +1123,7 @@ class Redis(
         return True
 
     async def himport_discard(self, fieldset_name: str) -> int:
-        """Remove a runtime fieldset. Raises ``DataError`` for init-declared ones."""
+        """Remove a fieldset from the registry."""
         await self.initialize()
         removed = self.himport_registry.discard(fieldset_name)
         conn = self.connection
@@ -1148,7 +1135,7 @@ class Redis(
         return 1 if removed else 0
 
     async def himport_discard_all(self) -> int:
-        """Remove all runtime fieldsets. Raises ``DataError`` if any init one exists."""
+        """Remove all fieldsets from the registry."""
         await self.initialize()
         count = self.himport_registry.discard_all()
         conn = self.connection

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -76,15 +76,31 @@ from redis.event import (
 from redis.exceptions import (
     ConnectionError,
     ExecAbortError,
+    NoSuchFieldsetError,
     PubSubError,
     RedisError,
     ResponseError,
     WatchError,
 )
-from redis.himport import HImportConfig
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+    HImportConfig,
+    himport_discard_command,
+    himport_prepare_command,
+    himport_set_command,
+)
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
-from redis.typing import ChannelT, EncodableT, KeyT, PubSubHandler, Subscription
+from redis.typing import (
+    ChannelT,
+    EncodableT,
+    FieldT,
+    KeyT,
+    PubSubHandler,
+    Subscription,
+)
 from redis.utils import (
     SENTINEL,
     SSL_AVAILABLE,
@@ -353,6 +369,13 @@ class Redis(
             will be enabled by default (logic is included in the connection pool
             initialization).
             Argument is ignored when connection_pool is provided.
+        himport_schemas:
+            optional mapping of `fieldset_name -> ordered field names` to register
+            as HIMPORT fieldsets at construction time - see `redis.himport` for
+            details. The pool owns the resulting `HImportConfig`, so this argument
+            is ignored when connection_pool is provided: to preconfigure schemas
+            with a caller-supplied pool, pass `himport_schemas` to the pool itself
+            (e.g. `ConnectionPool(..., himport_schemas=...)`).
         """
         kwargs: Dict[str, Any]
         if event_dispatcher is None:
@@ -546,8 +569,8 @@ class Redis(
         return self.connection_pool.connection_kwargs
 
     @property
-    def himport_config(self) -> Optional[HImportConfig]:
-        """The client's HIMPORT fieldset registry, or ``None`` if not configured.
+    def himport_config(self) -> HImportConfig:
+        """The client's HIMPORT fieldset registry (empty if none was declared).
 
         Read-only: the registry is mutated only through the HIMPORT command methods.
         """
@@ -844,8 +867,126 @@ class Redis(
         """
         Send a command and parse the response
         """
+        # HIMPORT SET is the one command whose wire form depends on per-connection
+        # state: the fieldset must be PREPAREd on this connection first, and any
+        # fieldset discarded since this connection last reconciled must be dropped.
+        # Handling it here (rather than in himport_set) lets himport_set reuse the
+        # full execute_command machinery — retry, disconnect-on-error, pooling — so
+        # a failed HIMPORT SET disconnects the connection like any other command.
+        # This per-command branch in the hot dispatch path is deliberate and has no
+        # cleaner alternative: this is the only seam where the concrete borrowed
+        # connection is known, and connection-scoped session setup can only happen
+        # once that connection is chosen. The overhead is one string compare per
+        # command.
+        if command_name == HIMPORT_SET:
+            # args == (HIMPORT_SET, key, fieldset_name, *values)
+            return await self._himport_execute_set(
+                conn, args[1], args[2], list(args[3:])
+            )
         await conn.send_command(*args)
         return await self.parse_response(conn, command_name, **options)
+
+    async def _himport_reconcile_discards(self, conn):
+        """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
+
+        Runs at most once per registry mutation: the connection records the config
+        ``revision`` it last reconciled against, so unchanged registries are a no-op.
+        """
+        cfg = conn.himport_config
+        if cfg is None or conn._himport_reconciled_revision == cfg.revision:
+            return
+        stale = cfg.names_to_discard(list(conn._himport_prepared))
+        if stale:
+            await conn.send_packed_command(
+                conn.pack_commands([himport_discard_command(n) for n in stale])
+            )
+            # One reply per packed DISCARD must be read regardless of a per-command
+            # ResponseError, otherwise the unread replies desync the pooled socket.
+            # Drain every reply, then surface the first error (ConnectionError is not
+            # caught: it tears the socket down, so no desync is possible).
+            first_error = None
+            for n in stale:
+                try:
+                    await self.parse_response(conn, HIMPORT_DISCARD)
+                except ResponseError as e:
+                    first_error = first_error or e
+                conn._himport_prepared.pop(n, None)
+            if first_error is not None:
+                raise first_error
+        conn._himport_reconciled_revision = cfg.revision
+
+    async def _himport_prepare_and_set(
+        self, conn, key, fieldset_name, values, fieldset
+    ):
+        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
+        await conn.send_packed_command(
+            conn.pack_commands(
+                [
+                    himport_prepare_command(fieldset_name, fieldset.fields),
+                    himport_set_command(key, fieldset_name, values),
+                ]
+            )
+        )
+        prep_error = set_error = None
+        set_resp = None
+        try:
+            await self.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            prep_error = e
+        try:
+            set_resp = await self.parse_response(conn, HIMPORT_SET)
+        except ResponseError as e:
+            set_error = e
+
+        if prep_error:
+            raise prep_error  # PREPARE failure is the root cause
+        else:
+            conn._himport_prepared[fieldset_name] = fieldset.version
+
+        if set_error:
+            raise set_error
+        return set_resp
+
+    async def _himport_execute_set(self, conn, key, fieldset_name, values):
+        """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
+
+        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
+        any fieldset discarded from the shared registry since this connection last
+        reconciled must be dropped. Both are applied here, on the borrowed
+        connection, so the enclosing ``execute_command`` machinery (retry,
+        disconnect-on-error, pooling) covers the whole exchange. The connection
+        carries the per-connection HIMPORT state; a ``CacheProxyConnection``
+        delegates it transparently, so this never inspects the connection type.
+        """
+        await self._himport_reconcile_discards(conn)
+
+        cfg = conn.himport_config
+        fieldset = cfg.get(fieldset_name) if cfg is not None else None
+        # Lazy PREPARE bundled with SET on first use of this fieldset.
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            return await self._himport_prepare_and_set(
+                conn, key, fieldset_name, values, fieldset
+            )
+
+        # Believed already prepared (or an unregistered fieldset): bare SET.
+        await conn.send_command(*himport_set_command(key, fieldset_name, values))
+        try:
+            return await self.parse_response(conn, HIMPORT_SET)
+        except NoSuchFieldsetError:
+            # The server can drop the fieldset mid-connection without dropping the
+            # socket (e.g. RESET / maxmemory-clients eviction). The connection is
+            # healthy, so don't reconnect: re-PREPARE on it and retry the SET once.
+            # Only for registry-backed fieldsets — manual/unregistered usage
+            # propagates unchanged (a re-prepare would send a fieldset we don't own).
+            if fieldset is None:
+                raise
+            conn._himport_prepared.pop(fieldset_name, None)
+            return await self._himport_prepare_and_set(
+                conn, key, fieldset_name, values, fieldset
+            )
 
     async def _close_connection(
         self,
@@ -969,6 +1110,45 @@ class Redis(
             retval = self.response_callbacks[command_name](response, **options)
             return await retval if inspect.isawaitable(retval) else retval
         return response
+
+    # HIMPORT orchestration (async mirror of redis.client.Redis). See
+    # ``.agents/himport_client_support_spec.md``.
+
+    async def himport_prepare(
+        self, fieldset_name: str, fields: Iterable[FieldT]
+    ) -> bool:
+        """Declare an HIMPORT fieldset for use by :meth:`himport_set`."""
+        await self.initialize()
+        fieldset = self.himport_config.prepare(fieldset_name, fields)
+        conn = self.connection
+        if self.single_connection_client and conn is not None and conn.is_connected:
+            await self.himport_prepare_internal(fieldset_name, fields)
+            conn._himport_prepared[fieldset_name] = fieldset.version
+        return True
+
+    async def himport_discard(self, fieldset_name: str) -> int:
+        """Remove a runtime fieldset. Raises ``DataError`` for init-declared ones."""
+        await self.initialize()
+        removed = self.himport_config.discard(fieldset_name)
+        conn = self.connection
+        if self.single_connection_client and conn is not None and conn.is_connected:
+            if removed:
+                await self.himport_discard_internal(fieldset_name)
+            conn._himport_prepared.pop(fieldset_name, None)
+            conn._himport_reconciled_revision = self.himport_config.revision
+        return 1 if removed else 0
+
+    async def himport_discard_all(self) -> int:
+        """Remove all runtime fieldsets. Raises ``DataError`` if any init one exists."""
+        await self.initialize()
+        count = self.himport_config.discard_all()
+        conn = self.connection
+        if self.single_connection_client and conn is not None and conn.is_connected:
+            if count:
+                await self.himport_discard_all_internal()
+            conn._himport_prepared.clear()
+            conn._himport_reconciled_revision = self.himport_config.revision
+        return count
 
 
 StrictRedis = Redis
@@ -1937,9 +2117,65 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
         self.command_stack.append((args, options))
         return self
 
+    async def _himport_prepare_pipeline(self, conn, commands):
+        """Pre-flight ``conn`` for a pipeline batch that contains ``HIMPORT SET``s.
+
+        A pipeline buffers commands and sends them packed, bypassing the per-command
+        lazy-PREPARE path, so the fieldsets referenced by the buffered SETs must be
+        PREPAREd on ``conn`` first. Reconciles deferred discards, then PREPAREs every
+        distinct registered fieldset the batch references that this connection has
+        not already prepared, in one packed write. No-op when the batch has no
+        registry-backed ``HIMPORT SET``.
+        """
+        # A pipeline may run on a connection type that never carries real HIMPORT
+        # state (e.g. mocked test doubles); only proceed for a real config.
+        cfg = getattr(conn, "himport_config", None)
+        if not isinstance(cfg, HImportConfig):
+            return
+        await self._himport_reconcile_discards(conn)
+        to_prepare = []
+        seen = set()
+        for args, _ in commands:
+            if not args or args[0] != HIMPORT_SET or len(args) < 3:
+                continue
+            fieldset_name = args[2]
+            if fieldset_name in seen:
+                continue
+            seen.add(fieldset_name)
+            fieldset = cfg.get(fieldset_name)
+            if (
+                fieldset is not None
+                and conn._himport_prepared.get(fieldset_name) != fieldset.version
+            ):
+                to_prepare.append(fieldset)
+        if not to_prepare:
+            return
+        await conn.send_packed_command(
+            conn.pack_commands(
+                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
+            )
+        )
+        # One reply per packed PREPARE must be read regardless of a per-command
+        # ResponseError, otherwise the unread replies desync the socket before the
+        # buffered batch is even sent. Drain every reply (marking only the ones that
+        # succeeded), then surface the first error as the root cause.
+        first_error = None
+        for fs in to_prepare:
+            try:
+                await self.parse_response(conn, HIMPORT_PREPARE)
+            except ResponseError as e:
+                first_error = first_error or e
+                continue
+            conn._himport_prepared[fs.name] = fs.version
+        if first_error is not None:
+            raise first_error
+
     async def _execute_transaction(  # noqa: C901
         self, connection: Connection, commands: CommandStackT, raise_on_error
     ):
+        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
+        # connection before the MULTI/EXEC block (session state, not transactional).
+        await self._himport_prepare_pipeline(connection, commands)
         pre: CommandT = (("MULTI",), {})
         post: CommandT = (("EXEC",), {})
         cmds = (pre, *commands, post)
@@ -2018,6 +2254,9 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
     async def _execute_pipeline(
         self, connection: Connection, commands: CommandStackT, raise_on_error: bool
     ):
+        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
+        # connection before the batched write (the per-command lazy path is bypassed).
+        await self._himport_prepare_pipeline(connection, commands)
         # build up all commands into a single request to increase network perf
         all_cmds = connection.pack_commands([args for args, _ in commands])
         await connection.send_packed_command(all_cmds)

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -81,6 +81,7 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
+from redis.himport import HImportConfig
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
 from redis.typing import ChannelT, EncodableT, KeyT, PubSubHandler, Subscription
@@ -308,6 +309,7 @@ class Redis(
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
         maint_notifications_config: MaintNotificationsConfig | None = None,
+        himport_schemas: Mapping[str, Iterable[str]] | None = None,
     ):
         """
         Initialize a new Redis client.
@@ -464,6 +466,11 @@ class Redis(
                         "maint_notifications_config": maint_notifications_config,
                     }
                 )
+            # The pool builds the HImportConfig from the schemas (see
+            # ConnectionPool.__init__) and owns it; the client never holds a mutable
+            # reference, so the registry is mutated only via the HIMPORT command methods.
+            if himport_schemas is not None:
+                kwargs.update({"himport_schemas": himport_schemas})
             # This arg only used if no pool is passed in
             self.auto_close_connection_pool = auto_close_connection_pool
             connection_pool = ConnectionPool(**kwargs)
@@ -537,6 +544,14 @@ class Redis(
     def get_connection_kwargs(self):
         """Get the connection's key-word arguments"""
         return self.connection_pool.connection_kwargs
+
+    @property
+    def himport_config(self) -> Optional[HImportConfig]:
+        """The client's HIMPORT fieldset registry, or ``None`` if not configured.
+
+        Read-only: the registry is mutated only through the HIMPORT command methods.
+        """
+        return self.connection_pool.himport_config
 
     def get_retry(self) -> Optional[Retry]:
         return self.get_connection_kwargs().get("retry")

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -865,8 +865,11 @@ class Redis(
         # connection is known, and connection-scoped session setup can only happen
         # once that connection is chosen. The overhead is one string compare per
         # command.
-        if command_name == HIMPORT_SET:
-            # args == (HIMPORT_SET, key, fieldset_name, *values)
+        if command_name == HIMPORT_SET and len(args) >= 3:
+            # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
+            # ``execute_command`` with too few args falls through to the normal send
+            # path so the server returns its arity error, preserving execute_command
+            # error semantics instead of raising a client-side IndexError here.
             return await self._himport_execute_set(
                 conn, args[1], args[2], list(args[3:])
             )

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -37,6 +37,7 @@ from redis._defaults import (
     DEFAULT_SOCKET_TIMEOUT,
 )
 from redis._parsers.helpers import bool_ok, get_response_callbacks
+from redis.asyncio import _himport_exec
 from redis.asyncio.connection import (
     Connection,
     ConnectionPool,
@@ -76,21 +77,12 @@ from redis.event import (
 from redis.exceptions import (
     ConnectionError,
     ExecAbortError,
-    NoSuchFieldsetError,
     PubSubError,
     RedisError,
     ResponseError,
     WatchError,
 )
-from redis.himport import (
-    HIMPORT_DISCARD,
-    HIMPORT_PREPARE,
-    HIMPORT_SET,
-    HImportRegistry,
-    himport_discard_command,
-    himport_prepare_command,
-    himport_set_command,
-)
+from redis.himport import HIMPORT_SET, HImportRegistry
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
 from redis.typing import (
@@ -877,115 +869,20 @@ class Redis(
         return await self.parse_response(conn, command_name, **options)
 
     async def _himport_reconcile_discards(self, conn):
-        """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
-
-        Runs at most once per registry mutation: the connection records the registry
-        ``revision`` it last reconciled against, so unchanged registries are a no-op.
-        """
-        registry = conn.himport_registry
-        if registry is None or conn._himport_reconciled_revision == registry.revision:
-            return
-        # Snapshot the revision *before* computing ``stale`` so the value stamped at
-        # the end is never newer than the registry state ``stale`` reflects. A
-        # concurrent ``himport_discard`` (thread-shared sync client, or another task
-        # while this awaits the DISCARD replies) that lands after this point only
-        # leaves the connection marked behind the live revision, so the next
-        # reconcile re-runs and catches it. Re-reading ``registry.revision`` at the
-        # end instead would stamp a discard this connection never sent, leaving the
-        # server session carrying a supposedly-discarded fieldset.
-        reconciled_to = registry.revision
-        stale = registry.names_to_discard(list(conn._himport_prepared))
-        if stale:
-            await conn.send_packed_command(
-                conn.pack_commands([himport_discard_command(n) for n in stale])
-            )
-            # One reply per packed DISCARD must be read regardless of a per-command
-            # ResponseError, otherwise the unread replies desync the pooled socket.
-            # Drain every reply, then surface the first error (ConnectionError is not
-            # caught: it tears the socket down, so no desync is possible).
-            first_error = None
-            for n in stale:
-                try:
-                    await self.parse_response(conn, HIMPORT_DISCARD)
-                except ResponseError as e:
-                    first_error = first_error or e
-                conn._himport_prepared.pop(n, None)
-            if first_error is not None:
-                raise first_error
-        conn._himport_reconciled_revision = reconciled_to
+        """Delegate to the shared async HIMPORT executor."""
+        return await _himport_exec.reconcile_discards(self, conn)
 
     async def _himport_prepare_and_set(
         self, conn, key, fieldset_name, values, fieldset
     ):
-        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
-        await conn.send_packed_command(
-            conn.pack_commands(
-                [
-                    himport_prepare_command(fieldset_name, fieldset.fields),
-                    himport_set_command(key, fieldset_name, values),
-                ]
-            )
+        """Delegate to the shared async HIMPORT executor."""
+        return await _himport_exec.prepare_and_set(
+            self, conn, key, fieldset_name, values, fieldset
         )
-        prep_error = set_error = None
-        set_resp = None
-        try:
-            await self.parse_response(conn, HIMPORT_PREPARE)
-        except ResponseError as e:
-            prep_error = e
-        try:
-            set_resp = await self.parse_response(conn, HIMPORT_SET)
-        except ResponseError as e:
-            set_error = e
-
-        if prep_error:
-            raise prep_error  # PREPARE failure is the root cause
-        else:
-            conn._himport_prepared[fieldset_name] = fieldset.version
-
-        if set_error:
-            raise set_error
-        return set_resp
 
     async def _himport_execute_set(self, conn, key, fieldset_name, values):
-        """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
-
-        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
-        any fieldset discarded from the shared registry since this connection last
-        reconciled must be dropped. Both are applied here, on the borrowed
-        connection, so the enclosing ``execute_command`` machinery (retry,
-        disconnect-on-error, pooling) covers the whole exchange. The connection
-        carries the per-connection HIMPORT state; a ``CacheProxyConnection``
-        delegates it transparently, so this never inspects the connection type.
-        """
-        await self._himport_reconcile_discards(conn)
-
-        registry = conn.himport_registry
-        fieldset = registry.get(fieldset_name) if registry is not None else None
-        # Lazy PREPARE bundled with SET on first use of this fieldset.
-        if (
-            fieldset is not None
-            and conn._himport_prepared.get(fieldset_name) != fieldset.version
-        ):
-            return await self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset
-            )
-
-        # Believed already prepared (or an unregistered fieldset): bare SET.
-        await conn.send_command(*himport_set_command(key, fieldset_name, values))
-        try:
-            return await self.parse_response(conn, HIMPORT_SET)
-        except NoSuchFieldsetError:
-            # The server can drop the fieldset mid-connection without dropping the
-            # socket (e.g. RESET / maxmemory-clients eviction). The connection is
-            # healthy, so don't reconnect: re-PREPARE on it and retry the SET once.
-            # Only for registry-backed fieldsets — manual/unregistered usage
-            # propagates unchanged (a re-prepare would send a fieldset we don't own).
-            if fieldset is None:
-                raise
-            conn._himport_prepared.pop(fieldset_name, None)
-            return await self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset
-            )
+        """Delegate to the shared async HIMPORT executor."""
+        return await _himport_exec.execute_set(self, conn, key, fieldset_name, values)
 
     async def _close_connection(
         self,
@@ -2117,57 +2014,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
         return self
 
     async def _himport_prepare_pipeline(self, conn, commands):
-        """Pre-flight ``conn`` for a pipeline batch that contains ``HIMPORT SET``s.
-
-        A pipeline buffers commands and sends them packed, bypassing the per-command
-        lazy-PREPARE path, so the fieldsets referenced by the buffered SETs must be
-        PREPAREd on ``conn`` first. Reconciles deferred discards, then PREPAREs every
-        distinct registered fieldset the batch references that this connection has
-        not already prepared, in one packed write. No-op when the batch has no
-        registry-backed ``HIMPORT SET``.
-        """
-        # A pipeline may run on a connection type that never carries real HIMPORT
-        # state (e.g. mocked test doubles); only proceed for a real config.
-        registry = getattr(conn, "himport_registry", None)
-        if not isinstance(registry, HImportRegistry):
-            return
-        await self._himport_reconcile_discards(conn)
-        to_prepare = []
-        seen = set()
-        for args, _ in commands:
-            if not args or args[0] != HIMPORT_SET or len(args) < 3:
-                continue
-            fieldset_name = args[2]
-            if fieldset_name in seen:
-                continue
-            seen.add(fieldset_name)
-            fieldset = registry.get(fieldset_name)
-            if (
-                fieldset is not None
-                and conn._himport_prepared.get(fieldset_name) != fieldset.version
-            ):
-                to_prepare.append(fieldset)
-        if not to_prepare:
-            return
-        await conn.send_packed_command(
-            conn.pack_commands(
-                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
-            )
-        )
-        # One reply per packed PREPARE must be read regardless of a per-command
-        # ResponseError, otherwise the unread replies desync the socket before the
-        # buffered batch is even sent. Drain every reply (marking only the ones that
-        # succeeded), then surface the first error as the root cause.
-        first_error = None
-        for fs in to_prepare:
-            try:
-                await self.parse_response(conn, HIMPORT_PREPARE)
-            except ResponseError as e:
-                first_error = first_error or e
-                continue
-            conn._himport_prepared[fs.name] = fs.version
-        if first_error is not None:
-            raise first_error
+        """Delegate to the shared async HIMPORT executor."""
+        await _himport_exec.prepare_pipeline(self, conn, [args for args, _ in commands])
 
     async def _execute_transaction(  # noqa: C901
         self, connection: Connection, commands: CommandStackT, raise_on_error

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -100,6 +100,7 @@ from redis.utils import (
     check_protocol_version,
     deprecated_args,
     deprecated_function,
+    experimental_method,
     safe_str,
     str_if_bytes,
     truncate_text,
@@ -1011,6 +1012,7 @@ class Redis(
     # HIMPORT orchestration (async mirror of redis.client.Redis). See
     # ``.agents/himport_client_support_spec.md``.
 
+    @experimental_method()
     async def himport_prepare(
         self, fieldset_name: str, fields: Iterable[FieldT]
     ) -> bool:
@@ -1023,6 +1025,7 @@ class Redis(
             conn._himport_prepared[fieldset_name] = fieldset.version
         return True
 
+    @experimental_method()
     async def himport_discard(self, fieldset_name: str) -> int:
         """Remove a fieldset from the registry."""
         await self.initialize()
@@ -1035,6 +1038,7 @@ class Redis(
             conn._himport_reconciled_revision = self.himport_registry.revision
         return 1 if removed else 0
 
+    @experimental_method()
     async def himport_discard_all(self) -> int:
         """Remove all fieldsets from the registry."""
         await self.initialize()

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -82,7 +82,7 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
-from redis.himport import HImportRegistry, is_himport_set_command
+from redis.himport import HImportRegistry, parse_himport_set_args
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
 from redis.typing import (
@@ -857,14 +857,15 @@ class Redis(
         # connection is known, and connection-scoped session setup can only happen
         # once that connection is chosen. The overhead is one string compare per
         # command.
-        if is_himport_set_command(command_name) and len(args) >= 3:
-            # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
-            # ``execute_command`` with too few args falls through to the normal send
-            # path so the server returns its arity error, preserving execute_command
-            # error semantics instead of raising a client-side IndexError here.
-            return await self._himport_execute_set(
-                conn, args[1], args[2], list(args[3:])
-            )
+        himport_set = parse_himport_set_args(args)
+        if himport_set is not None:
+            # ``args`` is an HIMPORT SET in either the joined ("HIMPORT SET", key,
+            # ...) or split ("HIMPORT", "SET", key, ...) raw form; the operands come
+            # back at the right offsets for the form. A command with too few operands
+            # returns None and falls through to the normal send path so the server
+            # returns its arity error instead of a client-side IndexError here.
+            key, fieldset_name, values = himport_set
+            return await self._himport_execute_set(conn, key, fieldset_name, values)
         await conn.send_command(*args)
         return await self.parse_response(conn, command_name, **options)
 

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -82,7 +82,7 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
-from redis.himport import HIMPORT_SET, HImportRegistry
+from redis.himport import HImportRegistry, is_himport_set_command
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.observability.attributes import PubSubDirection
 from redis.typing import (
@@ -857,7 +857,7 @@ class Redis(
         # connection is known, and connection-scoped session setup can only happen
         # once that connection is chosen. The overhead is one string compare per
         # command.
-        if command_name == HIMPORT_SET and len(args) >= 3:
+        if is_himport_set_command(command_name) and len(args) >= 3:
             # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
             # ``execute_command`` with too few args falls through to the normal send
             # path so the server returns its arity error, preserving execute_command
@@ -2101,12 +2101,26 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
     async def _execute_pipeline(
         self, connection: Connection, commands: CommandStackT, raise_on_error: bool
     ):
-        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
-        # connection before the batched write (the per-command lazy path is bypassed).
-        await self._himport_prepare_pipeline(connection, commands)
+        # Fold any first-use HIMPORT PREPAREs for referenced fieldsets into the same
+        # packed write as the queued commands, so a pipeline that lands on a fresh or
+        # reconnected connection stays a single round trip (the batched write bypasses
+        # the per-command lazy PREPARE path). Deferred-discard reconciliation happens
+        # inside pipeline_prepares and only touches the socket when discards are
+        # actually pending.
+        fieldsets = await _himport_exec.pipeline_prepares(
+            self, connection, [args for args, _ in commands]
+        )
+        preflight = _himport_exec.prepare_wire_commands(fieldsets)
         # build up all commands into a single request to increase network perf
-        all_cmds = connection.pack_commands([args for args, _ in commands])
+        all_cmds = connection.pack_commands(preflight + [args for args, _ in commands])
         await connection.send_packed_command(all_cmds)
+
+        # Drain the leading PREPARE replies (bookkeeping + capture the first error)
+        # before the queued replies. Everything on the wire is read before raising so
+        # the pooled socket never desyncs.
+        prep_error = await _himport_exec.drain_pipeline_prepares(
+            self, connection, fieldsets
+        )
 
         response = []
         for args, options in commands:
@@ -2117,6 +2131,11 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
             except ResponseError as e:
                 response.append(e)
 
+        # A PREPARE failure (rare: an invalid fieldset definition) is a hard error,
+        # raised regardless of raise_on_error as it was before folding -- only now
+        # every reply has already been drained.
+        if prep_error is not None:
+            raise prep_error
         if raise_on_error:
             self.raise_first_error(commands, response)
         return response

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -928,12 +928,12 @@ class RedisCluster(
         return True
 
     async def himport_discard(self, fieldset_name: str) -> int:
-        """Remove a runtime fieldset cluster-wide. Raises ``DataError`` for init ones."""
+        """Remove an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
         await self.initialize()
         return 1 if self._himport_registry.discard(fieldset_name) else 0
 
     async def himport_discard_all(self) -> int:
-        """Remove all runtime fieldsets cluster-wide. Raises ``DataError`` on init ones."""
+        """Remove all HIMPORT fieldsets cluster-wide (shared registry, applied lazily)."""
         await self.initialize()
         return self._himport_registry.discard_all()
 
@@ -1866,8 +1866,11 @@ class ClusterNode:
             # On an ASK redirect ``asking`` is passed here rather than sent as a
             # separate ASKING command so the allowance sits on this same connection,
             # folded into the SET's own write immediately before the SET.
-            if args[0] == HIMPORT_SET:
-                # args == (HIMPORT_SET, key, fieldset_name, *values)
+            if args[0] == HIMPORT_SET and len(args) >= 3:
+                # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
+                # ``execute_command`` with too few args falls through to the normal
+                # send path below so the server returns its arity error instead of a
+                # client-side IndexError.
                 return await self._himport_execute_set(
                     connection, args[1], args[2], list(args[3:]), asking=asking
                 )

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -462,7 +462,6 @@ class RedisCluster(
         event_dispatcher: EventDispatcher | None = None,
         policy_resolver: AsyncPolicyResolver = AsyncStaticPolicyResolver(),
         maint_notifications_config: MaintNotificationsConfig | None = None,
-        himport_schemas: Mapping[str, Iterable[str]] | None = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -558,13 +557,13 @@ class RedisCluster(
         else:
             kwargs["response_callbacks"]["CLUSTER SHARDS"] = parse_cluster_shards
 
-        # Build the client-level HIMPORT registry once (empty if no schemas) and share
-        # the same object with every node connection. It rides in connection_kwargs ->
-        # ClusterNode -> each node's Connection, so the registry is shared cluster-wide
-        # and runtime himport_prepare mutates one object. (Async has no per-node Redis
-        # client, so the object flows via connection_kwargs directly to the Connection,
-        # which is internal plumbing, not a public param.)
-        self._himport_registry = HImportRegistry(himport_schemas)
+        # Build the client-level HIMPORT registry once (always empty at construction)
+        # and share the same object with every node connection. It rides in
+        # connection_kwargs -> ClusterNode -> each node's Connection, so the registry is
+        # shared cluster-wide and runtime himport_prepare mutates one object. (Async has
+        # no per-node Redis client, so the object flows via connection_kwargs directly to
+        # the Connection, which is internal plumbing, not a public param.)
+        self._himport_registry = HImportRegistry()
         kwargs["himport_registry"] = self._himport_registry
 
         self.connection_kwargs = kwargs
@@ -2012,7 +2011,18 @@ class ClusterNode:
                     [("ASKING",), himport_set_command(key, fieldset_name, values)]
                 )
             )
-            await self.parse_response(conn, "ASKING")
+            try:
+                await self.parse_response(conn, "ASKING")
+            except ResponseError as ask_error:
+                # ASKING and SET were one packed write, so the SET reply is still
+                # queued. Drain it before surfacing the ASKING error, otherwise the
+                # connection returns to the pool with an unread reply and desyncs
+                # the next borrower.
+                try:
+                    await self.parse_response(conn, HIMPORT_SET)
+                except ResponseError:
+                    pass
+                raise ask_error
         else:
             await conn.send_command(*himport_set_command(key, fieldset_name, values))
         try:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1260,10 +1260,18 @@ class RedisCluster(
 
         while ttl > 0:
             ttl -= 1
+            ask_himport = False
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
-                    await target_node.execute_command("ASKING")
+                    if command == HIMPORT_SET:
+                        # ASKING must sit on the same connection as the SET,
+                        # immediately before it. HIMPORT SET's own executor folds
+                        # ASKING into the SET's packed write after the session setup,
+                        # so don't send it here as a separately pooled command.
+                        ask_himport = True
+                    else:
+                        await target_node.execute_command("ASKING")
                     asking = False
                 elif moved:
                     # MOVED occurred and the slots cache was updated,
@@ -1278,7 +1286,9 @@ class RedisCluster(
                     )
                     moved = False
 
-                response = await target_node.execute_command(*args, **kwargs)
+                response = await target_node.execute_command(
+                    *args, asking=ask_himport, **kwargs
+                )
                 await self._record_command_metric(
                     command_name=command,
                     duration_seconds=time.monotonic() - start_time,
@@ -1834,7 +1844,9 @@ class ClusterNode:
 
         return response
 
-    async def execute_command(self, *args: Any, **kwargs: Any) -> Any:
+    async def execute_command(
+        self, *args: Any, asking: bool = False, **kwargs: Any
+    ) -> Any:
         # Acquire connection
         connection = self.acquire_connection()
         try:
@@ -1852,10 +1864,13 @@ class ClusterNode:
             # connection is known, and connection-scoped session setup can only happen
             # once that connection is chosen. The overhead is one comparison per
             # command.
+            # On an ASK redirect ``asking`` is passed here rather than sent as a
+            # separate ASKING command so the allowance sits on this same connection,
+            # folded into the SET's own write immediately before the SET.
             if args[0] == HIMPORT_SET:
                 # args == (HIMPORT_SET, key, fieldset_name, *values)
                 return await self._himport_execute_set(
-                    connection, args[1], args[2], list(args[3:])
+                    connection, args[1], args[2], list(args[3:]), asking=asking
                 )
 
             # Execute command
@@ -1896,23 +1911,39 @@ class ClusterNode:
         conn._himport_reconciled_revision = cfg.revision
 
     async def _himport_prepare_and_set(
-        self, conn: "Connection", key: KeyT, fieldset_name: str, values: List, fieldset
+        self,
+        conn: "Connection",
+        key: KeyT,
+        fieldset_name: str,
+        values: List,
+        fieldset,
+        asking: bool = False,
     ) -> Any:
-        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
-        await conn.send_packed_command(
-            conn.pack_commands(
-                [
-                    himport_prepare_command(fieldset_name, fieldset.fields),
-                    himport_set_command(key, fieldset_name, values),
-                ]
-            )
-        )
-        prep_error = set_error = None
+        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write).
+
+        When ``asking`` is set (an ASK-redirected cluster SET) the batch becomes
+        ``[PREPARE, ASKING, SET]`` so the per-command ASKING allowance falls
+        immediately before the SET — the only slot-scoped command. PREPARE is a
+        connection-session command that the ASKING flag does not gate, so placing
+        it before ASKING is safe. Every reply is drained even on a per-command
+        error so the packed replies never desync the pooled socket.
+        """
+        commands = [himport_prepare_command(fieldset_name, fieldset.fields)]
+        if asking:
+            commands.append(("ASKING",))
+        commands.append(himport_set_command(key, fieldset_name, values))
+        await conn.send_packed_command(conn.pack_commands(commands))
+        prep_error = ask_error = set_error = None
         set_resp = None
         try:
             await self.parse_response(conn, HIMPORT_PREPARE)
         except ResponseError as e:
             prep_error = e
+        if asking:
+            try:
+                await self.parse_response(conn, "ASKING")
+            except ResponseError as e:
+                ask_error = e
         try:
             set_resp = await self.parse_response(conn, HIMPORT_SET)
         except ResponseError as e:
@@ -1923,12 +1954,19 @@ class ClusterNode:
         else:
             conn._himport_prepared[fieldset_name] = fieldset.version
 
+        if ask_error:
+            raise ask_error
         if set_error:
             raise set_error
         return set_resp
 
     async def _himport_execute_set(
-        self, conn: "Connection", key: KeyT, fieldset_name: str, values: List
+        self,
+        conn: "Connection",
+        key: KeyT,
+        fieldset_name: str,
+        values: List,
+        asking: bool = False,
     ) -> Any:
         """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
 
@@ -1937,6 +1975,12 @@ class ClusterNode:
         reconciled must be dropped. Both are applied here, on the acquired
         connection, so the caller's full retry / MOVED-ASK / disconnect-on-error
         handling covers the whole exchange.
+
+        When ``asking`` is set (an ASK-redirected cluster SET) the ASKING allowance
+        is folded into the SET's own packed write so it immediately precedes the
+        SET. The session setup (deferred DISCARDs, lazy PREPARE) still runs first,
+        before ASKING, since those are connection-session commands the flag does
+        not gate; only the SET is slot-scoped and must carry the allowance.
         """
         await self._himport_reconcile_discards(conn)
 
@@ -1948,11 +1992,20 @@ class ClusterNode:
             and conn._himport_prepared.get(fieldset_name) != fieldset.version
         ):
             return await self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset
+                conn, key, fieldset_name, values, fieldset, asking=asking
             )
 
-        # Believed already prepared (or an unregistered fieldset): bare SET.
-        await conn.send_command(*himport_set_command(key, fieldset_name, values))
+        # Believed already prepared (or an unregistered fieldset): bare SET, with
+        # ASKING packed immediately before it when this is an ASK redirect.
+        if asking:
+            await conn.send_packed_command(
+                conn.pack_commands(
+                    [("ASKING",), himport_set_command(key, fieldset_name, values)]
+                )
+            )
+            await self.parse_response(conn, "ASKING")
+        else:
+            await conn.send_command(*himport_set_command(key, fieldset_name, values))
         try:
             return await self.parse_response(conn, HIMPORT_SET)
         except NoSuchFieldsetError:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -105,6 +105,7 @@ from redis.exceptions import (
     InvalidPipelineStack,
     MaxConnectionsError,
     MovedError,
+    NoSuchFieldsetError,
     RedisClusterException,
     RedisError,
     ResponseError,
@@ -113,12 +114,21 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import HImportConfig
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+    HImportConfig,
+    himport_discard_command,
+    himport_prepare_command,
+    himport_set_command,
+)
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.typing import (
     AnyKeyT,
     ChannelT,
     EncodableT,
+    FieldT,
     KeyT,
     PubSubHandler,
     Subscription,
@@ -366,7 +376,7 @@ class RedisCluster(
         "_lock",
         "maint_notifications_config",
         "_oss_cluster_maint_notifications_handler",
-        "himport_config",
+        "_himport_config",
         "retry",
         "command_flags",
         "commands_parser",
@@ -548,16 +558,14 @@ class RedisCluster(
         else:
             kwargs["response_callbacks"]["CLUSTER SHARDS"] = parse_cluster_shards
 
-        # Build the client-level HIMPORT config once and share the same object with
-        # every node connection. It rides in connection_kwargs -> ClusterNode ->
-        # each node's Connection, so the fieldset registry is shared cluster-wide.
-        # (Async has no per-node Redis client, so the object flows via connection_kwargs
-        # directly to the Connection, which is internal plumbing, not a public param.)
-        self.himport_config = (
-            HImportConfig(himport_schemas) if himport_schemas is not None else None
-        )
-        if self.himport_config is not None:
-            kwargs["himport_config"] = self.himport_config
+        # Build the client-level HIMPORT config once (empty if no schemas) and share
+        # the same object with every node connection. It rides in connection_kwargs ->
+        # ClusterNode -> each node's Connection, so the registry is shared cluster-wide
+        # and runtime himport_prepare mutates one object. (Async has no per-node Redis
+        # client, so the object flows via connection_kwargs directly to the Connection,
+        # which is internal plumbing, not a public param.)
+        self._himport_config = HImportConfig(himport_schemas)
+        kwargs["himport_config"] = self._himport_config
 
         self.connection_kwargs = kwargs
 
@@ -898,6 +906,37 @@ class RedisCluster(
         See: https://redis.io/docs/manual/scaling/#redis-cluster-data-sharding
         """
         return key_slot(self.encoder.encode(key))
+
+    # HIMPORT orchestration (async mirror of redis.cluster.RedisCluster). The one
+    # shared HImportConfig is mutated once by PREPARE/DISCARD/DISCARDALL and applied
+    # lazily per node; SET routes by key slot to the owning primary's ClusterNode.
+    # See ``.agents/himport_client_support_spec.md``.
+
+    @property
+    def himport_config(self) -> HImportConfig:
+        """The cluster-wide HIMPORT fieldset registry (empty if none was declared).
+
+        Read-only: the registry is mutated only through the HIMPORT command methods.
+        """
+        return self._himport_config
+
+    async def himport_prepare(
+        self, fieldset_name: str, fields: Iterable[FieldT]
+    ) -> bool:
+        """Declare an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
+        await self.initialize()
+        self._himport_config.prepare(fieldset_name, fields)
+        return True
+
+    async def himport_discard(self, fieldset_name: str) -> int:
+        """Remove a runtime fieldset cluster-wide. Raises ``DataError`` for init ones."""
+        await self.initialize()
+        return 1 if self._himport_config.discard(fieldset_name) else 0
+
+    async def himport_discard_all(self) -> int:
+        """Remove all runtime fieldsets cluster-wide. Raises ``DataError`` on init ones."""
+        await self.initialize()
+        return self._himport_config.discard_all()
 
     def get_encoder(self) -> Encoder:
         """Get the encoder object of the client."""
@@ -1802,6 +1841,23 @@ class ClusterNode:
             # Handle lazy disconnect for connections marked for reconnect
             await self.disconnect_if_needed(connection)
 
+            # HIMPORT SET is the one command whose wire form depends on
+            # per-connection state: the fieldset must be PREPAREd on this
+            # connection first, and any fieldset discarded since this connection
+            # last reconciled must be dropped. Doing it here (rather than in
+            # RedisCluster.himport_set) reuses the caller's full retry, MOVED/ASK
+            # and disconnect-on-error handling for HIMPORT SET too.
+            # This per-command branch in the hot dispatch path is deliberate and has
+            # no cleaner alternative: this is the only seam where the concrete routed
+            # connection is known, and connection-scoped session setup can only happen
+            # once that connection is chosen. The overhead is one comparison per
+            # command.
+            if args[0] == HIMPORT_SET:
+                # args == (HIMPORT_SET, key, fieldset_name, *values)
+                return await self._himport_execute_set(
+                    connection, args[1], args[2], list(args[3:])
+                )
+
             # Execute command
             await connection.send_packed_command(connection.pack_command(*args))
 
@@ -1814,12 +1870,166 @@ class ClusterNode:
                 # Release connection
                 self.release(connection)
 
+    async def _himport_reconcile_discards(self, conn: "Connection") -> None:
+        """DISCARD, on ``conn``, any prepared fieldset removed from the registry."""
+        cfg = conn.himport_config
+        if cfg is None or conn._himport_reconciled_revision == cfg.revision:
+            return
+        stale = cfg.names_to_discard(list(conn._himport_prepared))
+        if stale:
+            await conn.send_packed_command(
+                conn.pack_commands([himport_discard_command(n) for n in stale])
+            )
+            # One reply per packed DISCARD must be read regardless of a per-command
+            # ResponseError, otherwise the unread replies desync the pooled socket.
+            # Drain every reply, then surface the first error (ConnectionError is not
+            # caught: it tears the socket down, so no desync is possible).
+            first_error = None
+            for n in stale:
+                try:
+                    await self.parse_response(conn, HIMPORT_DISCARD)
+                except ResponseError as e:
+                    first_error = first_error or e
+                conn._himport_prepared.pop(n, None)
+            if first_error is not None:
+                raise first_error
+        conn._himport_reconciled_revision = cfg.revision
+
+    async def _himport_prepare_and_set(
+        self, conn: "Connection", key: KeyT, fieldset_name: str, values: List, fieldset
+    ) -> Any:
+        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
+        await conn.send_packed_command(
+            conn.pack_commands(
+                [
+                    himport_prepare_command(fieldset_name, fieldset.fields),
+                    himport_set_command(key, fieldset_name, values),
+                ]
+            )
+        )
+        prep_error = set_error = None
+        set_resp = None
+        try:
+            await self.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            prep_error = e
+        try:
+            set_resp = await self.parse_response(conn, HIMPORT_SET)
+        except ResponseError as e:
+            set_error = e
+
+        if prep_error:
+            raise prep_error  # PREPARE failure is the root cause
+        else:
+            conn._himport_prepared[fieldset_name] = fieldset.version
+
+        if set_error:
+            raise set_error
+        return set_resp
+
+    async def _himport_execute_set(
+        self, conn: "Connection", key: KeyT, fieldset_name: str, values: List
+    ) -> Any:
+        """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
+
+        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
+        any fieldset discarded from the shared registry since this connection last
+        reconciled must be dropped. Both are applied here, on the acquired
+        connection, so the caller's full retry / MOVED-ASK / disconnect-on-error
+        handling covers the whole exchange.
+        """
+        await self._himport_reconcile_discards(conn)
+
+        cfg = conn.himport_config
+        fieldset = cfg.get(fieldset_name) if cfg is not None else None
+        # Lazy PREPARE bundled with SET on first use of this fieldset.
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            return await self._himport_prepare_and_set(
+                conn, key, fieldset_name, values, fieldset
+            )
+
+        # Believed already prepared (or an unregistered fieldset): bare SET.
+        await conn.send_command(*himport_set_command(key, fieldset_name, values))
+        try:
+            return await self.parse_response(conn, HIMPORT_SET)
+        except NoSuchFieldsetError:
+            # Server dropped the fieldset mid-connection without dropping the socket
+            # (e.g. RESET / maxmemory-clients eviction): re-PREPARE on this healthy
+            # connection and retry the SET once rather than reconnecting. Only for
+            # registry-backed fieldsets; manual/unregistered usage propagates.
+            if fieldset is None:
+                raise
+            conn._himport_prepared.pop(fieldset_name, None)
+            return await self._himport_prepare_and_set(
+                conn, key, fieldset_name, values, fieldset
+            )
+
+    async def _himport_prepare_pipeline(
+        self, conn: "Connection", commands: List["PipelineCommand"]
+    ) -> None:
+        """Pre-flight ``conn`` for a pipeline batch containing ``HIMPORT SET``s.
+
+        The packed pipeline write bypasses the per-command lazy PREPARE, so PREPARE
+        every distinct registered fieldset the batch references (and reconcile
+        deferred discards) on ``conn`` first, in one packed write.
+        """
+        # A pipeline may run on a connection type that never carries real HIMPORT
+        # state (e.g. mocked test doubles); only proceed for a real config.
+        cfg = getattr(conn, "himport_config", None)
+        if not isinstance(cfg, HImportConfig):
+            return
+        await self._himport_reconcile_discards(conn)
+        to_prepare = []
+        seen = set()
+        for cmd in commands:
+            args = cmd.args
+            if not args or args[0] != HIMPORT_SET or len(args) < 3:
+                continue
+            fieldset_name = args[2]
+            if fieldset_name in seen:
+                continue
+            seen.add(fieldset_name)
+            fieldset = cfg.get(fieldset_name)
+            if (
+                fieldset is not None
+                and conn._himport_prepared.get(fieldset_name) != fieldset.version
+            ):
+                to_prepare.append(fieldset)
+        if not to_prepare:
+            return
+        await conn.send_packed_command(
+            conn.pack_commands(
+                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
+            )
+        )
+        # One reply per packed PREPARE must be read regardless of a per-command
+        # ResponseError, otherwise the unread replies desync the socket before the
+        # buffered batch is even sent. Drain every reply (marking only the ones that
+        # succeeded), then surface the first error as the root cause.
+        first_error = None
+        for fs in to_prepare:
+            try:
+                await self.parse_response(conn, HIMPORT_PREPARE)
+            except ResponseError as e:
+                first_error = first_error or e
+                continue
+            conn._himport_prepared[fs.name] = fs.version
+        if first_error is not None:
+            raise first_error
+
     async def execute_pipeline(self, commands: List["PipelineCommand"]) -> bool:
         # Acquire connection
         connection = self.acquire_connection()
         try:
             # Handle lazy disconnect for connections marked for reconnect
             await self.disconnect_if_needed(connection)
+
+            # PREPARE fieldsets referenced by buffered HIMPORT SETs before the
+            # batched write (it bypasses the per-command lazy prepare path).
+            await self._himport_prepare_pipeline(connection, commands)
 
             # Execute command
             await connection.send_packed_command(
@@ -3192,6 +3402,11 @@ class TransactionStrategy(AbstractStrategy):
         # Only disconnect if not watching - disconnecting would lose WATCH state
         if not self._watching:
             await redis_node.disconnect_if_needed(connection)
+
+        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
+        # node's connection before the MULTI/EXEC block (session state, not
+        # transactional). All keys share one slot here, so it is a single node.
+        await redis_node._himport_prepare_pipeline(connection, stack)
 
         stack = chain(
             [PipelineCommand(0, "MULTI")],

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -118,7 +118,7 @@ from redis.himport import (
     HIMPORT_DISCARD,
     HIMPORT_PREPARE,
     HIMPORT_SET,
-    HImportConfig,
+    HImportRegistry,
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
@@ -376,7 +376,7 @@ class RedisCluster(
         "_lock",
         "maint_notifications_config",
         "_oss_cluster_maint_notifications_handler",
-        "_himport_config",
+        "_himport_registry",
         "retry",
         "command_flags",
         "commands_parser",
@@ -558,14 +558,14 @@ class RedisCluster(
         else:
             kwargs["response_callbacks"]["CLUSTER SHARDS"] = parse_cluster_shards
 
-        # Build the client-level HIMPORT config once (empty if no schemas) and share
+        # Build the client-level HIMPORT registry once (empty if no schemas) and share
         # the same object with every node connection. It rides in connection_kwargs ->
         # ClusterNode -> each node's Connection, so the registry is shared cluster-wide
         # and runtime himport_prepare mutates one object. (Async has no per-node Redis
         # client, so the object flows via connection_kwargs directly to the Connection,
         # which is internal plumbing, not a public param.)
-        self._himport_config = HImportConfig(himport_schemas)
-        kwargs["himport_config"] = self._himport_config
+        self._himport_registry = HImportRegistry(himport_schemas)
+        kwargs["himport_registry"] = self._himport_registry
 
         self.connection_kwargs = kwargs
 
@@ -908,35 +908,35 @@ class RedisCluster(
         return key_slot(self.encoder.encode(key))
 
     # HIMPORT orchestration (async mirror of redis.cluster.RedisCluster). The one
-    # shared HImportConfig is mutated once by PREPARE/DISCARD/DISCARDALL and applied
+    # shared HImportRegistry is mutated once by PREPARE/DISCARD/DISCARDALL and applied
     # lazily per node; SET routes by key slot to the owning primary's ClusterNode.
     # See ``.agents/himport_client_support_spec.md``.
 
     @property
-    def himport_config(self) -> HImportConfig:
+    def himport_registry(self) -> HImportRegistry:
         """The cluster-wide HIMPORT fieldset registry (empty if none was declared).
 
         Read-only: the registry is mutated only through the HIMPORT command methods.
         """
-        return self._himport_config
+        return self._himport_registry
 
     async def himport_prepare(
         self, fieldset_name: str, fields: Iterable[FieldT]
     ) -> bool:
         """Declare an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
         await self.initialize()
-        self._himport_config.prepare(fieldset_name, fields)
+        self._himport_registry.prepare(fieldset_name, fields)
         return True
 
     async def himport_discard(self, fieldset_name: str) -> int:
         """Remove a runtime fieldset cluster-wide. Raises ``DataError`` for init ones."""
         await self.initialize()
-        return 1 if self._himport_config.discard(fieldset_name) else 0
+        return 1 if self._himport_registry.discard(fieldset_name) else 0
 
     async def himport_discard_all(self) -> int:
         """Remove all runtime fieldsets cluster-wide. Raises ``DataError`` on init ones."""
         await self.initialize()
-        return self._himport_config.discard_all()
+        return self._himport_registry.discard_all()
 
     def get_encoder(self) -> Encoder:
         """Get the encoder object of the client."""
@@ -1887,10 +1887,19 @@ class ClusterNode:
 
     async def _himport_reconcile_discards(self, conn: "Connection") -> None:
         """DISCARD, on ``conn``, any prepared fieldset removed from the registry."""
-        cfg = conn.himport_config
-        if cfg is None or conn._himport_reconciled_revision == cfg.revision:
+        registry = conn.himport_registry
+        if registry is None or conn._himport_reconciled_revision == registry.revision:
             return
-        stale = cfg.names_to_discard(list(conn._himport_prepared))
+        # Snapshot the revision *before* computing ``stale`` so the value stamped at
+        # the end is never newer than the registry state ``stale`` reflects. A
+        # concurrent ``himport_discard`` (thread-shared sync client, or another task
+        # while this awaits the DISCARD replies) that lands after this point only
+        # leaves the connection marked behind the live revision, so the next
+        # reconcile re-runs and catches it. Re-reading ``registry.revision`` at the
+        # end instead would stamp a discard this connection never sent, leaving the
+        # server session carrying a supposedly-discarded fieldset.
+        reconciled_to = registry.revision
+        stale = registry.names_to_discard(list(conn._himport_prepared))
         if stale:
             await conn.send_packed_command(
                 conn.pack_commands([himport_discard_command(n) for n in stale])
@@ -1908,7 +1917,7 @@ class ClusterNode:
                 conn._himport_prepared.pop(n, None)
             if first_error is not None:
                 raise first_error
-        conn._himport_reconciled_revision = cfg.revision
+        conn._himport_reconciled_revision = reconciled_to
 
     async def _himport_prepare_and_set(
         self,
@@ -1984,8 +1993,8 @@ class ClusterNode:
         """
         await self._himport_reconcile_discards(conn)
 
-        cfg = conn.himport_config
-        fieldset = cfg.get(fieldset_name) if cfg is not None else None
+        registry = conn.himport_registry
+        fieldset = registry.get(fieldset_name) if registry is not None else None
         # Lazy PREPARE bundled with SET on first use of this fieldset.
         if (
             fieldset is not None
@@ -2017,7 +2026,7 @@ class ClusterNode:
                 raise
             conn._himport_prepared.pop(fieldset_name, None)
             return await self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset
+                conn, key, fieldset_name, values, fieldset, asking=asking
             )
 
     async def _himport_prepare_pipeline(
@@ -2031,8 +2040,8 @@ class ClusterNode:
         """
         # A pipeline may run on a connection type that never carries real HIMPORT
         # state (e.g. mocked test doubles); only proceed for a real config.
-        cfg = getattr(conn, "himport_config", None)
-        if not isinstance(cfg, HImportConfig):
+        registry = getattr(conn, "himport_registry", None)
+        if not isinstance(registry, HImportRegistry):
             return
         await self._himport_reconcile_discards(conn)
         to_prepare = []
@@ -2045,7 +2054,7 @@ class ClusterNode:
             if fieldset_name in seen:
                 continue
             seen.add(fieldset_name)
-            fieldset = cfg.get(fieldset_name)
+            fieldset = registry.get(fieldset_name)
             if (
                 fieldset is not None
                 and conn._himport_prepared.get(fieldset_name) != fieldset.version

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -3398,8 +3398,25 @@ class TransactionStrategy(AbstractStrategy):
         Send a command and parse the response
         """
 
-        await connection.send_command(*args)
-        output = await redis_node.parse_response(connection, command_name, **options)
+        # HIMPORT SET's wire form depends on per-connection state: the fieldset
+        # must be PREPAREd on this connection first, and any fieldset discarded
+        # since this connection last reconciled must be dropped. The
+        # immediate/watched path (commands issued after WATCH, before MULTI)
+        # would otherwise send a bare HIMPORT SET and fail with "no such
+        # fieldset". Route it through the node's HIMPORT executor, the same way
+        # the normal cluster path, the batched MULTI/EXEC path, and standalone
+        # watched pipelines all do.
+        if command_name == HIMPORT_SET and len(args) >= 3:
+            # args == (HIMPORT_SET, key, fieldset_name, *values). Too few args
+            # fall through to the bare send so the server returns its arity error.
+            output = await redis_node._himport_execute_set(
+                connection, args[1], args[2], list(args[3:])
+            )
+        else:
+            await connection.send_command(*args)
+            output = await redis_node.parse_response(
+                connection, command_name, **options
+            )
 
         if command_name in self.UNWATCH_COMMANDS:
             self._watching = False

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -20,6 +20,7 @@ from typing import (
     Deque,
     Dict,
     Generator,
+    Iterable,
     List,
     Literal,
     Mapping,
@@ -112,6 +113,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
+from redis.himport import HImportConfig
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.typing import (
     AnyKeyT,
@@ -364,6 +366,7 @@ class RedisCluster(
         "_lock",
         "maint_notifications_config",
         "_oss_cluster_maint_notifications_handler",
+        "himport_config",
         "retry",
         "command_flags",
         "commands_parser",
@@ -449,6 +452,7 @@ class RedisCluster(
         event_dispatcher: EventDispatcher | None = None,
         policy_resolver: AsyncPolicyResolver = AsyncStaticPolicyResolver(),
         maint_notifications_config: MaintNotificationsConfig | None = None,
+        himport_schemas: Mapping[str, Iterable[str]] | None = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -543,6 +547,18 @@ class RedisCluster(
             )
         else:
             kwargs["response_callbacks"]["CLUSTER SHARDS"] = parse_cluster_shards
+
+        # Build the client-level HIMPORT config once and share the same object with
+        # every node connection. It rides in connection_kwargs -> ClusterNode ->
+        # each node's Connection, so the fieldset registry is shared cluster-wide.
+        # (Async has no per-node Redis client, so the object flows via connection_kwargs
+        # directly to the Connection, which is internal plumbing, not a public param.)
+        self.himport_config = (
+            HImportConfig(himport_schemas) if himport_schemas is not None else None
+        )
+        if self.himport_config is not None:
+            kwargs["himport_config"] = self.himport_config
+
         self.connection_kwargs = kwargs
 
         # Validate maint_notifications_config before NodesManager is constructed

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -2677,6 +2677,33 @@ class ClusterPipeline(AbstractRedis, AbstractRedisCluster, AsyncRedisClusterComm
         """Get the nodes manager from the cluster client."""
         return self.cluster_client.nodes_manager
 
+    # HIMPORT lifecycle on a cluster pipeline delegates to the parent client, mutating
+    # the one shared registry that every node pool references. A fieldset declared here
+    # is therefore visible to the batched himport_set pre-flight, mirroring the sync
+    # ClusterPipeline (which inherits these from RedisCluster over the shared registry).
+
+    @property
+    def himport_registry(self) -> HImportRegistry:
+        """The cluster-wide HIMPORT fieldset registry (empty if none was declared).
+
+        Read-only: the registry is mutated only through the HIMPORT command methods.
+        """
+        return self.cluster_client.himport_registry
+
+    async def himport_prepare(
+        self, fieldset_name: str, fields: Iterable[FieldT]
+    ) -> bool:
+        """Declare an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
+        return await self.cluster_client.himport_prepare(fieldset_name, fields)
+
+    async def himport_discard(self, fieldset_name: str) -> int:
+        """Remove an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
+        return await self.cluster_client.himport_discard(fieldset_name)
+
+    async def himport_discard_all(self) -> int:
+        """Remove all HIMPORT fieldsets cluster-wide (shared registry, applied lazily)."""
+        return await self.cluster_client.himport_discard_all()
+
     def set_response_callback(self, command: str, callback: ResponseCallbackT) -> None:
         """Set a custom response callback on the cluster client."""
         self.cluster_client.set_response_callback(command, callback)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -114,7 +114,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import HImportRegistry, is_himport_set_command
+from redis.himport import HImportRegistry, parse_himport_set_args
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.typing import (
     AnyKeyT,
@@ -1255,7 +1255,7 @@ class RedisCluster(
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
-                    if is_himport_set_command(command):
+                    if parse_himport_set_args(args) is not None:
                         # ASKING must sit on the same connection as the SET,
                         # immediately before it. HIMPORT SET's own executor folds
                         # ASKING into the SET's packed write after the session setup,
@@ -1858,13 +1858,16 @@ class ClusterNode:
             # On an ASK redirect ``asking`` is passed here rather than sent as a
             # separate ASKING command so the allowance sits on this same connection,
             # folded into the SET's own write immediately before the SET.
-            if is_himport_set_command(args[0]) and len(args) >= 3:
-                # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
-                # ``execute_command`` with too few args falls through to the normal
-                # send path below so the server returns its arity error instead of a
-                # client-side IndexError.
+            himport_set = parse_himport_set_args(args)
+            if himport_set is not None:
+                # HIMPORT SET in the joined ("HIMPORT SET", key, ...) or split
+                # ("HIMPORT", "SET", key, ...) raw form; operands at the right
+                # offsets. Too few operands returns None and falls through to the
+                # normal send path below so the server returns its arity error
+                # instead of a client-side IndexError.
+                key, fieldset_name, values = himport_set
                 return await self._himport_execute_set(
-                    connection, args[1], args[2], list(args[3:]), asking=asking
+                    connection, key, fieldset_name, values, asking=asking
                 )
 
             # Execute command
@@ -3227,11 +3230,14 @@ class TransactionStrategy(AbstractStrategy):
         # fieldset". Route it through the node's HIMPORT executor, the same way
         # the normal cluster path, the batched MULTI/EXEC path, and standalone
         # watched pipelines all do.
-        if is_himport_set_command(command_name) and len(args) >= 3:
-            # args == (HIMPORT_SET, key, fieldset_name, *values). Too few args
-            # fall through to the bare send so the server returns its arity error.
+        himport_set = parse_himport_set_args(args)
+        if himport_set is not None:
+            # HIMPORT SET in the joined or split raw form; operands at the right
+            # offsets. Too few operands returns None and falls through to the bare
+            # send so the server returns its arity error.
+            key, fieldset_name, values = himport_set
             output = await redis_node._himport_execute_set(
-                connection, args[1], args[2], list(args[3:])
+                connection, key, fieldset_name, values
             )
         else:
             await connection.send_command(*args)

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -131,6 +131,7 @@ from redis.utils import (
     check_protocol_version,
     deprecated_args,
     deprecated_function,
+    experimental_method,
     safe_str,
     str_if_bytes,
     truncate_text,
@@ -911,6 +912,7 @@ class RedisCluster(
         """
         return self._himport_registry
 
+    @experimental_method()
     async def himport_prepare(
         self, fieldset_name: str, fields: Iterable[FieldT]
     ) -> bool:
@@ -919,11 +921,13 @@ class RedisCluster(
         self._himport_registry.prepare(fieldset_name, fields)
         return True
 
+    @experimental_method()
     async def himport_discard(self, fieldset_name: str) -> int:
         """Remove an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
         await self.initialize()
         return 1 if self._himport_registry.discard(fieldset_name) else 0
 
+    @experimental_method()
     async def himport_discard_all(self) -> int:
         """Remove all HIMPORT fieldsets cluster-wide (shared registry, applied lazily)."""
         await self.initialize()

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -114,7 +114,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import HIMPORT_SET, HImportRegistry
+from redis.himport import HImportRegistry, is_himport_set_command
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.typing import (
     AnyKeyT,
@@ -1255,7 +1255,7 @@ class RedisCluster(
             try:
                 if asking:
                     target_node = self.get_node(node_name=redirect_addr)
-                    if command == HIMPORT_SET:
+                    if is_himport_set_command(command):
                         # ASKING must sit on the same connection as the SET,
                         # immediately before it. HIMPORT SET's own executor folds
                         # ASKING into the SET's packed write after the session setup,
@@ -1858,7 +1858,7 @@ class ClusterNode:
             # On an ASK redirect ``asking`` is passed here rather than sent as a
             # separate ASKING command so the allowance sits on this same connection,
             # folded into the SET's own write immediately before the SET.
-            if args[0] == HIMPORT_SET and len(args) >= 3:
+            if is_himport_set_command(args[0]) and len(args) >= 3:
                 # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
                 # ``execute_command`` with too few args falls through to the normal
                 # send path below so the server returns its arity error instead of a
@@ -3227,7 +3227,7 @@ class TransactionStrategy(AbstractStrategy):
         # fieldset". Route it through the node's HIMPORT executor, the same way
         # the normal cluster path, the batched MULTI/EXEC path, and standalone
         # watched pipelines all do.
-        if command_name == HIMPORT_SET and len(args) >= 3:
+        if is_himport_set_command(command_name) and len(args) >= 3:
             # args == (HIMPORT_SET, key, fieldset_name, *values). Too few args
             # fall through to the bare send so the server returns its arity error.
             output = await redis_node._himport_execute_set(

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -48,6 +48,7 @@ from redis._defaults import (
 from redis._parsers import AsyncCommandsParser, Encoder
 from redis._parsers.commands import CommandPolicies, RequestPolicy, ResponsePolicy
 from redis._parsers.helpers import get_response_callbacks
+from redis.asyncio import _himport_exec
 from redis.asyncio.client import PubSub, ResponseCallbackT
 from redis.asyncio.connection import (
     AbstractConnection,
@@ -105,7 +106,6 @@ from redis.exceptions import (
     InvalidPipelineStack,
     MaxConnectionsError,
     MovedError,
-    NoSuchFieldsetError,
     RedisClusterException,
     RedisError,
     ResponseError,
@@ -114,15 +114,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import (
-    HIMPORT_DISCARD,
-    HIMPORT_PREPARE,
-    HIMPORT_SET,
-    HImportRegistry,
-    himport_discard_command,
-    himport_prepare_command,
-    himport_set_command,
-)
+from redis.himport import HIMPORT_SET, HImportRegistry
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.typing import (
     AnyKeyT,
@@ -1888,38 +1880,8 @@ class ClusterNode:
                 self.release(connection)
 
     async def _himport_reconcile_discards(self, conn: "Connection") -> None:
-        """DISCARD, on ``conn``, any prepared fieldset removed from the registry."""
-        registry = conn.himport_registry
-        if registry is None or conn._himport_reconciled_revision == registry.revision:
-            return
-        # Snapshot the revision *before* computing ``stale`` so the value stamped at
-        # the end is never newer than the registry state ``stale`` reflects. A
-        # concurrent ``himport_discard`` (thread-shared sync client, or another task
-        # while this awaits the DISCARD replies) that lands after this point only
-        # leaves the connection marked behind the live revision, so the next
-        # reconcile re-runs and catches it. Re-reading ``registry.revision`` at the
-        # end instead would stamp a discard this connection never sent, leaving the
-        # server session carrying a supposedly-discarded fieldset.
-        reconciled_to = registry.revision
-        stale = registry.names_to_discard(list(conn._himport_prepared))
-        if stale:
-            await conn.send_packed_command(
-                conn.pack_commands([himport_discard_command(n) for n in stale])
-            )
-            # One reply per packed DISCARD must be read regardless of a per-command
-            # ResponseError, otherwise the unread replies desync the pooled socket.
-            # Drain every reply, then surface the first error (ConnectionError is not
-            # caught: it tears the socket down, so no desync is possible).
-            first_error = None
-            for n in stale:
-                try:
-                    await self.parse_response(conn, HIMPORT_DISCARD)
-                except ResponseError as e:
-                    first_error = first_error or e
-                conn._himport_prepared.pop(n, None)
-            if first_error is not None:
-                raise first_error
-        conn._himport_reconciled_revision = reconciled_to
+        """Delegate to the shared async HIMPORT executor."""
+        return await _himport_exec.reconcile_discards(self, conn)
 
     async def _himport_prepare_and_set(
         self,
@@ -1930,46 +1892,10 @@ class ClusterNode:
         fieldset,
         asking: bool = False,
     ) -> Any:
-        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write).
-
-        When ``asking`` is set (an ASK-redirected cluster SET) the batch becomes
-        ``[PREPARE, ASKING, SET]`` so the per-command ASKING allowance falls
-        immediately before the SET — the only slot-scoped command. PREPARE is a
-        connection-session command that the ASKING flag does not gate, so placing
-        it before ASKING is safe. Every reply is drained even on a per-command
-        error so the packed replies never desync the pooled socket.
-        """
-        commands = [himport_prepare_command(fieldset_name, fieldset.fields)]
-        if asking:
-            commands.append(("ASKING",))
-        commands.append(himport_set_command(key, fieldset_name, values))
-        await conn.send_packed_command(conn.pack_commands(commands))
-        prep_error = ask_error = set_error = None
-        set_resp = None
-        try:
-            await self.parse_response(conn, HIMPORT_PREPARE)
-        except ResponseError as e:
-            prep_error = e
-        if asking:
-            try:
-                await self.parse_response(conn, "ASKING")
-            except ResponseError as e:
-                ask_error = e
-        try:
-            set_resp = await self.parse_response(conn, HIMPORT_SET)
-        except ResponseError as e:
-            set_error = e
-
-        if prep_error:
-            raise prep_error  # PREPARE failure is the root cause
-        else:
-            conn._himport_prepared[fieldset_name] = fieldset.version
-
-        if ask_error:
-            raise ask_error
-        if set_error:
-            raise set_error
-        return set_resp
+        """Delegate to the shared async HIMPORT executor."""
+        return await _himport_exec.prepare_and_set(
+            self, conn, key, fieldset_name, values, fieldset, asking=asking
+        )
 
     async def _himport_execute_set(
         self,
@@ -1979,121 +1905,16 @@ class ClusterNode:
         values: List,
         asking: bool = False,
     ) -> Any:
-        """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
-
-        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
-        any fieldset discarded from the shared registry since this connection last
-        reconciled must be dropped. Both are applied here, on the acquired
-        connection, so the caller's full retry / MOVED-ASK / disconnect-on-error
-        handling covers the whole exchange.
-
-        When ``asking`` is set (an ASK-redirected cluster SET) the ASKING allowance
-        is folded into the SET's own packed write so it immediately precedes the
-        SET. The session setup (deferred DISCARDs, lazy PREPARE) still runs first,
-        before ASKING, since those are connection-session commands the flag does
-        not gate; only the SET is slot-scoped and must carry the allowance.
-        """
-        await self._himport_reconcile_discards(conn)
-
-        registry = conn.himport_registry
-        fieldset = registry.get(fieldset_name) if registry is not None else None
-        # Lazy PREPARE bundled with SET on first use of this fieldset.
-        if (
-            fieldset is not None
-            and conn._himport_prepared.get(fieldset_name) != fieldset.version
-        ):
-            return await self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset, asking=asking
-            )
-
-        # Believed already prepared (or an unregistered fieldset): bare SET, with
-        # ASKING packed immediately before it when this is an ASK redirect.
-        if asking:
-            await conn.send_packed_command(
-                conn.pack_commands(
-                    [("ASKING",), himport_set_command(key, fieldset_name, values)]
-                )
-            )
-            try:
-                await self.parse_response(conn, "ASKING")
-            except ResponseError as ask_error:
-                # ASKING and SET were one packed write, so the SET reply is still
-                # queued. Drain it before surfacing the ASKING error, otherwise the
-                # connection returns to the pool with an unread reply and desyncs
-                # the next borrower.
-                try:
-                    await self.parse_response(conn, HIMPORT_SET)
-                except ResponseError:
-                    pass
-                raise ask_error
-        else:
-            await conn.send_command(*himport_set_command(key, fieldset_name, values))
-        try:
-            return await self.parse_response(conn, HIMPORT_SET)
-        except NoSuchFieldsetError:
-            # Server dropped the fieldset mid-connection without dropping the socket
-            # (e.g. RESET / maxmemory-clients eviction): re-PREPARE on this healthy
-            # connection and retry the SET once rather than reconnecting. Only for
-            # registry-backed fieldsets; manual/unregistered usage propagates.
-            if fieldset is None:
-                raise
-            conn._himport_prepared.pop(fieldset_name, None)
-            return await self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset, asking=asking
-            )
+        """Delegate to the shared async HIMPORT executor."""
+        return await _himport_exec.execute_set(
+            self, conn, key, fieldset_name, values, asking=asking
+        )
 
     async def _himport_prepare_pipeline(
         self, conn: "Connection", commands: List["PipelineCommand"]
     ) -> None:
-        """Pre-flight ``conn`` for a pipeline batch containing ``HIMPORT SET``s.
-
-        The packed pipeline write bypasses the per-command lazy PREPARE, so PREPARE
-        every distinct registered fieldset the batch references (and reconcile
-        deferred discards) on ``conn`` first, in one packed write.
-        """
-        # A pipeline may run on a connection type that never carries real HIMPORT
-        # state (e.g. mocked test doubles); only proceed for a real config.
-        registry = getattr(conn, "himport_registry", None)
-        if not isinstance(registry, HImportRegistry):
-            return
-        await self._himport_reconcile_discards(conn)
-        to_prepare = []
-        seen = set()
-        for cmd in commands:
-            args = cmd.args
-            if not args or args[0] != HIMPORT_SET or len(args) < 3:
-                continue
-            fieldset_name = args[2]
-            if fieldset_name in seen:
-                continue
-            seen.add(fieldset_name)
-            fieldset = registry.get(fieldset_name)
-            if (
-                fieldset is not None
-                and conn._himport_prepared.get(fieldset_name) != fieldset.version
-            ):
-                to_prepare.append(fieldset)
-        if not to_prepare:
-            return
-        await conn.send_packed_command(
-            conn.pack_commands(
-                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
-            )
-        )
-        # One reply per packed PREPARE must be read regardless of a per-command
-        # ResponseError, otherwise the unread replies desync the socket before the
-        # buffered batch is even sent. Drain every reply (marking only the ones that
-        # succeeded), then surface the first error as the root cause.
-        first_error = None
-        for fs in to_prepare:
-            try:
-                await self.parse_response(conn, HIMPORT_PREPARE)
-            except ResponseError as e:
-                first_error = first_error or e
-                continue
-            conn._himport_prepared[fs.name] = fs.version
-        if first_error is not None:
-            raise first_error
+        """Delegate to the shared async HIMPORT executor."""
+        await _himport_exec.prepare_pipeline(self, conn, [cmd.args for cmd in commands])
 
     async def execute_pipeline(self, commands: List["PipelineCommand"]) -> bool:
         # Acquire connection

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2626,18 +2626,16 @@ class ConnectionPool(
         self._connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
-        # Resolve the HIMPORT config. A pre-built ``himport_registry`` (shared, e.g.
-        # from the cluster client) takes precedence; otherwise build one from the
-        # ``himport_schemas`` dict (empty if none). A registry always exists so runtime
-        # ``himport_prepare`` mutates a single object every connection already shares.
-        # The object stays in ``connection_kwargs`` so it reaches every connection,
-        # while ``himport_schemas`` is consumed here. It is injected unconditionally
-        # (like other auto-added pool kwargs), so a custom ``connection_class`` must
-        # accept ``**kwargs`` (or a ``himport_registry`` parameter), as built-ins do.
+        # Resolve the HIMPORT registry. A pre-built ``himport_registry`` (shared, e.g.
+        # from the cluster client) takes precedence; otherwise build a fresh empty one.
+        # A registry always exists so runtime ``himport_prepare`` mutates a single object
+        # every connection already shares. The object stays in ``connection_kwargs`` so
+        # it reaches every connection. It is injected unconditionally (like other
+        # auto-added pool kwargs), so a custom ``connection_class`` must accept
+        # ``**kwargs`` (or a ``himport_registry`` parameter), as built-ins do.
         himport_registry = connection_kwargs.get("himport_registry")
-        himport_schemas = connection_kwargs.pop("himport_schemas", None)
         if himport_registry is None:
-            himport_registry = HImportRegistry(himport_schemas)
+            himport_registry = HImportRegistry()
             connection_kwargs["himport_registry"] = himport_registry
         self.himport_registry = himport_registry
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -713,13 +713,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         self.set_parser(parser_class)
 
         # HIMPORT client-side state. `himport_config` is the shared client-level
-        # registry (or None). `_himport_prepared` maps fieldset name -> the version
-        # this connection last prepared on the server; `_himport_reconciled_revision`
-        # is the config revision this connection last reconciled discards against.
-        # These are populated here for propagation only and are not used yet.
+        # registry (empty if unconfigured) and persists across reconnects.
         self.himport_config = himport_config
-        self._himport_prepared: dict[str, int] = {}
-        self._himport_reconciled_revision: int = 0
+        self._reset_himport_state()
 
         AsyncMaintNotificationsAbstractConnection.__init__(
             self,
@@ -930,11 +926,22 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
     def get_protocol(self):
         return self.protocol
 
+    def _reset_himport_state(self) -> None:
+        # A fresh server session has no prepared HIMPORT fieldsets, so the next
+        # himport_set must re-prepare on this connection. ``_himport_prepared`` maps
+        # fieldset name -> the version prepared on the server; ``_himport_reconciled
+        # _revision`` is the config revision this connection last reconciled discards
+        # against. Both are reset on connect/disconnect since the session is gone.
+        self._himport_prepared: dict[str, int] = {}
+        self._himport_reconciled_revision: int = 0
+
     async def on_connect(self) -> None:
         """Initialize the connection, authenticate and select a database"""
         await self.on_connect_check_health(check_health=True)
 
     async def on_connect_check_health(self, check_health: bool = True) -> None:
+        # A fresh socket is a new server session: no prepared HIMPORT fieldsets.
+        self._reset_himport_state()
         self._parser.on_connect(self)
         parser = self._parser
 
@@ -1064,6 +1071,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         health_check_failed: bool = False,
     ) -> None:
         """Disconnects from the Redis server"""
+        # The server session is gone, so any HIMPORT fieldsets prepared on this
+        # socket no longer exist; reset the tracking.
+        self._reset_himport_state()
         # On Python 3.13+, asyncio.timeout() raises RuntimeError when called
         # outside a running Task (e.g. during GC finalization or event-loop
         # callbacks).  In that context we fall back to a synchronous close.
@@ -2617,12 +2627,14 @@ class ConnectionPool(
         self.max_connections = max_connections
 
         # Resolve the HIMPORT config. A pre-built ``himport_config`` (shared, e.g.
-        # from the cluster client) takes precedence; otherwise build one from a
-        # ``himport_schemas`` dict. The resolved config stays in ``connection_kwargs``
-        # so it reaches every connection, while ``himport_schemas`` is consumed here.
+        # from the cluster client) takes precedence; otherwise build one from the
+        # ``himport_schemas`` dict (empty if none). A config always exists so runtime
+        # ``himport_prepare`` mutates a single object every connection already shares.
+        # The object stays in ``connection_kwargs`` so it reaches every connection,
+        # while ``himport_schemas`` is consumed here.
         himport_config = connection_kwargs.get("himport_config")
         himport_schemas = connection_kwargs.pop("himport_schemas", None)
-        if himport_config is None and himport_schemas is not None:
+        if himport_config is None:
             himport_config = HImportConfig(himport_schemas)
             connection_kwargs["himport_config"] = himport_config
         self.himport_config = himport_config
@@ -2651,11 +2663,15 @@ class ConnectionPool(
         }
     )
 
+    # Internal plumbing kwargs omitted from __repr__ (not user-facing config).
+    OMIT_REPR_KEYS = frozenset({"himport_config"})
+
     def __repr__(self):
         conn_kwargs = ",".join(
             [
                 f"{k}={'<REDACTED>' if k in self.SENSITIVE_REPR_KEYS else v}"
                 for k, v in self.connection_kwargs.items()
+                if k not in self.OMIT_REPR_KEYS
             ]
         )
         return (

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -2631,7 +2631,9 @@ class ConnectionPool(
         # ``himport_schemas`` dict (empty if none). A config always exists so runtime
         # ``himport_prepare`` mutates a single object every connection already shares.
         # The object stays in ``connection_kwargs`` so it reaches every connection,
-        # while ``himport_schemas`` is consumed here.
+        # while ``himport_schemas`` is consumed here. It is injected unconditionally
+        # (like other auto-added pool kwargs), so a custom ``connection_class`` must
+        # accept ``**kwargs`` (or a ``himport_config`` parameter), as built-ins do.
         himport_config = connection_kwargs.get("himport_config")
         himport_schemas = connection_kwargs.pop("himport_schemas", None)
         if himport_config is None:

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -85,7 +85,7 @@ from redis.exceptions import (
     ResponseError,
     TimeoutError,
 )
-from redis.himport import HImportConfig
+from redis.himport import HImportRegistry
 from redis.maint_notifications import (
     MaintenanceState,
     MaintNotificationsConfig,
@@ -622,7 +622,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         oss_cluster_maint_notifications_handler: (
             AsyncOSSMaintNotificationsHandler | None
         ) = None,
-        himport_config: HImportConfig | None = None,
+        himport_registry: HImportRegistry | None = None,
     ):
         """
         Initialize a new async Connection.
@@ -712,9 +712,9 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                 parser_class = _AsyncRESP2Parser
         self.set_parser(parser_class)
 
-        # HIMPORT client-side state. `himport_config` is the shared client-level
+        # HIMPORT client-side state. `himport_registry` is the shared client-level
         # registry (empty if unconfigured) and persists across reconnects.
-        self.himport_config = himport_config
+        self.himport_registry = himport_registry
         self._reset_himport_state()
 
         AsyncMaintNotificationsAbstractConnection.__init__(
@@ -930,7 +930,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         # A fresh server session has no prepared HIMPORT fieldsets, so the next
         # himport_set must re-prepare on this connection. ``_himport_prepared`` maps
         # fieldset name -> the version prepared on the server; ``_himport_reconciled
-        # _revision`` is the config revision this connection last reconciled discards
+        # _revision`` is the registry revision this connection last reconciled discards
         # against. Both are reset on connect/disconnect since the session is gone.
         self._himport_prepared: dict[str, int] = {}
         self._himport_reconciled_revision: int = 0
@@ -2626,20 +2626,20 @@ class ConnectionPool(
         self._connection_kwargs = connection_kwargs
         self.max_connections = max_connections
 
-        # Resolve the HIMPORT config. A pre-built ``himport_config`` (shared, e.g.
+        # Resolve the HIMPORT config. A pre-built ``himport_registry`` (shared, e.g.
         # from the cluster client) takes precedence; otherwise build one from the
-        # ``himport_schemas`` dict (empty if none). A config always exists so runtime
+        # ``himport_schemas`` dict (empty if none). A registry always exists so runtime
         # ``himport_prepare`` mutates a single object every connection already shares.
         # The object stays in ``connection_kwargs`` so it reaches every connection,
         # while ``himport_schemas`` is consumed here. It is injected unconditionally
         # (like other auto-added pool kwargs), so a custom ``connection_class`` must
-        # accept ``**kwargs`` (or a ``himport_config`` parameter), as built-ins do.
-        himport_config = connection_kwargs.get("himport_config")
+        # accept ``**kwargs`` (or a ``himport_registry`` parameter), as built-ins do.
+        himport_registry = connection_kwargs.get("himport_registry")
         himport_schemas = connection_kwargs.pop("himport_schemas", None)
-        if himport_config is None:
-            himport_config = HImportConfig(himport_schemas)
-            connection_kwargs["himport_config"] = himport_config
-        self.himport_config = himport_config
+        if himport_registry is None:
+            himport_registry = HImportRegistry(himport_schemas)
+            connection_kwargs["himport_registry"] = himport_registry
+        self.himport_registry = himport_registry
 
         self._available_connections: List[AbstractConnection] = []
         self._in_use_connections: Set[AbstractConnection] = set()
@@ -2666,7 +2666,7 @@ class ConnectionPool(
     )
 
     # Internal plumbing kwargs omitted from __repr__ (not user-facing config).
-    OMIT_REPR_KEYS = frozenset({"himport_config"})
+    OMIT_REPR_KEYS = frozenset({"himport_registry"})
 
     def __repr__(self):
         conn_kwargs = ",".join(

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -85,6 +85,7 @@ from redis.exceptions import (
     ResponseError,
     TimeoutError,
 )
+from redis.himport import HImportConfig
 from redis.maint_notifications import (
     MaintenanceState,
     MaintNotificationsConfig,
@@ -621,6 +622,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         oss_cluster_maint_notifications_handler: (
             AsyncOSSMaintNotificationsHandler | None
         ) = None,
+        himport_config: HImportConfig | None = None,
     ):
         """
         Initialize a new async Connection.
@@ -709,6 +711,16 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             elif self.protocol == 2 and parser_class == _AsyncRESP3Parser:
                 parser_class = _AsyncRESP2Parser
         self.set_parser(parser_class)
+
+        # HIMPORT client-side state. `himport_config` is the shared client-level
+        # registry (or None). `_himport_prepared` maps fieldset name -> the version
+        # this connection last prepared on the server; `_himport_reconciled_revision`
+        # is the config revision this connection last reconciled discards against.
+        # These are populated here for propagation only and are not used yet.
+        self.himport_config = himport_config
+        self._himport_prepared: dict[str, int] = {}
+        self._himport_reconciled_revision: int = 0
+
         AsyncMaintNotificationsAbstractConnection.__init__(
             self,
             maint_notifications_config,
@@ -2603,6 +2615,17 @@ class ConnectionPool(
         self.connection_class = connection_class
         self._connection_kwargs = connection_kwargs
         self.max_connections = max_connections
+
+        # Resolve the HIMPORT config. A pre-built ``himport_config`` (shared, e.g.
+        # from the cluster client) takes precedence; otherwise build one from a
+        # ``himport_schemas`` dict. The resolved config stays in ``connection_kwargs``
+        # so it reaches every connection, while ``himport_schemas`` is consumed here.
+        himport_config = connection_kwargs.get("himport_config")
+        himport_schemas = connection_kwargs.pop("himport_schemas", None)
+        if himport_config is None and himport_schemas is not None:
+            himport_config = HImportConfig(himport_schemas)
+            connection_kwargs["himport_config"] = himport_config
+        self.himport_config = himport_config
 
         self._available_connections: List[AbstractConnection] = []
         self._in_use_connections: Set[AbstractConnection] = set()

--- a/redis/asyncio/multidb/client.py
+++ b/redis/asyncio/multidb/client.py
@@ -516,16 +516,16 @@ class Pipeline(AsyncRedisModuleCommands, AsyncCoreCommands):
     # pipeline inherits ``himport_set`` from ``AsyncCoreCommands`` and would otherwise
     # queue an unprepared ``HIMPORT SET`` that fails with a confusing server-side
     # error, bypassing the client-level guard. Block all HIMPORT methods here too.
-    async def himport_prepare(self, *args: Any, **kwargs: Any) -> Any:
+    def himport_prepare(self, *args: Any, **kwargs: Any) -> Any:
         raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
 
-    async def himport_set(self, *args: Any, **kwargs: Any) -> Any:
+    def himport_set(self, *args: Any, **kwargs: Any) -> Any:
         raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
 
-    async def himport_discard(self, *args: Any, **kwargs: Any) -> Any:
+    def himport_discard(self, *args: Any, **kwargs: Any) -> Any:
         raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
 
-    async def himport_discard_all(self, *args: Any, **kwargs: Any) -> Any:
+    def himport_discard_all(self, *args: Any, **kwargs: Any) -> Any:
         raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
 
     async def execute(self) -> List[Any]:

--- a/redis/asyncio/multidb/client.py
+++ b/redis/asyncio/multidb/client.py
@@ -16,6 +16,7 @@ from redis.asyncio.retry import Retry
 from redis.background import BackgroundScheduler
 from redis.backoff import NoBackoff
 from redis.commands import AsyncCoreCommands, AsyncRedisModuleCommands
+from redis.exceptions import DataError
 from redis.multidb.circuit import CircuitBreaker
 from redis.multidb.circuit import State as CBState
 from redis.multidb.exception import (
@@ -290,6 +291,29 @@ class MultiDBClient(AsyncRedisModuleCommands, AsyncCoreCommands):
             await self.initialize()
 
         return await self.command_executor.execute_command(*args, **options)
+
+    # HIMPORT is not supported on the multi-database client. A HIMPORT fieldset is
+    # per-connection server session state tracked by a single client's registry;
+    # there is no coherent way to keep that state consistent across independent
+    # database clients through failover. ``himport_set`` is inherited from
+    # ``AsyncCoreCommands`` (and the lifecycle methods would otherwise be missing
+    # entirely), so override them to fail early and clearly instead of surfacing a
+    # confusing ``no such fieldset`` at runtime.
+    _HIMPORT_UNSUPPORTED = (
+        "HIMPORT is not supported on the multi-database (Active-Active) client"
+    )
+
+    async def himport_prepare(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
+
+    async def himport_set(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
+
+    async def himport_discard(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
+
+    async def himport_discard_all(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
 
     def pipeline(self):
         """

--- a/redis/asyncio/multidb/client.py
+++ b/redis/asyncio/multidb/client.py
@@ -512,6 +512,22 @@ class Pipeline(AsyncRedisModuleCommands, AsyncCoreCommands):
         """Adds a command to the stack"""
         return self.pipeline_execute_command(*args, **kwargs)
 
+    # HIMPORT is unsupported on the multi-database client (see MultiDBClient). A
+    # pipeline inherits ``himport_set`` from ``AsyncCoreCommands`` and would otherwise
+    # queue an unprepared ``HIMPORT SET`` that fails with a confusing server-side
+    # error, bypassing the client-level guard. Block all HIMPORT methods here too.
+    async def himport_prepare(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
+    async def himport_set(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
+    async def himport_discard(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
+    async def himport_discard_all(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
     async def execute(self) -> List[Any]:
         """Execute all the commands in the current pipeline"""
         if not self._client.initialized:

--- a/redis/asyncio/sentinel.py
+++ b/redis/asyncio/sentinel.py
@@ -418,6 +418,18 @@ class Sentinel(AsyncSentinelCommands):
         All other keyword arguments are merged with any connection_kwargs
         passed to this class and passed to the connection pool as keyword
         arguments to be used to initialize Redis connections.
+
+        HIMPORT note: the returned client exposes the HIMPORT command family
+        (``himport_prepare``, ``himport_set``, ``himport_discard``,
+        ``himport_discard_all``). Fieldsets are declared at runtime with
+        ``himport_prepare`` on the client and live on that client's shared registry,
+        so they survive Sentinel failover automatically: the pool re-points to the
+        new master and the fieldset is re-prepared lazily on the next
+        ``himport_set``. Each call to current command returns a *new* client with its *own* empty
+        registry, so call ``himport_prepare`` on the long-lived client you reuse
+        rather than creating a fresh one per operation; otherwise ``himport_set``
+        fails with ``no such fieldset``. (``himport_set`` is a write and is served by
+        the master.)
         """
         kwargs["is_master"] = True
         connection_kwargs = dict(self.connection_kwargs)
@@ -450,6 +462,18 @@ class Sentinel(AsyncSentinelCommands):
         All other keyword arguments are merged with any connection_kwargs
         passed to this class and passed to the connection pool as keyword
         arguments to be used to initialize Redis connections.
+
+        HIMPORT note: the returned client exposes the HIMPORT command family
+        (``himport_prepare``, ``himport_set``, ``himport_discard``,
+        ``himport_discard_all``). Fieldsets are declared at runtime with
+        ``himport_prepare`` on the client and live on that client's shared registry,
+        so they survive Sentinel failover automatically: the pool re-points to the
+        new master and the fieldset is re-prepared lazily on the next
+        ``himport_set``. Each call to current command returns a *new* client with its *own* empty
+        registry, so call ``himport_prepare`` on the long-lived client you reuse
+        rather than creating a fresh one per operation; otherwise ``himport_set``
+        fails with ``no such fieldset``. (``himport_set`` is a write and is served by
+        the master.)
         """
         kwargs["is_master"] = False
         connection_kwargs = dict(self.connection_kwargs)

--- a/redis/client.py
+++ b/redis/client.py
@@ -68,7 +68,7 @@ from redis.himport import (
     HIMPORT_DISCARD,
     HIMPORT_PREPARE,
     HIMPORT_SET,
-    HImportConfig,
+    HImportRegistry,
     himport_discard_command,
     himport_prepare_command,
     himport_set_command,
@@ -399,7 +399,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         himport_schemas:
             optional mapping of `fieldset_name -> ordered field names` to register
             as HIMPORT fieldsets at construction time - see `redis.himport` for
-            details. The pool owns the resulting `HImportConfig`, so this argument
+            details. The pool owns the resulting `HImportRegistry`, so this argument
             is ignored when connection_pool is provided: to preconfigure schemas
             with a caller-supplied pool, pass `himport_schemas` to the pool itself
             (e.g. `ConnectionPool(..., himport_schemas=...)`).
@@ -518,7 +518,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                             "oss_cluster_maint_notifications_handler": oss_cluster_maint_notifications_handler,
                         }
                     )
-            # The pool builds the HImportConfig from the schemas (see
+            # The pool builds the HImportRegistry from the schemas (see
             # ConnectionPool.__init__) and owns it; the client never holds a
             # mutable reference, so the registry is mutated only via the HIMPORT
             # command methods.
@@ -580,13 +580,13 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         return self.connection_pool.connection_kwargs
 
     @property
-    def himport_config(self) -> HImportConfig:
+    def himport_registry(self) -> HImportRegistry:
         """The client's HIMPORT fieldset registry (contains empty
         schema registry if none was declared).
 
         Read-only: the registry is mutated only through the HIMPORT command methods.
         """
-        return self.connection_pool.himport_config
+        return self.connection_pool.himport_registry
 
     def get_retry(self) -> Optional[Retry]:
         return self.get_connection_kwargs().get("retry")
@@ -836,13 +836,22 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     def _himport_reconcile_discards(self, conn):
         """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
 
-        Runs at most once per registry mutation: the connection records the config
+        Runs at most once per registry mutation: the connection records the registry
         ``revision`` it last reconciled against, so unchanged registries are a no-op.
         """
-        cfg = conn.himport_config
-        if cfg is None or conn._himport_reconciled_revision == cfg.revision:
+        registry = conn.himport_registry
+        if registry is None or conn._himport_reconciled_revision == registry.revision:
             return
-        stale = cfg.names_to_discard(list(conn._himport_prepared))
+        # Snapshot the revision *before* computing ``stale`` so the value stamped at
+        # the end is never newer than the registry state ``stale`` reflects. A
+        # concurrent ``himport_discard`` (thread-shared sync client, or another task
+        # while this awaits the DISCARD replies) that lands after this point only
+        # leaves the connection marked behind the live revision, so the next
+        # reconcile re-runs and catches it. Re-reading ``registry.revision`` at the
+        # end instead would stamp a discard this connection never sent, leaving the
+        # server session carrying a supposedly-discarded fieldset.
+        reconciled_to = registry.revision
+        stale = registry.names_to_discard(list(conn._himport_prepared))
         if stale:
             conn.send_packed_command(
                 conn.pack_commands([himport_discard_command(n) for n in stale])
@@ -860,7 +869,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                 conn._himport_prepared.pop(n, None)
             if first_error is not None:
                 raise first_error
-        conn._himport_reconciled_revision = cfg.revision
+        conn._himport_reconciled_revision = reconciled_to
 
     def _himport_prepare_and_set(self, conn, key, fieldset_name, values, fieldset):
         """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
@@ -905,8 +914,8 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         """
         self._himport_reconcile_discards(conn)
 
-        cfg = conn.himport_config
-        fieldset = cfg.get(fieldset_name) if cfg is not None else None
+        registry = conn.himport_registry
+        fieldset = registry.get(fieldset_name) if registry is not None else None
         # Lazy PREPARE bundled with SET on first use of this fieldset.
         if (
             fieldset is not None
@@ -1052,7 +1061,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     def get_cache(self) -> Optional[CacheInterface]:
         return self.connection_pool.cache
 
-    # HIMPORT orchestration. The registry lives on the shared HImportConfig; the
+    # HIMPORT orchestration. The registry lives on the shared HImportRegistry; the
     # server-side effect is applied lazily per connection (PREPARE bundled into the
     # first himport_set; DISCARD reconciled when a connection is next borrowed for a
     # himport_set). The connection carries the per-connection HIMPORT state; a
@@ -1069,7 +1078,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         while that connection is not connected there is no session state to prepare,
         so the next ``himport_set`` prepares it lazily instead.
         """
-        fieldset = self.himport_config.prepare(fieldset_name, fields)
+        fieldset = self.himport_registry.prepare(fieldset_name, fields)
         conn = self.connection
         if self._single_connection_client and conn is not None and conn.is_connected:
             self.himport_prepare_internal(fieldset_name, fieldset.fields)
@@ -1086,13 +1095,13 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         connected there is nothing prepared on the server to discard (its tracking is
         reset on connect), so no server call is made.
         """
-        removed = self.himport_config.discard(fieldset_name)
+        removed = self.himport_registry.discard(fieldset_name)
         conn = self.connection
         if self._single_connection_client and conn is not None and conn.is_connected:
             if removed:
                 self.himport_discard_internal(fieldset_name)
             conn._himport_prepared.pop(fieldset_name, None)
-            conn._himport_reconciled_revision = self.himport_config.revision
+            conn._himport_reconciled_revision = self.himport_registry.revision
         return 1 if removed else 0
 
     def himport_discard_all(self) -> int:
@@ -1101,13 +1110,13 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         Returns the number removed from the registry. Server-side removal follows the
         same live/lazy rule as :meth:`himport_discard`.
         """
-        count = self.himport_config.discard_all()
+        count = self.himport_registry.discard_all()
         conn = self.connection
         if self._single_connection_client and conn is not None and conn.is_connected:
             if count:
                 self.himport_discard_all_internal()
             conn._himport_prepared.clear()
-            conn._himport_reconciled_revision = self.himport_config.revision
+            conn._himport_reconciled_revision = self.himport_registry.revision
         return count
 
 
@@ -2118,8 +2127,8 @@ class Pipeline(Redis):
         """
         # A pipeline may run on a connection type that never carries real HIMPORT
         # state (e.g. mocked test doubles); only proceed for a real config.
-        cfg = getattr(conn, "himport_config", None)
-        if not isinstance(cfg, HImportConfig):
+        registry = getattr(conn, "himport_registry", None)
+        if not isinstance(registry, HImportRegistry):
             return
         self._himport_reconcile_discards(conn)
         to_prepare = []
@@ -2131,7 +2140,7 @@ class Pipeline(Redis):
             if fieldset_name in seen:
                 continue
             seen.add(fieldset_name)
-            fieldset = cfg.get(fieldset_name)
+            fieldset = registry.get(fieldset_name)
             if (
                 fieldset is not None
                 and conn._himport_prepared.get(fieldset_name) != fieldset.version

--- a/redis/client.py
+++ b/redis/client.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Literal,
     Mapping,
@@ -62,6 +63,7 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
+from redis.himport import HImportConfig
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -315,6 +317,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         maint_notifications_config: MaintNotificationsConfig | None = None,
         oss_cluster_maint_notifications_handler: OSSMaintNotificationsHandler
         | None = None,
+        himport_schemas: Mapping[str, Iterable[str]] | None = None,
     ) -> None:
         """
         Initialize a new Redis client.
@@ -494,6 +497,12 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                             "oss_cluster_maint_notifications_handler": oss_cluster_maint_notifications_handler,
                         }
                     )
+                # The pool builds the HImportConfig from the schemas (see
+                # ConnectionPool.__init__) and owns it; the client never holds a
+                # mutable reference, so the registry is mutated only via the HIMPORT
+                # command methods.
+                if himport_schemas is not None:
+                    kwargs.update({"himport_schemas": himport_schemas})
             connection_pool = ConnectionPool(**kwargs)
             self._event_dispatcher.dispatch(
                 AfterPooledConnectionsInstantiationEvent(
@@ -548,6 +557,14 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     def get_connection_kwargs(self) -> Dict:
         """Get the connection's key-word arguments"""
         return self.connection_pool.connection_kwargs
+
+    @property
+    def himport_config(self) -> Optional[HImportConfig]:
+        """The client's HIMPORT fieldset registry, or ``None`` if not configured.
+
+        Read-only: the registry is mutated only through the HIMPORT command methods.
+        """
+        return self.connection_pool.himport_config
 
     def get_retry(self) -> Optional[Retry]:
         return self.get_connection_kwargs().get("retry")

--- a/redis/client.py
+++ b/redis/client.py
@@ -58,12 +58,21 @@ from redis.event import (
 from redis.exceptions import (
     ConnectionError,
     ExecAbortError,
+    NoSuchFieldsetError,
     PubSubError,
     RedisError,
     ResponseError,
     WatchError,
 )
-from redis.himport import HImportConfig
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+    HImportConfig,
+    himport_discard_command,
+    himport_prepare_command,
+    himport_set_command,
+)
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -76,7 +85,12 @@ from redis.observability.recorder import (
     record_pubsub_message,
 )
 from redis.retry import Retry
-from redis.typing import ChannelT, PubSubHandler, Subscription
+from redis.typing import (
+    ChannelT,
+    FieldT,
+    PubSubHandler,
+    Subscription,
+)
 from redis.utils import (
     SENTINEL,
     _set_info_logger,
@@ -382,6 +396,13 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             `redis.maint_notifications.OSSMaintNotificationsHandler` for details.
             Only supported with RESP3
             Argument is ignored when connection_pool is provided.
+        himport_schemas:
+            optional mapping of `fieldset_name -> ordered field names` to register
+            as HIMPORT fieldsets at construction time - see `redis.himport` for
+            details. The pool owns the resulting `HImportConfig`, so this argument
+            is ignored when connection_pool is provided: to preconfigure schemas
+            with a caller-supplied pool, pass `himport_schemas` to the pool itself
+            (e.g. `ConnectionPool(..., himport_schemas=...)`).
         """
         if event_dispatcher is None:
             self._event_dispatcher = EventDispatcher()
@@ -559,8 +580,9 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         return self.connection_pool.connection_kwargs
 
     @property
-    def himport_config(self) -> Optional[HImportConfig]:
-        """The client's HIMPORT fieldset registry, or ``None`` if not configured.
+    def himport_config(self) -> HImportConfig:
+        """The client's HIMPORT fieldset registry (contains empty
+        schema registry if none was declared).
 
         Read-only: the registry is mutated only through the HIMPORT command methods.
         """
@@ -794,8 +816,122 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         """
         Send a command and parse the response
         """
+        # HIMPORT SET is the one command whose wire form depends on per-connection
+        # state: the fieldset must be PREPAREd on this connection first, and any
+        # fieldset discarded since this connection last reconciled must be dropped.
+        # Handling it here (rather than in himport_set) lets himport_set reuse the
+        # full execute_command machinery — retry, disconnect-on-error, pooling — so
+        # a failed HIMPORT SET disconnects the connection like any other command.
+        # This per-command branch in the hot dispatch path is deliberate and has no
+        # cleaner alternative: this is the only seam where the concrete borrowed
+        # connection is known, and connection-scoped session setup can only happen
+        # once that connection is chosen. The overhead is one string compare per
+        # command.
+        if command_name == HIMPORT_SET:
+            # args == (HIMPORT_SET, key, fieldset_name, *values)
+            return self._himport_execute_set(conn, args[1], args[2], list(args[3:]))
         conn.send_command(*args, **options)
         return self.parse_response(conn, command_name, **options)
+
+    def _himport_reconcile_discards(self, conn):
+        """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
+
+        Runs at most once per registry mutation: the connection records the config
+        ``revision`` it last reconciled against, so unchanged registries are a no-op.
+        """
+        cfg = conn.himport_config
+        if cfg is None or conn._himport_reconciled_revision == cfg.revision:
+            return
+        stale = cfg.names_to_discard(list(conn._himport_prepared))
+        if stale:
+            conn.send_packed_command(
+                conn.pack_commands([himport_discard_command(n) for n in stale])
+            )
+            # One reply per packed DISCARD must be read regardless of a per-command
+            # ResponseError, otherwise the unread replies desync the pooled socket.
+            # Drain every reply, then surface the first error (ConnectionError is not
+            # caught: it tears the socket down, so no desync is possible).
+            first_error = None
+            for n in stale:
+                try:
+                    self.parse_response(conn, HIMPORT_DISCARD)
+                except ResponseError as e:
+                    first_error = first_error or e
+                conn._himport_prepared.pop(n, None)
+            if first_error is not None:
+                raise first_error
+        conn._himport_reconciled_revision = cfg.revision
+
+    def _himport_prepare_and_set(self, conn, key, fieldset_name, values, fieldset):
+        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
+        conn.send_packed_command(
+            conn.pack_commands(
+                [
+                    himport_prepare_command(fieldset_name, fieldset.fields),
+                    himport_set_command(key, fieldset_name, values),
+                ]
+            )
+        )
+        prep_error = set_error = None
+        set_resp = None
+        try:
+            self.parse_response(conn, HIMPORT_PREPARE)
+        except ResponseError as e:
+            prep_error = e
+        try:
+            set_resp = self.parse_response(conn, HIMPORT_SET)
+        except ResponseError as e:
+            set_error = e
+
+        if prep_error:
+            raise prep_error  # PREPARE failure is the root cause
+        else:
+            conn._himport_prepared[fieldset_name] = fieldset.version
+
+        if set_error:
+            raise set_error
+        return set_resp
+
+    def _himport_execute_set(self, conn, key, fieldset_name, values):
+        """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
+
+        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
+        any fieldset discarded from the shared registry since this connection last
+        reconciled must be dropped. Both are applied here, on the borrowed
+        connection, so the enclosing ``execute_command`` machinery (retry,
+        disconnect-on-error, pooling) covers the whole exchange. The connection
+        carries the per-connection HIMPORT state; a ``CacheProxyConnection``
+        delegates it transparently, so this never inspects the connection type.
+        """
+        self._himport_reconcile_discards(conn)
+
+        cfg = conn.himport_config
+        fieldset = cfg.get(fieldset_name) if cfg is not None else None
+        # Lazy PREPARE bundled with SET on first use of this fieldset.
+        if (
+            fieldset is not None
+            and conn._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            return self._himport_prepare_and_set(
+                conn, key, fieldset_name, values, fieldset
+            )
+
+        # Believed already prepared (or an unregistered fieldset): bare SET.
+        conn.send_command(*himport_set_command(key, fieldset_name, values))
+        try:
+            return self.parse_response(conn, HIMPORT_SET)
+        except NoSuchFieldsetError:
+            # The server can drop the fieldset mid-connection without dropping the
+            # socket (e.g. RESET / maxmemory-clients eviction). The connection is
+            # healthy, so don't reconnect: re-PREPARE on it and retry the SET once.
+            # Only for registry-backed fieldsets — manual/unregistered usage
+            # propagates unchanged (a re-prepare would send a fieldset we don't own).
+            if fieldset is None:
+                raise
+            conn._himport_prepared.pop(fieldset_name, None)
+            return self._himport_prepare_and_set(
+                conn, key, fieldset_name, values, fieldset
+            )
 
     def _close_connection(
         self,
@@ -915,6 +1051,64 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
 
     def get_cache(self) -> Optional[CacheInterface]:
         return self.connection_pool.cache
+
+    # HIMPORT orchestration. The registry lives on the shared HImportConfig; the
+    # server-side effect is applied lazily per connection (PREPARE bundled into the
+    # first himport_set; DISCARD reconciled when a connection is next borrowed for a
+    # himport_set). The connection carries the per-connection HIMPORT state; a
+    # CacheProxyConnection transparently delegates it to the wrapped connection, so
+    # this code never needs to know which connection type it holds.
+
+    def himport_prepare(self, fieldset_name: str, fields: Iterable[FieldT]) -> bool:
+        """Declare an HIMPORT fieldset for use by :meth:`himport_set`.
+
+        Registers ``fieldset_name`` (ordered ``fields``, verbatim) in the client's
+        shared registry. On a pooled client the server-side ``PREPARE`` is deferred
+        and bundled into the next ``himport_set`` per connection. On a single
+        connection client it is run immediately when the pinned connection is live;
+        while that connection is not connected there is no session state to prepare,
+        so the next ``himport_set`` prepares it lazily instead.
+        """
+        fieldset = self.himport_config.prepare(fieldset_name, fields)
+        conn = self.connection
+        if self._single_connection_client and conn is not None and conn.is_connected:
+            self.himport_prepare_internal(fieldset_name, fields)
+            conn._himport_prepared[fieldset_name] = fieldset.version
+        return True
+
+    def himport_discard(self, fieldset_name: str) -> int:
+        """Remove a runtime fieldset. Raises ``DataError`` for init-declared ones.
+
+        Returns ``1`` if it was registered, ``0`` otherwise. On a pooled client the
+        server-side ``DISCARD`` is reconciled lazily when each connection is next
+        used for ``himport_set``. On a single connection client it runs immediately
+        on the pinned connection when it is live; while that connection is not
+        connected there is nothing prepared on the server to discard (its tracking is
+        reset on connect), so no server call is made.
+        """
+        removed = self.himport_config.discard(fieldset_name)
+        conn = self.connection
+        if self._single_connection_client and conn is not None and conn.is_connected:
+            if removed:
+                self.himport_discard_internal(fieldset_name)
+            conn._himport_prepared.pop(fieldset_name, None)
+            conn._himport_reconciled_revision = self.himport_config.revision
+        return 1 if removed else 0
+
+    def himport_discard_all(self) -> int:
+        """Remove all runtime fieldsets. Raises ``DataError`` if any init one exists.
+
+        Returns the number removed from the registry. Server-side removal follows the
+        same live/lazy rule as :meth:`himport_discard`.
+        """
+        count = self.himport_config.discard_all()
+        conn = self.connection
+        if self._single_connection_client and conn is not None and conn.is_connected:
+            if count:
+                self.himport_discard_all_internal()
+            conn._himport_prepared.clear()
+            conn._himport_reconciled_revision = self.himport_config.revision
+        return count
 
 
 StrictRedis = Redis
@@ -1912,9 +2106,65 @@ class Pipeline(Redis):
         self.command_stack.append((args, options))
         return self
 
+    def _himport_prepare_pipeline(self, conn, commands):
+        """Pre-flight ``conn`` for a pipeline batch that contains ``HIMPORT SET``s.
+
+        A pipeline buffers commands and sends them packed, bypassing the per-command
+        lazy-PREPARE path, so the fieldsets referenced by the buffered SETs must be
+        PREPAREd on ``conn`` first. Reconciles deferred discards, then PREPAREs every
+        distinct registered fieldset the batch references that this connection has
+        not already prepared, in one packed write. No-op when the batch has no
+        registry-backed ``HIMPORT SET``.
+        """
+        # A pipeline may run on a connection type that never carries real HIMPORT
+        # state (e.g. mocked test doubles); only proceed for a real config.
+        cfg = getattr(conn, "himport_config", None)
+        if not isinstance(cfg, HImportConfig):
+            return
+        self._himport_reconcile_discards(conn)
+        to_prepare = []
+        seen = set()
+        for args, _ in commands:
+            if not args or args[0] != HIMPORT_SET or len(args) < 3:
+                continue
+            fieldset_name = args[2]
+            if fieldset_name in seen:
+                continue
+            seen.add(fieldset_name)
+            fieldset = cfg.get(fieldset_name)
+            if (
+                fieldset is not None
+                and conn._himport_prepared.get(fieldset_name) != fieldset.version
+            ):
+                to_prepare.append(fieldset)
+        if not to_prepare:
+            return
+        conn.send_packed_command(
+            conn.pack_commands(
+                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
+            )
+        )
+        # One reply per packed PREPARE must be read regardless of a per-command
+        # ResponseError, otherwise the unread replies desync the socket before the
+        # buffered batch is even sent. Drain every reply (marking only the ones that
+        # succeeded), then surface the first error as the root cause.
+        first_error = None
+        for fs in to_prepare:
+            try:
+                self.parse_response(conn, HIMPORT_PREPARE)
+            except ResponseError as e:
+                first_error = first_error or e
+                continue
+            conn._himport_prepared[fs.name] = fs.version
+        if first_error is not None:
+            raise first_error
+
     def _execute_transaction(
         self, connection: Connection, commands, raise_on_error
     ) -> List:
+        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
+        # connection before the MULTI/EXEC block (session state, not transactional).
+        self._himport_prepare_pipeline(connection, commands)
         cmds = chain([(("MULTI",), {})], commands, [(("EXEC",), {})])
         all_cmds = connection.pack_commands(
             [args for args, options in cmds if EMPTY_RESPONSE not in options]
@@ -1985,6 +2235,9 @@ class Pipeline(Redis):
         return data
 
     def _execute_pipeline(self, connection, commands, raise_on_error):
+        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
+        # connection before the batched write (the per-command lazy path is bypassed).
+        self._himport_prepare_pipeline(connection, commands)
         # build up all commands into a single request to increase network perf
         all_cmds = connection.pack_commands([args for args, _ in commands])
         connection.send_packed_command(all_cmds)

--- a/redis/client.py
+++ b/redis/client.py
@@ -518,12 +518,12 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                             "oss_cluster_maint_notifications_handler": oss_cluster_maint_notifications_handler,
                         }
                     )
-                # The pool builds the HImportConfig from the schemas (see
-                # ConnectionPool.__init__) and owns it; the client never holds a
-                # mutable reference, so the registry is mutated only via the HIMPORT
-                # command methods.
-                if himport_schemas is not None:
-                    kwargs.update({"himport_schemas": himport_schemas})
+            # The pool builds the HImportConfig from the schemas (see
+            # ConnectionPool.__init__) and owns it; the client never holds a
+            # mutable reference, so the registry is mutated only via the HIMPORT
+            # command methods.
+            if himport_schemas is not None:
+                kwargs.update({"himport_schemas": himport_schemas})
             connection_pool = ConnectionPool(**kwargs)
             self._event_dispatcher.dispatch(
                 AfterPooledConnectionsInstantiationEvent(
@@ -1072,7 +1072,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         fieldset = self.himport_config.prepare(fieldset_name, fields)
         conn = self.connection
         if self._single_connection_client and conn is not None and conn.is_connected:
-            self.himport_prepare_internal(fieldset_name, fields)
+            self.himport_prepare_internal(fieldset_name, fieldset.fields)
             conn._himport_prepared[fieldset_name] = fieldset.version
         return True
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -331,7 +331,6 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         maint_notifications_config: MaintNotificationsConfig | None = None,
         oss_cluster_maint_notifications_handler: OSSMaintNotificationsHandler
         | None = None,
-        himport_schemas: Mapping[str, Iterable[str]] | None = None,
     ) -> None:
         """
         Initialize a new Redis client.
@@ -396,13 +395,6 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             `redis.maint_notifications.OSSMaintNotificationsHandler` for details.
             Only supported with RESP3
             Argument is ignored when connection_pool is provided.
-        himport_schemas:
-            optional mapping of `fieldset_name -> ordered field names` to register
-            as HIMPORT fieldsets at construction time - see `redis.himport` for
-            details. The pool owns the resulting `HImportRegistry`, so this argument
-            is ignored when connection_pool is provided: to preconfigure schemas
-            with a caller-supplied pool, pass `himport_schemas` to the pool itself
-            (e.g. `ConnectionPool(..., himport_schemas=...)`).
         """
         if event_dispatcher is None:
             self._event_dispatcher = EventDispatcher()
@@ -518,12 +510,6 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                             "oss_cluster_maint_notifications_handler": oss_cluster_maint_notifications_handler,
                         }
                     )
-            # The pool builds the HImportRegistry from the schemas (see
-            # ConnectionPool.__init__) and owns it; the client never holds a
-            # mutable reference, so the registry is mutated only via the HIMPORT
-            # command methods.
-            if himport_schemas is not None:
-                kwargs.update({"himport_schemas": himport_schemas})
             connection_pool = ConnectionPool(**kwargs)
             self._event_dispatcher.dispatch(
                 AfterPooledConnectionsInstantiationEvent(
@@ -1086,7 +1072,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         return True
 
     def himport_discard(self, fieldset_name: str) -> int:
-        """Remove a runtime fieldset. Raises ``DataError`` for init-declared ones.
+        """Remove a fieldset from the registry.
 
         Returns ``1`` if it was registered, ``0`` otherwise. On a pooled client the
         server-side ``DISCARD`` is reconciled lazily when each connection is next
@@ -1105,7 +1091,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         return 1 if removed else 0
 
     def himport_discard_all(self) -> int:
-        """Remove all runtime fieldsets. Raises ``DataError`` if any init one exists.
+        """Remove all fieldsets from the registry.
 
         Returns the number removed from the registry. Server-side removal follows the
         same live/lazy rule as :meth:`himport_discard`.

--- a/redis/client.py
+++ b/redis/client.py
@@ -813,8 +813,11 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         # connection is known, and connection-scoped session setup can only happen
         # once that connection is chosen. The overhead is one string compare per
         # command.
-        if command_name == HIMPORT_SET:
-            # args == (HIMPORT_SET, key, fieldset_name, *values)
+        if command_name == HIMPORT_SET and len(args) >= 3:
+            # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
+            # ``execute_command`` with too few args falls through to the normal send
+            # path so the server returns its arity error, preserving execute_command
+            # error semantics instead of raising a client-side IndexError here.
             return self._himport_execute_set(conn, args[1], args[2], list(args[3:]))
         conn.send_command(*args, **options)
         return self.parse_response(conn, command_name, **options)

--- a/redis/client.py
+++ b/redis/client.py
@@ -88,6 +88,7 @@ from redis.utils import (
     _set_info_logger,
     check_protocol_version,
     deprecated_args,
+    experimental_method,
     safe_str,
     str_if_bytes,
     truncate_text,
@@ -957,6 +958,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
     # CacheProxyConnection transparently delegates it to the wrapped connection, so
     # this code never needs to know which connection type it holds.
 
+    @experimental_method()
     def himport_prepare(self, fieldset_name: str, fields: Iterable[FieldT]) -> bool:
         """Declare an HIMPORT fieldset for use by :meth:`himport_set`.
 
@@ -974,6 +976,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             conn._himport_prepared[fieldset_name] = fieldset.version
         return True
 
+    @experimental_method()
     def himport_discard(self, fieldset_name: str) -> int:
         """Remove a fieldset from the registry.
 
@@ -993,6 +996,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             conn._himport_reconciled_revision = self.himport_registry.revision
         return 1 if removed else 0
 
+    @experimental_method()
     def himport_discard_all(self) -> int:
         """Remove all fieldsets from the registry.
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -19,6 +19,7 @@ from typing import (
     Union,
 )
 
+from redis import _himport_exec
 from redis._defaults import (
     DEFAULT_RETRY_BASE,
     DEFAULT_RETRY_CAP,
@@ -58,21 +59,12 @@ from redis.event import (
 from redis.exceptions import (
     ConnectionError,
     ExecAbortError,
-    NoSuchFieldsetError,
     PubSubError,
     RedisError,
     ResponseError,
     WatchError,
 )
-from redis.himport import (
-    HIMPORT_DISCARD,
-    HIMPORT_PREPARE,
-    HIMPORT_SET,
-    HImportRegistry,
-    himport_discard_command,
-    himport_prepare_command,
-    himport_set_command,
-)
+from redis.himport import HIMPORT_SET, HImportRegistry
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -823,113 +815,18 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         return self.parse_response(conn, command_name, **options)
 
     def _himport_reconcile_discards(self, conn):
-        """DISCARD, on ``conn``, any prepared fieldset removed from the registry.
-
-        Runs at most once per registry mutation: the connection records the registry
-        ``revision`` it last reconciled against, so unchanged registries are a no-op.
-        """
-        registry = conn.himport_registry
-        if registry is None or conn._himport_reconciled_revision == registry.revision:
-            return
-        # Snapshot the revision *before* computing ``stale`` so the value stamped at
-        # the end is never newer than the registry state ``stale`` reflects. A
-        # concurrent ``himport_discard`` (thread-shared sync client, or another task
-        # while this awaits the DISCARD replies) that lands after this point only
-        # leaves the connection marked behind the live revision, so the next
-        # reconcile re-runs and catches it. Re-reading ``registry.revision`` at the
-        # end instead would stamp a discard this connection never sent, leaving the
-        # server session carrying a supposedly-discarded fieldset.
-        reconciled_to = registry.revision
-        stale = registry.names_to_discard(list(conn._himport_prepared))
-        if stale:
-            conn.send_packed_command(
-                conn.pack_commands([himport_discard_command(n) for n in stale])
-            )
-            # One reply per packed DISCARD must be read regardless of a per-command
-            # ResponseError, otherwise the unread replies desync the pooled socket.
-            # Drain every reply, then surface the first error (ConnectionError is not
-            # caught: it tears the socket down, so no desync is possible).
-            first_error = None
-            for n in stale:
-                try:
-                    self.parse_response(conn, HIMPORT_DISCARD)
-                except ResponseError as e:
-                    first_error = first_error or e
-                conn._himport_prepared.pop(n, None)
-            if first_error is not None:
-                raise first_error
-        conn._himport_reconciled_revision = reconciled_to
+        """Delegate to the shared sync HIMPORT executor."""
+        return _himport_exec.reconcile_discards(self, conn)
 
     def _himport_prepare_and_set(self, conn, key, fieldset_name, values, fieldset):
-        """PREPARE ``fieldset`` bundled with the SET on ``conn`` (one packed write)."""
-        conn.send_packed_command(
-            conn.pack_commands(
-                [
-                    himport_prepare_command(fieldset_name, fieldset.fields),
-                    himport_set_command(key, fieldset_name, values),
-                ]
-            )
+        """Delegate to the shared sync HIMPORT executor."""
+        return _himport_exec.prepare_and_set(
+            self, conn, key, fieldset_name, values, fieldset
         )
-        prep_error = set_error = None
-        set_resp = None
-        try:
-            self.parse_response(conn, HIMPORT_PREPARE)
-        except ResponseError as e:
-            prep_error = e
-        try:
-            set_resp = self.parse_response(conn, HIMPORT_SET)
-        except ResponseError as e:
-            set_error = e
-
-        if prep_error:
-            raise prep_error  # PREPARE failure is the root cause
-        else:
-            conn._himport_prepared[fieldset_name] = fieldset.version
-
-        if set_error:
-            raise set_error
-        return set_resp
 
     def _himport_execute_set(self, conn, key, fieldset_name, values):
-        """Execute an ``HIMPORT SET`` on ``conn`` with the required session setup.
-
-        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
-        any fieldset discarded from the shared registry since this connection last
-        reconciled must be dropped. Both are applied here, on the borrowed
-        connection, so the enclosing ``execute_command`` machinery (retry,
-        disconnect-on-error, pooling) covers the whole exchange. The connection
-        carries the per-connection HIMPORT state; a ``CacheProxyConnection``
-        delegates it transparently, so this never inspects the connection type.
-        """
-        self._himport_reconcile_discards(conn)
-
-        registry = conn.himport_registry
-        fieldset = registry.get(fieldset_name) if registry is not None else None
-        # Lazy PREPARE bundled with SET on first use of this fieldset.
-        if (
-            fieldset is not None
-            and conn._himport_prepared.get(fieldset_name) != fieldset.version
-        ):
-            return self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset
-            )
-
-        # Believed already prepared (or an unregistered fieldset): bare SET.
-        conn.send_command(*himport_set_command(key, fieldset_name, values))
-        try:
-            return self.parse_response(conn, HIMPORT_SET)
-        except NoSuchFieldsetError:
-            # The server can drop the fieldset mid-connection without dropping the
-            # socket (e.g. RESET / maxmemory-clients eviction). The connection is
-            # healthy, so don't reconnect: re-PREPARE on it and retry the SET once.
-            # Only for registry-backed fieldsets — manual/unregistered usage
-            # propagates unchanged (a re-prepare would send a fieldset we don't own).
-            if fieldset is None:
-                raise
-            conn._himport_prepared.pop(fieldset_name, None)
-            return self._himport_prepare_and_set(
-                conn, key, fieldset_name, values, fieldset
-            )
+        """Delegate to the shared sync HIMPORT executor."""
+        return _himport_exec.execute_set(self, conn, key, fieldset_name, values)
 
     def _close_connection(
         self,
@@ -2105,57 +2002,8 @@ class Pipeline(Redis):
         return self
 
     def _himport_prepare_pipeline(self, conn, commands):
-        """Pre-flight ``conn`` for a pipeline batch that contains ``HIMPORT SET``s.
-
-        A pipeline buffers commands and sends them packed, bypassing the per-command
-        lazy-PREPARE path, so the fieldsets referenced by the buffered SETs must be
-        PREPAREd on ``conn`` first. Reconciles deferred discards, then PREPAREs every
-        distinct registered fieldset the batch references that this connection has
-        not already prepared, in one packed write. No-op when the batch has no
-        registry-backed ``HIMPORT SET``.
-        """
-        # A pipeline may run on a connection type that never carries real HIMPORT
-        # state (e.g. mocked test doubles); only proceed for a real config.
-        registry = getattr(conn, "himport_registry", None)
-        if not isinstance(registry, HImportRegistry):
-            return
-        self._himport_reconcile_discards(conn)
-        to_prepare = []
-        seen = set()
-        for args, _ in commands:
-            if not args or args[0] != HIMPORT_SET or len(args) < 3:
-                continue
-            fieldset_name = args[2]
-            if fieldset_name in seen:
-                continue
-            seen.add(fieldset_name)
-            fieldset = registry.get(fieldset_name)
-            if (
-                fieldset is not None
-                and conn._himport_prepared.get(fieldset_name) != fieldset.version
-            ):
-                to_prepare.append(fieldset)
-        if not to_prepare:
-            return
-        conn.send_packed_command(
-            conn.pack_commands(
-                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
-            )
-        )
-        # One reply per packed PREPARE must be read regardless of a per-command
-        # ResponseError, otherwise the unread replies desync the socket before the
-        # buffered batch is even sent. Drain every reply (marking only the ones that
-        # succeeded), then surface the first error as the root cause.
-        first_error = None
-        for fs in to_prepare:
-            try:
-                self.parse_response(conn, HIMPORT_PREPARE)
-            except ResponseError as e:
-                first_error = first_error or e
-                continue
-            conn._himport_prepared[fs.name] = fs.version
-        if first_error is not None:
-            raise first_error
+        """Delegate to the shared sync HIMPORT executor."""
+        _himport_exec.prepare_pipeline(self, conn, [args for args, _ in commands])
 
     def _execute_transaction(
         self, connection: Connection, commands, raise_on_error

--- a/redis/client.py
+++ b/redis/client.py
@@ -64,7 +64,7 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
-from redis.himport import HImportRegistry, is_himport_set_command
+from redis.himport import HImportRegistry, parse_himport_set_args
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -805,12 +805,15 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         # connection is known, and connection-scoped session setup can only happen
         # once that connection is chosen. The overhead is one string compare per
         # command.
-        if is_himport_set_command(command_name) and len(args) >= 3:
-            # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
-            # ``execute_command`` with too few args falls through to the normal send
-            # path so the server returns its arity error, preserving execute_command
-            # error semantics instead of raising a client-side IndexError here.
-            return self._himport_execute_set(conn, args[1], args[2], list(args[3:]))
+        himport_set = parse_himport_set_args(args)
+        if himport_set is not None:
+            # ``args`` is an HIMPORT SET in either the joined ("HIMPORT SET", key,
+            # ...) or split ("HIMPORT", "SET", key, ...) raw form; the operands come
+            # back at the right offsets for the form. A command with too few operands
+            # returns None and falls through to the normal send path so the server
+            # returns its arity error instead of a client-side IndexError here.
+            key, fieldset_name, values = himport_set
+            return self._himport_execute_set(conn, key, fieldset_name, values)
         conn.send_command(*args, **options)
         return self.parse_response(conn, command_name, **options)
 

--- a/redis/client.py
+++ b/redis/client.py
@@ -64,7 +64,7 @@ from redis.exceptions import (
     ResponseError,
     WatchError,
 )
-from redis.himport import HIMPORT_SET, HImportRegistry
+from redis.himport import HImportRegistry, is_himport_set_command
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -805,7 +805,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         # connection is known, and connection-scoped session setup can only happen
         # once that connection is chosen. The overhead is one string compare per
         # command.
-        if command_name == HIMPORT_SET and len(args) >= 3:
+        if is_himport_set_command(command_name) and len(args) >= 3:
             # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
             # ``execute_command`` with too few args falls through to the normal send
             # path so the server returns its arity error, preserving execute_command
@@ -2081,12 +2081,24 @@ class Pipeline(Redis):
         return data
 
     def _execute_pipeline(self, connection, commands, raise_on_error):
-        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
-        # connection before the batched write (the per-command lazy path is bypassed).
-        self._himport_prepare_pipeline(connection, commands)
+        # Fold any first-use HIMPORT PREPAREs for referenced fieldsets into the same
+        # packed write as the queued commands, so a pipeline that lands on a fresh or
+        # reconnected connection stays a single round trip (the batched write bypasses
+        # the per-command lazy PREPARE path). Deferred-discard reconciliation happens
+        # inside pipeline_prepares and only touches the socket when discards are
+        # actually pending.
+        fieldsets = _himport_exec.pipeline_prepares(
+            self, connection, [args for args, _ in commands]
+        )
+        preflight = _himport_exec.prepare_wire_commands(fieldsets)
         # build up all commands into a single request to increase network perf
-        all_cmds = connection.pack_commands([args for args, _ in commands])
+        all_cmds = connection.pack_commands(preflight + [args for args, _ in commands])
         connection.send_packed_command(all_cmds)
+
+        # Drain the leading PREPARE replies (bookkeeping + capture the first error)
+        # before the queued replies. Everything on the wire is read before raising so
+        # the pooled socket never desyncs.
+        prep_error = _himport_exec.drain_pipeline_prepares(self, connection, fieldsets)
 
         responses = []
         for args, options in commands:
@@ -2095,6 +2107,11 @@ class Pipeline(Redis):
             except ResponseError as e:
                 responses.append(e)
 
+        # A PREPARE failure (rare: an invalid fieldset definition) is a hard error,
+        # raised regardless of raise_on_error as it was before folding -- only now
+        # every reply has already been drained.
+        if prep_error is not None:
+            raise prep_error
         if raise_on_error:
             self.raise_first_error(commands, responses)
 

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -17,8 +17,10 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Literal,
+    Mapping,
     Optional,
     Set,
     Tuple,
@@ -73,6 +75,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
+from redis.himport import HImportConfig
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -712,6 +715,7 @@ class RedisCluster(
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: PolicyResolver = StaticPolicyResolver(),
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
+        himport_schemas: Optional[Mapping[str, Iterable[str]]] = None,
         **kwargs,
     ):
         """
@@ -887,6 +891,15 @@ class RedisCluster(
         if check_protocol_version(protocol, 3) and maint_notifications_config is None:
             maint_notifications_config = MaintNotificationsConfig()
 
+        # Build the client-level HIMPORT config once and share the same object with
+        # every node pool, so the fieldset registry is shared cluster-wide. It is handed
+        # to the NodesManager and injected onto each node's pool in create_redis_node;
+        # it is deliberately NOT forwarded through connection_kwargs, so nodes reuse the
+        # one shared object rather than each rebuilding its own from the schemas.
+        self.himport_config = (
+            HImportConfig(himport_schemas) if himport_schemas is not None else None
+        )
+
         self.command_flags = self.__class__.COMMAND_FLAGS.copy()
         self.node_flags = self.__class__.NODE_FLAGS.copy()
         self.read_from_replicas = read_from_replicas
@@ -909,6 +922,7 @@ class RedisCluster(
             cache_config=cache_config,
             event_dispatcher=self._event_dispatcher,
             maint_notifications_config=maint_notifications_config,
+            himport_config=self.himport_config,
             **kwargs,
         )
 
@@ -2121,8 +2135,13 @@ class NodesManager:
         cache_factory: Optional[CacheFactoryInterface] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
+        himport_config: Optional[HImportConfig] = None,
         **kwargs,
     ):
+        # Shared, cluster-wide HIMPORT config object, injected onto every node's pool
+        # in create_redis_node (not forwarded through connection_kwargs, so all nodes
+        # reuse the one object rather than rebuilding it per node).
+        self.himport_config = himport_config
         self.nodes_cache: dict[str, ClusterNode] = {}
         self.slots_cache: dict[int, list[ClusterNode]] = {}
         self.startup_nodes: dict[str, ClusterNode] = {n.name: n for n in startup_nodes}
@@ -2403,6 +2422,12 @@ class NodesManager:
                 retry=node_retry_config,
                 **kwargs,
             )
+        # Share the one cluster-wide HIMPORT config with this node's pool. Injected
+        # here (rather than forwarded via connection_kwargs) so every node reuses the
+        # same object; the node has no connections yet, so this is safe.
+        if self.himport_config is not None:
+            r.connection_pool.himport_config = self.himport_config
+            r.connection_pool.connection_kwargs["himport_config"] = self.himport_config
         return r
 
     def _get_or_create_cluster_node(self, host, port, role, tmp_nodes_cache):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1677,6 +1677,31 @@ class RedisCluster(
                         )
                     raise e
 
+    def _himport_prepare_for_asking(self, redis_node, connection, fieldset_name):
+        """Apply the connection-session setup an ASK-redirected HIMPORT SET needs.
+
+        Reconciles deferred DISCARDs and PREPAREs the fieldset on ``connection`` if
+        this connection has not already, so the subsequent bare SET (issued by the
+        node executor) is the only command after ASKING and keeps its allowance. A
+        no-op when the fieldset is unregistered or already prepared. Uses the same
+        reconcile/prepare idioms as the pipeline pre-flight
+        (:meth:`AbstractStrategy._himport_prepare_pipeline`).
+        """
+        cfg = getattr(connection, "himport_config", None)
+        if not isinstance(cfg, HImportConfig):
+            return
+        redis_node._himport_reconcile_discards(connection)
+        fieldset = cfg.get(fieldset_name)
+        if (
+            fieldset is not None
+            and connection._himport_prepared.get(fieldset_name) != fieldset.version
+        ):
+            connection.send_command(
+                *himport_prepare_command(fieldset_name, fieldset.fields)
+            )
+            redis_node.parse_response(connection, HIMPORT_PREPARE)
+            connection._himport_prepared[fieldset_name] = fieldset.version
+
     def _execute_command(self, target_node, *args, **kwargs):
         """
         Send a command to a node in the cluster
@@ -1712,7 +1737,7 @@ class RedisCluster(
 
                 redis_node = self.get_redis_connection(target_node)
                 connection = get_connection(redis_node)
-                if asking:
+                if asking and command != HIMPORT_SET:
                     connection.send_command("ASKING")
                     redis_node.parse_response(connection, "ASKING", **kwargs)
                     asking = False
@@ -1726,6 +1751,20 @@ class RedisCluster(
                     # and has no cleaner alternative: this is the only seam where the
                     # concrete routed connection is known, and connection-scoped
                     # session setup can only happen once that connection is chosen.
+                    if asking:
+                        # ASK redirect: the SET must carry the per-command ASKING
+                        # allowance, which Redis clears after the very next command.
+                        # Run the connection-session setup here first — deferred
+                        # DISCARD reconcile and lazy PREPARE, neither of which needs
+                        # nor may consume the allowance — then send ASKING so it lands
+                        # immediately before the SET. The executor below then finds the
+                        # session already reconciled and prepared and issues a bare SET.
+                        self._himport_prepare_for_asking(
+                            redis_node, connection, args[2]
+                        )
+                        connection.send_command("ASKING")
+                        redis_node.parse_response(connection, "ASKING", **kwargs)
+                        asking = False
                     response = redis_node._himport_execute_set(
                         connection, args[1], args[2], list(args[3:])
                     )

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -67,6 +67,7 @@ from redis.exceptions import (
     InvalidPipelineStack,
     MaxConnectionsError,
     MovedError,
+    NoSuchFieldsetError,
     RedisClusterException,
     RedisError,
     ResponseError,
@@ -78,8 +79,9 @@ from redis.exceptions import (
 from redis.himport import (
     HIMPORT_PREPARE,
     HIMPORT_SET,
-    HImportConfig,
+    HImportRegistry,
     himport_prepare_command,
+    himport_set_command,
 )
 from redis.lock import Lock
 from redis.maint_notifications import (
@@ -901,13 +903,13 @@ class RedisCluster(
         if check_protocol_version(protocol, 3) and maint_notifications_config is None:
             maint_notifications_config = MaintNotificationsConfig()
 
-        # Build the client-level HIMPORT config once (empty if no schemas) and share
+        # Build the client-level HIMPORT registry once (empty if no schemas) and share
         # the same object with every node pool, so the fieldset registry is shared
         # cluster-wide and runtime himport_prepare mutates one object. It is handed to
         # the NodesManager and injected onto each node's pool in create_redis_node;
         # it is deliberately NOT forwarded through connection_kwargs, so nodes reuse the
         # one shared object rather than each rebuilding its own from the schemas.
-        self._himport_config = HImportConfig(himport_schemas)
+        self._himport_registry = HImportRegistry(himport_schemas)
 
         self.command_flags = self.__class__.COMMAND_FLAGS.copy()
         self.node_flags = self.__class__.NODE_FLAGS.copy()
@@ -931,7 +933,7 @@ class RedisCluster(
             cache_config=cache_config,
             event_dispatcher=self._event_dispatcher,
             maint_notifications_config=maint_notifications_config,
-            himport_config=self._himport_config,
+            himport_registry=self._himport_registry,
             **kwargs,
         )
 
@@ -1394,31 +1396,31 @@ class RedisCluster(
         return key_slot(k)
 
     # HIMPORT orchestration. PREPARE/DISCARD/DISCARDALL mutate the one shared
-    # HImportConfig exactly once (every node pool references the same object, so the
+    # HImportRegistry exactly once (every node pool references the same object, so the
     # change is visible cluster-wide and applied lazily per node). SET routes by key
     # slot to the owning primary and reuses that node's standalone himport_set (lazy
     # PREPARE bundled with SET). See ``.agents/himport_client_support_spec.md``.
 
     @property
-    def himport_config(self) -> HImportConfig:
+    def himport_registry(self) -> HImportRegistry:
         """The cluster-wide HIMPORT fieldset registry (empty if none was declared).
 
         Read-only: the registry is mutated only through the HIMPORT command methods.
         """
-        return self._himport_config
+        return self._himport_registry
 
     def himport_prepare(self, fieldset_name: str, fields: Iterable[FieldT]) -> bool:
         """Declare an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
-        self._himport_config.prepare(fieldset_name, fields)
+        self._himport_registry.prepare(fieldset_name, fields)
         return True
 
     def himport_discard(self, fieldset_name: str) -> int:
         """Remove a runtime fieldset cluster-wide. Raises ``DataError`` for init ones."""
-        return 1 if self._himport_config.discard(fieldset_name) else 0
+        return 1 if self._himport_registry.discard(fieldset_name) else 0
 
     def himport_discard_all(self) -> int:
         """Remove all runtime fieldsets cluster-wide. Raises ``DataError`` on init ones."""
-        return self._himport_config.discard_all()
+        return self._himport_registry.discard_all()
 
     def _get_command_keys(self, *args):
         """
@@ -1677,30 +1679,129 @@ class RedisCluster(
                         )
                     raise e
 
-    def _himport_prepare_for_asking(self, redis_node, connection, fieldset_name):
-        """Apply the connection-session setup an ASK-redirected HIMPORT SET needs.
+    def _himport_prepare_and_set(
+        self,
+        redis_node,
+        connection,
+        key,
+        fieldset_name,
+        values,
+        fieldset,
+        asking: bool = False,
+    ):
+        """PREPARE ``fieldset`` bundled with the SET on ``connection`` (one packed write).
 
-        Reconciles deferred DISCARDs and PREPAREs the fieldset on ``connection`` if
-        this connection has not already, so the subsequent bare SET (issued by the
-        node executor) is the only command after ASKING and keeps its allowance. A
-        no-op when the fieldset is unregistered or already prepared. Uses the same
-        reconcile/prepare idioms as the pipeline pre-flight
-        (:meth:`AbstractStrategy._himport_prepare_pipeline`).
+        When ``asking`` is set (an ASK-redirected cluster SET) the batch becomes
+        ``[PREPARE, ASKING, SET]`` so the per-command ASKING allowance falls
+        immediately before the SET -- the only slot-scoped command. PREPARE is a
+        connection-session command that the ASKING flag does not gate, so placing
+        it before ASKING is safe. Every reply is drained even on a per-command
+        error so the packed replies never desync the pooled socket.
         """
-        cfg = getattr(connection, "himport_config", None)
-        if not isinstance(cfg, HImportConfig):
-            return
+        commands = [himport_prepare_command(fieldset_name, fieldset.fields)]
+        if asking:
+            commands.append(("ASKING",))
+        commands.append(himport_set_command(key, fieldset_name, values))
+        connection.send_packed_command(connection.pack_commands(commands))
+        prep_error = ask_error = set_error = None
+        set_resp = None
+        try:
+            redis_node.parse_response(connection, HIMPORT_PREPARE)
+        except ResponseError as e:
+            prep_error = e
+        if asking:
+            try:
+                redis_node.parse_response(connection, "ASKING")
+            except ResponseError as e:
+                ask_error = e
+        try:
+            set_resp = redis_node.parse_response(connection, HIMPORT_SET)
+        except ResponseError as e:
+            set_error = e
+
+        if prep_error:
+            raise prep_error  # PREPARE failure is the root cause
+        else:
+            connection._himport_prepared[fieldset_name] = fieldset.version
+
+        if ask_error:
+            raise ask_error
+        if set_error:
+            raise set_error
+        return set_resp
+
+    def _himport_execute_set(
+        self,
+        redis_node,
+        connection,
+        key,
+        fieldset_name,
+        values,
+        asking: bool = False,
+    ):
+        """Execute an ``HIMPORT SET`` on ``connection`` with the required session setup.
+
+        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
+        any fieldset discarded from the shared registry since this connection last
+        reconciled must be dropped. Both are applied here, on the acquired
+        connection, so the caller's full retry / MOVED-ASK / disconnect-on-error
+        handling covers the whole exchange.
+
+        When ``asking`` is set (an ASK-redirected cluster SET) the ASKING allowance
+        is folded into the SET's own packed write so it immediately precedes the
+        SET. The session setup (deferred DISCARDs, lazy PREPARE) still runs first,
+        before ASKING, since those are connection-session commands the flag does
+        not gate; only the SET is slot-scoped and must carry the allowance.
+        """
         redis_node._himport_reconcile_discards(connection)
-        fieldset = cfg.get(fieldset_name)
+
+        registry = connection.himport_registry
+        fieldset = registry.get(fieldset_name) if registry is not None else None
+        # Lazy PREPARE bundled with SET on first use of this fieldset.
         if (
             fieldset is not None
             and connection._himport_prepared.get(fieldset_name) != fieldset.version
         ):
-            connection.send_command(
-                *himport_prepare_command(fieldset_name, fieldset.fields)
+            return self._himport_prepare_and_set(
+                redis_node,
+                connection,
+                key,
+                fieldset_name,
+                values,
+                fieldset,
+                asking=asking,
             )
-            redis_node.parse_response(connection, HIMPORT_PREPARE)
-            connection._himport_prepared[fieldset_name] = fieldset.version
+
+        # Believed already prepared (or an unregistered fieldset): bare SET, with
+        # ASKING packed immediately before it when this is an ASK redirect.
+        if asking:
+            connection.send_packed_command(
+                connection.pack_commands(
+                    [("ASKING",), himport_set_command(key, fieldset_name, values)]
+                )
+            )
+            redis_node.parse_response(connection, "ASKING")
+        else:
+            connection.send_command(*himport_set_command(key, fieldset_name, values))
+        try:
+            return redis_node.parse_response(connection, HIMPORT_SET)
+        except NoSuchFieldsetError:
+            # Server dropped the fieldset mid-connection without dropping the socket
+            # (e.g. RESET / maxmemory-clients eviction): re-PREPARE on this healthy
+            # connection and retry the SET once rather than reconnecting. Only for
+            # registry-backed fieldsets; manual/unregistered usage propagates.
+            if fieldset is None:
+                raise
+            connection._himport_prepared.pop(fieldset_name, None)
+            return self._himport_prepare_and_set(
+                redis_node,
+                connection,
+                key,
+                fieldset_name,
+                values,
+                fieldset,
+                asking=asking,
+            )
 
     def _execute_command(self, target_node, *args, **kwargs):
         """
@@ -1742,32 +1843,27 @@ class RedisCluster(
                     redis_node.parse_response(connection, "ASKING", **kwargs)
                     asking = False
                 if command == HIMPORT_SET:
-                    # args == (HIMPORT_SET, key, fieldset_name, *values). The node's
-                    # own executor lazily PREPAREs the fieldset on this connection
-                    # and reconciles deferred DISCARDs, then SETs; it already applies
-                    # the HIMPORT SET response callback, so it bypasses the cluster
-                    # callback block below.
+                    # args == (HIMPORT_SET, key, fieldset_name, *values). The cluster
+                    # executor lazily PREPAREs the fieldset on this connection and
+                    # reconciles deferred DISCARDs, then SETs; it already applies the
+                    # HIMPORT SET response callback, so it bypasses the cluster callback
+                    # block below.
                     # This per-command branch in the hot dispatch path is deliberate
                     # and has no cleaner alternative: this is the only seam where the
                     # concrete routed connection is known, and connection-scoped
                     # session setup can only happen once that connection is chosen.
-                    if asking:
-                        # ASK redirect: the SET must carry the per-command ASKING
-                        # allowance, which Redis clears after the very next command.
-                        # Run the connection-session setup here first — deferred
-                        # DISCARD reconcile and lazy PREPARE, neither of which needs
-                        # nor may consume the allowance — then send ASKING so it lands
-                        # immediately before the SET. The executor below then finds the
-                        # session already reconciled and prepared and issues a bare SET.
-                        self._himport_prepare_for_asking(
-                            redis_node, connection, args[2]
-                        )
-                        connection.send_command("ASKING")
-                        redis_node.parse_response(connection, "ASKING", **kwargs)
-                        asking = False
-                    response = redis_node._himport_execute_set(
-                        connection, args[1], args[2], list(args[3:])
+                    # On an ASK redirect ``asking`` is folded into the SET's own packed
+                    # write (see the guard above that suppresses the standalone ASKING
+                    # for HIMPORT SET) so the allowance sits immediately before the SET.
+                    response = self._himport_execute_set(
+                        redis_node,
+                        connection,
+                        args[1],
+                        args[2],
+                        list(args[3:]),
+                        asking=asking,
                     )
+                    asking = False
                     kwargs.pop("keys", None)
                 else:
                     connection.send_command(*args, **kwargs)
@@ -2225,13 +2321,13 @@ class NodesManager:
         cache_factory: Optional[CacheFactoryInterface] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
-        himport_config: HImportConfig | None = None,
+        himport_registry: HImportRegistry | None = None,
         **kwargs,
     ):
-        # Shared, cluster-wide HIMPORT config object, injected onto every node's pool
+        # Shared, cluster-wide HIMPORT registry object, injected onto every node's pool
         # in create_redis_node (not forwarded through connection_kwargs, so all nodes
         # reuse the one object rather than rebuilding it per node).
-        self.himport_config = himport_config
+        self.himport_registry = himport_registry
         self.nodes_cache: dict[str, ClusterNode] = {}
         self.slots_cache: dict[int, list[ClusterNode]] = {}
         self.startup_nodes: dict[str, ClusterNode] = {n.name: n for n in startup_nodes}
@@ -2512,12 +2608,14 @@ class NodesManager:
                 retry=node_retry_config,
                 **kwargs,
             )
-        # Share the one cluster-wide HIMPORT config with this node's pool. Injected
+        # Share the one cluster-wide HIMPORT registry with this node's pool. Injected
         # here (rather than forwarded via connection_kwargs) so every node reuses the
         # same object; the node has no connections yet, so this is safe.
-        if self.himport_config is not None:
-            r.connection_pool.himport_config = self.himport_config
-            r.connection_pool.connection_kwargs["himport_config"] = self.himport_config
+        if self.himport_registry is not None:
+            r.connection_pool.himport_registry = self.himport_registry
+            r.connection_pool.connection_kwargs["himport_registry"] = (
+                self.himport_registry
+            )
         return r
 
     def _get_or_create_cluster_node(self, host, port, role, tmp_nodes_cache):
@@ -4066,8 +4164,8 @@ class AbstractStrategy(ExecutionStrategy):
         """
         # A node may run on a connection type that never carries real HIMPORT state
         # (e.g. mocked test doubles); only proceed for a real config.
-        cfg = getattr(conn, "himport_config", None)
-        if not isinstance(cfg, HImportConfig):
+        registry = getattr(conn, "himport_registry", None)
+        if not isinstance(registry, HImportRegistry):
             return
         redis_node._himport_reconcile_discards(conn)
         to_prepare = []
@@ -4079,7 +4177,7 @@ class AbstractStrategy(ExecutionStrategy):
             if fieldset_name in seen:
                 continue
             seen.add(fieldset_name)
-            fieldset = cfg.get(fieldset_name)
+            fieldset = registry.get(fieldset_name)
             if (
                 fieldset is not None
                 and conn._himport_prepared.get(fieldset_name) != fieldset.version

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1868,15 +1868,20 @@ class RedisCluster(
                     # On an ASK redirect ``asking`` is folded into the SET's own packed
                     # write (see the guard above that suppresses the standalone ASKING
                     # for HIMPORT SET) so the allowance sits immediately before the SET.
+                    # Clear ``asking`` first and carry the allowance in a dedicated
+                    # local: ``_himport_execute_set`` can raise a retriable MOVED/TRYAGAIN
+                    # mid-exchange, and a stale ``asking`` would shadow the moved-retry
+                    # branch on the next loop iteration (mirrors the async client).
+                    ask_himport = asking
+                    asking = False
                     response = self._himport_execute_set(
                         redis_node,
                         connection,
                         args[1],
                         args[2],
                         list(args[3:]),
-                        asking=asking,
+                        asking=ask_himport,
                     )
-                    asking = False
                     kwargs.pop("keys", None)
                 else:
                     connection.send_command(*args, **kwargs)

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1413,11 +1413,11 @@ class RedisCluster(
         return True
 
     def himport_discard(self, fieldset_name: str) -> int:
-        """Remove a runtime fieldset cluster-wide. Raises ``DataError`` for init ones."""
+        """Remove an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
         return 1 if self._himport_registry.discard(fieldset_name) else 0
 
     def himport_discard_all(self) -> int:
-        """Remove all runtime fieldsets cluster-wide. Raises ``DataError`` on init ones."""
+        """Remove all HIMPORT fieldsets cluster-wide (shared registry, applied lazily)."""
         return self._himport_registry.discard_all()
 
     def _get_command_keys(self, *args):
@@ -1851,8 +1851,12 @@ class RedisCluster(
                     connection.send_command("ASKING")
                     redis_node.parse_response(connection, "ASKING", **kwargs)
                     asking = False
-                if command == HIMPORT_SET:
-                    # args == (HIMPORT_SET, key, fieldset_name, *values). The cluster
+                if command == HIMPORT_SET and len(args) >= 3:
+                    # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
+                    # ``execute_command`` with too few args falls through to the
+                    # normal send path below so the server returns its arity error
+                    # instead of a client-side IndexError.
+                    # The cluster
                     # executor lazily PREPAREs the fieldset on this connection and
                     # reconciles deferred DISCARDs, then SETs; it already applies the
                     # HIMPORT SET response callback, so it bypasses the cluster callback

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -75,7 +75,12 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import HImportConfig
+from redis.himport import (
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+    HImportConfig,
+    himport_prepare_command,
+)
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -86,7 +91,12 @@ from redis.observability.recorder import (
     record_operation_duration,
 )
 from redis.retry import Retry
-from redis.typing import ChannelT, PubSubHandler, Subscription
+from redis.typing import (
+    ChannelT,
+    FieldT,
+    PubSubHandler,
+    Subscription,
+)
 from redis.utils import (
     check_protocol_version,
     deprecated_args,
@@ -715,7 +725,7 @@ class RedisCluster(
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: PolicyResolver = StaticPolicyResolver(),
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
-        himport_schemas: Optional[Mapping[str, Iterable[str]]] = None,
+        himport_schemas: Mapping[str, Iterable[str]] | None = None,
         **kwargs,
     ):
         """
@@ -891,14 +901,13 @@ class RedisCluster(
         if check_protocol_version(protocol, 3) and maint_notifications_config is None:
             maint_notifications_config = MaintNotificationsConfig()
 
-        # Build the client-level HIMPORT config once and share the same object with
-        # every node pool, so the fieldset registry is shared cluster-wide. It is handed
-        # to the NodesManager and injected onto each node's pool in create_redis_node;
+        # Build the client-level HIMPORT config once (empty if no schemas) and share
+        # the same object with every node pool, so the fieldset registry is shared
+        # cluster-wide and runtime himport_prepare mutates one object. It is handed to
+        # the NodesManager and injected onto each node's pool in create_redis_node;
         # it is deliberately NOT forwarded through connection_kwargs, so nodes reuse the
         # one shared object rather than each rebuilding its own from the schemas.
-        self.himport_config = (
-            HImportConfig(himport_schemas) if himport_schemas is not None else None
-        )
+        self._himport_config = HImportConfig(himport_schemas)
 
         self.command_flags = self.__class__.COMMAND_FLAGS.copy()
         self.node_flags = self.__class__.NODE_FLAGS.copy()
@@ -922,7 +931,7 @@ class RedisCluster(
             cache_config=cache_config,
             event_dispatcher=self._event_dispatcher,
             maint_notifications_config=maint_notifications_config,
-            himport_config=self.himport_config,
+            himport_config=self._himport_config,
             **kwargs,
         )
 
@@ -1384,6 +1393,33 @@ class RedisCluster(
         k = self.encoder.encode(key)
         return key_slot(k)
 
+    # HIMPORT orchestration. PREPARE/DISCARD/DISCARDALL mutate the one shared
+    # HImportConfig exactly once (every node pool references the same object, so the
+    # change is visible cluster-wide and applied lazily per node). SET routes by key
+    # slot to the owning primary and reuses that node's standalone himport_set (lazy
+    # PREPARE bundled with SET). See ``.agents/himport_client_support_spec.md``.
+
+    @property
+    def himport_config(self) -> HImportConfig:
+        """The cluster-wide HIMPORT fieldset registry (empty if none was declared).
+
+        Read-only: the registry is mutated only through the HIMPORT command methods.
+        """
+        return self._himport_config
+
+    def himport_prepare(self, fieldset_name: str, fields: Iterable[FieldT]) -> bool:
+        """Declare an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
+        self._himport_config.prepare(fieldset_name, fields)
+        return True
+
+    def himport_discard(self, fieldset_name: str) -> int:
+        """Remove a runtime fieldset cluster-wide. Raises ``DataError`` for init ones."""
+        return 1 if self._himport_config.discard(fieldset_name) else 0
+
+    def himport_discard_all(self) -> int:
+        """Remove all runtime fieldsets cluster-wide. Raises ``DataError`` on init ones."""
+        return self._himport_config.discard_all()
+
     def _get_command_keys(self, *args):
         """
         Get the keys in the command. If the command has no keys in in, None is
@@ -1680,16 +1716,31 @@ class RedisCluster(
                     connection.send_command("ASKING")
                     redis_node.parse_response(connection, "ASKING", **kwargs)
                     asking = False
-                connection.send_command(*args, **kwargs)
-                response = redis_node.parse_response(connection, command, **kwargs)
-
-                # Remove keys entry, it needs only for cache.
-                kwargs.pop("keys", None)
-
-                if command in self.cluster_response_callbacks:
-                    response = self.cluster_response_callbacks[command](
-                        response, **kwargs
+                if command == HIMPORT_SET:
+                    # args == (HIMPORT_SET, key, fieldset_name, *values). The node's
+                    # own executor lazily PREPAREs the fieldset on this connection
+                    # and reconciles deferred DISCARDs, then SETs; it already applies
+                    # the HIMPORT SET response callback, so it bypasses the cluster
+                    # callback block below.
+                    # This per-command branch in the hot dispatch path is deliberate
+                    # and has no cleaner alternative: this is the only seam where the
+                    # concrete routed connection is known, and connection-scoped
+                    # session setup can only happen once that connection is chosen.
+                    response = redis_node._himport_execute_set(
+                        connection, args[1], args[2], list(args[3:])
                     )
+                    kwargs.pop("keys", None)
+                else:
+                    connection.send_command(*args, **kwargs)
+                    response = redis_node.parse_response(connection, command, **kwargs)
+
+                    # Remove keys entry, it needs only for cache.
+                    kwargs.pop("keys", None)
+
+                    if command in self.cluster_response_callbacks:
+                        response = self.cluster_response_callbacks[command](
+                            response, **kwargs
+                        )
 
                 self._record_command_metric(
                     command_name=command,
@@ -2135,7 +2186,7 @@ class NodesManager:
         cache_factory: Optional[CacheFactoryInterface] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
-        himport_config: Optional[HImportConfig] = None,
+        himport_config: HImportConfig | None = None,
         **kwargs,
     ):
         # Shared, cluster-wide HIMPORT config object, injected onto every node's pool
@@ -3963,6 +4014,60 @@ class AbstractStrategy(ExecutionStrategy):
         )
         return self._pipe
 
+    def _himport_prepare_pipeline(self, redis_node, conn, commands):
+        """Pre-flight ``conn`` for a node's pipeline batch containing ``HIMPORT SET``s.
+
+        The cluster pipeline packs each node's commands and writes them bypassing the
+        per-command lazy-PREPARE path, so the fieldsets referenced by the buffered
+        SETs must be PREPAREd on ``conn`` first. Reconciles deferred discards, then
+        PREPAREs every distinct registered fieldset the batch references that this
+        connection has not already prepared, in one packed write. No-op when the
+        batch has no registry-backed ``HIMPORT SET``. Uses ``redis_node`` (the owning
+        node's client) for reconcile and response parsing on ``conn``.
+        """
+        # A node may run on a connection type that never carries real HIMPORT state
+        # (e.g. mocked test doubles); only proceed for a real config.
+        cfg = getattr(conn, "himport_config", None)
+        if not isinstance(cfg, HImportConfig):
+            return
+        redis_node._himport_reconcile_discards(conn)
+        to_prepare = []
+        seen = set()
+        for args, _ in commands:
+            if not args or args[0] != HIMPORT_SET or len(args) < 3:
+                continue
+            fieldset_name = args[2]
+            if fieldset_name in seen:
+                continue
+            seen.add(fieldset_name)
+            fieldset = cfg.get(fieldset_name)
+            if (
+                fieldset is not None
+                and conn._himport_prepared.get(fieldset_name) != fieldset.version
+            ):
+                to_prepare.append(fieldset)
+        if not to_prepare:
+            return
+        conn.send_packed_command(
+            conn.pack_commands(
+                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
+            )
+        )
+        # One reply per packed PREPARE must be read regardless of a per-command
+        # ResponseError, otherwise the unread replies desync the node connection
+        # before the buffered batch is even sent. Drain every reply (marking only the
+        # ones that succeeded), then surface the first error as the root cause.
+        first_error = None
+        for fs in to_prepare:
+            try:
+                redis_node.parse_response(conn, HIMPORT_PREPARE)
+            except ResponseError as e:
+                first_error = first_error or e
+                continue
+            conn._himport_prepared[fs.name] = fs.version
+        if first_error is not None:
+            raise first_error
+
     @abstractmethod
     def execute(self, raise_on_error: bool = True) -> List[Any]:
         pass
@@ -4102,6 +4207,9 @@ class PipelineStrategy(AbstractStrategy):
         is_default_node = False
         # build a list of node objects based on node names we need to
         nodes: dict[str, NodeCommands] = {}
+        # node objects keyed by name, so each node's connection can be pre-flighted
+        # for HIMPORT SET (PREPARE) before the batched write.
+        node_objs: dict = {}
         nodes_written = 0
         nodes_read = 0
 
@@ -4202,6 +4310,7 @@ class PipelineStrategy(AbstractStrategy):
                         redis_node.connection_pool,
                         connection,
                     )
+                    node_objs[node_name] = node
                 nodes[node_name].append(c)
 
             # send the commands in sequence.
@@ -4212,6 +4321,15 @@ class PipelineStrategy(AbstractStrategy):
             # so that we can read them from different sockets as they come back.
             # we don't multiplex on the sockets as they come available,
             # but that shouldn't make too much difference.
+
+            # HIMPORT SETs in the batch need their fieldsets prepared on each
+            # node's connection first; the packed write bypasses the per-command
+            # lazy prepare, so pre-flight the PREPARE (once per node) here.
+            for node_name, n in nodes.items():
+                redis_node = self._pipe.get_redis_connection(node_objs[node_name])
+                self._himport_prepare_pipeline(
+                    redis_node, n.connection, [(c.args, c.options) for c in n.commands]
+                )
 
             # Start timing for observability
             start_time = time.monotonic()
@@ -4669,6 +4787,13 @@ class TransactionStrategy(AbstractStrategy):
         self._executing = True
 
         redis_node, connection = self._get_client_and_connection_for_transaction()
+
+        # Ensure fieldsets referenced by buffered HIMPORT SETs are prepared on this
+        # node's connection before the MULTI/EXEC block (session state, not
+        # transactional). All keys share one slot here, so it is a single node.
+        self._himport_prepare_pipeline(
+            redis_node, connection, [(c.args, c.options) for c in stack]
+        )
 
         stack = chain(
             [PipelineCommand(("MULTI",))],

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -3648,6 +3648,11 @@ class ClusterPipeline(RedisCluster):
         """ """
         self.command_stack = []
         self.nodes_manager = nodes_manager
+        # Share the parent cluster's HIMPORT registry (held on the NodesManager and
+        # referenced by every node pool). The inherited himport_prepare/discard/
+        # discard_all mutate this one object, so a fieldset declared on the pipeline is
+        # visible to the batched himport_set pre-flight exactly as on the parent client.
+        self._himport_registry = nodes_manager.himport_registry
         self.commands_parser = commands_parser
         self.refresh_table_asap = False
         self.result_callbacks = (

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -20,7 +20,6 @@ from typing import (
     Iterable,
     List,
     Literal,
-    Mapping,
     Optional,
     Set,
     Tuple,
@@ -727,7 +726,6 @@ class RedisCluster(
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: PolicyResolver = StaticPolicyResolver(),
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
-        himport_schemas: Mapping[str, Iterable[str]] | None = None,
         **kwargs,
     ):
         """
@@ -903,13 +901,13 @@ class RedisCluster(
         if check_protocol_version(protocol, 3) and maint_notifications_config is None:
             maint_notifications_config = MaintNotificationsConfig()
 
-        # Build the client-level HIMPORT registry once (empty if no schemas) and share
-        # the same object with every node pool, so the fieldset registry is shared
-        # cluster-wide and runtime himport_prepare mutates one object. It is handed to
-        # the NodesManager and injected onto each node's pool in create_redis_node;
-        # it is deliberately NOT forwarded through connection_kwargs, so nodes reuse the
-        # one shared object rather than each rebuilding its own from the schemas.
-        self._himport_registry = HImportRegistry(himport_schemas)
+        # Build the client-level HIMPORT registry once (always empty at construction)
+        # and share the same object with every node pool, so the fieldset registry is
+        # shared cluster-wide and runtime himport_prepare mutates one object. It is
+        # handed to the NodesManager and injected onto each node's pool in
+        # create_redis_node; it is deliberately NOT forwarded through connection_kwargs,
+        # so nodes reuse the one shared object rather than each rebuilding their own.
+        self._himport_registry = HImportRegistry()
 
         self.command_flags = self.__class__.COMMAND_FLAGS.copy()
         self.node_flags = self.__class__.NODE_FLAGS.copy()
@@ -1780,7 +1778,18 @@ class RedisCluster(
                     [("ASKING",), himport_set_command(key, fieldset_name, values)]
                 )
             )
-            redis_node.parse_response(connection, "ASKING")
+            try:
+                redis_node.parse_response(connection, "ASKING")
+            except ResponseError as ask_error:
+                # ASKING and SET were one packed write, so the SET reply is still
+                # queued. Drain it before surfacing the ASKING error, otherwise the
+                # connection returns to the pool with an unread reply and desyncs
+                # the next borrower.
+                try:
+                    redis_node.parse_response(connection, HIMPORT_SET)
+                except ResponseError:
+                    pass
+                raise ask_error
         else:
             connection.send_command(*himport_set_command(key, fieldset_name, values))
         try:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -4845,8 +4845,23 @@ class TransactionStrategy(AbstractStrategy):
         Send a command and parse the response
         """
 
-        conn.send_command(*args)
-        output = redis_node.parse_response(conn, command_name, **options)
+        # HIMPORT SET's wire form depends on per-connection state: the fieldset
+        # must be PREPAREd on this connection first, and any fieldset discarded
+        # since this connection last reconciled must be dropped. The
+        # immediate/watched path (commands issued after WATCH, before MULTI)
+        # would otherwise send a bare HIMPORT SET and fail with "no such
+        # fieldset". Route it through the node's HIMPORT executor, the same way
+        # the normal cluster path, the batched MULTI/EXEC path, and standalone
+        # watched pipelines all do.
+        if command_name == HIMPORT_SET and len(args) >= 3:
+            # args == (HIMPORT_SET, key, fieldset_name, *values). Too few args
+            # fall through to the bare send so the server returns its arity error.
+            output = redis_node._himport_execute_set(
+                conn, args[1], args[2], list(args[3:])
+            )
+        else:
+            conn.send_command(*args)
+            output = redis_node.parse_response(conn, command_name, **options)
 
         if command_name in self.UNWATCH_COMMANDS:
             self._watching = False

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -75,7 +75,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import HIMPORT_SET, HImportRegistry
+from redis.himport import HImportRegistry, is_himport_set_command
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -1745,11 +1745,11 @@ class RedisCluster(
 
                 redis_node = self.get_redis_connection(target_node)
                 connection = get_connection(redis_node)
-                if asking and command != HIMPORT_SET:
+                if asking and not is_himport_set_command(command):
                     connection.send_command("ASKING")
                     redis_node.parse_response(connection, "ASKING", **kwargs)
                     asking = False
-                if command == HIMPORT_SET and len(args) >= 3:
+                if is_himport_set_command(command) and len(args) >= 3:
                     # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
                     # ``execute_command`` with too few args falls through to the
                     # normal send path below so the server returns its arity error
@@ -4701,7 +4701,7 @@ class TransactionStrategy(AbstractStrategy):
         # fieldset". Route it through the node's HIMPORT executor, the same way
         # the normal cluster path, the batched MULTI/EXEC path, and standalone
         # watched pipelines all do.
-        if command_name == HIMPORT_SET and len(args) >= 3:
+        if is_himport_set_command(command_name) and len(args) >= 3:
             # args == (HIMPORT_SET, key, fieldset_name, *values). Too few args
             # fall through to the bare send so the server returns its arity error.
             output = redis_node._himport_execute_set(

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -97,6 +97,7 @@ from redis.utils import (
     deprecated_args,
     deprecated_function,
     dict_merge,
+    experimental_method,
     list_keys_to_dict,
     merge_result,
     safe_str,
@@ -1401,15 +1402,18 @@ class RedisCluster(
         """
         return self._himport_registry
 
+    @experimental_method()
     def himport_prepare(self, fieldset_name: str, fields: Iterable[FieldT]) -> bool:
         """Declare an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
         self._himport_registry.prepare(fieldset_name, fields)
         return True
 
+    @experimental_method()
     def himport_discard(self, fieldset_name: str) -> int:
         """Remove an HIMPORT fieldset cluster-wide (shared registry, applied lazily)."""
         return 1 if self._himport_registry.discard(fieldset_name) else 0
 
+    @experimental_method()
     def himport_discard_all(self) -> int:
         """Remove all HIMPORT fieldsets cluster-wide (shared registry, applied lazily)."""
         return self._himport_registry.discard_all()

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -30,6 +30,7 @@ from typing import (
 if TYPE_CHECKING:
     from redis.keyspace_notifications import ClusterKeyspaceNotifications
 
+from redis import _himport_exec
 from redis._defaults import DEFAULT_RETRY_BASE, DEFAULT_RETRY_CAP, DEFAULT_RETRY_COUNT
 from redis._parsers import CommandsParser, Encoder
 from redis._parsers.commands import CommandPolicies, RequestPolicy, ResponsePolicy
@@ -66,7 +67,6 @@ from redis.exceptions import (
     InvalidPipelineStack,
     MaxConnectionsError,
     MovedError,
-    NoSuchFieldsetError,
     RedisClusterException,
     RedisError,
     ResponseError,
@@ -75,13 +75,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import (
-    HIMPORT_PREPARE,
-    HIMPORT_SET,
-    HImportRegistry,
-    himport_prepare_command,
-    himport_set_command,
-)
+from redis.himport import HIMPORT_SET, HImportRegistry
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -1677,6 +1671,10 @@ class RedisCluster(
                         )
                     raise e
 
+    def _himport_reconcile_discards(self, redis_node, connection):
+        """Delegate to the shared sync HIMPORT executor."""
+        return _himport_exec.reconcile_discards(redis_node, connection)
+
     def _himport_prepare_and_set(
         self,
         redis_node,
@@ -1687,46 +1685,16 @@ class RedisCluster(
         fieldset,
         asking: bool = False,
     ):
-        """PREPARE ``fieldset`` bundled with the SET on ``connection`` (one packed write).
-
-        When ``asking`` is set (an ASK-redirected cluster SET) the batch becomes
-        ``[PREPARE, ASKING, SET]`` so the per-command ASKING allowance falls
-        immediately before the SET -- the only slot-scoped command. PREPARE is a
-        connection-session command that the ASKING flag does not gate, so placing
-        it before ASKING is safe. Every reply is drained even on a per-command
-        error so the packed replies never desync the pooled socket.
-        """
-        commands = [himport_prepare_command(fieldset_name, fieldset.fields)]
-        if asking:
-            commands.append(("ASKING",))
-        commands.append(himport_set_command(key, fieldset_name, values))
-        connection.send_packed_command(connection.pack_commands(commands))
-        prep_error = ask_error = set_error = None
-        set_resp = None
-        try:
-            redis_node.parse_response(connection, HIMPORT_PREPARE)
-        except ResponseError as e:
-            prep_error = e
-        if asking:
-            try:
-                redis_node.parse_response(connection, "ASKING")
-            except ResponseError as e:
-                ask_error = e
-        try:
-            set_resp = redis_node.parse_response(connection, HIMPORT_SET)
-        except ResponseError as e:
-            set_error = e
-
-        if prep_error:
-            raise prep_error  # PREPARE failure is the root cause
-        else:
-            connection._himport_prepared[fieldset_name] = fieldset.version
-
-        if ask_error:
-            raise ask_error
-        if set_error:
-            raise set_error
-        return set_resp
+        """Delegate to the shared sync HIMPORT executor."""
+        return _himport_exec.prepare_and_set(
+            redis_node,
+            connection,
+            key,
+            fieldset_name,
+            values,
+            fieldset,
+            asking=asking,
+        )
 
     def _himport_execute_set(
         self,
@@ -1737,80 +1705,10 @@ class RedisCluster(
         values,
         asking: bool = False,
     ):
-        """Execute an ``HIMPORT SET`` on ``connection`` with the required session setup.
-
-        ``HIMPORT SET`` needs the fieldset PREPAREd on this connection first, and
-        any fieldset discarded from the shared registry since this connection last
-        reconciled must be dropped. Both are applied here, on the acquired
-        connection, so the caller's full retry / MOVED-ASK / disconnect-on-error
-        handling covers the whole exchange.
-
-        When ``asking`` is set (an ASK-redirected cluster SET) the ASKING allowance
-        is folded into the SET's own packed write so it immediately precedes the
-        SET. The session setup (deferred DISCARDs, lazy PREPARE) still runs first,
-        before ASKING, since those are connection-session commands the flag does
-        not gate; only the SET is slot-scoped and must carry the allowance.
-        """
-        redis_node._himport_reconcile_discards(connection)
-
-        registry = connection.himport_registry
-        fieldset = registry.get(fieldset_name) if registry is not None else None
-        # Lazy PREPARE bundled with SET on first use of this fieldset.
-        if (
-            fieldset is not None
-            and connection._himport_prepared.get(fieldset_name) != fieldset.version
-        ):
-            return self._himport_prepare_and_set(
-                redis_node,
-                connection,
-                key,
-                fieldset_name,
-                values,
-                fieldset,
-                asking=asking,
-            )
-
-        # Believed already prepared (or an unregistered fieldset): bare SET, with
-        # ASKING packed immediately before it when this is an ASK redirect.
-        if asking:
-            connection.send_packed_command(
-                connection.pack_commands(
-                    [("ASKING",), himport_set_command(key, fieldset_name, values)]
-                )
-            )
-            try:
-                redis_node.parse_response(connection, "ASKING")
-            except ResponseError as ask_error:
-                # ASKING and SET were one packed write, so the SET reply is still
-                # queued. Drain it before surfacing the ASKING error, otherwise the
-                # connection returns to the pool with an unread reply and desyncs
-                # the next borrower.
-                try:
-                    redis_node.parse_response(connection, HIMPORT_SET)
-                except ResponseError:
-                    pass
-                raise ask_error
-        else:
-            connection.send_command(*himport_set_command(key, fieldset_name, values))
-        try:
-            return redis_node.parse_response(connection, HIMPORT_SET)
-        except NoSuchFieldsetError:
-            # Server dropped the fieldset mid-connection without dropping the socket
-            # (e.g. RESET / maxmemory-clients eviction): re-PREPARE on this healthy
-            # connection and retry the SET once rather than reconnecting. Only for
-            # registry-backed fieldsets; manual/unregistered usage propagates.
-            if fieldset is None:
-                raise
-            connection._himport_prepared.pop(fieldset_name, None)
-            return self._himport_prepare_and_set(
-                redis_node,
-                connection,
-                key,
-                fieldset_name,
-                values,
-                fieldset,
-                asking=asking,
-            )
+        """Delegate to the shared sync HIMPORT executor."""
+        return _himport_exec.execute_set(
+            redis_node, connection, key, fieldset_name, values, asking=asking
+        )
 
     def _execute_command(self, target_node, *args, **kwargs):
         """
@@ -4175,58 +4073,8 @@ class AbstractStrategy(ExecutionStrategy):
         return self._pipe
 
     def _himport_prepare_pipeline(self, redis_node, conn, commands):
-        """Pre-flight ``conn`` for a node's pipeline batch containing ``HIMPORT SET``s.
-
-        The cluster pipeline packs each node's commands and writes them bypassing the
-        per-command lazy-PREPARE path, so the fieldsets referenced by the buffered
-        SETs must be PREPAREd on ``conn`` first. Reconciles deferred discards, then
-        PREPAREs every distinct registered fieldset the batch references that this
-        connection has not already prepared, in one packed write. No-op when the
-        batch has no registry-backed ``HIMPORT SET``. Uses ``redis_node`` (the owning
-        node's client) for reconcile and response parsing on ``conn``.
-        """
-        # A node may run on a connection type that never carries real HIMPORT state
-        # (e.g. mocked test doubles); only proceed for a real config.
-        registry = getattr(conn, "himport_registry", None)
-        if not isinstance(registry, HImportRegistry):
-            return
-        redis_node._himport_reconcile_discards(conn)
-        to_prepare = []
-        seen = set()
-        for args, _ in commands:
-            if not args or args[0] != HIMPORT_SET or len(args) < 3:
-                continue
-            fieldset_name = args[2]
-            if fieldset_name in seen:
-                continue
-            seen.add(fieldset_name)
-            fieldset = registry.get(fieldset_name)
-            if (
-                fieldset is not None
-                and conn._himport_prepared.get(fieldset_name) != fieldset.version
-            ):
-                to_prepare.append(fieldset)
-        if not to_prepare:
-            return
-        conn.send_packed_command(
-            conn.pack_commands(
-                [himport_prepare_command(fs.name, fs.fields) for fs in to_prepare]
-            )
-        )
-        # One reply per packed PREPARE must be read regardless of a per-command
-        # ResponseError, otherwise the unread replies desync the node connection
-        # before the buffered batch is even sent. Drain every reply (marking only the
-        # ones that succeeded), then surface the first error as the root cause.
-        first_error = None
-        for fs in to_prepare:
-            try:
-                redis_node.parse_response(conn, HIMPORT_PREPARE)
-            except ResponseError as e:
-                first_error = first_error or e
-                continue
-            conn._himport_prepared[fs.name] = fs.version
-        if first_error is not None:
-            raise first_error
+        """Delegate to the shared sync HIMPORT executor."""
+        _himport_exec.prepare_pipeline(redis_node, conn, [args for args, _ in commands])
 
     @abstractmethod
     def execute(self, raise_on_error: bool = True) -> List[Any]:

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -75,7 +75,7 @@ from redis.exceptions import (
     TryAgainError,
     WatchError,
 )
-from redis.himport import HImportRegistry, is_himport_set_command
+from redis.himport import HImportRegistry, parse_himport_set_args
 from redis.lock import Lock
 from redis.maint_notifications import (
     MaintNotificationsConfig,
@@ -1745,11 +1745,12 @@ class RedisCluster(
 
                 redis_node = self.get_redis_connection(target_node)
                 connection = get_connection(redis_node)
-                if asking and not is_himport_set_command(command):
+                himport_set = parse_himport_set_args(args)
+                if asking and himport_set is None:
                     connection.send_command("ASKING")
                     redis_node.parse_response(connection, "ASKING", **kwargs)
                     asking = False
-                if is_himport_set_command(command) and len(args) >= 3:
+                if himport_set is not None:
                     # args == (HIMPORT_SET, key, fieldset_name, *values). A raw
                     # ``execute_command`` with too few args falls through to the
                     # normal send path below so the server returns its arity error
@@ -1770,14 +1771,15 @@ class RedisCluster(
                     # local: ``_himport_execute_set`` can raise a retriable MOVED/TRYAGAIN
                     # mid-exchange, and a stale ``asking`` would shadow the moved-retry
                     # branch on the next loop iteration (mirrors the async client).
+                    key, fieldset_name, values = himport_set
                     ask_himport = asking
                     asking = False
                     response = self._himport_execute_set(
                         redis_node,
                         connection,
-                        args[1],
-                        args[2],
-                        list(args[3:]),
+                        key,
+                        fieldset_name,
+                        values,
                         asking=ask_himport,
                     )
                     kwargs.pop("keys", None)
@@ -4701,12 +4703,13 @@ class TransactionStrategy(AbstractStrategy):
         # fieldset". Route it through the node's HIMPORT executor, the same way
         # the normal cluster path, the batched MULTI/EXEC path, and standalone
         # watched pipelines all do.
-        if is_himport_set_command(command_name) and len(args) >= 3:
-            # args == (HIMPORT_SET, key, fieldset_name, *values). Too few args
-            # fall through to the bare send so the server returns its arity error.
-            output = redis_node._himport_execute_set(
-                conn, args[1], args[2], list(args[3:])
-            )
+        himport_set = parse_himport_set_args(args)
+        if himport_set is not None:
+            # HIMPORT SET in the joined or split raw form; operands at the right
+            # offsets. Too few operands returns None and falls through to the bare
+            # send so the server returns its arity error.
+            key, fieldset_name, values = himport_set
+            output = redis_node._himport_execute_set(conn, key, fieldset_name, values)
         else:
             conn.send_command(*args)
             output = redis_node.parse_response(conn, command_name, **options)

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -10834,7 +10834,7 @@ class HashCommands(CommandsProtocol):
         """
         # A bare str/bytes-like value is iterable element-by-element; splatting it
         # would send single chars/bytes as separate positional values instead of one
-        # value. Reject it as a caller mistake, mirroring HImportConfig's field-list
+        # value. Reject it as a caller mistake, mirroring HImportRegistry's field-list
         # guard.
         if isinstance(values, (str, bytes, bytearray, memoryview)):
             raise DataError(

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -37,6 +37,12 @@ from redis.asyncio.observability.recorder import (
     record_streaming_lag_from_response as async_record_streaming_lag,
 )
 from redis.exceptions import ConnectionError, DataError, NoScriptError, RedisError
+from redis.himport import (
+    HIMPORT_DISCARD,
+    HIMPORT_DISCARDALL,
+    HIMPORT_PREPARE,
+    HIMPORT_SET,
+)
 from redis.typing import (
     AbsExpiryT,
     ACLGetUserData,
@@ -10747,6 +10753,132 @@ class HashCommands(CommandsProtocol):
         return self.execute_command(
             "HPTTL", key, "FIELDS", len(fields), *fields, keys=[key]
         )
+
+    # -- HIMPORT (Hinted Hash Templates) --------------------------------------
+    # himport_set is the full public command: the executor lazily PREPAREs the
+    # fieldset on the serving connection and reconciles deferred DISCARDs, so it
+    # needs no client-level wrapper. The *_internal methods are the pure PREPARE /
+    # DISCARD / DISCARDALL wire mappings; the client-side orchestration around them
+    # (the shared registry, and running them immediately on a single-connection
+    # client) lives on the client classes as himport_prepare / himport_discard /
+    # himport_discard_all.
+
+    @overload
+    def himport_prepare_internal(
+        self: SyncClientProtocol, fieldset_name: str, fields: Iterable[FieldT]
+    ) -> bool: ...
+
+    @overload
+    def himport_prepare_internal(
+        self: AsyncClientProtocol, fieldset_name: str, fields: Iterable[FieldT]
+    ) -> Awaitable[bool]: ...
+
+    def himport_prepare_internal(
+        self, fieldset_name: str, fields: Iterable[FieldT]
+    ) -> bool | Awaitable[bool]:
+        """Send ``HIMPORT PREPARE fieldset_name field [field ...]``.
+
+        Registers the ordered field list under ``fieldset_name`` in the executing
+        connection's session. Fields are sent in the caller's order, unmodified.
+
+        .. warning::
+            Internal wire mapping — not for direct use on a pooled client. It
+            PREPAREs on a single arbitrary borrowed connection and bypasses the
+            client's shared fieldset registry, so other connections stay unaware and
+            reintroduce the nondeterministic "no such fieldset" the HIMPORT design
+            prevents. Use the client's ``himport_prepare`` instead; call this only
+            on a pinned single-connection client where you manage session state
+            yourself.
+        """
+        return self.execute_command(HIMPORT_PREPARE, fieldset_name, *fields)
+
+    @overload
+    def himport_set(
+        self: SyncClientProtocol,
+        key: KeyT,
+        fieldset_name: str,
+        values: Iterable[EncodableT],
+    ) -> bool: ...
+
+    @overload
+    def himport_set(
+        self: AsyncClientProtocol,
+        key: KeyT,
+        fieldset_name: str,
+        values: Iterable[EncodableT],
+    ) -> Awaitable[bool]: ...
+
+    def himport_set(
+        self, key: KeyT, fieldset_name: str, values: Iterable[EncodableT]
+    ) -> bool | Awaitable[bool]:
+        """Create/replace ``key`` as a hash using ``fieldset_name``'s field list.
+
+        Values are sent in the caller's order and map positionally to the prepared
+        fields. The fieldset is prepared on the serving connection on first use
+        (PREPARE bundled with SET in one write) and reused on subsequent calls;
+        runtime discards are reconciled on the next use of the connection. All of
+        this happens inside the normal command path, so retry, disconnect-on-error
+        and (for the cluster) routing / MOVED-ASK apply exactly as for any command.
+
+        .. note::
+            Recovery from a mid-connection fieldset loss (the server dropping the
+            prepared fieldset without dropping the socket, e.g. ``RESET`` or
+            ``maxmemory-clients`` eviction) applies only to a standalone
+            ``himport_set`` call: it catches the resulting ``no such fieldset`` and
+            re-prepares on the same socket, retrying the SET once. A ``himport_set``
+            buffered in a **pipeline or transaction** has no such per-command
+            recovery — its fieldset is PREPAREd once as a pre-flight before the
+            batch, and if the server loses it between that pre-flight and the batch
+            the SET fails and surfaces as an error in the batch results. Callers who
+            need the automatic recovery should issue those sets outside a pipeline.
+        """
+        return self.execute_command(
+            HIMPORT_SET, key, fieldset_name, *values, keys=[key]
+        )
+
+    @overload
+    def himport_discard_internal(
+        self: SyncClientProtocol, fieldset_name: str
+    ) -> int: ...
+
+    @overload
+    def himport_discard_internal(
+        self: AsyncClientProtocol, fieldset_name: str
+    ) -> Awaitable[int]: ...
+
+    def himport_discard_internal(self, fieldset_name: str) -> int | Awaitable[int]:
+        """Send ``HIMPORT DISCARD fieldset_name`` (``1`` removed, ``0`` not found).
+
+        .. warning::
+            Internal wire mapping — not for direct use on a pooled client. It
+            DISCARDs on a single arbitrary borrowed connection and bypasses the
+            client's shared fieldset registry, leaving other connections and the
+            registry out of sync. Use the client's ``himport_discard`` instead; call
+            this only on a pinned single-connection client where you manage session
+            state yourself.
+        """
+        return self.execute_command(HIMPORT_DISCARD, fieldset_name)
+
+    @overload
+    def himport_discard_all_internal(self: SyncClientProtocol) -> int: ...
+
+    @overload
+    def himport_discard_all_internal(
+        self: AsyncClientProtocol,
+    ) -> Awaitable[int]: ...
+
+    def himport_discard_all_internal(self) -> int | Awaitable[int]:
+        """Send ``HIMPORT DISCARDALL`` (returns the number of fieldsets removed).
+
+        .. warning::
+            Internal wire mapping — not for direct use on a pooled client. It
+            DISCARDs on a single arbitrary borrowed connection and bypasses the
+            client's shared fieldset registry, leaving other connections and the
+            registry out of sync. Use the client's ``himport_discard_all`` instead;
+            call this only on a pinned single-connection client where you manage
+            session state yourself.
+        """
+        return self.execute_command(HIMPORT_DISCARDALL)
 
 
 AsyncHashCommands = HashCommands

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -10832,6 +10832,14 @@ class HashCommands(CommandsProtocol):
             the SET fails and surfaces as an error in the batch results. Callers who
             need the automatic recovery should issue those sets outside a pipeline.
         """
+        # A bare str/bytes-like value is iterable element-by-element; splatting it
+        # would send single chars/bytes as separate positional values instead of one
+        # value. Reject it as a caller mistake, mirroring HImportConfig's field-list
+        # guard.
+        if isinstance(values, (str, bytes, bytearray, memoryview)):
+            raise DataError(
+                "HIMPORT values must be a collection of values, not a string"
+            )
         return self.execute_command(
             HIMPORT_SET, key, fieldset_name, *values, keys=[key]
         )

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -10808,6 +10808,7 @@ class HashCommands(CommandsProtocol):
         values: Iterable[EncodableT],
     ) -> Awaitable[bool]: ...
 
+    @experimental_method()
     def himport_set(
         self, key: KeyT, fieldset_name: str, values: Iterable[EncodableT]
     ) -> bool | Awaitable[bool]:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -55,6 +55,7 @@ from .exceptions import (
     ResponseError,
     TimeoutError,
 )
+from .himport import HImportConfig
 from .maint_notifications import (
     MaintenanceState,
     MaintNotificationsConfig,
@@ -841,6 +842,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
+        himport_config: Optional[HImportConfig] = None,
     ):
         """
         Initialize a new Connection.
@@ -938,6 +940,15 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
 
         self._command_packer = self._construct_command_packer(command_packer)
         self._should_reconnect = False
+
+        # HIMPORT client-side state. `himport_config` is the shared client-level
+        # registry (or None). `_himport_prepared` maps fieldset name -> the version
+        # this connection last prepared on the server; `_himport_reconciled_revision`
+        # is the config revision this connection last reconciled discards against.
+        # These are populated here for propagation only and are not used yet.
+        self.himport_config = himport_config
+        self._himport_prepared: dict[str, int] = {}
+        self._himport_reconciled_revision: int = 0
 
         # Set up maintenance notifications
         MaintNotificationsAbstractConnection.__init__(
@@ -2980,6 +2991,17 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
 
         connection_kwargs.pop("cache", None)
         connection_kwargs.pop("cache_config", None)
+
+        # Resolve the HIMPORT config. A pre-built ``himport_config`` (shared, e.g.
+        # from the cluster client) takes precedence; otherwise build one from a
+        # ``himport_schemas`` dict. The resolved config stays in ``connection_kwargs``
+        # so it reaches every connection, while ``himport_schemas`` is consumed here.
+        himport_config = connection_kwargs.get("himport_config")
+        himport_schemas = connection_kwargs.pop("himport_schemas", None)
+        if himport_config is None and himport_schemas is not None:
+            himport_config = HImportConfig(himport_schemas)
+            connection_kwargs["himport_config"] = himport_config
+        self.himport_config = himport_config
 
         # a lock to protect the critical section in _checkpid().
         # this lock is acquired when the process id changes, such as

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -842,7 +842,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
-        himport_config: Optional[HImportConfig] = None,
+        himport_config: HImportConfig | None = None,
     ):
         """
         Initialize a new Connection.
@@ -942,13 +942,9 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         self._should_reconnect = False
 
         # HIMPORT client-side state. `himport_config` is the shared client-level
-        # registry (or None). `_himport_prepared` maps fieldset name -> the version
-        # this connection last prepared on the server; `_himport_reconciled_revision`
-        # is the config revision this connection last reconciled discards against.
-        # These are populated here for propagation only and are not used yet.
+        # registry (empty if unconfigured) and persists across reconnects.
         self.himport_config = himport_config
-        self._himport_prepared: dict[str, int] = {}
-        self._himport_reconciled_revision: int = 0
+        self._reset_himport_state()
 
         # Set up maintenance notifications
         MaintNotificationsAbstractConnection.__init__(
@@ -1113,11 +1109,22 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
     def _error_message(self, exception):
         return format_error_message(self._host_error(), exception)
 
+    def _reset_himport_state(self):
+        # A fresh server session has no prepared HIMPORT fieldsets, so the next
+        # himport_set must re-prepare on this connection. ``_himport_prepared`` maps
+        # fieldset name -> the version prepared on the server; ``_himport_reconciled
+        # _revision`` is the config revision this connection last reconciled discards
+        # against. Both are reset on connect/disconnect since the session is gone.
+        self._himport_prepared: dict[str, int] = {}
+        self._himport_reconciled_revision: int = 0
+
     def on_connect(self):
         self.on_connect_check_health(check_health=True)
 
     def on_connect_check_health(self, check_health: bool = True):
         "Initialize the connection, authenticate and select a database"
+        # A fresh socket is a new server session: no prepared HIMPORT fieldsets.
+        self._reset_himport_state()
         self._parser.on_connect(self)
         parser = self._parser
 
@@ -1234,6 +1241,9 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
 
     def disconnect(self, *args, **kwargs):
         "Disconnects from the Redis server"
+        # The server session is gone, so any HIMPORT fieldsets prepared on this
+        # socket no longer exist; reset the tracking.
+        self._reset_himport_state()
         self._parser.on_disconnect()
 
         conn_sock = self._sock
@@ -1732,6 +1742,9 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
     def send_packed_command(self, command, check_health=True):
         # TODO: Investigate if it's possible to unpack command
         #  or extract keys from packed command
+        # Pre-packed commands are not individually cacheable, so make sure the
+        # next read_response does not try to cache their reply under a stale key.
+        self._current_command_cache_key = None
         self._conn.send_packed_command(command)
 
     def send_command(self, *args, **kwargs):
@@ -1863,6 +1876,25 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
 
     def pack_commands(self, commands):
         return self._conn.pack_commands(commands)
+
+    # HIMPORT state lives on the wrapped connection (HIMPORT is never cacheable);
+    # delegate so callers treat the proxy like a plain connection and never need
+    # to know a proxy is in play.
+    @property
+    def himport_config(self):
+        return self._conn.himport_config
+
+    @property
+    def _himport_prepared(self):
+        return self._conn._himport_prepared
+
+    @property
+    def _himport_reconciled_revision(self):
+        return self._conn._himport_reconciled_revision
+
+    @_himport_reconciled_revision.setter
+    def _himport_reconciled_revision(self, value):
+        self._conn._himport_reconciled_revision = value
 
     @property
     def handshake_metadata(self) -> Union[Dict[bytes, bytes], Dict[str, str]]:
@@ -2993,12 +3025,14 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         connection_kwargs.pop("cache_config", None)
 
         # Resolve the HIMPORT config. A pre-built ``himport_config`` (shared, e.g.
-        # from the cluster client) takes precedence; otherwise build one from a
-        # ``himport_schemas`` dict. The resolved config stays in ``connection_kwargs``
-        # so it reaches every connection, while ``himport_schemas`` is consumed here.
+        # from the cluster client) takes precedence; otherwise build one from the
+        # ``himport_schemas`` dict (empty if none). A config always exists so runtime
+        # ``himport_prepare`` mutates a single object every connection already shares.
+        # The object stays in ``connection_kwargs`` so it reaches every connection,
+        # while ``himport_schemas`` is consumed here.
         himport_config = connection_kwargs.get("himport_config")
         himport_schemas = connection_kwargs.pop("himport_schemas", None)
-        if himport_config is None and himport_schemas is not None:
+        if himport_config is None:
             himport_config = HImportConfig(himport_schemas)
             connection_kwargs["himport_config"] = himport_config
         self.himport_config = himport_config
@@ -3038,11 +3072,15 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         }
     )
 
+    # Internal plumbing kwargs omitted from __repr__ (not user-facing config).
+    OMIT_REPR_KEYS = frozenset({"himport_config"})
+
     def __repr__(self) -> str:
         conn_kwargs = ",".join(
             [
                 f"{k}={'<REDACTED>' if k in self.SENSITIVE_REPR_KEYS else v}"
                 for k, v in self.connection_kwargs.items()
+                if k not in self.OMIT_REPR_KEYS
             ]
         )
         return (

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3024,18 +3024,16 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         connection_kwargs.pop("cache", None)
         connection_kwargs.pop("cache_config", None)
 
-        # Resolve the HIMPORT config. A pre-built ``himport_registry`` (shared, e.g.
-        # from the cluster client) takes precedence; otherwise build one from the
-        # ``himport_schemas`` dict (empty if none). A registry always exists so runtime
-        # ``himport_prepare`` mutates a single object every connection already shares.
-        # The object stays in ``connection_kwargs`` so it reaches every connection,
-        # while ``himport_schemas`` is consumed here. It is injected unconditionally
-        # (like other auto-added pool kwargs), so a custom ``connection_class`` must
-        # accept ``**kwargs`` (or a ``himport_registry`` parameter), as built-ins do.
+        # Resolve the HIMPORT registry. A pre-built ``himport_registry`` (shared, e.g.
+        # from the cluster client) takes precedence; otherwise build a fresh empty one.
+        # A registry always exists so runtime ``himport_prepare`` mutates a single object
+        # every connection already shares. The object stays in ``connection_kwargs`` so
+        # it reaches every connection. It is injected unconditionally (like other
+        # auto-added pool kwargs), so a custom ``connection_class`` must accept
+        # ``**kwargs`` (or a ``himport_registry`` parameter), as built-ins do.
         himport_registry = connection_kwargs.get("himport_registry")
-        himport_schemas = connection_kwargs.pop("himport_schemas", None)
         if himport_registry is None:
-            himport_registry = HImportRegistry(himport_schemas)
+            himport_registry = HImportRegistry()
             connection_kwargs["himport_registry"] = himport_registry
         self.himport_registry = himport_registry
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -3029,7 +3029,9 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         # ``himport_schemas`` dict (empty if none). A config always exists so runtime
         # ``himport_prepare`` mutates a single object every connection already shares.
         # The object stays in ``connection_kwargs`` so it reaches every connection,
-        # while ``himport_schemas`` is consumed here.
+        # while ``himport_schemas`` is consumed here. It is injected unconditionally
+        # (like other auto-added pool kwargs), so a custom ``connection_class`` must
+        # accept ``**kwargs`` (or a ``himport_config`` parameter), as built-ins do.
         himport_config = connection_kwargs.get("himport_config")
         himport_schemas = connection_kwargs.pop("himport_schemas", None)
         if himport_config is None:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -55,7 +55,7 @@ from .exceptions import (
     ResponseError,
     TimeoutError,
 )
-from .himport import HImportConfig
+from .himport import HImportRegistry
 from .maint_notifications import (
     MaintenanceState,
     MaintNotificationsConfig,
@@ -842,7 +842,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         oss_cluster_maint_notifications_handler: Optional[
             OSSMaintNotificationsHandler
         ] = None,
-        himport_config: HImportConfig | None = None,
+        himport_registry: HImportRegistry | None = None,
     ):
         """
         Initialize a new Connection.
@@ -941,9 +941,9 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         self._command_packer = self._construct_command_packer(command_packer)
         self._should_reconnect = False
 
-        # HIMPORT client-side state. `himport_config` is the shared client-level
+        # HIMPORT client-side state. `himport_registry` is the shared client-level
         # registry (empty if unconfigured) and persists across reconnects.
-        self.himport_config = himport_config
+        self.himport_registry = himport_registry
         self._reset_himport_state()
 
         # Set up maintenance notifications
@@ -1113,7 +1113,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         # A fresh server session has no prepared HIMPORT fieldsets, so the next
         # himport_set must re-prepare on this connection. ``_himport_prepared`` maps
         # fieldset name -> the version prepared on the server; ``_himport_reconciled
-        # _revision`` is the config revision this connection last reconciled discards
+        # _revision`` is the registry revision this connection last reconciled discards
         # against. Both are reset on connect/disconnect since the session is gone.
         self._himport_prepared: dict[str, int] = {}
         self._himport_reconciled_revision: int = 0
@@ -1881,8 +1881,8 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
     # delegate so callers treat the proxy like a plain connection and never need
     # to know a proxy is in play.
     @property
-    def himport_config(self):
-        return self._conn.himport_config
+    def himport_registry(self):
+        return self._conn.himport_registry
 
     @property
     def _himport_prepared(self):
@@ -3024,20 +3024,20 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
         connection_kwargs.pop("cache", None)
         connection_kwargs.pop("cache_config", None)
 
-        # Resolve the HIMPORT config. A pre-built ``himport_config`` (shared, e.g.
+        # Resolve the HIMPORT config. A pre-built ``himport_registry`` (shared, e.g.
         # from the cluster client) takes precedence; otherwise build one from the
-        # ``himport_schemas`` dict (empty if none). A config always exists so runtime
+        # ``himport_schemas`` dict (empty if none). A registry always exists so runtime
         # ``himport_prepare`` mutates a single object every connection already shares.
         # The object stays in ``connection_kwargs`` so it reaches every connection,
         # while ``himport_schemas`` is consumed here. It is injected unconditionally
         # (like other auto-added pool kwargs), so a custom ``connection_class`` must
-        # accept ``**kwargs`` (or a ``himport_config`` parameter), as built-ins do.
-        himport_config = connection_kwargs.get("himport_config")
+        # accept ``**kwargs`` (or a ``himport_registry`` parameter), as built-ins do.
+        himport_registry = connection_kwargs.get("himport_registry")
         himport_schemas = connection_kwargs.pop("himport_schemas", None)
-        if himport_config is None:
-            himport_config = HImportConfig(himport_schemas)
-            connection_kwargs["himport_config"] = himport_config
-        self.himport_config = himport_config
+        if himport_registry is None:
+            himport_registry = HImportRegistry(himport_schemas)
+            connection_kwargs["himport_registry"] = himport_registry
+        self.himport_registry = himport_registry
 
         # a lock to protect the critical section in _checkpid().
         # this lock is acquired when the process id changes, such as
@@ -3075,7 +3075,7 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
     )
 
     # Internal plumbing kwargs omitted from __repr__ (not user-facing config).
-    OMIT_REPR_KEYS = frozenset({"himport_config"})
+    OMIT_REPR_KEYS = frozenset({"himport_registry"})
 
     def __repr__(self) -> str:
         conn_kwargs = ",".join(

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1888,6 +1888,15 @@ class CacheProxyConnection(MaintNotificationsAbstractConnection, ConnectionInter
     def _himport_prepared(self):
         return self._conn._himport_prepared
 
+    @_himport_prepared.setter
+    def _himport_prepared(self, value):
+        # Delegate reassignment to the wrapped connection, mirroring
+        # ``_himport_reconciled_revision``. Production code only mutates the dict
+        # in place, but ``_reset_himport_state`` (and any future caller) reassigns
+        # it, and a getter-only property here would raise ``AttributeError`` only
+        # when client-side caching is enabled -- a caching-specific latent trap.
+        self._conn._himport_prepared = value
+
     @property
     def _himport_reconciled_revision(self):
         return self._conn._himport_reconciled_revision

--- a/redis/exceptions.py
+++ b/redis/exceptions.py
@@ -11,7 +11,7 @@ class ExceptionType(Enum):
 
 
 class RedisError(Exception):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args)
         self.error_type = ExceptionType.SERVER
         self.status_code = status_code
@@ -21,31 +21,31 @@ class RedisError(Exception):
 
 
 class ConnectionError(RedisError):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.NETWORK
 
 
 class TimeoutError(RedisError):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.NETWORK
 
 
 class AuthenticationError(ConnectionError):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.AUTH
 
 
 class AuthorizationError(ConnectionError):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.AUTH
 
 
 class BusyLoadingError(ConnectionError):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.NETWORK
 
@@ -95,12 +95,25 @@ class ReadOnlyError(ResponseError):
 
 
 class NoPermissionError(ResponseError):
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.AUTH
 
 
 class ModuleError(ResponseError):
+    pass
+
+
+class NoSuchFieldsetError(ResponseError):
+    """Server reply when ``HIMPORT SET`` targets a fieldset the connection has not
+    prepared.
+
+    Under lazy PREPARE bundling this is nearly unreachable, but the server can drop
+    session state mid-connection without dropping the socket (e.g. ``RESET`` or
+    ``maxmemory-clients`` eviction). The client catches this to re-prepare on the same
+    socket and retry the SET once instead of failing.
+    """
+
     pass
 
 
@@ -136,7 +149,7 @@ class AuthenticationWrongNumberOfArgsError(ResponseError):
     were sent to the AUTH command
     """
 
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.AUTH
 
@@ -160,7 +173,7 @@ class ClusterError(RedisError):
     command execution TTL
     """
 
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.SERVER
 
@@ -176,7 +189,7 @@ class ClusterDownError(ClusterError, ResponseError):
     are covered again.
     """
 
-    def __init__(self, resp, status_code: str = None):
+    def __init__(self, resp, status_code: str | None = None):
         self.args = (resp,)
         self.message = resp
         self.error_type = ExceptionType.SERVER
@@ -199,7 +212,7 @@ class AskError(ResponseError):
         any op will be allowed after asking command
     """
 
-    def __init__(self, resp, status_code: str = None):
+    def __init__(self, resp, status_code: str | None = None):
         """should only redirect to master node"""
         super().__init__(resp, status_code=status_code)
         self.args = (resp,)
@@ -217,7 +230,7 @@ class TryAgainError(ResponseError):
     between the source and destination nodes, will generate a -TRYAGAIN error.
     """
 
-    def __init__(self, *args, status_code: str = None, **kwargs):
+    def __init__(self, *args, status_code: str | None = None, **kwargs):
         super().__init__(*args, status_code=status_code)
 
 
@@ -230,7 +243,7 @@ class ClusterCrossSlotError(ResponseError):
 
     message = "Keys in request don't hash to the same slot"
 
-    def __init__(self, *args, status_code: str = None):
+    def __init__(self, *args, status_code: str | None = None):
         super().__init__(*args, status_code=status_code)
         self.error_type = ExceptionType.SERVER
 

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -21,11 +21,52 @@ Example::
     True
 """
 
+import threading
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
 
 from redis.exceptions import DataError
+from redis.typing import EncodableT, FieldT, KeyT
+
+# ---------------------------------------------------------------------------
+# Wire command tokens
+# ---------------------------------------------------------------------------
+# Centralised so the sync/async clients, the cluster clients and the
+# CoreCommands mixin never repeat the literal HIMPORT strings. ``HIMPORT_*`` are
+# the full command names passed to ``execute_command`` and registered as
+# response callbacks (the request packer splits the space). The
+# ``himport_*_command`` builders return the positional wire args used when a
+# connection packs commands directly (lazy PREPARE bundled with SET, deferred
+# DISCARD reconcile, etc.).
+
+_HIMPORT = "HIMPORT"
+_PREPARE = "PREPARE"
+_SET = "SET"
+_DISCARD = "DISCARD"
+_DISCARDALL = "DISCARDALL"
+
+HIMPORT_PREPARE = f"{_HIMPORT} {_PREPARE}"
+HIMPORT_SET = f"{_HIMPORT} {_SET}"
+HIMPORT_DISCARD = f"{_HIMPORT} {_DISCARD}"
+HIMPORT_DISCARDALL = f"{_HIMPORT} {_DISCARDALL}"
+
+
+def himport_prepare_command(fieldset_name: str, fields: Iterable[FieldT]) -> tuple:
+    """Positional wire args for ``HIMPORT PREPARE fieldset_name field [field ...]``."""
+    return (_HIMPORT, _PREPARE, fieldset_name, *fields)
+
+
+def himport_set_command(
+    key: KeyT, fieldset_name: str, values: Iterable[EncodableT]
+) -> tuple:
+    """Positional wire args for ``HIMPORT SET key fieldset_name value [value ...]``."""
+    return (_HIMPORT, _SET, key, fieldset_name, *values)
+
+
+def himport_discard_command(fieldset_name: str) -> tuple:
+    """Positional wire args for ``HIMPORT DISCARD fieldset_name``."""
+    return (_HIMPORT, _DISCARD, fieldset_name)
 
 
 class FieldsetOrigin(Enum):
@@ -62,7 +103,7 @@ class HImportFieldset:
     """
 
     name: str
-    fields: tuple[str, ...]
+    fields: tuple[FieldT, ...]
     origin: FieldsetOrigin
     version: int
 
@@ -73,7 +114,9 @@ class HImportConfig:
     Pure in-memory state, shared by the sync and async clients. It is mutated only
     through the client's ``himport_prepare`` / ``himport_discard`` /
     ``himport_discard_all`` methods and exposed read-only through the client's
-    ``himport_config`` property.
+    ``himport_config`` property. Mutations are serialized under a lock so the
+    revision bump and dict change stay consistent when a sync ``Redis`` instance is
+    shared across threads; the async client runs single-threaded and never contends.
 
     Args:
         schemas: Optional mapping of ``fieldset_name -> ordered field names`` to
@@ -83,6 +126,11 @@ class HImportConfig:
 
     def __init__(self, schemas: Mapping[str, Iterable[str]] | None = None) -> None:
         self._fieldsets: dict[str, HImportFieldset] = {}
+        # Serializes mutations (prepare/discard/discard_all) so the revision bump and
+        # the dict change are applied atomically under concurrent access from a
+        # thread-shared sync client. Held only across the synchronous mutation body,
+        # never across I/O, so it is harmless for the single-threaded async client.
+        self._lock = threading.Lock()
         # Monotonic mutation clock. It advances on every registry change (prepare
         # and discard). prepare stamps the new entry with the advanced value as its
         # per-fieldset version; discard has no surviving entry to stamp, so the
@@ -96,13 +144,16 @@ class HImportConfig:
                 self._set(name, fields, FieldsetOrigin.INIT)
 
     # -- internal helpers -------------------------------------------------
+    # ``_advance`` and ``_set`` assume ``_lock`` is already held (they run under the
+    # public mutation methods) or that no other thread can observe the instance yet
+    # (during ``__init__``); they never acquire the lock themselves.
 
     def _advance(self) -> int:
         self._revision += 1
         return self._revision
 
     def _set(
-        self, name: str, fields: Iterable[str], origin: FieldsetOrigin
+        self, name: str, fields: Iterable[FieldT], origin: FieldsetOrigin
     ) -> HImportFieldset:
         # A bare str/bytes is iterable character-by-character; that is almost
         # certainly a caller mistake and would silently register single-character
@@ -125,7 +176,7 @@ class HImportConfig:
 
     # -- mutation ---------------------------------------------------------
 
-    def prepare(self, name: str, fields: Iterable[str]) -> HImportFieldset:
+    def prepare(self, name: str, fields: Iterable[FieldT]) -> HImportFieldset:
         """Add or replace a fieldset, bumping its version, and return the entry.
 
         A new name is registered as :attr:`FieldsetOrigin.RUNTIME`. Re-declaring
@@ -134,9 +185,10 @@ class HImportConfig:
         re-prepared, so discard protection cannot be bypassed by re-preparing.
         Field order is preserved verbatim; nothing is reordered or deduplicated.
         """
-        existing = self._fieldsets.get(name)
-        origin = existing.origin if existing is not None else FieldsetOrigin.RUNTIME
-        return self._set(name, fields, origin)
+        with self._lock:
+            existing = self._fieldsets.get(name)
+            origin = existing.origin if existing is not None else FieldsetOrigin.RUNTIME
+            return self._set(name, fields, origin)
 
     def discard(self, name: str) -> bool:
         """Remove a runtime fieldset from the registry.
@@ -146,16 +198,17 @@ class HImportConfig:
         fieldset was declared at client init (:attr:`FieldsetOrigin.INIT`).
         Advances :attr:`revision` when a fieldset is actually removed.
         """
-        existing = self._fieldsets.get(name)
-        if existing is None:
-            return False
-        if existing.origin is FieldsetOrigin.INIT:
-            raise DataError(
-                f"cannot discard HIMPORT fieldset {name!r} declared at client init"
-            )
-        del self._fieldsets[name]
-        self._advance()
-        return True
+        with self._lock:
+            existing = self._fieldsets.get(name)
+            if existing is None:
+                return False
+            if existing.origin is FieldsetOrigin.INIT:
+                raise DataError(
+                    f"cannot discard HIMPORT fieldset {name!r} declared at client init"
+                )
+            del self._fieldsets[name]
+            self._advance()
+            return True
 
     def discard_all(self) -> int:
         """Remove all runtime fieldsets and return the number removed.
@@ -165,21 +218,22 @@ class HImportConfig:
         discarded, so ``discard_all`` is rejected whenever one is present.
         Advances :attr:`revision` when at least one fieldset is removed.
         """
-        init_names = [
-            name
-            for name, fieldset in self._fieldsets.items()
-            if fieldset.origin is FieldsetOrigin.INIT
-        ]
-        if init_names:
-            raise DataError(
-                "cannot discard all HIMPORT fieldsets while init-declared "
-                "fieldsets exist: " + ", ".join(repr(n) for n in init_names)
-            )
-        count = len(self._fieldsets)
-        if count:
-            self._fieldsets.clear()
-            self._advance()
-        return count
+        with self._lock:
+            init_names = [
+                name
+                for name, fieldset in self._fieldsets.items()
+                if fieldset.origin is FieldsetOrigin.INIT
+            ]
+            if init_names:
+                raise DataError(
+                    "cannot discard all HIMPORT fieldsets while init-declared "
+                    "fieldsets exist: " + ", ".join(repr(n) for n in init_names)
+                )
+            count = len(self._fieldsets)
+            if count:
+                self._fieldsets.clear()
+                self._advance()
+            return count
 
     # -- read-only access -------------------------------------------------
 

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -13,18 +13,16 @@ clients.
 
 Example::
 
-    >>> from redis.himport import HImportRegistry, FieldsetOrigin
-    >>> registry = HImportRegistry({"account_data": ["name", "email", "age"]})
+    >>> from redis.himport import HImportRegistry
+    >>> registry = HImportRegistry()
+    >>> registry.prepare("account_data", ["name", "email", "age"])
     >>> registry.get("account_data").fields
     ('name', 'email', 'age')
-    >>> registry.get("account_data").origin is FieldsetOrigin.INIT
-    True
 """
 
 import threading
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from enum import Enum
 
 from redis.exceptions import DataError
 from redis.typing import EncodableT, FieldT, KeyT
@@ -69,18 +67,6 @@ def himport_discard_command(fieldset_name: str) -> tuple:
     return (_HIMPORT, _DISCARD, fieldset_name)
 
 
-class FieldsetOrigin(Enum):
-    """How a fieldset entered the HIMPORT registry.
-
-    ``INIT`` fieldsets are declared in the client constructor and are treated as
-    permanent for the client's lifetime — they cannot be discarded. ``RUNTIME``
-    fieldsets are added later via ``himport_prepare`` and may be discarded.
-    """
-
-    INIT = "INIT"
-    RUNTIME = "RUNTIME"
-
-
 @dataclass(frozen=True)
 class HImportFieldset:
     """An immutable HIMPORT fieldset entry.
@@ -91,7 +77,6 @@ class HImportFieldset:
             never reordered or deduplicated (HLD R.2): the server canonicalizes
             field order internally and rejects duplicate field names, so the
             client only preserves the caller's positional order.
-        origin: Whether the fieldset was declared at client init or at runtime.
         version: Monotonic stamp bumped each time the fieldset is (re)declared.
             Connections compare the version they last prepared against this value
             to detect a stale prepared state; the stamp is drawn from the registry's
@@ -104,7 +89,6 @@ class HImportFieldset:
 
     name: str
     fields: tuple[FieldT, ...]
-    origin: FieldsetOrigin
     version: int
 
 
@@ -122,13 +106,11 @@ class HImportRegistry:
     ``__contains__``, ``__len__``, :attr:`revision`) are atomic and stay lock-free.
     The async client runs single-threaded and never contends.
 
-    Args:
-        schemas: Optional mapping of ``fieldset_name -> ordered field names`` to
-            register at construction time. These entries are given
-            :attr:`FieldsetOrigin.INIT` and cannot later be discarded.
+    The registry always starts empty; fieldsets are declared at runtime through the
+    client's ``himport_prepare`` method.
     """
 
-    def __init__(self, schemas: Mapping[str, Iterable[str]] | None = None) -> None:
+    def __init__(self) -> None:
         self._fieldsets: dict[str, HImportFieldset] = {}
         # Serializes mutations (prepare/discard/discard_all) so the revision bump and
         # the dict change are applied atomically under concurrent access from a
@@ -145,22 +127,16 @@ class HImportRegistry:
         # comparing per-fieldset versions still avoids forcing unrelated fieldsets
         # to re-prepare.
         self._revision: int = 0
-        if schemas:
-            for name, fields in schemas.items():
-                self._set(name, fields, FieldsetOrigin.INIT)
 
     # -- internal helpers -------------------------------------------------
     # ``_advance`` and ``_set`` assume ``_lock`` is already held (they run under the
-    # public mutation methods) or that no other thread can observe the instance yet
-    # (during ``__init__``); they never acquire the lock themselves.
+    # public mutation methods); they never acquire the lock themselves.
 
     def _advance(self) -> int:
         self._revision += 1
         return self._revision
 
-    def _set(
-        self, name: str, fields: Iterable[FieldT], origin: FieldsetOrigin
-    ) -> HImportFieldset:
+    def _set(self, name: str, fields: Iterable[FieldT]) -> HImportFieldset:
         # A bare single field name (str/bytes/bytearray/memoryview) is itself
         # iterable element-by-element; that is almost certainly a caller mistake and
         # would silently register single-character/single-byte "fields" (e.g.
@@ -177,7 +153,6 @@ class HImportRegistry:
         fieldset = HImportFieldset(
             name=name,
             fields=field_tuple,
-            origin=origin,
             version=self._advance(),
         )
         self._fieldsets[name] = fieldset
@@ -188,56 +163,31 @@ class HImportRegistry:
     def prepare(self, name: str, fields: Iterable[FieldT]) -> HImportFieldset:
         """Add or replace a fieldset, bumping its version, and return the entry.
 
-        A new name is registered as :attr:`FieldsetOrigin.RUNTIME`. Re-declaring
-        an existing name preserves its current origin — in particular an
-        ``INIT`` fieldset stays ``INIT`` (and therefore undiscardable) when
-        re-prepared, so discard protection cannot be bypassed by re-preparing.
+        Re-declaring an existing name replaces its fields and bumps its version.
         Field order is preserved verbatim; nothing is reordered or deduplicated.
         """
         with self._lock:
-            existing = self._fieldsets.get(name)
-            origin = existing.origin if existing is not None else FieldsetOrigin.RUNTIME
-            return self._set(name, fields, origin)
+            return self._set(name, fields)
 
     def discard(self, name: str) -> bool:
-        """Remove a runtime fieldset from the registry.
+        """Remove a fieldset from the registry.
 
         Returns ``True`` if a fieldset was removed, ``False`` if ``name`` was not
-        registered. Raises :class:`~redis.exceptions.DataError` if the named
-        fieldset was declared at client init (:attr:`FieldsetOrigin.INIT`).
-        Advances :attr:`revision` when a fieldset is actually removed.
+        registered. Advances :attr:`revision` when a fieldset is actually removed.
         """
         with self._lock:
-            existing = self._fieldsets.get(name)
-            if existing is None:
+            if name not in self._fieldsets:
                 return False
-            if existing.origin is FieldsetOrigin.INIT:
-                raise DataError(
-                    f"cannot discard HIMPORT fieldset {name!r} declared at client init"
-                )
             del self._fieldsets[name]
             self._advance()
             return True
 
     def discard_all(self) -> int:
-        """Remove all runtime fieldsets and return the number removed.
+        """Remove all fieldsets and return the number removed.
 
-        Raises :class:`~redis.exceptions.DataError` if any init-declared fieldset
-        exists, leaving the registry unchanged: init fieldsets cannot be
-        discarded, so ``discard_all`` is rejected whenever one is present.
         Advances :attr:`revision` when at least one fieldset is removed.
         """
         with self._lock:
-            init_names = [
-                name
-                for name, fieldset in self._fieldsets.items()
-                if fieldset.origin is FieldsetOrigin.INIT
-            ]
-            if init_names:
-                raise DataError(
-                    "cannot discard all HIMPORT fieldsets while init-declared "
-                    "fieldsets exist: " + ", ".join(repr(n) for n in init_names)
-                )
             count = len(self._fieldsets)
             if count:
                 self._fieldsets.clear()
@@ -307,7 +257,6 @@ class HImportRegistry:
         with self._lock:
             entries = list(self._fieldsets.items())
         body = ", ".join(
-            f"{name}={fieldset.origin.value}:{list(fieldset.fields)}"
-            for name, fieldset in entries
+            f"{name}={list(fieldset.fields)}" for name, fieldset in entries
         )
         return f"{self.__class__.__name__}({body})"

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -1,0 +1,234 @@
+"""HIMPORT client-side configuration for redis-py.
+
+`HIMPORT` lets a client register an ordered list of hash field names once per
+connection (a *fieldset*) and then create many hashes by sending only values.
+Because a fieldset is server-side session state bound to a single physical
+connection, redis-py keeps a client-level registry of the fieldsets the
+application has declared and prepares them lazily, per connection, on first use
+by ``himport_set``.
+
+This module holds only that registry. It is pure in-memory state with no I/O and
+no ``asyncio`` primitives, so a single class is shared by both the sync and async
+clients.
+
+Example::
+
+    >>> from redis.himport import HImportConfig, FieldsetOrigin
+    >>> cfg = HImportConfig({"account_data": ["name", "email", "age"]})
+    >>> cfg.get("account_data").fields
+    ('name', 'email', 'age')
+    >>> cfg.get("account_data").origin is FieldsetOrigin.INIT
+    True
+"""
+
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+from redis.exceptions import DataError
+
+
+class FieldsetOrigin(Enum):
+    """How a fieldset entered the HIMPORT config.
+
+    ``INIT`` fieldsets are declared in the client constructor and are treated as
+    permanent for the client's lifetime — they cannot be discarded. ``RUNTIME``
+    fieldsets are added later via ``himport_prepare`` and may be discarded.
+    """
+
+    INIT = "INIT"
+    RUNTIME = "RUNTIME"
+
+
+@dataclass(frozen=True)
+class HImportFieldset:
+    """An immutable HIMPORT fieldset entry.
+
+    Attributes:
+        name: Fieldset name used by ``HIMPORT SET`` / ``HIMPORT DISCARD``.
+        fields: Ordered field names, exactly as supplied by the caller. They are
+            never reordered or deduplicated (HLD R.2): the server canonicalizes
+            field order internally and rejects duplicate field names, so the
+            client only preserves the caller's positional order.
+        origin: Whether the fieldset was declared at client init or at runtime.
+        version: Monotonic stamp bumped each time the fieldset is (re)declared.
+            Connections compare the version they last prepared against this value
+            to detect a stale prepared state; the stamp is drawn from the config's
+            mutation clock (:attr:`HImportConfig.revision`), which never repeats,
+            so discarding and re-declaring the same name yields a fresh version
+            rather than a colliding one. This is the prepare-side signal; the
+            discard-side counterpart is the clock advancing on removal, since a
+            removed fieldset leaves no entry to stamp.
+    """
+
+    name: str
+    fields: tuple[str, ...]
+    origin: FieldsetOrigin
+    version: int
+
+
+class HImportConfig:
+    """Client-level registry of HIMPORT fieldsets.
+
+    Pure in-memory state, shared by the sync and async clients. It is mutated only
+    through the client's ``himport_prepare`` / ``himport_discard`` /
+    ``himport_discard_all`` methods and exposed read-only through the client's
+    ``himport_config`` property.
+
+    Args:
+        schemas: Optional mapping of ``fieldset_name -> ordered field names`` to
+            register at construction time. These entries are given
+            :attr:`FieldsetOrigin.INIT` and cannot later be discarded.
+    """
+
+    def __init__(self, schemas: Mapping[str, Iterable[str]] | None = None) -> None:
+        self._fieldsets: dict[str, HImportFieldset] = {}
+        # Monotonic mutation clock. It advances on every registry change (prepare
+        # and discard). prepare stamps the new entry with the advanced value as its
+        # per-fieldset version; discard has no surviving entry to stamp, so the
+        # advance itself is the signal that a removal happened. Because the clock
+        # only ever increases, a re-declared name never reuses a stamp, while
+        # comparing per-fieldset versions still avoids forcing unrelated fieldsets
+        # to re-prepare.
+        self._revision: int = 0
+        if schemas:
+            for name, fields in schemas.items():
+                self._set(name, fields, FieldsetOrigin.INIT)
+
+    # -- internal helpers -------------------------------------------------
+
+    def _advance(self) -> int:
+        self._revision += 1
+        return self._revision
+
+    def _set(
+        self, name: str, fields: Iterable[str], origin: FieldsetOrigin
+    ) -> HImportFieldset:
+        # A bare str/bytes is iterable character-by-character; that is almost
+        # certainly a caller mistake and would silently register single-character
+        # "fields", so reject it as invalid local API usage.
+        if isinstance(fields, (str, bytes)):
+            raise DataError(
+                "HIMPORT fields must be a collection of field names, not a string"
+            )
+        field_tuple = tuple(fields)
+        if not field_tuple:
+            raise DataError("HIMPORT fieldset must have at least one field")
+        fieldset = HImportFieldset(
+            name=name,
+            fields=field_tuple,
+            origin=origin,
+            version=self._advance(),
+        )
+        self._fieldsets[name] = fieldset
+        return fieldset
+
+    # -- mutation ---------------------------------------------------------
+
+    def prepare(self, name: str, fields: Iterable[str]) -> HImportFieldset:
+        """Add or replace a fieldset, bumping its version, and return the entry.
+
+        A new name is registered as :attr:`FieldsetOrigin.RUNTIME`. Re-declaring
+        an existing name preserves its current origin — in particular an
+        ``INIT`` fieldset stays ``INIT`` (and therefore undiscardable) when
+        re-prepared, so discard protection cannot be bypassed by re-preparing.
+        Field order is preserved verbatim; nothing is reordered or deduplicated.
+        """
+        existing = self._fieldsets.get(name)
+        origin = existing.origin if existing is not None else FieldsetOrigin.RUNTIME
+        return self._set(name, fields, origin)
+
+    def discard(self, name: str) -> bool:
+        """Remove a runtime fieldset from the registry.
+
+        Returns ``True`` if a fieldset was removed, ``False`` if ``name`` was not
+        registered. Raises :class:`~redis.exceptions.DataError` if the named
+        fieldset was declared at client init (:attr:`FieldsetOrigin.INIT`).
+        Advances :attr:`revision` when a fieldset is actually removed.
+        """
+        existing = self._fieldsets.get(name)
+        if existing is None:
+            return False
+        if existing.origin is FieldsetOrigin.INIT:
+            raise DataError(
+                f"cannot discard HIMPORT fieldset {name!r} declared at client init"
+            )
+        del self._fieldsets[name]
+        self._advance()
+        return True
+
+    def discard_all(self) -> int:
+        """Remove all runtime fieldsets and return the number removed.
+
+        Raises :class:`~redis.exceptions.DataError` if any init-declared fieldset
+        exists, leaving the registry unchanged: init fieldsets cannot be
+        discarded, so ``discard_all`` is rejected whenever one is present.
+        Advances :attr:`revision` when at least one fieldset is removed.
+        """
+        init_names = [
+            name
+            for name, fieldset in self._fieldsets.items()
+            if fieldset.origin is FieldsetOrigin.INIT
+        ]
+        if init_names:
+            raise DataError(
+                "cannot discard all HIMPORT fieldsets while init-declared "
+                "fieldsets exist: " + ", ".join(repr(n) for n in init_names)
+            )
+        count = len(self._fieldsets)
+        if count:
+            self._fieldsets.clear()
+            self._advance()
+        return count
+
+    # -- read-only access -------------------------------------------------
+
+    @property
+    def revision(self) -> int:
+        """Monotonic mutation clock, advanced on every registry change.
+
+        It is the discard-side counterpart to per-fieldset
+        :attr:`HImportFieldset.version`. A connection records the revision it last
+        reconciled against; when it differs, a discard (or prepare) has occurred
+        since, so the connection recomputes which of its prepared fieldsets are no
+        longer registered — see :meth:`names_to_discard` — and discards those when
+        it is released back to the pool.
+        """
+        return self._revision
+
+    def names_to_discard(self, prepared_names: Iterable[str]) -> list[str]:
+        """Return which of ``prepared_names`` are no longer registered.
+
+        Given the fieldset names a connection has prepared on the server, this is
+        the set that must be sent ``HIMPORT DISCARD`` (typically when the
+        connection is released), because they have been removed from the registry.
+        """
+        return [name for name in prepared_names if name not in self._fieldsets]
+
+    def get(self, name: str) -> HImportFieldset | None:
+        """Return the fieldset registered under ``name``, or ``None``."""
+        return self._fieldsets.get(name)
+
+    def names(self) -> list[str]:
+        """Return the registered fieldset names."""
+        return list(self._fieldsets)
+
+    def items(self) -> list[tuple[str, HImportFieldset]]:
+        """Return a snapshot of ``(name, fieldset)`` pairs."""
+        return list(self._fieldsets.items())
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._fieldsets
+
+    def __len__(self) -> int:
+        return len(self._fieldsets)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._fieldsets)
+
+    def __repr__(self) -> str:
+        entries = ", ".join(
+            f"{name}={fieldset.origin.value}:{list(fieldset.fields)}"
+            for name, fieldset in self._fieldsets.items()
+        )
+        return f"{self.__class__.__name__}({entries})"

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -1,4 +1,4 @@
-"""HIMPORT client-side configuration for redis-py.
+"""HIMPORT client-side fieldset registry for redis-py.
 
 `HIMPORT` lets a client register an ordered list of hash field names once per
 connection (a *fieldset*) and then create many hashes by sending only values.
@@ -13,11 +13,11 @@ clients.
 
 Example::
 
-    >>> from redis.himport import HImportConfig, FieldsetOrigin
-    >>> cfg = HImportConfig({"account_data": ["name", "email", "age"]})
-    >>> cfg.get("account_data").fields
+    >>> from redis.himport import HImportRegistry, FieldsetOrigin
+    >>> registry = HImportRegistry({"account_data": ["name", "email", "age"]})
+    >>> registry.get("account_data").fields
     ('name', 'email', 'age')
-    >>> cfg.get("account_data").origin is FieldsetOrigin.INIT
+    >>> registry.get("account_data").origin is FieldsetOrigin.INIT
     True
 """
 
@@ -70,7 +70,7 @@ def himport_discard_command(fieldset_name: str) -> tuple:
 
 
 class FieldsetOrigin(Enum):
-    """How a fieldset entered the HIMPORT config.
+    """How a fieldset entered the HIMPORT registry.
 
     ``INIT`` fieldsets are declared in the client constructor and are treated as
     permanent for the client's lifetime — they cannot be discarded. ``RUNTIME``
@@ -94,8 +94,8 @@ class HImportFieldset:
         origin: Whether the fieldset was declared at client init or at runtime.
         version: Monotonic stamp bumped each time the fieldset is (re)declared.
             Connections compare the version they last prepared against this value
-            to detect a stale prepared state; the stamp is drawn from the config's
-            mutation clock (:attr:`HImportConfig.revision`), which never repeats,
+            to detect a stale prepared state; the stamp is drawn from the registry's
+            mutation clock (:attr:`HImportRegistry.revision`), which never repeats,
             so discarding and re-declaring the same name yields a fresh version
             rather than a colliding one. This is the prepare-side signal; the
             discard-side counterpart is the clock advancing on removal, since a
@@ -108,15 +108,19 @@ class HImportFieldset:
     version: int
 
 
-class HImportConfig:
+class HImportRegistry:
     """Client-level registry of HIMPORT fieldsets.
 
     Pure in-memory state, shared by the sync and async clients. It is mutated only
     through the client's ``himport_prepare`` / ``himport_discard`` /
     ``himport_discard_all`` methods and exposed read-only through the client's
-    ``himport_config`` property. Mutations are serialized under a lock so the
+    ``himport_registry`` property. Mutations are serialized under a lock so the
     revision bump and dict change stay consistent when a sync ``Redis`` instance is
-    shared across threads; the async client runs single-threaded and never contends.
+    shared across threads. Reads that iterate or snapshot the registry take the same
+    lock, so a concurrent mutation cannot make them observe a torn view or raise
+    ``dictionary changed size during iteration``; single-key/scalar reads (``get``,
+    ``__contains__``, ``__len__``, :attr:`revision`) are atomic and stay lock-free.
+    The async client runs single-threaded and never contends.
 
     Args:
         schemas: Optional mapping of ``fieldset_name -> ordered field names`` to
@@ -128,8 +132,10 @@ class HImportConfig:
         self._fieldsets: dict[str, HImportFieldset] = {}
         # Serializes mutations (prepare/discard/discard_all) so the revision bump and
         # the dict change are applied atomically under concurrent access from a
-        # thread-shared sync client. Held only across the synchronous mutation body,
-        # never across I/O, so it is harmless for the single-threaded async client.
+        # thread-shared sync client, and guards the reads that iterate/snapshot the
+        # dict so they never see a torn view or a mid-iteration resize. Held only
+        # across synchronous, non-blocking bodies, never across I/O, so it is harmless
+        # for the single-threaded async client.
         self._lock = threading.Lock()
         # Monotonic mutation clock. It advances on every registry change (prepare
         # and discard). prepare stamps the new entry with the advanced value as its
@@ -155,12 +161,15 @@ class HImportConfig:
     def _set(
         self, name: str, fields: Iterable[FieldT], origin: FieldsetOrigin
     ) -> HImportFieldset:
-        # A bare str/bytes is iterable character-by-character; that is almost
-        # certainly a caller mistake and would silently register single-character
-        # "fields", so reject it as invalid local API usage.
-        if isinstance(fields, (str, bytes)):
+        # A bare single field name (str/bytes/bytearray/memoryview) is itself
+        # iterable element-by-element; that is almost certainly a caller mistake and
+        # would silently register single-character/single-byte "fields" (e.g.
+        # memoryview(b"id") -> field names 105, 100), so reject it as invalid local
+        # API usage. int/float are not iterable, so tuple() below rejects them.
+        if isinstance(fields, (str, bytes, bytearray, memoryview)):
             raise DataError(
-                "HIMPORT fields must be a collection of field names, not a string"
+                "HIMPORT fields must be a collection of field names, "
+                "not a single string or binary value"
             )
         field_tuple = tuple(fields)
         if not field_tuple:
@@ -236,6 +245,10 @@ class HImportConfig:
             return count
 
     # -- read-only access -------------------------------------------------
+    # Reads that iterate or build a snapshot of the dict take ``_lock`` so a
+    # concurrent mutation cannot resize it mid-iteration or expose a torn view;
+    # single-key/scalar reads below (get/__contains__/__len__/revision) are atomic
+    # and deliberately stay lock-free.
 
     @property
     def revision(self) -> int:
@@ -257,7 +270,11 @@ class HImportConfig:
         the set that must be sent ``HIMPORT DISCARD`` (typically when the
         connection is released), because they have been removed from the registry.
         """
-        return [name for name in prepared_names if name not in self._fieldsets]
+        # Hold the lock across the comprehension so every membership test sees one
+        # consistent snapshot; ``prepared_names`` is an external iterable of plain
+        # strings and never calls back into the registry.
+        with self._lock:
+            return [name for name in prepared_names if name not in self._fieldsets]
 
     def get(self, name: str) -> HImportFieldset | None:
         """Return the fieldset registered under ``name``, or ``None``."""
@@ -265,11 +282,13 @@ class HImportConfig:
 
     def names(self) -> list[str]:
         """Return the registered fieldset names."""
-        return list(self._fieldsets)
+        with self._lock:
+            return list(self._fieldsets)
 
     def items(self) -> list[tuple[str, HImportFieldset]]:
         """Return a snapshot of ``(name, fieldset)`` pairs."""
-        return list(self._fieldsets.items())
+        with self._lock:
+            return list(self._fieldsets.items())
 
     def __contains__(self, name: object) -> bool:
         return name in self._fieldsets
@@ -278,11 +297,17 @@ class HImportConfig:
         return len(self._fieldsets)
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self._fieldsets)
+        # Snapshot under the lock and iterate the copy, so the lock is never held
+        # across caller consumption and a concurrent mutation cannot resize the
+        # underlying dict mid-iteration.
+        with self._lock:
+            return iter(list(self._fieldsets))
 
     def __repr__(self) -> str:
-        entries = ", ".join(
+        with self._lock:
+            entries = list(self._fieldsets.items())
+        body = ", ".join(
             f"{name}={fieldset.origin.value}:{list(fieldset.fields)}"
-            for name, fieldset in self._fieldsets.items()
+            for name, fieldset in entries
         )
-        return f"{self.__class__.__name__}({entries})"
+        return f"{self.__class__.__name__}({body})"

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -67,6 +67,35 @@ def himport_discard_command(fieldset_name: str) -> tuple:
     return (_HIMPORT, _DISCARD, fieldset_name)
 
 
+_HIMPORT_SET_LEN = len(HIMPORT_SET)
+_HIMPORT_SET_BYTES = HIMPORT_SET.encode()
+
+
+def is_himport_set_command(command_name) -> bool:
+    """Return ``True`` if ``command_name`` names the ``HIMPORT SET`` command.
+
+    Redis command names are case-insensitive on the wire, and a caller using the
+    raw ``execute_command`` API may pass the name in any case and as either
+    ``str`` or ``bytes`` (e.g. ``execute_command("himport set", ...)`` or
+    ``b"HIMPORT SET"``). The connection-state-aware ``HIMPORT SET`` path keys off
+    the command name, so it must recognise all of those spellings: an exact
+    comparison against :data:`HIMPORT_SET` would miss them and send a bare SET
+    that fails with ``no such fieldset`` for a fieldset registered in the client
+    but not yet PREPAREd on the borrowed connection. The length check keeps the
+    per-command cost on the hot path to a single comparison for the common case
+    of a differently-sized command name (``upper()`` runs only on a size match).
+    """
+    if isinstance(command_name, str):
+        return (
+            len(command_name) == _HIMPORT_SET_LEN
+            and command_name.upper() == HIMPORT_SET
+        )
+    if isinstance(command_name, (bytes, bytearray, memoryview)):
+        raw = bytes(command_name)
+        return len(raw) == _HIMPORT_SET_LEN and raw.upper() == _HIMPORT_SET_BYTES
+    return False
+
+
 @dataclass(frozen=True)
 class HImportFieldset:
     """An immutable HIMPORT fieldset entry.

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -96,6 +96,63 @@ def is_himport_set_command(command_name) -> bool:
     return False
 
 
+_HIMPORT_BYTES = _HIMPORT.encode()
+_SET_BYTES = _SET.encode()
+
+
+def _token_is(value, upper_token: str, upper_token_bytes: bytes) -> bool:
+    """Case-insensitive match of a single ``str``/``bytes`` command token.
+
+    ``upper_token`` / ``upper_token_bytes`` must already be upper-cased. The
+    length guard keeps the hot path to a single comparison for a differently
+    sized token (``upper()`` runs only on a size match).
+    """
+    n = len(upper_token)
+    if isinstance(value, str):
+        return len(value) == n and value.upper() == upper_token
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raw = bytes(value)
+        return len(raw) == n and raw.upper() == upper_token_bytes
+    return False
+
+
+def parse_himport_set_args(args):
+    """Detect an ``HIMPORT SET`` command in ``args`` and return its operands.
+
+    ``HIMPORT SET`` reaches the raw ``execute_command`` API in two wire-equivalent
+    forms that the serializer both accept:
+
+    * the joined form ``("HIMPORT SET", key, fieldset, *values)`` (``args[0]`` is
+      the two-word command name the request packer splits on the space), and
+    * the split form ``("HIMPORT", "SET", key, fieldset, *values)``.
+
+    Both are case- and encoding-insensitive. The connection-state-aware executor
+    and the pipeline pre-flight need the operands at the right offsets for either
+    form, so this returns ``(key, fieldset_name, values_list)`` when ``args`` is an
+    ``HIMPORT SET`` with enough operands, or ``None`` otherwise (a non-``HIMPORT
+    SET`` command, or one with too few operands -- which falls through to the plain
+    send so the server returns its own arity error).
+    """
+    if not args:
+        return None
+    first = args[0]
+    # Joined form: args[0] == "HIMPORT SET".
+    if is_himport_set_command(first):
+        if len(args) < 3:
+            return None
+        return args[1], args[2], list(args[3:])
+    # Split form: args[0] == "HIMPORT", args[1] == "SET".
+    if (
+        len(args) >= 2
+        and _token_is(first, _HIMPORT, _HIMPORT_BYTES)
+        and _token_is(args[1], _SET, _SET_BYTES)
+    ):
+        if len(args) < 4:
+            return None
+        return args[2], args[3], list(args[4:])
+    return None
+
+
 @dataclass(frozen=True)
 class HImportFieldset:
     """An immutable HIMPORT fieldset entry.

--- a/redis/himport.py
+++ b/redis/himport.py
@@ -222,7 +222,17 @@ class HImportRegistry:
         self._revision += 1
         return self._revision
 
-    def _set(self, name: str, fields: Iterable[FieldT]) -> HImportFieldset:
+    @staticmethod
+    def _materialize_fields(fields: Iterable[FieldT]) -> tuple:
+        """Validate and materialize the caller's field iterable into a tuple.
+
+        Done *before* the mutation lock is taken: consuming an arbitrary iterable
+        can be slow, or -- for a generator that inspects this same registry -- can
+        re-enter a locked read (e.g. ``yield`` then ``registry.names()``). Running
+        it under the non-reentrant ``_lock`` would stall every registry user or
+        deadlock permanently. Field order is preserved; nothing is reordered or
+        deduplicated.
+        """
         # A bare single field name (str/bytes/bytearray/memoryview) is itself
         # iterable element-by-element; that is almost certainly a caller mistake and
         # would silently register single-character/single-byte "fields" (e.g.
@@ -236,6 +246,13 @@ class HImportRegistry:
         field_tuple = tuple(fields)
         if not field_tuple:
             raise DataError("HIMPORT fieldset must have at least one field")
+        return field_tuple
+
+    def _set(self, name: str, field_tuple: tuple) -> HImportFieldset:
+        # ``field_tuple`` is already validated/materialized by
+        # :meth:`_materialize_fields`; only the (cheap, non-blocking) revision bump
+        # and dict mutation run here, so ``_lock`` is never held across arbitrary
+        # caller code.
         fieldset = HImportFieldset(
             name=name,
             fields=field_tuple,
@@ -252,8 +269,12 @@ class HImportRegistry:
         Re-declaring an existing name replaces its fields and bumps its version.
         Field order is preserved verbatim; nothing is reordered or deduplicated.
         """
+        # Materialize/validate the iterable *outside* the lock so a slow or
+        # registry-re-entrant generator can never stall or deadlock other users;
+        # the lock then covers only the atomic revision-bump + dict mutation.
+        field_tuple = self._materialize_fields(fields)
         with self._lock:
-            return self._set(name, fields)
+            return self._set(name, field_tuple)
 
     def discard(self, name: str) -> bool:
         """Remove a fieldset from the registry.

--- a/redis/multidb/client.py
+++ b/redis/multidb/client.py
@@ -515,6 +515,22 @@ class Pipeline(RedisModuleCommands, CoreCommands):
         """Adds a command to the stack"""
         return self.pipeline_execute_command(*args, **kwargs)
 
+    # HIMPORT is unsupported on the multi-database client (see MultiDBClient). A
+    # pipeline inherits ``himport_set`` from ``CoreCommands`` and would otherwise
+    # queue an unprepared ``HIMPORT SET`` that fails with a confusing server-side
+    # error, bypassing the client-level guard. Block all HIMPORT methods here too.
+    def himport_prepare(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
+    def himport_set(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
+    def himport_discard(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
+    def himport_discard_all(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(MultiDBClient._HIMPORT_UNSUPPORTED)
+
     def execute(self) -> List[Any]:
         """Execute all the commands in the current pipeline"""
         if not self._client.initialized:

--- a/redis/multidb/client.py
+++ b/redis/multidb/client.py
@@ -8,6 +8,7 @@ from redis.background import BackgroundScheduler
 from redis.backoff import NoBackoff
 from redis.client import PubSubWorkerThread
 from redis.commands import CoreCommands, RedisModuleCommands
+from redis.exceptions import DataError
 from redis.maint_notifications import MaintNotificationsConfig
 from redis.multidb.circuit import CircuitBreaker
 from redis.multidb.circuit import State as CBState
@@ -287,6 +288,29 @@ class MultiDBClient(RedisModuleCommands, CoreCommands):
             self.initialize()
 
         return self.command_executor.execute_command(*args, **options)
+
+    # HIMPORT is not supported on the multi-database client. A HIMPORT fieldset is
+    # per-connection server session state tracked by a single client's registry;
+    # there is no coherent way to keep that state consistent across independent
+    # database clients through failover. ``himport_set`` is inherited from
+    # ``CoreCommands`` (and the lifecycle methods would otherwise be missing entirely),
+    # so override them to fail early and clearly instead of surfacing a confusing
+    # ``no such fieldset`` at runtime.
+    _HIMPORT_UNSUPPORTED = (
+        "HIMPORT is not supported on the multi-database (Active-Active) client"
+    )
+
+    def himport_prepare(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
+
+    def himport_set(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
+
+    def himport_discard(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
+
+    def himport_discard_all(self, *args: Any, **kwargs: Any) -> Any:
+        raise DataError(self._HIMPORT_UNSUPPORTED)
 
     def pipeline(self):
         """

--- a/redis/sentinel.py
+++ b/redis/sentinel.py
@@ -450,6 +450,18 @@ class Sentinel(SentinelCommands):
         All other keyword arguments are merged with any connection_kwargs
         passed to this class and passed to the connection pool as keyword
         arguments to be used to initialize Redis connections.
+
+        HIMPORT note: the returned client exposes the HIMPORT command family
+        (``himport_prepare``, ``himport_set``, ``himport_discard``,
+        ``himport_discard_all``). Fieldsets are declared at runtime with
+        ``himport_prepare`` on the client and live on that client's shared registry,
+        so they survive Sentinel failover automatically: the pool re-points to the
+        new master and the fieldset is re-prepared lazily on the next
+        ``himport_set``. Each call to the current method returns a *new* client with
+        its *own* empty registry, so call ``himport_prepare`` on the long-lived client
+        you reuse rather than creating a fresh one per operation; otherwise ``himport_set``
+        fails with ``no such fieldset``. (``himport_set`` is a write and is served by
+        the master.)
         """
         kwargs["is_master"] = True
         connection_kwargs = dict(self.connection_kwargs)
@@ -481,6 +493,18 @@ class Sentinel(SentinelCommands):
         All other keyword arguments are merged with any connection_kwargs
         passed to this class and passed to the connection pool as keyword
         arguments to be used to initialize Redis connections.
+
+        HIMPORT note: the returned client exposes the HIMPORT command family
+        (``himport_prepare``, ``himport_set``, ``himport_discard``,
+        ``himport_discard_all``). Fieldsets are declared at runtime with
+        ``himport_prepare`` on the client and live on that client's shared registry,
+        so they survive Sentinel failover automatically: the pool re-points to the
+        new master and the fieldset is re-prepared lazily on the next
+        ``himport_set``. Each call to current method returns a *new* client with
+        its *own* empty registry, so call ``himport_prepare`` on the long-lived client
+        you reuse rather than creating a fresh one per operation; otherwise ``himport_set``
+        fails with ``no such fieldset``. (``himport_set`` is a write and is served by
+        the master.)
         """
         kwargs["is_master"] = False
         connection_kwargs = dict(self.connection_kwargs)

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -51,6 +51,7 @@ from redis.exceptions import (
     RedisError,
     ResponseError,
 )
+from redis.himport import HIMPORT_SET
 from redis.utils import str_if_bytes
 from tests.conftest import (
     assert_resp_response,
@@ -655,6 +656,60 @@ class TestRedisClusterObj:
             execute_command.side_effect = ask_redirect_effect
 
             assert await r.execute_command("SET", "foo", "bar") == "MOCK_OK"
+
+    async def test_himport_set_moved_after_ask_uses_moved_target(
+        self, r: RedisCluster
+    ) -> None:
+        """An HIMPORT SET that is ASK-redirected and then hits a MOVED
+        mid-exchange must retry against the MOVED target, not the stale ASK
+        target.
+
+        HIMPORT SET folds the ASK allowance into its own packed write, so the
+        retry loop must clear ``asking`` before the exchange runs; otherwise a
+        MOVED raised mid-exchange would leave ``asking`` set and shadow the
+        moved-retry branch on the next iteration.
+        """
+        key = "himport:key"
+        slot = r.keyslot(key)
+        primary = r.nodes_manager.get_node_from_slot(slot)
+        others = [n for n in r.get_primaries() if n.name != primary.name]
+        if len(others) < 2:
+            pytest.skip("requires at least 3 primaries")
+        ask_node, moved_node = others[0], others[1]
+
+        calls = []
+
+        def himport_effect(self, *args, **kwargs):
+            calls.append((self.host, self.port))
+            if len(calls) == 1:
+                raise AskError(f"{slot} {ask_node.host}:{ask_node.port}")
+            if len(calls) == 2:
+                raise MovedError(f"{slot} {moved_node.host}:{moved_node.port}")
+            return "MOCK_OK"
+
+        # ``_determine_slot`` parses HIMPORT SET keys via COMMAND INFO, which the
+        # test server may not know; pin it so the moved branch can recompute the
+        # target without a live HIMPORT-capable server.
+        with (
+            mock.patch.object(
+                RedisCluster, "_determine_slot", new=mock.AsyncMock(return_value=slot)
+            ),
+            mock.patch.object(
+                ClusterNode,
+                "execute_command",
+                autospec=True,
+                side_effect=himport_effect,
+            ),
+        ):
+            assert (
+                await r._execute_command(primary, HIMPORT_SET, key, "shared", "alice")
+                == "MOCK_OK"
+            )
+
+        assert calls[0] == (primary.host, primary.port)
+        assert calls[1] == (ask_node.host, ask_node.port)
+        # Third attempt must follow the MOVED redirect, not the stale ASK target.
+        assert calls[2] == (moved_node.host, moved_node.port)
 
     async def test_moved_redirection(
         self, create_redis: Callable[..., RedisCluster]

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -682,13 +682,15 @@ class TestConnectionPoolUnixSocketURLParsing:
     def test_defaults(self):
         pool = redis.ConnectionPool.from_url("unix:///socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket"}
+        assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket"})
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self):
         pool = redis.ConnectionPool.from_url("unix://myuser:@/socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "username": "myuser"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"path": "/socket", "username": "myuser"}
+        )
 
     @skip_if_server_version_lt("6.0.0")
     def test_quoted_username(self):
@@ -696,45 +698,56 @@ class TestConnectionPoolUnixSocketURLParsing:
             "unix://%2Fmyuser%2F%2B name%3D%24+:@/socket"
         )
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {
-            "path": "/socket",
-            "username": "/myuser/+ name=$+",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "path": "/socket",
+                "username": "/myuser/+ name=$+",
+            },
+        )
 
     def test_password(self):
         pool = redis.ConnectionPool.from_url("unix://:mypassword@/socket")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "password": "mypassword"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"path": "/socket", "password": "mypassword"}
+        )
 
     def test_quoted_password(self):
         pool = redis.ConnectionPool.from_url(
             "unix://:%2Fmypass%2F%2B word%3D%24+@/socket"
         )
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {
-            "path": "/socket",
-            "password": "/mypass/+ word=$+",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "path": "/socket",
+                "password": "/mypass/+ word=$+",
+            },
+        )
 
     def test_quoted_path(self):
         pool = redis.ConnectionPool.from_url(
             "unix://:mypassword@/my%2Fpath%2Fto%2F..%2F+_%2B%3D%24ocket"
         )
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {
-            "path": "/my/path/to/../+_+=$ocket",
-            "password": "mypassword",
-        }
+        assert_kwargs_subset(
+            pool.connection_kwargs,
+            {
+                "path": "/my/path/to/../+_+=$ocket",
+                "password": "mypassword",
+            },
+        )
 
     def test_db_as_argument(self):
         pool = redis.ConnectionPool.from_url("unix:///socket", db=1)
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "db": 1}
+        assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket", "db": 1})
 
     def test_db_in_querystring(self):
         pool = redis.ConnectionPool.from_url("unix:///socket?db=2", db=1)
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "db": 2}
+        assert_kwargs_subset(pool.connection_kwargs, {"path": "/socket", "db": 2})
 
     def test_client_name_in_querystring(self):
         pool = redis.ConnectionPool.from_url("redis://location?client_name=test-client")
@@ -743,7 +756,9 @@ class TestConnectionPoolUnixSocketURLParsing:
     def test_extra_querystring_options(self):
         pool = redis.ConnectionPool.from_url("unix:///socket?a=1&b=2")
         assert pool.connection_class == redis.UnixDomainSocketConnection
-        assert pool.connection_kwargs == {"path": "/socket", "a": "1", "b": "2"}
+        assert_kwargs_subset(
+            pool.connection_kwargs, {"path": "/socket", "a": "1", "b": "2"}
+        )
 
 
 @pytest.mark.fixed_client

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -77,11 +77,15 @@ async def track_himport_wire(conn):
 @pytest_asyncio.fixture()
 async def hr(create_redis):
     """A client (single/pooled standalone, or cluster) with a declared HIMPORT schema."""
-    return await create_redis(himport_schemas=dict(SCHEMAS))
+    client = await create_redis()
+    # Populate the registry directly (mirrors what init schemas did) without an eager
+    # PREPARE, so lazy-bundling wire assertions in the tests still hold.
+    client.himport_registry.prepare("shared", SCHEMAS["shared"])
+    return client
 
 
 async def test_runtime_prepare_without_init_schemas(create_redis):
-    """A client built with no himport_schemas can still declare + use fieldsets."""
+    """A client that declares nothing up front can still declare + use fieldsets."""
     client = await create_redis()
     await client.himport_prepare("ronly", ["a", "b"])
     await client.delete("r:{u}:1")
@@ -93,9 +97,8 @@ async def test_runtime_prepare_without_init_schemas(create_redis):
 async def test_disconnect_clears_prepared_state(create_redis):
     """A disconnect drops the server session; prepared state is cleared and the
     next himport_set transparently re-prepares."""
-    client = await create_redis(
-        single_connection_client=True, himport_schemas=dict(SCHEMAS)
-    )
+    client = await create_redis(single_connection_client=True)
+    client.himport_registry.prepare("shared", SCHEMAS["shared"])
     conn = client.connection
     async with track_himport_wire(conn) as events:
         # First use of the fieldset bundles PREPARE with SET; the second reuses
@@ -149,9 +152,9 @@ async def test_himport_set_retries_and_reprepares(create_redis):
     the retry re-prepares the fieldset before the SET."""
     client = await create_redis(
         single_connection_client=True,
-        himport_schemas=dict(SCHEMAS),
         retry=Retry(NoBackoff(), 1),
     )
+    client.himport_registry.prepare("shared", SCHEMAS["shared"])
     # Warm the pinned connection so "shared" is already prepared on it.
     await client.himport_set("h:{u}:warm", "shared", ["w", "w@x", "0"])
     conn = client.connection
@@ -280,9 +283,8 @@ async def test_himport_set_recovers_when_fieldset_lost_midconnection(create_redi
     """If the server drops a prepared fieldset mid-connection (e.g. RESET or
     maxmemory-clients eviction) without dropping the socket, the next himport_set
     re-prepares on the same connection and retries the SET once — no reconnect."""
-    client = await create_redis(
-        single_connection_client=True, himport_schemas=dict(SCHEMAS)
-    )
+    client = await create_redis(single_connection_client=True)
+    client.himport_registry.prepare("shared", SCHEMAS["shared"])
     await client.himport_set("rst:{u}:1", "shared", ["a", "a@x", "1"])
     conn = client.connection
     assert "shared" in conn._himport_prepared

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -132,7 +132,7 @@ async def test_discard_on_disconnected_single_connection(create_redis):
         assert await client.himport_discard("tmp") == 1
         discard_wire.assert_not_called()
     assert conn.is_connected is False
-    assert "tmp" not in client.himport_config
+    assert "tmp" not in client.himport_registry
     # A later himport_set still works: the prepare (while still disconnected)
     # sends nothing, and the set reconnects and bundles PREPARE lazily.
     async with track_himport_wire(conn) as events:

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -268,6 +268,20 @@ async def test_pipeline_runtime_prepared_fieldset(hr):
     assert await hr.hget("h:{u}:pl1", "y") == b"2"
 
 
+async def test_pipeline_watch_immediate_himport_set(hr):
+    # An HIMPORT SET issued after WATCH (before MULTI) runs on the immediate
+    # execution path, not the batched one. That path must lazily PREPARE the
+    # fieldset on the watched connection like the normal and batched paths do;
+    # otherwise the bare HIMPORT SET fails with "no such fieldset".
+    key = "h:{u}:w1"
+    async with hr.pipeline(transaction=True) as pipe:
+        await pipe.watch(key)
+        # Executed immediately on the watched connection.
+        await pipe.himport_set(key, "shared", ["alice", "alice@x", "25"])
+    assert await hr.hget(key, "name") == b"alice"
+    assert await hr.hget(key, "age") == b"25"
+
+
 @pytest.mark.onlynoncluster
 async def test_himport_set_recovers_when_fieldset_lost_midconnection(create_redis):
     """If the server drops a prepared fieldset mid-connection (e.g. RESET or

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -1,0 +1,310 @@
+"""Async integration tests for the HIMPORT command family against a real server.
+
+Mirrors ``tests/test_himport_integration.py``. Runs against standalone (single
+and pooled) under ``invoke standalone-tests`` and cluster under
+``invoke cluster-tests``. HIMPORT was introduced in Redis 8.9.0, so the whole
+module is gated on that server version.
+"""
+
+import contextlib
+from unittest import mock
+
+import pytest
+import pytest_asyncio
+
+import redis
+from redis.asyncio.retry import Retry
+from redis.backoff import NoBackoff
+from tests.conftest import skip_if_server_version_lt
+
+SCHEMAS = {"shared": ["name", "email", "age"]}
+
+# HIMPORT (Hinted Hash Templates) landed in Redis 8.9.0; gate the whole module.
+pytestmark = skip_if_server_version_lt("8.9.0")
+
+
+def _himport_verb(parts):
+    """Return the HIMPORT subcommand for a command's leading tokens, or ``None``.
+
+    Handles both wire forms: the joined ``"HIMPORT SET"`` produced by
+    ``execute_command`` and the split ``("HIMPORT", "SET")`` produced by the
+    command builders used in the bundled path.
+    """
+    joined = " ".join(str(p) for p in list(parts)[:2])
+    for verb in ("PREPARE", "SET", "DISCARDALL", "DISCARD"):
+        if joined.startswith(f"HIMPORT {verb}"):
+            return verb
+    return None
+
+
+@contextlib.asynccontextmanager
+async def track_himport_wire(conn):
+    """Record how each HIMPORT write reached the socket, in order.
+
+    Wraps ``conn``'s write primitives (calling through to the real ones, so the
+    exchange still happens for real) and yields a list of markers:
+
+    - ``"PREPARE+SET"`` — lazy PREPARE bundled with the SET in one packed write
+    - ``"SET"``         — bare SET (fieldset already prepared on this connection)
+    - ``"PREPARE"`` / ``"DISCARD"`` — a standalone command
+    - ``"DISCARD*N"``   — a deferred-discard reconcile of ``N`` fieldsets
+    """
+    events = []
+    real_pack = conn.pack_commands
+    real_send = conn.send_command
+
+    def pack(commands, *args, **kwargs):
+        verbs = [_himport_verb(cmd) for cmd in commands]
+        if "PREPARE" in verbs:
+            events.append("PREPARE+SET")
+        elif verbs and all(v == "DISCARD" for v in verbs):
+            events.append(f"DISCARD*{len(verbs)}")
+        return real_pack(commands, *args, **kwargs)
+
+    async def send(*args, **kwargs):
+        verb = _himport_verb(args)
+        if verb is not None:
+            events.append(verb)
+        return await real_send(*args, **kwargs)
+
+    with (
+        mock.patch.object(conn, "pack_commands", new=pack),
+        mock.patch.object(conn, "send_command", new=send),
+    ):
+        yield events
+
+
+@pytest_asyncio.fixture()
+async def hr(create_redis):
+    """A client (single/pooled standalone, or cluster) with a declared HIMPORT schema."""
+    return await create_redis(himport_schemas=dict(SCHEMAS))
+
+
+async def test_runtime_prepare_without_init_schemas(create_redis):
+    """A client built with no himport_schemas can still declare + use fieldsets."""
+    client = await create_redis()
+    await client.himport_prepare("ronly", ["a", "b"])
+    await client.delete("r:{u}:1")
+    await client.himport_set("r:{u}:1", "ronly", ["1", "2"])
+    assert await client.hget("r:{u}:1", "b") == b"2"
+
+
+@pytest.mark.onlynoncluster
+async def test_disconnect_clears_prepared_state(create_redis):
+    """A disconnect drops the server session; prepared state is cleared and the
+    next himport_set transparently re-prepares."""
+    client = await create_redis(
+        single_connection_client=True, himport_schemas=dict(SCHEMAS)
+    )
+    conn = client.connection
+    async with track_himport_wire(conn) as events:
+        # First use of the fieldset bundles PREPARE with SET; the second reuses
+        # the already-prepared connection and sends bare.
+        await client.himport_set("d:{u}:1", "shared", ["a", "a@x", "1"])
+        await client.himport_set("d:{u}:x", "shared", ["c", "c@x", "3"])
+    assert events == ["PREPARE+SET", "SET"]
+    assert "shared" in conn._himport_prepared
+    await conn.disconnect()
+    assert conn._himport_prepared == {}
+    # The reconnected socket has no session state, so the next set re-bundles.
+    async with track_himport_wire(conn) as events:
+        await client.himport_set("d:{u}:2", "shared", ["b", "b@x", "2"])
+    assert events == ["PREPARE+SET"]
+    assert await client.hget("d:{u}:2", "name") == b"b"
+
+
+@pytest.mark.onlynoncluster
+async def test_discard_on_disconnected_single_connection(create_redis):
+    """Discarding on a single-connection client whose socket is not connected
+    updates the registry without reconnecting or issuing a server DISCARD (a fresh
+    connection re-prepares lazily on the next himport_set)."""
+    client = await create_redis(single_connection_client=True)
+    await client.himport_prepare("tmp", ["a", "b"])
+    await client.himport_set("z:{u}:1", "tmp", ["1", "2"])
+    conn = client.connection
+    assert "tmp" in conn._himport_prepared
+    await conn.disconnect()
+    assert conn.is_connected is False
+    # While disconnected the branch must skip the wire DISCARD entirely: spy the
+    # internal command to prove it is never issued, and confirm the socket stays
+    # closed (a DISCARD would have reconnected it).
+    with mock.patch.object(client, "himport_discard_internal") as discard_wire:
+        assert await client.himport_discard("tmp") == 1
+        discard_wire.assert_not_called()
+    assert conn.is_connected is False
+    assert "tmp" not in client.himport_config
+    # A later himport_set still works: the prepare (while still disconnected)
+    # sends nothing, and the set reconnects and bundles PREPARE lazily.
+    async with track_himport_wire(conn) as events:
+        await client.himport_prepare("tmp2", ["c", "d"])
+        await client.himport_set("z:{u}:2", "tmp2", ["3", "4"])
+    assert events == ["PREPARE+SET"]
+    assert await client.hget("z:{u}:2", "d") == b"4"
+
+
+@pytest.mark.onlynoncluster
+async def test_himport_set_retries_and_reprepares(create_redis):
+    """himport_set uses the normal command path, so a retryable error triggers the
+    standard reconnect-and-retry: the dropped socket clears the prepared state and
+    the retry re-prepares the fieldset before the SET."""
+    client = await create_redis(
+        single_connection_client=True,
+        himport_schemas=dict(SCHEMAS),
+        retry=Retry(NoBackoff(), 1),
+    )
+    # Warm the pinned connection so "shared" is already prepared on it.
+    await client.himport_set("h:{u}:warm", "shared", ["w", "w@x", "0"])
+    conn = client.connection
+    real_parse = client.parse_response
+    injected = {"done": False}
+
+    async def flaky(connection, command_name, **options):
+        # Drop the connection once, while reading the first SET reply.
+        if command_name == "HIMPORT SET" and not injected["done"]:
+            injected["done"] = True
+            raise redis.ConnectionError("simulated drop")
+        return await real_parse(connection, command_name, **options)
+
+    with mock.patch.object(client, "parse_response", side_effect=flaky):
+        assert await client.himport_set("h:{u}:r", "shared", ["a", "a@x", "1"]) is True
+    assert injected["done"] is True  # the failure actually fired
+    # The command still succeeded and the reconnected socket was re-prepared.
+    assert await client.hget("h:{u}:r", "email") == b"a@x"
+    assert "shared" in conn._himport_prepared
+
+
+async def test_prepare_set_readback(hr):
+    await hr.himport_set("h:{u}:1", "shared", ["alice", "alice@x", "25"])
+    await hr.himport_set("h:{u}:2", "shared", ["bob", "bob@x", "30"])
+    assert await hr.hget("h:{u}:1", "name") == b"alice"
+    assert await hr.hget("h:{u}:2", "email") == b"bob@x"
+    assert await hr.hgetall("h:{u}:1") == {
+        b"name": b"alice",
+        b"email": b"alice@x",
+        b"age": b"25",
+    }
+
+
+async def test_positional_value_mapping(hr):
+    await hr.himport_set("h:{u}:p", "shared", ["x", "y", "99"])
+    assert await hr.hget("h:{u}:p", "age") == b"99"
+
+
+async def test_create_or_replace(hr):
+    await hr.himport_set("h:{u}:r", "shared", ["a", "a@x", "1"])
+    await hr.himport_set("h:{u}:r", "shared", ["b", "b@x", "2"])
+    assert await hr.hget("h:{u}:r", "name") == b"b"
+    assert await hr.hget("h:{u}:r", "age") == b"2"
+
+
+async def test_wrongtype_on_non_hash_key(hr):
+    await hr.set("h:{u}:str", "notahash")
+    with pytest.raises(redis.ResponseError):
+        await hr.himport_set("h:{u}:str", "shared", ["a", "a@x", "1"])
+
+
+async def test_value_count_mismatch_propagates(hr):
+    with pytest.raises(redis.ResponseError):
+        await hr.himport_set("h:{u}:bad", "shared", ["only-one-value"])
+
+
+async def test_runtime_prepare_then_set(hr):
+    assert await hr.himport_prepare("ord", ["a", "b", "c"]) is True
+    await hr.himport_set("h:{u}:o", "ord", ["va", "vb", "vc"])
+    assert await hr.hget("h:{u}:o", "b") == b"vb"
+
+
+async def test_discard_runtime(hr):
+    await hr.himport_prepare("tmp", ["f1", "f2"])
+    await hr.himport_set("h:{u}:t", "tmp", ["1", "2"])
+    assert await hr.himport_discard("tmp") == 1
+    assert await hr.himport_discard("tmp") == 0
+    assert await hr.hget("h:{u}:t", "f1") == b"1"
+
+
+async def test_discard_init_raises(hr):
+    with pytest.raises(redis.DataError):
+        await hr.himport_discard("shared")
+
+
+async def test_discard_all_rejected_when_init_present(hr):
+    with pytest.raises(redis.DataError):
+        await hr.himport_discard_all()
+
+
+async def test_pool_churn_lazy_prepare(hr):
+    n = 20
+    for i in range(n):
+        await hr.himport_set(f"h:{{u}}:c{i}", "shared", [f"n{i}", f"e{i}@x", str(i)])
+    for i in range(n):
+        assert await hr.hget(f"h:{{u}}:c{i}", "name") == f"n{i}".encode()
+
+
+async def test_pipeline_non_transaction(hr):
+    # A pipeline bypasses the per-command lazy prepare; the fieldset is prepared on
+    # the pipeline connection as a pre-flight before the batch.
+    pipe = hr.pipeline(transaction=False)
+    pipe.himport_set("h:{u}:np1", "shared", ["a", "a@x", "1"])
+    pipe.himport_set("h:{u}:np2", "shared", ["b", "b@x", "2"])
+    pipe.hget("h:{u}:np1", "name")
+    result = await pipe.execute()
+    assert not any(isinstance(r, Exception) for r in result)
+    assert result[-1] == b"a"
+    assert await hr.hget("h:{u}:np2", "email") == b"b@x"
+
+
+async def test_pipeline_transaction(hr):
+    # Same fieldset inside MULTI/EXEC; PREPARE is pre-flighted before MULTI.
+    pipe = hr.pipeline(transaction=True)
+    pipe.himport_set("h:{u}:tp1", "shared", ["c", "c@x", "3"])
+    pipe.himport_set("h:{u}:tp2", "shared", ["d", "d@x", "4"])
+    pipe.hget("h:{u}:tp1", "age")
+    result = await pipe.execute()
+    assert not any(isinstance(r, Exception) for r in result)
+    assert result[-1] == b"3"
+    assert await hr.hget("h:{u}:tp2", "name") == b"d"
+
+
+async def test_pipeline_runtime_prepared_fieldset(hr):
+    # A fieldset declared at runtime is also pre-flighted for the pipeline.
+    await hr.himport_prepare("pl", ["x", "y"])
+    pipe = hr.pipeline(transaction=False)
+    pipe.himport_set("h:{u}:pl1", "pl", ["1", "2"])
+    result = await pipe.execute()
+    assert not any(isinstance(r, Exception) for r in result)
+    assert await hr.hget("h:{u}:pl1", "y") == b"2"
+
+
+@pytest.mark.onlynoncluster
+async def test_himport_set_recovers_when_fieldset_lost_midconnection(create_redis):
+    """If the server drops a prepared fieldset mid-connection (e.g. RESET or
+    maxmemory-clients eviction) without dropping the socket, the next himport_set
+    re-prepares on the same connection and retries the SET once — no reconnect."""
+    client = await create_redis(
+        single_connection_client=True, himport_schemas=dict(SCHEMAS)
+    )
+    await client.himport_set("rst:{u}:1", "shared", ["a", "a@x", "1"])
+    conn = client.connection
+    assert "shared" in conn._himport_prepared
+    # Drop the fieldset server-side on this exact socket without touching the
+    # client's tracking, simulating a mid-connection loss.
+    await client.execute_command("HIMPORT", "DISCARD", "shared")
+    assert "shared" in conn._himport_prepared  # client still believes it exists
+    assert conn.is_connected is True
+    async with track_himport_wire(conn) as events:
+        assert (
+            await client.himport_set("rst:{u}:2", "shared", ["b", "b@x", "2"]) is True
+        )
+    # The bare SET fails with NoSuchFieldsetError, then a PREPARE+SET recovers it.
+    assert events == ["SET", "PREPARE+SET"]
+    assert conn.is_connected is True  # recovery never reconnected
+    assert await client.hget("rst:{u}:2", "name") == b"b"
+
+
+@pytest.mark.onlycluster
+async def test_cluster_multi_slot(hr):
+    keys = [f"h:{{s{i}}}:k" for i in range(8)]
+    for i, k in enumerate(keys):
+        await hr.himport_set(k, "shared", [f"n{i}", f"e{i}@x", str(i)])
+    for i, k in enumerate(keys):
+        assert await hr.hget(k, "name") == f"n{i}".encode()

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -225,16 +225,6 @@ async def test_discard_runtime(hr):
     assert await hr.hget("h:{u}:t", "f1") == b"1"
 
 
-async def test_discard_init_raises(hr):
-    with pytest.raises(redis.DataError):
-        await hr.himport_discard("shared")
-
-
-async def test_discard_all_rejected_when_init_present(hr):
-    with pytest.raises(redis.DataError):
-        await hr.himport_discard_all()
-
-
 async def test_pool_churn_lazy_prepare(hr):
     n = 20
     for i in range(n):

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -340,6 +340,22 @@ async def test_pipeline_folds_prepare_into_single_write(hr):
     assert await hr.hget("pf:{u}:2", "y") == b"4"
 
 
+@pytest.mark.onlynoncluster
+async def test_pipeline_raw_case_insensitive_himport_set_is_preflighted(hr):
+    # A raw, case/encoding-insensitive HIMPORT SET buffered in a pipeline must be
+    # detected by the pre-flight so its fieldset is PREPAREd before the batch --
+    # matching the per-command path. Otherwise the batched SET fails "no such
+    # fieldset" (the fieldset is only in the client registry, not on the socket).
+    await hr.himport_prepare("plraw", ["x", "y"])
+    pipe = hr.pipeline(transaction=False)
+    pipe.execute_command("himport set", "plraw:{u}:1", "plraw", "1", "2")
+    pipe.execute_command(b"HImPoRt SeT", "plraw:{u}:2", "plraw", "3", "4")
+    result = await pipe.execute()
+    assert not any(isinstance(r, Exception) for r in result)
+    assert await hr.hget("plraw:{u}:1", "x") == b"1"
+    assert await hr.hget("plraw:{u}:2", "y") == b"4"
+
+
 async def test_pipeline_watch_immediate_himport_set(hr):
     # An HIMPORT SET issued after WATCH (before MULTI) runs on the immediate
     # execution path, not the batched one. That path must lazily PREPARE the

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -133,6 +133,15 @@ async def test_raw_case_insensitive_himport_set_is_intercepted(hr):
     # Mixed-case bytes name.
     assert await hr.execute_command(b"HImPoRt SeT", "raw:{u}:2", "rawcmd", "bob", "b@x")
     assert await hr.hget("raw:{u}:2", "email") == b"b@x"
+    # Split-token wire-equivalent form: ("HIMPORT", "SET", key, fieldset, *values).
+    assert await hr.execute_command(
+        "HIMPORT", "SET", "raw:{u}:3", "rawcmd", "cara", "c@x"
+    )
+    assert await hr.hget("raw:{u}:3", "name") == b"cara"
+    assert await hr.execute_command(
+        b"himport", b"set", "raw:{u}:4", "rawcmd", "dan", "d@x"
+    )
+    assert await hr.hget("raw:{u}:4", "email") == b"d@x"
 
 
 async def test_runtime_prepare_without_init_schemas(create_redis):
@@ -350,10 +359,13 @@ async def test_pipeline_raw_case_insensitive_himport_set_is_preflighted(hr):
     pipe = hr.pipeline(transaction=False)
     pipe.execute_command("himport set", "plraw:{u}:1", "plraw", "1", "2")
     pipe.execute_command(b"HImPoRt SeT", "plraw:{u}:2", "plraw", "3", "4")
+    # Split-token form must also be recognised by the pre-flight.
+    pipe.execute_command("HIMPORT", "SET", "plraw:{u}:3", "plraw", "5", "6")
     result = await pipe.execute()
     assert not any(isinstance(r, Exception) for r in result)
     assert await hr.hget("plraw:{u}:1", "x") == b"1"
     assert await hr.hget("plraw:{u}:2", "y") == b"4"
+    assert await hr.hget("plraw:{u}:3", "y") == b"6"
 
 
 async def test_pipeline_watch_immediate_himport_set(hr):

--- a/tests/test_asyncio/test_himport_integration.py
+++ b/tests/test_asyncio/test_himport_integration.py
@@ -38,6 +38,40 @@ def _himport_verb(parts):
 
 
 @contextlib.asynccontextmanager
+async def capture_himport_packed_writes(pool):
+    """Yield a list of every HIMPORT-carrying packed write on connections the pool
+    hands out while the context is active. Used to prove the pipeline folds its
+    PREPARE into a single ``send_packed_command`` rather than a separate exchange.
+    """
+    blobs = []
+    real_get = pool.get_connection
+
+    async def get_connection(*args, **kwargs):
+        conn = await real_get(*args, **kwargs)
+        if not getattr(conn, "_himport_write_spy", False):
+            conn._himport_write_spy = True
+            real_send = conn.send_packed_command
+
+            async def send_packed_command(*a, **k):
+                blob = a[0] if a else k.get("command", b"")
+                # pack_commands() returns a list of byte chunks; a single command
+                # is bytes. Normalise both to one bytestring for inspection.
+                if isinstance(blob, (list, tuple)):
+                    data = b"".join(bytes(x) for x in blob)
+                else:
+                    data = bytes(blob)
+                if b"HIMPORT" in data:
+                    blobs.append(data)
+                return await real_send(*a, **k)
+
+            conn.send_packed_command = send_packed_command
+        return conn
+
+    with mock.patch.object(pool, "get_connection", new=get_connection):
+        yield blobs
+
+
+@contextlib.asynccontextmanager
 async def track_himport_wire(conn):
     """Record how each HIMPORT write reached the socket, in order.
 
@@ -82,6 +116,23 @@ async def hr(create_redis):
     # PREPARE, so lazy-bundling wire assertions in the tests still hold.
     client.himport_registry.prepare("shared", SCHEMAS["shared"])
     return client
+
+
+@pytest.mark.onlynoncluster
+async def test_raw_case_insensitive_himport_set_is_intercepted(hr):
+    # A registered-but-not-yet-prepared fieldset used through the raw, case- and
+    # encoding-insensitive command name must still take the connection-state-aware
+    # path (lazy PREPARE), not send a bare SET that fails ``no such fieldset``.
+    await hr.himport_prepare("rawcmd", ["name", "email"])
+    await hr.delete("raw:{u}:1", "raw:{u}:2")
+    # Lowercase str name.
+    assert await hr.execute_command(
+        "himport set", "raw:{u}:1", "rawcmd", "alice", "a@x"
+    )
+    assert await hr.hget("raw:{u}:1", "name") == b"alice"
+    # Mixed-case bytes name.
+    assert await hr.execute_command(b"HImPoRt SeT", "raw:{u}:2", "rawcmd", "bob", "b@x")
+    assert await hr.hget("raw:{u}:2", "email") == b"b@x"
 
 
 async def test_runtime_prepare_without_init_schemas(create_redis):
@@ -266,6 +317,27 @@ async def test_pipeline_runtime_prepared_fieldset(hr):
     result = await pipe.execute()
     assert not any(isinstance(r, Exception) for r in result)
     assert await hr.hget("h:{u}:pl1", "y") == b"2"
+
+
+@pytest.mark.onlynoncluster
+async def test_pipeline_folds_prepare_into_single_write(hr):
+    # First pipeline use of a registered-but-not-yet-prepared fieldset must fold the
+    # PREPARE into the single batched write, not do a separate PREPARE round trip
+    # first. Spy every connection the pool hands out and assert exactly one HIMPORT-
+    # carrying packed write, containing both the PREPARE and the SETs.
+    await hr.himport_prepare("pfold", ["x", "y"])
+    pipe = hr.pipeline(transaction=False)
+    pipe.himport_set("pf:{u}:1", "pfold", ["1", "2"])
+    pipe.himport_set("pf:{u}:2", "pfold", ["3", "4"])
+    async with capture_himport_packed_writes(hr.connection_pool) as blobs:
+        await pipe.execute()
+    assert len(blobs) == 1, (
+        "PREPARE must be folded into the single pipeline write, "
+        f"got {len(blobs)} HIMPORT writes"
+    )
+    assert b"PREPARE" in blobs[0] and b"SET" in blobs[0]
+    assert await hr.hget("pf:{u}:1", "x") == b"1"
+    assert await hr.hget("pf:{u}:2", "y") == b"4"
 
 
 async def test_pipeline_watch_immediate_himport_set(hr):

--- a/tests/test_asyncio/test_multidb/test_pipeline.py
+++ b/tests/test_asyncio/test_multidb/test_pipeline.py
@@ -524,12 +524,15 @@ class TestPipelineHImportUnsupported:
     blocked there too. The overrides raise before touching the client, so no config
     or server is needed."""
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "method",
         ["himport_prepare", "himport_set", "himport_discard", "himport_discard_all"],
     )
-    async def test_pipeline_himport_methods_raise(self, method):
+    def test_pipeline_himport_methods_raise(self, method):
+        # Pipeline commands are staged synchronously (``pipe.set(...)`` returns the
+        # pipe, not a coroutine), so the guard must raise at call time without an
+        # ``await``; an ``async def`` override would only return an un-awaited
+        # coroutine and skip the command silently.
         pipe = MultiDBPipeline(Mock(spec=MultiDBClient))
         with pytest.raises(DataError, match="not supported on the multi-database"):
-            await getattr(pipe, method)("users", ["a"])
+            getattr(pipe, method)("users", ["a"])

--- a/tests/test_asyncio/test_multidb/test_pipeline.py
+++ b/tests/test_asyncio/test_multidb/test_pipeline.py
@@ -5,7 +5,8 @@ import pybreaker
 import pytest
 
 from redis.asyncio.client import Pipeline
-from redis.asyncio.multidb.client import MultiDBClient
+from redis.asyncio.multidb.client import MultiDBClient, Pipeline as MultiDBPipeline
+from redis.exceptions import DataError
 from redis.asyncio.multidb.config import InitialHealthCheck
 from redis.asyncio.multidb.failover import WeightBasedFailoverStrategy
 from redis.multidb.circuit import State as CBState, PBCircuitBreakerAdapter
@@ -513,3 +514,22 @@ class TestTransaction:
                 )
 
                 assert await client.transaction(callback) == ["OK1", "value"]
+
+
+@pytest.mark.onlynoncluster
+class TestPipelineHImportUnsupported:
+    """HIMPORT is unsupported on the multi-database client. The lifecycle methods
+    are blocked on ``MultiDBClient``; the pipeline inherits ``himport_set`` from
+    ``AsyncCoreCommands`` and would otherwise queue it silently, so it must be
+    blocked there too. The overrides raise before touching the client, so no config
+    or server is needed."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method",
+        ["himport_prepare", "himport_set", "himport_discard", "himport_discard_all"],
+    )
+    async def test_pipeline_himport_methods_raise(self, method):
+        pipe = MultiDBPipeline(Mock(spec=MultiDBClient))
+        with pytest.raises(DataError, match="not supported on the multi-database"):
+            await getattr(pipe, method)("users", ["a"])

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -2925,7 +2925,11 @@ class TestSearchWithVamana(AsyncSearchTestsBase):
 
 class TestHybridSearch(AsyncSearchTestsBase):
     _HYBRID_TIMEOUT_DIM = 8192
-    _HYBRID_TIMEOUT_DOCS = 1500
+    # The 1ms timeout only fires once the query runs long enough to hit a
+    # server timeout checkpoint; smaller data sets slip through and return no
+    # warnings. 6000 docs keeps the query comfortably above the 1ms limit so
+    # the timeout reliably triggers across hardware.
+    _HYBRID_TIMEOUT_DOCS = 6000
 
     async def _create_hybrid_search_index(self, decoded_r: redis.Redis, dim=4):
         await decoded_r.ft().create_index(

--- a/tests/test_asyncio/test_sentinel.py
+++ b/tests/test_asyncio/test_sentinel.py
@@ -478,3 +478,63 @@ async def test_sentinel_commands_with_strict_redis_client(request):
     assert isinstance(await client.sentinel_ckquorum("redis-py-test"), bool)
 
     await client.close()
+
+
+# ---------------------------------------------------------------------------
+# HIMPORT on Sentinel (async)
+# ---------------------------------------------------------------------------
+# Mirrors tests/test_sentinel.py: the client from ``master_for`` inherits the shared
+# ``HImportRegistry`` from ``ConnectionPool`` and declares fieldsets at runtime; the
+# registry lives on the long-lived pool so it survives failover.
+
+
+@pytest.mark.onlynoncluster
+async def test_himport_master_for_exposes_runtime_prepare(sentinel):
+    """``master_for`` returns a client exposing the HIMPORT family; runtime
+    ``himport_prepare`` populates the client's registry with no init argument, and
+    discard is never forbidden."""
+    async with sentinel.master_for("mymaster", db=9) as master:
+        assert await master.himport_prepare("users", ["name", "email", "age"]) is True
+        fs = master.himport_registry.get("users")
+        assert fs is not None
+        assert fs.fields == ("name", "email", "age")
+        assert await master.himport_discard("users") == 1
+        assert master.himport_registry.get("users") is None
+
+
+@pytest.mark.onlynoncluster
+async def test_himport_registry_shared_with_pool_connections(sentinel):
+    """The runtime-prepared fieldset lives on the pool-level registry object injected
+    into every connection via ``connection_kwargs``, so a connection created after a
+    Sentinel failover (pool re-point) still sees it."""
+    async with sentinel.master_for("mymaster", db=9) as master:
+        await master.himport_prepare("shared", ["a", "b"])
+        pool = master.connection_pool
+        assert pool.connection_kwargs["himport_registry"] is pool.himport_registry
+        assert "shared" in pool.himport_registry
+
+
+@pytest.mark.onlynoncluster
+async def test_himport_prepare_set_survives_reconnect(deployed_sentinel):
+    """Async mirror of the sync reconnect test: runtime ``himport_prepare`` on a
+    reused ``master_for`` client survives a connection drop (the Sentinel-failover
+    analog); the fieldset is re-prepared lazily on the next ``himport_set`` against
+    the re-pointed pool. Requires a deployed Sentinel and Redis >= 8.9.0."""
+    master = await deployed_sentinel.master_for("redis-py-test", db=0)
+    try:
+        await master.himport_prepare("users", ["name", "email"])
+        await master.delete("himport:sentinel:async:1")
+        await master.himport_set(
+            "himport:sentinel:async:1", "users", ["alice", "a@x.com"]
+        )
+    except exceptions.ResponseError as exc:
+        if "unknown command" in str(exc).lower() or "no such fieldset" in str(exc):
+            pytest.skip("server does not support HIMPORT")
+        raise
+    assert await master.hget("himport:sentinel:async:1", "name") == "alice"
+    # Drop pooled connections to simulate the failover reconnect, then reuse the same
+    # client: the fieldset is re-prepared lazily on the next himport_set.
+    await master.connection_pool.disconnect()
+    await master.delete("himport:sentinel:async:2")
+    await master.himport_set("himport:sentinel:async:2", "users", ["bob", "b@x.com"])
+    assert await master.hget("himport:sentinel:async:2", "email") == "b@x.com"

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -49,6 +49,7 @@ from redis.exceptions import (
     ResponseError,
     TimeoutError,
 )
+from redis.himport import HIMPORT_SET
 from redis.observability import recorder
 from redis.observability.config import OTelConfig, MetricGroup
 from redis.observability.metrics import RedisMetricsCollector
@@ -500,6 +501,56 @@ class TestRedisClusterObj:
             parse_response.side_effect = ask_redirect_effect
 
             assert r.execute_command("SET", "foo", "bar") == "MOCK_OK"
+
+    def test_himport_set_moved_after_ask_uses_moved_target(self, r):
+        """An HIMPORT SET that is ASK-redirected and then hits a MOVED
+        mid-exchange must retry against the MOVED target, not the stale ASK
+        target.
+
+        HIMPORT SET folds the ASK allowance into its own packed write, so the
+        retry loop keeps ``asking`` set until ``_himport_execute_set`` returns.
+        Regression guard: if that method raises a MOVED before returning,
+        ``asking`` must still be cleared so the next iteration takes the
+        moved-retry branch instead of re-sending to the old ASK node.
+        """
+        key = "himport:key"
+        slot = r.keyslot(key)
+        primary = r.nodes_manager.get_node_from_slot(slot)
+        others = [n for n in r.get_primaries() if n.name != primary.name]
+        if len(others) < 2:
+            pytest.skip("requires at least 3 primaries")
+        ask_node, moved_node = others[0], others[1]
+
+        calls = []
+
+        def himport_effect(redis_node, connection, *args, **kwargs):
+            calls.append((connection.host, connection.port))
+            if len(calls) == 1:
+                raise AskError(f"{slot} {ask_node.host}:{ask_node.port}")
+            if len(calls) == 2:
+                # MOVED raised from within the HIMPORT SET exchange, before the
+                # caller could clear ``asking``.
+                raise MovedError(f"{slot} {moved_node.host}:{moved_node.port}")
+            return "MOCK_OK"
+
+        # ``determine_slot`` parses HIMPORT SET keys via COMMAND INFO, which the
+        # test server may not know; pin it so the moved branch can recompute the
+        # target without a live HIMPORT-capable server.
+        with (
+            patch.object(RedisCluster, "determine_slot", return_value=slot),
+            patch.object(
+                RedisCluster, "_himport_execute_set", side_effect=himport_effect
+            ),
+        ):
+            assert (
+                r._execute_command(primary, HIMPORT_SET, key, "shared", "alice")
+                == "MOCK_OK"
+            )
+
+        assert calls[0] == (primary.host, primary.port)
+        assert calls[1] == (ask_node.host, ask_node.port)
+        # Third attempt must follow the MOVED redirect, not the stale ASK target.
+        assert calls[2] == (moved_node.host, moved_node.port)
 
     def test_handling_cluster_failover_to_a_replica(self, r):
         # Set the key we'll test for

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -995,6 +995,26 @@ class TestUnitCacheProxyConnection:
 
         assert len(cache.collection) == 0
 
+    def test_himport_prepared_is_reassignable_through_proxy(self):
+        # Regression: `_himport_prepared` must have a setter that delegates to the
+        # wrapped connection, mirroring `_himport_reconciled_revision`. A getter-only
+        # property would make `conn._himport_prepared = {}` (as `_reset_himport_state`
+        # does) raise AttributeError -- but only when client-side caching is enabled.
+        # Exercise the property descriptors directly, no full construction needed.
+        proxy = object.__new__(CacheProxyConnection)
+
+        class _Wrapped:
+            _himport_prepared = {"fs": 1}
+            _himport_reconciled_revision = 3
+
+        proxy._conn = _Wrapped()
+        assert proxy._himport_prepared == {"fs": 1}  # getter delegates
+        proxy._himport_prepared = {}  # setter delegates (was AttributeError)
+        assert proxy._conn._himport_prepared == {}
+        # symmetry with the existing reconciled-revision setter
+        proxy._himport_reconciled_revision = 7
+        assert proxy._conn._himport_reconciled_revision == 7
+
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
         reason="Pypy doesn't support side_effect",

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -13,278 +13,281 @@ from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool
 from redis.connection import BlockingConnectionPool, ConnectionPool
 from redis._parsers.base import BaseParser
 from redis.exceptions import DataError, NoSuchFieldsetError, ResponseError
-from redis.himport import HIMPORT_SET, FieldsetOrigin, HImportConfig, HImportFieldset
+from redis.himport import HIMPORT_SET, FieldsetOrigin, HImportRegistry, HImportFieldset
 from redis.sentinel import Sentinel, SentinelConnectionPool
 
 
 @pytest.mark.fixed_client
-class TestHImportConfig:
+class TestHImportRegistry:
     # -- construction -----------------------------------------------------
 
     def test_empty_by_default(self):
-        cfg = HImportConfig()
-        assert len(cfg) == 0
-        assert cfg.names() == []
-        assert cfg.items() == []
-        assert list(cfg) == []
-        assert cfg.get("missing") is None
-        assert "missing" not in cfg
+        registry = HImportRegistry()
+        assert len(registry) == 0
+        assert registry.names() == []
+        assert registry.items() == []
+        assert list(registry) == []
+        assert registry.get("missing") is None
+        assert "missing" not in registry
 
     def test_none_schemas_is_empty(self):
-        assert len(HImportConfig(None)) == 0
+        assert len(HImportRegistry(None)) == 0
 
     def test_constructor_entries_are_init(self):
-        cfg = HImportConfig({"shared": ["name", "email", "age"]})
-        fs = cfg.get("shared")
+        registry = HImportRegistry({"shared": ["name", "email", "age"]})
+        fs = registry.get("shared")
         assert isinstance(fs, HImportFieldset)
         assert fs.name == "shared"
         assert fs.fields == ("name", "email", "age")
         assert fs.origin is FieldsetOrigin.INIT
-        assert "shared" in cfg
-        assert cfg.names() == ["shared"]
+        assert "shared" in registry
+        assert registry.names() == ["shared"]
 
     def test_multiple_constructor_entries(self):
-        cfg = HImportConfig({"a": ["x"], "b": ["y", "z"]})
-        assert len(cfg) == 2
-        assert {name for name, _ in cfg.items()} == {"a", "b"}
-        assert all(fs.origin is FieldsetOrigin.INIT for _, fs in cfg.items())
+        registry = HImportRegistry({"a": ["x"], "b": ["y", "z"]})
+        assert len(registry) == 2
+        assert {name for name, _ in registry.items()} == {"a", "b"}
+        assert all(fs.origin is FieldsetOrigin.INIT for _, fs in registry.items())
 
     # -- field-order fidelity --------------------------------------------
 
     def test_field_order_preserved(self):
-        cfg = HImportConfig()
-        cfg.prepare("fs", ["c", "a", "b"])
-        assert cfg.get("fs").fields == ("c", "a", "b")
+        registry = HImportRegistry()
+        registry.prepare("fs", ["c", "a", "b"])
+        assert registry.get("fs").fields == ("c", "a", "b")
 
     def test_duplicates_not_deduplicated(self):
         # The server rejects duplicate field names; the client must not silently
         # deduplicate and hide that error.
-        cfg = HImportConfig()
-        cfg.prepare("fs", ["a", "a", "b"])
-        assert cfg.get("fs").fields == ("a", "a", "b")
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a", "a", "b"])
+        assert registry.get("fs").fields == ("a", "a", "b")
 
     def test_accepts_various_iterables(self):
-        cfg = HImportConfig()
-        cfg.prepare("tuple", ("a", "b"))
-        cfg.prepare("gen", (f"f{i}" for i in range(3)))
-        assert cfg.get("tuple").fields == ("a", "b")
-        assert cfg.get("gen").fields == ("f0", "f1", "f2")
+        registry = HImportRegistry()
+        registry.prepare("tuple", ("a", "b"))
+        registry.prepare("gen", (f"f{i}" for i in range(3)))
+        assert registry.get("tuple").fields == ("a", "b")
+        assert registry.get("gen").fields == ("f0", "f1", "f2")
 
     def test_empty_string_names_and_fields_allowed(self):
         # Empty strings are valid fieldset names and field names per the HLD;
         # the client must not reject them locally.
-        cfg = HImportConfig({"": [""]})
-        assert cfg.get("").fields == ("",)
-        cfg.prepare("fs", ["", "x", ""])
-        assert cfg.get("fs").fields == ("", "x", "")
+        registry = HImportRegistry({"": [""]})
+        assert registry.get("").fields == ("",)
+        registry.prepare("fs", ["", "x", ""])
+        assert registry.get("fs").fields == ("", "x", "")
 
     # -- validation -------------------------------------------------------
 
     def test_empty_field_list_rejected(self):
-        cfg = HImportConfig()
+        registry = HImportRegistry()
         with pytest.raises(DataError):
-            cfg.prepare("fs", [])
+            registry.prepare("fs", [])
 
     def test_empty_field_list_rejected_in_constructor(self):
         with pytest.raises(DataError):
-            HImportConfig({"fs": []})
+            HImportRegistry({"fs": []})
 
-    @pytest.mark.parametrize("bad", ["name", b"name"])
+    @pytest.mark.parametrize(
+        "bad", ["name", b"name", bytearray(b"name"), memoryview(b"name")]
+    )
     def test_string_fields_rejected(self, bad):
-        # A bare string would iterate character-by-character; reject it rather
-        # than silently register single-character fields.
-        cfg = HImportConfig()
+        # A bare single field name (str/bytes/bytearray/memoryview) would iterate
+        # element-by-element; reject it rather than silently register
+        # single-character/single-byte fields.
+        registry = HImportRegistry()
         with pytest.raises(DataError):
-            cfg.prepare("fs", bad)
+            registry.prepare("fs", bad)
 
     # -- versioning -------------------------------------------------------
 
     def test_versions_are_monotonic(self):
-        cfg = HImportConfig()
-        v1 = cfg.prepare("a", ["x"]).version
-        v2 = cfg.prepare("b", ["y"]).version
+        registry = HImportRegistry()
+        v1 = registry.prepare("a", ["x"]).version
+        v2 = registry.prepare("b", ["y"]).version
         assert v2 > v1
 
     def test_replace_bumps_version_and_updates_fields(self):
-        cfg = HImportConfig()
-        first = cfg.prepare("fs", ["a"])
-        second = cfg.prepare("fs", ["a", "b"])
+        registry = HImportRegistry()
+        first = registry.prepare("fs", ["a"])
+        second = registry.prepare("fs", ["a", "b"])
         assert second.version > first.version
-        assert cfg.get("fs").fields == ("a", "b")
-        assert len(cfg) == 1
+        assert registry.get("fs").fields == ("a", "b")
+        assert len(registry) == 1
 
     def test_readd_after_discard_gets_fresh_version(self):
-        cfg = HImportConfig()
-        first = cfg.prepare("fs", ["a"])
-        assert cfg.discard("fs") is True
-        reAdded = cfg.prepare("fs", ["a"])
+        registry = HImportRegistry()
+        first = registry.prepare("fs", ["a"])
+        assert registry.discard("fs") is True
+        reAdded = registry.prepare("fs", ["a"])
         assert reAdded.version > first.version
 
     # -- revision (mutation clock) ---------------------------------------
 
     def test_revision_starts_at_zero(self):
-        assert HImportConfig().revision == 0
+        assert HImportRegistry().revision == 0
 
     def test_revision_advances_on_prepare(self):
-        cfg = HImportConfig()
-        before = cfg.revision
-        cfg.prepare("fs", ["a"])
-        assert cfg.revision > before
+        registry = HImportRegistry()
+        before = registry.revision
+        registry.prepare("fs", ["a"])
+        assert registry.revision > before
 
     def test_revision_advances_on_discard(self):
-        cfg = HImportConfig()
-        cfg.prepare("fs", ["a"])
-        before = cfg.revision
-        cfg.discard("fs")
-        assert cfg.revision > before
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
+        before = registry.revision
+        registry.discard("fs")
+        assert registry.revision > before
 
     def test_revision_advances_on_discard_all(self):
-        cfg = HImportConfig()
-        cfg.prepare("a", ["x"])
-        cfg.prepare("b", ["y"])
-        before = cfg.revision
-        cfg.discard_all()
-        assert cfg.revision > before
+        registry = HImportRegistry()
+        registry.prepare("a", ["x"])
+        registry.prepare("b", ["y"])
+        before = registry.revision
+        registry.discard_all()
+        assert registry.revision > before
 
     def test_revision_unchanged_on_noop_discard(self):
-        cfg = HImportConfig()
-        before = cfg.revision
-        assert cfg.discard("missing") is False
-        assert cfg.revision == before
+        registry = HImportRegistry()
+        before = registry.revision
+        assert registry.discard("missing") is False
+        assert registry.revision == before
 
     def test_revision_unchanged_on_empty_discard_all(self):
-        cfg = HImportConfig()
-        before = cfg.revision
-        assert cfg.discard_all() == 0
-        assert cfg.revision == before
+        registry = HImportRegistry()
+        before = registry.revision
+        assert registry.discard_all() == 0
+        assert registry.revision == before
 
     def test_revision_unchanged_when_discard_init_raises(self):
-        cfg = HImportConfig({"fs": ["a"]})
-        before = cfg.revision
+        registry = HImportRegistry({"fs": ["a"]})
+        before = registry.revision
         with pytest.raises(DataError):
-            cfg.discard("fs")
-        assert cfg.revision == before
+            registry.discard("fs")
+        assert registry.revision == before
 
     # -- names_to_discard -------------------------------------------------
 
     def test_names_to_discard_returns_removed_names(self):
-        cfg = HImportConfig()
-        cfg.prepare("a", ["x"])
-        cfg.prepare("b", ["y"])
-        cfg.discard("a")
+        registry = HImportRegistry()
+        registry.prepare("a", ["x"])
+        registry.prepare("b", ["y"])
+        registry.discard("a")
         # Connection had prepared "a" and "b"; only "a" is now gone.
-        assert cfg.names_to_discard(["a", "b"]) == ["a"]
+        assert registry.names_to_discard(["a", "b"]) == ["a"]
 
     def test_names_to_discard_empty_when_all_registered(self):
-        cfg = HImportConfig({"a": ["x"], "b": ["y"]})
-        assert cfg.names_to_discard(["a", "b"]) == []
+        registry = HImportRegistry({"a": ["x"], "b": ["y"]})
+        assert registry.names_to_discard(["a", "b"]) == []
 
     def test_names_to_discard_preserves_input_order(self):
-        cfg = HImportConfig()
-        assert cfg.names_to_discard(["c", "a", "b"]) == ["c", "a", "b"]
+        registry = HImportRegistry()
+        assert registry.names_to_discard(["c", "a", "b"]) == ["c", "a", "b"]
 
     def test_names_to_discard_ignores_readd(self):
         # A name discarded then re-declared is still registered, so it is not
         # flagged for discard (the version bump handles re-prepare instead).
-        cfg = HImportConfig()
-        cfg.prepare("fs", ["a"])
-        cfg.discard("fs")
-        cfg.prepare("fs", ["a", "b"])
-        assert cfg.names_to_discard(["fs"]) == []
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
+        registry.discard("fs")
+        registry.prepare("fs", ["a", "b"])
+        assert registry.names_to_discard(["fs"]) == []
 
     # -- origin semantics -------------------------------------------------
 
     def test_prepare_new_name_is_runtime(self):
-        cfg = HImportConfig()
-        assert cfg.prepare("fs", ["a"]).origin is FieldsetOrigin.RUNTIME
+        registry = HImportRegistry()
+        assert registry.prepare("fs", ["a"]).origin is FieldsetOrigin.RUNTIME
 
     def test_reprepare_preserves_init_origin(self):
         # Re-preparing an init fieldset must keep it INIT so discard protection
         # cannot be bypassed.
-        cfg = HImportConfig({"fs": ["a"]})
-        updated = cfg.prepare("fs", ["a", "b"])
+        registry = HImportRegistry({"fs": ["a"]})
+        updated = registry.prepare("fs", ["a", "b"])
         assert updated.origin is FieldsetOrigin.INIT
         with pytest.raises(DataError):
-            cfg.discard("fs")
+            registry.discard("fs")
 
     def test_reprepare_preserves_runtime_origin(self):
-        cfg = HImportConfig()
-        cfg.prepare("fs", ["a"])
-        assert cfg.prepare("fs", ["a", "b"]).origin is FieldsetOrigin.RUNTIME
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
+        assert registry.prepare("fs", ["a", "b"]).origin is FieldsetOrigin.RUNTIME
 
     # -- discard ----------------------------------------------------------
 
     def test_discard_runtime_removes_and_returns_true(self):
-        cfg = HImportConfig()
-        cfg.prepare("fs", ["a"])
-        assert cfg.discard("fs") is True
-        assert "fs" not in cfg
-        assert len(cfg) == 0
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
+        assert registry.discard("fs") is True
+        assert "fs" not in registry
+        assert len(registry) == 0
 
     def test_discard_unknown_returns_false(self):
-        cfg = HImportConfig()
-        assert cfg.discard("missing") is False
+        registry = HImportRegistry()
+        assert registry.discard("missing") is False
 
     def test_discard_init_raises_and_keeps_entry(self):
-        cfg = HImportConfig({"fs": ["a"]})
+        registry = HImportRegistry({"fs": ["a"]})
         with pytest.raises(DataError):
-            cfg.discard("fs")
-        assert "fs" in cfg
+            registry.discard("fs")
+        assert "fs" in registry
 
     # -- discard_all ------------------------------------------------------
 
     def test_discard_all_removes_runtime_and_returns_count(self):
-        cfg = HImportConfig()
-        cfg.prepare("a", ["x"])
-        cfg.prepare("b", ["y"])
-        assert cfg.discard_all() == 2
-        assert len(cfg) == 0
+        registry = HImportRegistry()
+        registry.prepare("a", ["x"])
+        registry.prepare("b", ["y"])
+        assert registry.discard_all() == 2
+        assert len(registry) == 0
 
     def test_discard_all_on_empty_returns_zero(self):
-        assert HImportConfig().discard_all() == 0
+        assert HImportRegistry().discard_all() == 0
 
     def test_discard_all_rejected_when_init_present(self):
-        cfg = HImportConfig({"init": ["a"]})
-        cfg.prepare("runtime", ["b"])
+        registry = HImportRegistry({"init": ["a"]})
+        registry.prepare("runtime", ["b"])
         with pytest.raises(DataError):
-            cfg.discard_all()
+            registry.discard_all()
         # Registry left untouched by the rejection.
-        assert len(cfg) == 2
-        assert "init" in cfg
-        assert "runtime" in cfg
+        assert len(registry) == 2
+        assert "init" in registry
+        assert "runtime" in registry
 
     # -- read-only access / immutability ----------------------------------
 
     def test_fieldset_is_immutable(self):
-        cfg = HImportConfig({"fs": ["a"]})
-        fs = cfg.get("fs")
+        registry = HImportRegistry({"fs": ["a"]})
+        fs = registry.get("fs")
         with pytest.raises(Exception):
             fs.fields = ("b",)
 
     def test_items_snapshot_does_not_mutate_registry(self):
-        cfg = HImportConfig({"fs": ["a"]})
-        items = cfg.items()
+        registry = HImportRegistry({"fs": ["a"]})
+        items = registry.items()
         items.clear()
-        assert "fs" in cfg
+        assert "fs" in registry
 
     def test_repr_lists_entries(self):
-        cfg = HImportConfig({"fs": ["a", "b"]})
-        text = repr(cfg)
+        registry = HImportRegistry({"fs": ["a", "b"]})
+        text = repr(registry)
         assert "fs" in text
         assert "INIT" in text
 
     def test_concurrent_prepares_do_not_lose_revision_bumps(self):
-        # A sync Redis instance (and its shared HImportConfig) is routinely used
+        # A sync Redis instance (and its shared HImportRegistry) is routinely used
         # across threads. Each prepare of a distinct name must advance the revision
         # exactly once; the mutation lock keeps the read-modify-write from racing and
         # collapsing bumps, which would let a connection skip a reconcile.
-        cfg = HImportConfig()
+        registry = HImportRegistry()
         count = 200
         barrier = threading.Barrier(count)
 
         def worker(i):
             barrier.wait()  # maximize contention on the mutation path
-            cfg.prepare(f"fs{i}", ["a"])
+            registry.prepare(f"fs{i}", ["a"])
 
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(count)]
         for t in threads:
@@ -292,8 +295,58 @@ class TestHImportConfig:
         for t in threads:
             t.join()
 
-        assert len(cfg) == count
-        assert cfg.revision == count  # no bump lost to a race
+        assert len(registry) == count
+        assert registry.revision == count  # no bump lost to a race
+
+    def test_concurrent_reads_and_mutations_never_raise(self):
+        # A shared sync registry may be iterated/snapshotted by one thread while
+        # another prepares/discards. The iterating reads take the mutation lock, so
+        # none of them may observe a mid-mutation resize (which would surface as
+        # "dictionary changed size during iteration") or a torn view.
+        registry = HImportRegistry()
+        # Seed some runtime entries so discards have something to remove from iteration 0.
+        for i in range(20):
+            registry.prepare(f"seed{i}", ["a"])
+
+        iterations = 500
+        errors = []
+        n_readers, n_mutators = 4, 4
+        barrier = threading.Barrier(n_readers + n_mutators)
+
+        def reader():
+            barrier.wait()
+            try:
+                for _ in range(iterations):
+                    list(registry)
+                    registry.items()
+                    registry.names()
+                    repr(registry)
+                    registry.names_to_discard([f"seed{j}" for j in range(20)])
+            except Exception as exc:  # pragma: no cover - only on regression
+                errors.append(exc)
+
+        def mutator(worker):
+            barrier.wait()
+            try:
+                for i in range(iterations):
+                    name = f"w{worker}-{i}"
+                    registry.prepare(name, ["a", "b"])
+                    registry.discard(name)
+                    if i % 50 == 0:
+                        registry.discard_all()
+            except Exception as exc:  # pragma: no cover - only on regression
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(n_readers)]
+        threads += [
+            threading.Thread(target=mutator, args=(w,)) for w in range(n_mutators)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
 
 
 class _RecordingConn:
@@ -304,8 +357,8 @@ class _RecordingConn:
     DISCARD/PREPARE read loops can be exercised without a real socket.
     """
 
-    def __init__(self, cfg, prepared=None):
-        self.himport_config = cfg
+    def __init__(self, registry, prepared=None):
+        self.himport_registry = registry
         self._himport_prepared = dict(prepared or {})
         self._himport_reconciled_revision = 0
 
@@ -329,8 +382,8 @@ class _CapturingConn(_RecordingConn):
     exact command ordering (e.g. that ASKING is packed immediately before the SET).
     """
 
-    def __init__(self, cfg, prepared=None):
-        super().__init__(cfg, prepared)
+    def __init__(self, registry, prepared=None):
+        super().__init__(registry, prepared)
         self.writes = []
 
     def send_packed_command(self, packed, **kwargs):
@@ -359,10 +412,10 @@ class TestHImportBatchedReadDrain:
         # prepare+discard advances the revision so the connection reconciles; it has
         # three stale prepared fieldsets, so three DISCARD replies must be read even
         # though the second one errors.
-        cfg = HImportConfig()
-        cfg.prepare("a", ["f"])
-        cfg.discard("a")
-        conn = _RecordingConn(cfg, {"a": 1, "b": 1, "c": 1})
+        registry = HImportRegistry()
+        registry.prepare("a", ["f"])
+        registry.discard("a")
+        conn = _RecordingConn(registry, {"a": 1, "b": 1, "c": 1})
         client = Redis()
         replies = [True, ResponseError("boom"), True]
         with mock.patch.object(client, "parse_response", side_effect=replies) as pr:
@@ -372,9 +425,9 @@ class TestHImportBatchedReadDrain:
         assert conn._himport_prepared == {}  # every stale name dropped regardless
 
     def test_prepare_pipeline_drains_all_replies_on_error(self):
-        cfg = HImportConfig({"a": ["f"], "b": ["f"]})
-        conn = _RecordingConn(cfg)
-        conn._himport_reconciled_revision = cfg.revision  # no discard to reconcile
+        registry = HImportRegistry({"a": ["f"], "b": ["f"]})
+        conn = _RecordingConn(registry)
+        conn._himport_reconciled_revision = registry.revision  # no discard to reconcile
         commands = [
             (("HIMPORT SET", "k1", "a", "v"), {}),
             (("HIMPORT SET", "k2", "b", "v"), {}),
@@ -391,10 +444,10 @@ class TestHImportBatchedReadDrain:
 
     def test_async_reconcile_discards_drains_all_replies_on_error(self):
         async def run():
-            cfg = HImportConfig()
-            cfg.prepare("a", ["f"])
-            cfg.discard("a")
-            conn = _AsyncRecordingConn(cfg, {"a": 1, "b": 1, "c": 1})
+            registry = HImportRegistry()
+            registry.prepare("a", ["f"])
+            registry.discard("a")
+            conn = _AsyncRecordingConn(registry, {"a": 1, "b": 1, "c": 1})
             client = AsyncRedis()
             client.parse_response = mock.AsyncMock(
                 side_effect=[True, ResponseError("boom"), True]
@@ -408,9 +461,9 @@ class TestHImportBatchedReadDrain:
 
     def test_async_prepare_pipeline_drains_all_replies_on_error(self):
         async def run():
-            cfg = HImportConfig({"a": ["f"], "b": ["f"]})
-            conn = _AsyncRecordingConn(cfg)
-            conn._himport_reconciled_revision = cfg.revision
+            registry = HImportRegistry({"a": ["f"], "b": ["f"]})
+            conn = _AsyncRecordingConn(registry)
+            conn._himport_reconciled_revision = registry.revision
             commands = [
                 (("HIMPORT SET", "k1", "a", "v"), {}),
                 (("HIMPORT SET", "k2", "b", "v"), {}),
@@ -428,12 +481,119 @@ class TestHImportBatchedReadDrain:
         asyncio.run(run())
 
 
+DISCARD_B = ("HIMPORT", "DISCARD", "b")
+
+
+@pytest.mark.fixed_client
+class TestHImportReconcileRevisionStamp:
+    """Reconcile must stamp the connection with the revision it actually caught up
+    to, not the live registry revision read after the DISCARD I/O completes.
+
+    A ``himport_discard`` that lands while reconcile is draining replies (a
+    thread-shared sync client, or another task while an async reconcile awaits)
+    advances the registry revision. If reconcile then re-read that live revision to
+    stamp the connection, the connection would be marked reconciled past a discard
+    it never sent — leaving the just-removed fieldset prepared on the server session
+    and permanently short-circuiting future reconciles. It must stamp the revision
+    snapshotted *before* ``stale`` was computed, so the next reconcile re-runs and
+    drops the fieldset.
+    """
+
+    def test_sync_reconcile_does_not_overstamp_on_concurrent_discard(self):
+        registry = HImportRegistry()
+        va = registry.prepare("a", ["f"]).version
+        vb = registry.prepare("b", ["f"]).version
+        registry.discard("a")  # "a" is stale; "b" still registered
+        conn = _CapturingConn(registry, {"a": va, "b": vb})
+        rev_after_a = registry.revision
+        client = Redis()
+
+        def drain(*args, **kwargs):
+            # A concurrent himport_discard lands while the DISCARD-"a" reply is read.
+            registry.discard("b")
+            return True
+
+        with mock.patch.object(client, "parse_response", side_effect=drain):
+            client._himport_reconcile_discards(conn)
+
+        # "a" was discarded and dropped from the connection's prepared set.
+        assert conn._himport_prepared == {"b": vb}
+        # The connection is stamped to the pre-drain snapshot, not the post-discard
+        # revision, so it is not falsely considered up to date for "b".
+        assert conn._himport_reconciled_revision == rev_after_a
+        assert conn._himport_reconciled_revision != registry.revision
+
+        # A second reconcile now sees "b" as stale and DISCARDs it on the connection.
+        conn.writes.clear()
+        with mock.patch.object(client, "parse_response", return_value=True):
+            client._himport_reconcile_discards(conn)
+        assert conn._himport_prepared == {}
+        assert conn.writes == [("packed", [DISCARD_B])]
+        assert conn._himport_reconciled_revision == registry.revision
+
+    def test_async_reconcile_does_not_overstamp_on_concurrent_discard(self):
+        async def run():
+            registry = HImportRegistry()
+            va = registry.prepare("a", ["f"]).version
+            vb = registry.prepare("b", ["f"]).version
+            registry.discard("a")
+            conn = _AsyncCapturingConn(registry, {"a": va, "b": vb})
+            rev_after_a = registry.revision
+            client = AsyncRedis()
+
+            def drain(*args, **kwargs):
+                registry.discard("b")
+                return True
+
+            client.parse_response = mock.AsyncMock(side_effect=drain)
+            await client._himport_reconcile_discards(conn)
+            assert conn._himport_prepared == {"b": vb}
+            assert conn._himport_reconciled_revision == rev_after_a
+            assert conn._himport_reconciled_revision != registry.revision
+
+            conn.writes.clear()
+            client.parse_response = mock.AsyncMock(return_value=True)
+            await client._himport_reconcile_discards(conn)
+            assert conn._himport_prepared == {}
+            assert conn.writes == [("packed", [DISCARD_B])]
+            assert conn._himport_reconciled_revision == registry.revision
+
+        asyncio.run(run())
+
+    def test_async_cluster_reconcile_does_not_overstamp_on_concurrent_discard(self):
+        # The async ClusterNode owns its own _himport_reconcile_discards; guard it too.
+        async def run():
+            registry = HImportRegistry()
+            va = registry.prepare("a", ["f"]).version
+            vb = registry.prepare("b", ["f"]).version
+            registry.discard("a")
+            conn = _AsyncCapturingConn(registry, {"a": va, "b": vb})
+            rev_after_a = registry.revision
+            node = mock.Mock()
+
+            def drain(*args, **kwargs):
+                registry.discard("b")
+                return True
+
+            node.parse_response = mock.AsyncMock(side_effect=drain)
+            await async_cluster_mod.ClusterNode._himport_reconcile_discards(node, conn)
+            assert conn._himport_prepared == {"b": vb}
+            assert conn._himport_reconciled_revision == rev_after_a
+            assert conn._himport_reconciled_revision != registry.revision
+
+            conn.writes.clear()
+            node.parse_response = mock.AsyncMock(return_value=True)
+            await async_cluster_mod.ClusterNode._himport_reconcile_discards(node, conn)
+            assert conn._himport_prepared == {}
+            assert conn.writes == [("packed", [DISCARD_B])]
+            assert conn._himport_reconciled_revision == registry.revision
+
+        asyncio.run(run())
+
+
 PREPARE_FS_AB = ("HIMPORT", "PREPARE", "fs", "a", "b")
 ASKING = ("ASKING",)
 SET_K_FS = ("HIMPORT", "SET", "k", "fs", "v")
-
-
-DISCARD_GONE = ("HIMPORT", "DISCARD", "gone")
 
 
 @pytest.mark.fixed_client
@@ -444,53 +604,105 @@ class TestHImportAskRedirectSync:
     Redis clears the per-command ASKING flag after the next command, so any
     session command (deferred DISCARD, lazy PREPARE) sent between ASKING and the
     SET would consume the allowance and leave the slot-scoped SET to fail or
-    redirect again during migration. On the sync cluster the dispatch loop runs
-    ``RedisCluster._himport_prepare_for_asking`` (reconcile + lazy PREPARE) before
-    sending ASKING, so ASKING lands right before the bare SET the node then issues.
-    ``_himport_prepare_for_asking`` ignores ``self``; call it unbound for the test.
+    redirect again during migration. The sync cluster owns its own HIMPORT
+    executor on ``RedisCluster`` (mirroring the async ``ClusterNode``): the ASKING
+    allowance is folded into the SET's own packed write so it lands immediately
+    before the SET. ``_himport_prepare_and_set`` ignores ``self`` (call it unbound);
+    ``_himport_execute_set`` dispatches to it via ``self``, so a stub ``self``
+    carrying the real methods exercises the real code. ``parse_response`` /
+    ``_himport_reconcile_discards`` are taken from the ``redis_node`` argument.
     """
 
-    def test_prepare_for_asking_sends_bare_prepare(self):
-        cfg = HImportConfig({"fs": ["a", "b"]})
-        conn = _CapturingConn(cfg)
-        conn._himport_reconciled_revision = cfg.revision  # nothing to reconcile
-        redis_node = Redis()
-        with mock.patch.object(redis_node, "parse_response", side_effect=["OK"]) as pr:
-            cluster_mod.RedisCluster._himport_prepare_for_asking(
-                None, redis_node, conn, "fs"
-            )
-        # A single bare PREPARE (the caller sends ASKING itself, right after).
-        assert conn.writes == [("cmd", PREPARE_FS_AB)]
-        assert conn._himport_prepared["fs"] == cfg.get("fs").version
-        assert pr.call_count == 1
+    class _ClusterStub:
+        _himport_execute_set = cluster_mod.RedisCluster._himport_execute_set
+        _himport_prepare_and_set = cluster_mod.RedisCluster._himport_prepare_and_set
 
-    def test_prepare_for_asking_noop_when_already_prepared(self):
-        cfg = HImportConfig({"fs": ["a"]})
-        fieldset = cfg.get("fs")
-        conn = _CapturingConn(cfg, prepared={"fs": fieldset.version})
-        conn._himport_reconciled_revision = cfg.revision
-        redis_node = Redis()
-        cluster_mod.RedisCluster._himport_prepare_for_asking(
-            None, redis_node, conn, "fs"
+    def test_prepare_and_set_packs_prepare_asking_set(self):
+        registry = HImportRegistry({"fs": ["a", "b"]})
+        conn = _CapturingConn(registry)
+        fieldset = registry.get("fs")
+        node = mock.Mock()
+        node.parse_response = mock.Mock(side_effect=["OK", "OK", 1])
+        resp = cluster_mod.RedisCluster._himport_prepare_and_set(
+            None, node, conn, "k", "fs", ["v"], fieldset, asking=True
         )
-        assert conn.writes == []  # nothing sent before ASKING
+        assert resp == 1
+        assert conn.writes == [("packed", [PREPARE_FS_AB, ASKING, SET_K_FS])]
+        assert conn._himport_prepared["fs"] == fieldset.version
+        assert node.parse_response.call_count == 3
 
-    def test_prepare_for_asking_reconciles_discards_first(self):
-        # A stale prepared fieldset is DISCARDed (session command, no allowance
-        # needed) ahead of everything; the already-prepared target needs no PREPARE.
-        cfg = HImportConfig({"fs": ["a"]})
-        cfg.prepare("gone", ["x"])
-        cfg.discard("gone")
-        fieldset = cfg.get("fs")
-        conn = _CapturingConn(cfg, prepared={"gone": 1, "fs": fieldset.version})
-        conn._himport_reconciled_revision = 0  # force a reconcile pass
-        redis_node = Redis()
-        with mock.patch.object(redis_node, "parse_response", side_effect=[1]):
-            cluster_mod.RedisCluster._himport_prepare_for_asking(
-                None, redis_node, conn, "fs"
-            )
-        assert conn.writes == [("packed", [DISCARD_GONE])]
-        assert "gone" not in conn._himport_prepared
+    def test_prepare_and_set_without_asking_keeps_bundle(self):
+        # Regression guard: without an ASK redirect the batch stays [PREPARE, SET].
+        registry = HImportRegistry({"fs": ["a", "b"]})
+        conn = _CapturingConn(registry)
+        fieldset = registry.get("fs")
+        node = mock.Mock()
+        node.parse_response = mock.Mock(side_effect=["OK", 1])
+        cluster_mod.RedisCluster._himport_prepare_and_set(
+            None, node, conn, "k", "fs", ["v"], fieldset
+        )
+        assert conn.writes == [("packed", [PREPARE_FS_AB, SET_K_FS])]
+
+    def test_bare_set_packs_asking_then_set(self):
+        registry = HImportRegistry({"fs": ["a"]})
+        fieldset = registry.get("fs")
+        conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
+        conn._himport_reconciled_revision = registry.revision
+        node = mock.Mock()
+        node._himport_reconcile_discards = mock.Mock()
+        node.parse_response = mock.Mock(side_effect=["OK", 1])
+        resp = self._ClusterStub()._himport_execute_set(
+            node, conn, "k", "fs", ["v"], asking=True
+        )
+        assert resp == 1
+        assert conn.writes == [("packed", [ASKING, SET_K_FS])]
+
+    def test_bare_set_recovers_with_asking_on_missing_fieldset(self):
+        # The bare SET's ASKING allowance is consumed by the failed SET, so the
+        # NoSuchFieldsetError recovery must re-arm ASKING: [PREPARE, ASKING, SET].
+        registry = HImportRegistry({"fs": ["a", "b"]})
+        fieldset = registry.get("fs")
+        conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
+        conn._himport_reconciled_revision = registry.revision
+        node = mock.Mock()
+        node._himport_reconcile_discards = mock.Mock()
+        node.parse_response = mock.Mock(
+            side_effect=[
+                "OK",  # ASKING (bare)
+                NoSuchFieldsetError("no such fieldset"),  # SET (bare) -> recover
+                "OK",  # PREPARE (recovery)
+                "OK",  # ASKING (recovery)
+                1,  # SET (recovery)
+            ]
+        )
+        resp = self._ClusterStub()._himport_execute_set(
+            node, conn, "k", "fs", ["v"], asking=True
+        )
+        assert resp == 1
+        assert conn.writes == [
+            ("packed", [ASKING, SET_K_FS]),
+            ("packed", [PREPARE_FS_AB, ASKING, SET_K_FS]),
+        ]
+        assert conn._himport_prepared["fs"] == fieldset.version
+        assert node.parse_response.call_count == 5
+
+    def test_bare_set_recovery_without_asking_keeps_bundle(self):
+        # Regression: a non-ASK recovery still packs [PREPARE, SET] (no ASKING).
+        registry = HImportRegistry({"fs": ["a", "b"]})
+        fieldset = registry.get("fs")
+        conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
+        conn._himport_reconciled_revision = registry.revision
+        node = mock.Mock()
+        node._himport_reconcile_discards = mock.Mock()
+        node.parse_response = mock.Mock(
+            side_effect=[NoSuchFieldsetError("no such fieldset"), "OK", 1]
+        )
+        resp = self._ClusterStub()._himport_execute_set(node, conn, "k", "fs", ["v"])
+        assert resp == 1
+        assert conn.writes == [
+            ("cmd", SET_K_FS),
+            ("packed", [PREPARE_FS_AB, SET_K_FS]),
+        ]
 
 
 @pytest.mark.fixed_client
@@ -504,9 +716,9 @@ class TestHImportAskRedirectAsyncCluster:
 
     def test_prepare_and_set_packs_prepare_asking_set(self):
         async def run():
-            cfg = HImportConfig({"fs": ["a", "b"]})
-            conn = _AsyncCapturingConn(cfg)
-            fieldset = cfg.get("fs")
+            registry = HImportRegistry({"fs": ["a", "b"]})
+            conn = _AsyncCapturingConn(registry)
+            fieldset = registry.get("fs")
             node = mock.Mock()
             node.parse_response = mock.AsyncMock(side_effect=["OK", "OK", 1])
             resp = await async_cluster_mod.ClusterNode._himport_prepare_and_set(
@@ -522,9 +734,9 @@ class TestHImportAskRedirectAsyncCluster:
     def test_prepare_and_set_without_asking_keeps_bundle(self):
         # Regression guard: without an ASK redirect the batch stays [PREPARE, SET].
         async def run():
-            cfg = HImportConfig({"fs": ["a", "b"]})
-            conn = _AsyncCapturingConn(cfg)
-            fieldset = cfg.get("fs")
+            registry = HImportRegistry({"fs": ["a", "b"]})
+            conn = _AsyncCapturingConn(registry)
+            fieldset = registry.get("fs")
             node = mock.Mock()
             node.parse_response = mock.AsyncMock(side_effect=["OK", 1])
             await async_cluster_mod.ClusterNode._himport_prepare_and_set(
@@ -536,10 +748,10 @@ class TestHImportAskRedirectAsyncCluster:
 
     def test_bare_set_packs_asking_then_set(self):
         async def run():
-            cfg = HImportConfig({"fs": ["a"]})
-            fieldset = cfg.get("fs")
-            conn = _AsyncCapturingConn(cfg, prepared={"fs": fieldset.version})
-            conn._himport_reconciled_revision = cfg.revision
+            registry = HImportRegistry({"fs": ["a"]})
+            fieldset = registry.get("fs")
+            conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
+            conn._himport_reconciled_revision = registry.revision
             node = mock.Mock()
             node._himport_reconcile_discards = mock.AsyncMock()
             node.parse_response = mock.AsyncMock(side_effect=["OK", 1])
@@ -551,13 +763,74 @@ class TestHImportAskRedirectAsyncCluster:
 
         asyncio.run(run())
 
+    def test_bare_set_recovers_with_asking_on_missing_fieldset(self):
+        # The bare SET's ASKING allowance is consumed by the failed SET, so the
+        # NoSuchFieldsetError recovery must re-arm ASKING: [PREPARE, ASKING, SET].
+        async def run():
+            registry = HImportRegistry({"fs": ["a", "b"]})
+            fieldset = registry.get("fs")
+            conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
+            conn._himport_reconciled_revision = registry.revision
+            node = mock.Mock()
+            node._himport_reconcile_discards = mock.AsyncMock()
+            node.parse_response = mock.AsyncMock(
+                side_effect=[
+                    "OK",  # ASKING (bare)
+                    NoSuchFieldsetError("no such fieldset"),  # SET (bare) -> recover
+                    "OK",  # PREPARE (recovery)
+                    "OK",  # ASKING (recovery)
+                    1,  # SET (recovery)
+                ]
+            )
+            node._himport_prepare_and_set = (
+                async_cluster_mod.ClusterNode._himport_prepare_and_set.__get__(node)
+            )
+            resp = await async_cluster_mod.ClusterNode._himport_execute_set(
+                node, conn, "k", "fs", ["v"], asking=True
+            )
+            assert resp == 1
+            assert conn.writes == [
+                ("packed", [ASKING, SET_K_FS]),
+                ("packed", [PREPARE_FS_AB, ASKING, SET_K_FS]),
+            ]
+            assert conn._himport_prepared["fs"] == fieldset.version
+            assert node.parse_response.call_count == 5
+
+        asyncio.run(run())
+
+    def test_bare_set_recovery_without_asking_keeps_bundle(self):
+        # Regression: a non-ASK recovery still packs [PREPARE, SET] (no ASKING).
+        async def run():
+            registry = HImportRegistry({"fs": ["a", "b"]})
+            fieldset = registry.get("fs")
+            conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
+            conn._himport_reconciled_revision = registry.revision
+            node = mock.Mock()
+            node._himport_reconcile_discards = mock.AsyncMock()
+            node.parse_response = mock.AsyncMock(
+                side_effect=[NoSuchFieldsetError("no such fieldset"), "OK", 1]
+            )
+            node._himport_prepare_and_set = (
+                async_cluster_mod.ClusterNode._himport_prepare_and_set.__get__(node)
+            )
+            resp = await async_cluster_mod.ClusterNode._himport_execute_set(
+                node, conn, "k", "fs", ["v"]
+            )
+            assert resp == 1
+            assert conn.writes == [
+                ("cmd", SET_K_FS),
+                ("packed", [PREPARE_FS_AB, SET_K_FS]),
+            ]
+
+        asyncio.run(run())
+
 
 @pytest.mark.fixed_client
 class TestHImportSingleConnectionPrepareMaterializesFields:
     """On a single-connection client the immediate wire PREPARE must send the
     fully materialized fields even when the caller passes a one-shot iterable.
 
-    ``himport_config.prepare`` consumes the iterable into a tuple, so re-passing
+    ``himport_registry.prepare`` consumes the iterable into a tuple, so re-passing
     the original ``fields`` to the wire call would forward an exhausted iterator
     and PREPARE zero fields. The wire call must reuse the stored
     ``HImportFieldset.fields`` returned by ``prepare`` instead.
@@ -573,7 +846,7 @@ class TestHImportSingleConnectionPrepareMaterializesFields:
         with mock.patch.object(client, "himport_prepare_internal") as internal:
             client.himport_prepare("fs", (f"f{i}" for i in range(3)))
         internal.assert_called_once_with("fs", ("f0", "f1", "f2"))
-        assert conn._himport_prepared["fs"] == client.himport_config.get("fs").version
+        assert conn._himport_prepared["fs"] == client.himport_registry.get("fs").version
 
     def test_async_generator_fields_reach_wire_prepare(self):
         async def run():
@@ -590,7 +863,8 @@ class TestHImportSingleConnectionPrepareMaterializesFields:
                 "fs", ("f0", "f1", "f2")
             )
             assert (
-                conn._himport_prepared["fs"] == client.himport_config.get("fs").version
+                conn._himport_prepared["fs"]
+                == client.himport_registry.get("fs").version
             )
 
         asyncio.run(run())
@@ -600,41 +874,41 @@ class TestHImportSingleConnectionPrepareMaterializesFields:
 class TestHImportPropagationSync:
     """Data propagation: client -> pool -> connection (standalone + sentinel)."""
 
-    def test_pool_builds_config_from_schemas(self):
+    def test_pool_builds_registry_from_schemas(self):
         pool = ConnectionPool(himport_schemas={"shared": ["a", "b"]})
-        assert isinstance(pool.himport_config, HImportConfig)
-        assert pool.himport_config.get("shared").fields == ("a", "b")
+        assert isinstance(pool.himport_registry, HImportRegistry)
+        assert pool.himport_registry.get("shared").fields == ("a", "b")
         conn = pool.make_connection()
         # Same shared object reaches the connection, plus empty per-conn state.
-        assert conn.himport_config is pool.himport_config
+        assert conn.himport_registry is pool.himport_registry
         assert conn._himport_prepared == {}
         assert conn._himport_reconciled_revision == 0
 
-    def test_pool_accepts_prebuilt_config_internally(self):
+    def test_pool_accepts_prebuilt_registry_internally(self):
         # Internal channel (used by the cluster to share one object): a pre-built
-        # himport_config passed via connection_kwargs is used as-is, not rebuilt.
-        cfg = HImportConfig({"x": ["1"]})
-        pool = ConnectionPool(himport_config=cfg)
-        assert pool.himport_config is cfg
-        assert pool.make_connection().himport_config is cfg
+        # himport_registry passed via connection_kwargs is used as-is, not rebuilt.
+        registry = HImportRegistry({"x": ["1"]})
+        pool = ConnectionPool(himport_registry=registry)
+        assert pool.himport_registry is registry
+        assert pool.make_connection().himport_registry is registry
 
-    def test_pool_empty_config_when_unconfigured(self):
-        # A config always exists (empty) so runtime himport_prepare has a single
+    def test_pool_empty_registry_when_unconfigured(self):
+        # A registry always exists (empty) so runtime himport_prepare has a single
         # shared object to mutate; the same object reaches connections.
         pool = ConnectionPool()
-        assert isinstance(pool.himport_config, HImportConfig)
-        assert len(pool.himport_config) == 0
-        assert pool.make_connection().himport_config is pool.himport_config
+        assert isinstance(pool.himport_registry, HImportRegistry)
+        assert len(pool.himport_registry) == 0
+        assert pool.make_connection().himport_registry is pool.himport_registry
 
     def test_blocking_pool_resolves(self):
         pool = BlockingConnectionPool(himport_schemas={"s": ["a"]})
-        assert pool.himport_config.get("s").fields == ("a",)
-        assert pool.make_connection().himport_config is pool.himport_config
+        assert pool.himport_registry.get("s").fields == ("a",)
+        assert pool.make_connection().himport_registry is pool.himport_registry
 
     def test_redis_property_and_propagation(self):
         r = Redis(himport_schemas={"shared": ["name", "email"]})
-        assert r.himport_config is r.connection_pool.himport_config
-        assert r.himport_config.get("shared").fields == ("name", "email")
+        assert r.himport_registry is r.connection_pool.himport_registry
+        assert r.himport_registry.get("shared").fields == ("name", "email")
 
     def test_redis_unix_socket_propagates_schemas(self):
         # Regression: himport_schemas must propagate for Unix-socket clients, not
@@ -643,18 +917,18 @@ class TestHImportPropagationSync:
             unix_socket_path="/tmp/does-not-connect.sock",
             himport_schemas={"shared": ["name", "email"]},
         )
-        assert r.himport_config is r.connection_pool.himport_config
-        assert r.himport_config.get("shared").fields == ("name", "email")
+        assert r.himport_registry is r.connection_pool.himport_registry
+        assert r.himport_registry.get("shared").fields == ("name", "email")
 
     def test_redis_unconfigured_is_empty(self):
-        cfg = Redis().himport_config
-        assert isinstance(cfg, HImportConfig)
-        assert len(cfg) == 0
+        registry = Redis().himport_registry
+        assert isinstance(registry, HImportRegistry)
+        assert len(registry) == 0
 
-    def test_redis_has_no_public_himport_config_param(self):
-        # himport_config (the object) is internal-only; the sole public knob is the
-        # schemas dict, so the client never holds a caller-supplied mutable config.
-        assert "himport_config" not in inspect.signature(Redis.__init__).parameters
+    def test_redis_has_no_public_himport_registry_param(self):
+        # himport_registry (the object) is internal-only; the sole public knob is the
+        # schemas dict, so the client never holds a caller-supplied mutable registry.
+        assert "himport_registry" not in inspect.signature(Redis.__init__).parameters
 
     def test_sentinel_pool_resolves_via_connection_kwargs(self):
         # Sentinel needs no edits: himport_schemas rides in connection_kwargs and
@@ -662,7 +936,7 @@ class TestHImportPropagationSync:
         s = Sentinel([("127.0.0.1", 26379)], himport_schemas={"s": ["a"]})
         assert s.connection_kwargs.get("himport_schemas") == {"s": ["a"]}
         pool = SentinelConnectionPool("mymaster", s, himport_schemas={"s": ["a"]})
-        assert pool.himport_config.get("s").fields == ("a",)
+        assert pool.himport_registry.get("s").fields == ("a",)
 
 
 @pytest.mark.fixed_client
@@ -672,17 +946,17 @@ class TestHImportPropagationAsync:
     def test_async_pool_and_client(self):
         async def run():
             pool = AsyncConnectionPool(himport_schemas={"s": ["a", "b"]})
-            assert pool.himport_config.get("s").fields == ("a", "b")
+            assert pool.himport_registry.get("s").fields == ("a", "b")
             conn = pool.make_connection()
-            assert conn.himport_config is pool.himport_config
+            assert conn.himport_registry is pool.himport_registry
             assert conn._himport_prepared == {}
             assert conn._himport_reconciled_revision == 0
 
             r = AsyncRedis(himport_schemas={"s": ["a"]})
-            assert r.himport_config is r.connection_pool.himport_config
-            assert r.himport_config.get("s").fields == ("a",)
+            assert r.himport_registry is r.connection_pool.himport_registry
+            assert r.himport_registry.get("s").fields == ("a",)
 
-            assert len(AsyncRedis().himport_config) == 0
+            assert len(AsyncRedis().himport_registry) == 0
 
         asyncio.run(run())
 
@@ -692,7 +966,7 @@ class TestHImportSetValueValidation:
     """himport_set must reject bare string-like value iterables (str/bytes/
     bytearray/memoryview): splatting them sends single chars/bytes as separate
     positional values instead of one value. The guard runs before any connection
-    use, so no server is needed. Mirrors HImportConfig's field-list guard."""
+    use, so no server is needed. Mirrors HImportRegistry's field-list guard."""
 
     @pytest.mark.parametrize("bad", ["abc", b"x", bytearray(b"x"), memoryview(b"x")])
     def test_sync_rejects_string_like_values(self, bad):
@@ -713,35 +987,35 @@ class TestHImportClusterWiring:
     """Cluster wiring guards (offline). Full topology behavior is covered by the
     cluster suite; here we assert the plumbing that makes propagation possible."""
 
-    def test_nodes_manager_accepts_shared_config(self):
-        # The one shared config is threaded to nodes via NodesManager (and injected
+    def test_nodes_manager_accepts_shared_registry(self):
+        # The one shared registry is threaded to nodes via NodesManager (and injected
         # onto each node pool), not through connection_kwargs.
         params = inspect.signature(cluster_mod.NodesManager.__init__).parameters
-        assert "himport_config" in params
+        assert "himport_registry" in params
 
     def test_sync_cluster_single_public_param(self):
         params = inspect.signature(cluster_mod.RedisCluster.__init__).parameters
         assert "himport_schemas" in params
-        assert "himport_config" not in params
+        assert "himport_registry" not in params
 
     def test_async_cluster_single_public_param(self):
         params = inspect.signature(async_cluster_mod.RedisCluster.__init__).parameters
         assert "himport_schemas" in params
-        assert "himport_config" not in params
+        assert "himport_registry" not in params
 
     def test_async_cluster_has_himport_slot(self):
         # Private backing attribute lives in __slots__; the public name is a property.
-        assert "_himport_config" in async_cluster_mod.RedisCluster.__slots__
+        assert "_himport_registry" in async_cluster_mod.RedisCluster.__slots__
 
-    def test_himport_config_is_read_only_property(self):
-        # All client classes expose himport_config as a read-only property (no setter),
+    def test_himport_registry_is_read_only_property(self):
+        # All client classes expose himport_registry as a read-only property (no setter),
         # so it cannot be rebound to desync the shared registry.
         from redis import Redis, RedisCluster
         from redis.asyncio import Redis as AsyncRedis
         from redis.asyncio import RedisCluster as AsyncRedisCluster
 
         for cls in (Redis, RedisCluster, AsyncRedis, AsyncRedisCluster):
-            attr = inspect.getattr_static(cls, "himport_config")
+            attr = inspect.getattr_static(cls, "himport_registry")
             assert isinstance(attr, property), cls
             assert attr.fset is None, cls  # read-only: no setter
 

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -1,0 +1,261 @@
+import pytest
+
+from redis.exceptions import DataError
+from redis.himport import FieldsetOrigin, HImportConfig, HImportFieldset
+
+
+@pytest.mark.fixed_client
+class TestHImportConfig:
+    # -- construction -----------------------------------------------------
+
+    def test_empty_by_default(self):
+        cfg = HImportConfig()
+        assert len(cfg) == 0
+        assert cfg.names() == []
+        assert cfg.items() == []
+        assert list(cfg) == []
+        assert cfg.get("missing") is None
+        assert "missing" not in cfg
+
+    def test_none_schemas_is_empty(self):
+        assert len(HImportConfig(None)) == 0
+
+    def test_constructor_entries_are_init(self):
+        cfg = HImportConfig({"shared": ["name", "email", "age"]})
+        fs = cfg.get("shared")
+        assert isinstance(fs, HImportFieldset)
+        assert fs.name == "shared"
+        assert fs.fields == ("name", "email", "age")
+        assert fs.origin is FieldsetOrigin.INIT
+        assert "shared" in cfg
+        assert cfg.names() == ["shared"]
+
+    def test_multiple_constructor_entries(self):
+        cfg = HImportConfig({"a": ["x"], "b": ["y", "z"]})
+        assert len(cfg) == 2
+        assert {name for name, _ in cfg.items()} == {"a", "b"}
+        assert all(fs.origin is FieldsetOrigin.INIT for _, fs in cfg.items())
+
+    # -- field-order fidelity --------------------------------------------
+
+    def test_field_order_preserved(self):
+        cfg = HImportConfig()
+        cfg.prepare("fs", ["c", "a", "b"])
+        assert cfg.get("fs").fields == ("c", "a", "b")
+
+    def test_duplicates_not_deduplicated(self):
+        # The server rejects duplicate field names; the client must not silently
+        # deduplicate and hide that error.
+        cfg = HImportConfig()
+        cfg.prepare("fs", ["a", "a", "b"])
+        assert cfg.get("fs").fields == ("a", "a", "b")
+
+    def test_accepts_various_iterables(self):
+        cfg = HImportConfig()
+        cfg.prepare("tuple", ("a", "b"))
+        cfg.prepare("gen", (f"f{i}" for i in range(3)))
+        assert cfg.get("tuple").fields == ("a", "b")
+        assert cfg.get("gen").fields == ("f0", "f1", "f2")
+
+    def test_empty_string_names_and_fields_allowed(self):
+        # Empty strings are valid fieldset names and field names per the HLD;
+        # the client must not reject them locally.
+        cfg = HImportConfig({"": [""]})
+        assert cfg.get("").fields == ("",)
+        cfg.prepare("fs", ["", "x", ""])
+        assert cfg.get("fs").fields == ("", "x", "")
+
+    # -- validation -------------------------------------------------------
+
+    def test_empty_field_list_rejected(self):
+        cfg = HImportConfig()
+        with pytest.raises(DataError):
+            cfg.prepare("fs", [])
+
+    def test_empty_field_list_rejected_in_constructor(self):
+        with pytest.raises(DataError):
+            HImportConfig({"fs": []})
+
+    @pytest.mark.parametrize("bad", ["name", b"name"])
+    def test_string_fields_rejected(self, bad):
+        # A bare string would iterate character-by-character; reject it rather
+        # than silently register single-character fields.
+        cfg = HImportConfig()
+        with pytest.raises(DataError):
+            cfg.prepare("fs", bad)
+
+    # -- versioning -------------------------------------------------------
+
+    def test_versions_are_monotonic(self):
+        cfg = HImportConfig()
+        v1 = cfg.prepare("a", ["x"]).version
+        v2 = cfg.prepare("b", ["y"]).version
+        assert v2 > v1
+
+    def test_replace_bumps_version_and_updates_fields(self):
+        cfg = HImportConfig()
+        first = cfg.prepare("fs", ["a"])
+        second = cfg.prepare("fs", ["a", "b"])
+        assert second.version > first.version
+        assert cfg.get("fs").fields == ("a", "b")
+        assert len(cfg) == 1
+
+    def test_readd_after_discard_gets_fresh_version(self):
+        cfg = HImportConfig()
+        first = cfg.prepare("fs", ["a"])
+        assert cfg.discard("fs") is True
+        reAdded = cfg.prepare("fs", ["a"])
+        assert reAdded.version > first.version
+
+    # -- revision (mutation clock) ---------------------------------------
+
+    def test_revision_starts_at_zero(self):
+        assert HImportConfig().revision == 0
+
+    def test_revision_advances_on_prepare(self):
+        cfg = HImportConfig()
+        before = cfg.revision
+        cfg.prepare("fs", ["a"])
+        assert cfg.revision > before
+
+    def test_revision_advances_on_discard(self):
+        cfg = HImportConfig()
+        cfg.prepare("fs", ["a"])
+        before = cfg.revision
+        cfg.discard("fs")
+        assert cfg.revision > before
+
+    def test_revision_advances_on_discard_all(self):
+        cfg = HImportConfig()
+        cfg.prepare("a", ["x"])
+        cfg.prepare("b", ["y"])
+        before = cfg.revision
+        cfg.discard_all()
+        assert cfg.revision > before
+
+    def test_revision_unchanged_on_noop_discard(self):
+        cfg = HImportConfig()
+        before = cfg.revision
+        assert cfg.discard("missing") is False
+        assert cfg.revision == before
+
+    def test_revision_unchanged_on_empty_discard_all(self):
+        cfg = HImportConfig()
+        before = cfg.revision
+        assert cfg.discard_all() == 0
+        assert cfg.revision == before
+
+    def test_revision_unchanged_when_discard_init_raises(self):
+        cfg = HImportConfig({"fs": ["a"]})
+        before = cfg.revision
+        with pytest.raises(DataError):
+            cfg.discard("fs")
+        assert cfg.revision == before
+
+    # -- names_to_discard -------------------------------------------------
+
+    def test_names_to_discard_returns_removed_names(self):
+        cfg = HImportConfig()
+        cfg.prepare("a", ["x"])
+        cfg.prepare("b", ["y"])
+        cfg.discard("a")
+        # Connection had prepared "a" and "b"; only "a" is now gone.
+        assert cfg.names_to_discard(["a", "b"]) == ["a"]
+
+    def test_names_to_discard_empty_when_all_registered(self):
+        cfg = HImportConfig({"a": ["x"], "b": ["y"]})
+        assert cfg.names_to_discard(["a", "b"]) == []
+
+    def test_names_to_discard_preserves_input_order(self):
+        cfg = HImportConfig()
+        assert cfg.names_to_discard(["c", "a", "b"]) == ["c", "a", "b"]
+
+    def test_names_to_discard_ignores_readd(self):
+        # A name discarded then re-declared is still registered, so it is not
+        # flagged for discard (the version bump handles re-prepare instead).
+        cfg = HImportConfig()
+        cfg.prepare("fs", ["a"])
+        cfg.discard("fs")
+        cfg.prepare("fs", ["a", "b"])
+        assert cfg.names_to_discard(["fs"]) == []
+
+    # -- origin semantics -------------------------------------------------
+
+    def test_prepare_new_name_is_runtime(self):
+        cfg = HImportConfig()
+        assert cfg.prepare("fs", ["a"]).origin is FieldsetOrigin.RUNTIME
+
+    def test_reprepare_preserves_init_origin(self):
+        # Re-preparing an init fieldset must keep it INIT so discard protection
+        # cannot be bypassed.
+        cfg = HImportConfig({"fs": ["a"]})
+        updated = cfg.prepare("fs", ["a", "b"])
+        assert updated.origin is FieldsetOrigin.INIT
+        with pytest.raises(DataError):
+            cfg.discard("fs")
+
+    def test_reprepare_preserves_runtime_origin(self):
+        cfg = HImportConfig()
+        cfg.prepare("fs", ["a"])
+        assert cfg.prepare("fs", ["a", "b"]).origin is FieldsetOrigin.RUNTIME
+
+    # -- discard ----------------------------------------------------------
+
+    def test_discard_runtime_removes_and_returns_true(self):
+        cfg = HImportConfig()
+        cfg.prepare("fs", ["a"])
+        assert cfg.discard("fs") is True
+        assert "fs" not in cfg
+        assert len(cfg) == 0
+
+    def test_discard_unknown_returns_false(self):
+        cfg = HImportConfig()
+        assert cfg.discard("missing") is False
+
+    def test_discard_init_raises_and_keeps_entry(self):
+        cfg = HImportConfig({"fs": ["a"]})
+        with pytest.raises(DataError):
+            cfg.discard("fs")
+        assert "fs" in cfg
+
+    # -- discard_all ------------------------------------------------------
+
+    def test_discard_all_removes_runtime_and_returns_count(self):
+        cfg = HImportConfig()
+        cfg.prepare("a", ["x"])
+        cfg.prepare("b", ["y"])
+        assert cfg.discard_all() == 2
+        assert len(cfg) == 0
+
+    def test_discard_all_on_empty_returns_zero(self):
+        assert HImportConfig().discard_all() == 0
+
+    def test_discard_all_rejected_when_init_present(self):
+        cfg = HImportConfig({"init": ["a"]})
+        cfg.prepare("runtime", ["b"])
+        with pytest.raises(DataError):
+            cfg.discard_all()
+        # Registry left untouched by the rejection.
+        assert len(cfg) == 2
+        assert "init" in cfg
+        assert "runtime" in cfg
+
+    # -- read-only access / immutability ----------------------------------
+
+    def test_fieldset_is_immutable(self):
+        cfg = HImportConfig({"fs": ["a"]})
+        fs = cfg.get("fs")
+        with pytest.raises(Exception):
+            fs.fields = ("b",)
+
+    def test_items_snapshot_does_not_mutate_registry(self):
+        cfg = HImportConfig({"fs": ["a"]})
+        items = cfg.items()
+        items.clear()
+        assert "fs" in cfg
+
+    def test_repr_lists_entries(self):
+        cfg = HImportConfig({"fs": ["a", "b"]})
+        text = repr(cfg)
+        assert "fs" in text
+        assert "INIT" in text

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -1,5 +1,7 @@
 import asyncio
 import inspect
+import threading
+from unittest import mock
 
 import pytest
 
@@ -9,8 +11,9 @@ from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool
 from redis.connection import BlockingConnectionPool, ConnectionPool
-from redis.exceptions import DataError
-from redis.himport import FieldsetOrigin, HImportConfig, HImportFieldset
+from redis._parsers.base import BaseParser
+from redis.exceptions import DataError, NoSuchFieldsetError, ResponseError
+from redis.himport import HIMPORT_SET, FieldsetOrigin, HImportConfig, HImportFieldset
 from redis.sentinel import Sentinel, SentinelConnectionPool
 
 
@@ -270,6 +273,133 @@ class TestHImportConfig:
         assert "fs" in text
         assert "INIT" in text
 
+    def test_concurrent_prepares_do_not_lose_revision_bumps(self):
+        # A sync Redis instance (and its shared HImportConfig) is routinely used
+        # across threads. Each prepare of a distinct name must advance the revision
+        # exactly once; the mutation lock keeps the read-modify-write from racing and
+        # collapsing bumps, which would let a connection skip a reconcile.
+        cfg = HImportConfig()
+        count = 200
+        barrier = threading.Barrier(count)
+
+        def worker(i):
+            barrier.wait()  # maximize contention on the mutation path
+            cfg.prepare(f"fs{i}", ["a"])
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(cfg) == count
+        assert cfg.revision == count  # no bump lost to a race
+
+
+class _RecordingConn:
+    """Minimal stand-in for a connection carrying HIMPORT state.
+
+    ``pack_commands`` / ``send_packed_command`` are no-ops (the client's
+    ``parse_response`` is mocked to supply the replies), so the batched
+    DISCARD/PREPARE read loops can be exercised without a real socket.
+    """
+
+    def __init__(self, cfg, prepared=None):
+        self.himport_config = cfg
+        self._himport_prepared = dict(prepared or {})
+        self._himport_reconciled_revision = 0
+
+    def pack_commands(self, commands):
+        return list(commands)
+
+    def send_packed_command(self, packed, **kwargs):
+        pass
+
+
+class _AsyncRecordingConn(_RecordingConn):
+    async def send_packed_command(self, packed, **kwargs):
+        pass
+
+
+@pytest.mark.fixed_client
+class TestHImportBatchedReadDrain:
+    """A per-command ResponseError inside a packed DISCARD/PREPARE batch must not
+    leave replies unread — that would desync the pooled connection. Each loop drains
+    every reply, marks only the ones that succeeded, then surfaces the first error.
+    """
+
+    def test_reconcile_discards_drains_all_replies_on_error(self):
+        # prepare+discard advances the revision so the connection reconciles; it has
+        # three stale prepared fieldsets, so three DISCARD replies must be read even
+        # though the second one errors.
+        cfg = HImportConfig()
+        cfg.prepare("a", ["f"])
+        cfg.discard("a")
+        conn = _RecordingConn(cfg, {"a": 1, "b": 1, "c": 1})
+        client = Redis()
+        replies = [True, ResponseError("boom"), True]
+        with mock.patch.object(client, "parse_response", side_effect=replies) as pr:
+            with pytest.raises(ResponseError, match="boom"):
+                client._himport_reconcile_discards(conn)
+        assert pr.call_count == 3  # every packed DISCARD reply drained
+        assert conn._himport_prepared == {}  # every stale name dropped regardless
+
+    def test_prepare_pipeline_drains_all_replies_on_error(self):
+        cfg = HImportConfig({"a": ["f"], "b": ["f"]})
+        conn = _RecordingConn(cfg)
+        conn._himport_reconciled_revision = cfg.revision  # no discard to reconcile
+        commands = [
+            (("HIMPORT SET", "k1", "a", "v"), {}),
+            (("HIMPORT SET", "k2", "b", "v"), {}),
+        ]
+        assert commands[0][0][0] == HIMPORT_SET  # guards the wire-token assumption
+        pipe = Redis().pipeline()
+        replies = [True, ResponseError("boom")]
+        with mock.patch.object(pipe, "parse_response", side_effect=replies) as pr:
+            with pytest.raises(ResponseError, match="boom"):
+                pipe._himport_prepare_pipeline(conn, commands)
+        assert pr.call_count == 2  # both PREPARE replies drained
+        assert "a" in conn._himport_prepared  # first PREPARE succeeded, marked
+        assert "b" not in conn._himport_prepared  # second errored, not marked
+
+    def test_async_reconcile_discards_drains_all_replies_on_error(self):
+        async def run():
+            cfg = HImportConfig()
+            cfg.prepare("a", ["f"])
+            cfg.discard("a")
+            conn = _AsyncRecordingConn(cfg, {"a": 1, "b": 1, "c": 1})
+            client = AsyncRedis()
+            client.parse_response = mock.AsyncMock(
+                side_effect=[True, ResponseError("boom"), True]
+            )
+            with pytest.raises(ResponseError, match="boom"):
+                await client._himport_reconcile_discards(conn)
+            assert client.parse_response.call_count == 3
+            assert conn._himport_prepared == {}
+
+        asyncio.run(run())
+
+    def test_async_prepare_pipeline_drains_all_replies_on_error(self):
+        async def run():
+            cfg = HImportConfig({"a": ["f"], "b": ["f"]})
+            conn = _AsyncRecordingConn(cfg)
+            conn._himport_reconciled_revision = cfg.revision
+            commands = [
+                (("HIMPORT SET", "k1", "a", "v"), {}),
+                (("HIMPORT SET", "k2", "b", "v"), {}),
+            ]
+            pipe = AsyncRedis().pipeline()
+            pipe.parse_response = mock.AsyncMock(
+                side_effect=[True, ResponseError("boom")]
+            )
+            with pytest.raises(ResponseError, match="boom"):
+                await pipe._himport_prepare_pipeline(conn, commands)
+            assert pipe.parse_response.call_count == 2
+            assert "a" in conn._himport_prepared
+            assert "b" not in conn._himport_prepared
+
+        asyncio.run(run())
+
 
 @pytest.mark.fixed_client
 class TestHImportPropagationSync:
@@ -293,10 +423,13 @@ class TestHImportPropagationSync:
         assert pool.himport_config is cfg
         assert pool.make_connection().himport_config is cfg
 
-    def test_pool_none_when_unconfigured(self):
+    def test_pool_empty_config_when_unconfigured(self):
+        # A config always exists (empty) so runtime himport_prepare has a single
+        # shared object to mutate; the same object reaches connections.
         pool = ConnectionPool()
-        assert pool.himport_config is None
-        assert pool.make_connection().himport_config is None
+        assert isinstance(pool.himport_config, HImportConfig)
+        assert len(pool.himport_config) == 0
+        assert pool.make_connection().himport_config is pool.himport_config
 
     def test_blocking_pool_resolves(self):
         pool = BlockingConnectionPool(himport_schemas={"s": ["a"]})
@@ -308,8 +441,10 @@ class TestHImportPropagationSync:
         assert r.himport_config is r.connection_pool.himport_config
         assert r.himport_config.get("shared").fields == ("name", "email")
 
-    def test_redis_unconfigured_is_none(self):
-        assert Redis().himport_config is None
+    def test_redis_unconfigured_is_empty(self):
+        cfg = Redis().himport_config
+        assert isinstance(cfg, HImportConfig)
+        assert len(cfg) == 0
 
     def test_redis_has_no_public_himport_config_param(self):
         # himport_config (the object) is internal-only; the sole public knob is the
@@ -342,7 +477,7 @@ class TestHImportPropagationAsync:
             assert r.himport_config is r.connection_pool.himport_config
             assert r.himport_config.get("s").fields == ("a",)
 
-            assert AsyncRedis().himport_config is None
+            assert len(AsyncRedis().himport_config) == 0
 
         asyncio.run(run())
 
@@ -369,4 +504,40 @@ class TestHImportClusterWiring:
         assert "himport_config" not in params
 
     def test_async_cluster_has_himport_slot(self):
-        assert "himport_config" in async_cluster_mod.RedisCluster.__slots__
+        # Private backing attribute lives in __slots__; the public name is a property.
+        assert "_himport_config" in async_cluster_mod.RedisCluster.__slots__
+
+    def test_himport_config_is_read_only_property(self):
+        # All client classes expose himport_config as a read-only property (no setter),
+        # so it cannot be rebound to desync the shared registry.
+        from redis import Redis, RedisCluster
+        from redis.asyncio import Redis as AsyncRedis
+        from redis.asyncio import RedisCluster as AsyncRedisCluster
+
+        for cls in (Redis, RedisCluster, AsyncRedis, AsyncRedisCluster):
+            attr = inspect.getattr_static(cls, "himport_config")
+            assert isinstance(attr, property), cls
+            assert attr.fset is None, cls  # read-only: no setter
+
+
+@pytest.mark.fixed_client
+class TestNoSuchFieldsetErrorMapping:
+    """The parser maps the server's "no such fieldset" reply to the dedicated
+    NoSuchFieldsetError so the HIMPORT SET recovery path can catch it by type.
+
+    The server reply is a fixed message with no fieldset name appended (verified
+    against the server: always exactly ``ERR no such fieldset``), so the mapping is
+    an exact match in ``EXCEPTION_CLASSES``, like the other ERR-message entries.
+    """
+
+    def test_maps_no_such_fieldset_reply(self):
+        # Exact wire reply the server sends for an unprepared fieldset.
+        exc = BaseParser.parse_error("ERR no such fieldset")
+        assert isinstance(exc, NoSuchFieldsetError)
+        assert isinstance(exc, ResponseError)  # remains a ResponseError subtype
+        assert exc.status_code == "ERR"
+
+    def test_unrelated_err_stays_generic(self):
+        exc = BaseParser.parse_error("ERR something else went wrong")
+        assert type(exc) is ResponseError
+        assert not isinstance(exc, NoSuchFieldsetError)

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -1,7 +1,17 @@
+import asyncio
+import inspect
+
 import pytest
 
+import redis.asyncio.cluster as async_cluster_mod
+import redis.cluster as cluster_mod
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
+from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool
+from redis.connection import BlockingConnectionPool, ConnectionPool
 from redis.exceptions import DataError
 from redis.himport import FieldsetOrigin, HImportConfig, HImportFieldset
+from redis.sentinel import Sentinel, SentinelConnectionPool
 
 
 @pytest.mark.fixed_client
@@ -259,3 +269,104 @@ class TestHImportConfig:
         text = repr(cfg)
         assert "fs" in text
         assert "INIT" in text
+
+
+@pytest.mark.fixed_client
+class TestHImportPropagationSync:
+    """Data propagation: client -> pool -> connection (standalone + sentinel)."""
+
+    def test_pool_builds_config_from_schemas(self):
+        pool = ConnectionPool(himport_schemas={"shared": ["a", "b"]})
+        assert isinstance(pool.himport_config, HImportConfig)
+        assert pool.himport_config.get("shared").fields == ("a", "b")
+        conn = pool.make_connection()
+        # Same shared object reaches the connection, plus empty per-conn state.
+        assert conn.himport_config is pool.himport_config
+        assert conn._himport_prepared == {}
+        assert conn._himport_reconciled_revision == 0
+
+    def test_pool_accepts_prebuilt_config_internally(self):
+        # Internal channel (used by the cluster to share one object): a pre-built
+        # himport_config passed via connection_kwargs is used as-is, not rebuilt.
+        cfg = HImportConfig({"x": ["1"]})
+        pool = ConnectionPool(himport_config=cfg)
+        assert pool.himport_config is cfg
+        assert pool.make_connection().himport_config is cfg
+
+    def test_pool_none_when_unconfigured(self):
+        pool = ConnectionPool()
+        assert pool.himport_config is None
+        assert pool.make_connection().himport_config is None
+
+    def test_blocking_pool_resolves(self):
+        pool = BlockingConnectionPool(himport_schemas={"s": ["a"]})
+        assert pool.himport_config.get("s").fields == ("a",)
+        assert pool.make_connection().himport_config is pool.himport_config
+
+    def test_redis_property_and_propagation(self):
+        r = Redis(himport_schemas={"shared": ["name", "email"]})
+        assert r.himport_config is r.connection_pool.himport_config
+        assert r.himport_config.get("shared").fields == ("name", "email")
+
+    def test_redis_unconfigured_is_none(self):
+        assert Redis().himport_config is None
+
+    def test_redis_has_no_public_himport_config_param(self):
+        # himport_config (the object) is internal-only; the sole public knob is the
+        # schemas dict, so the client never holds a caller-supplied mutable config.
+        assert "himport_config" not in inspect.signature(Redis.__init__).parameters
+
+    def test_sentinel_pool_resolves_via_connection_kwargs(self):
+        # Sentinel needs no edits: himport_schemas rides in connection_kwargs and
+        # the base pool (via SentinelConnectionPool) resolves it.
+        s = Sentinel([("127.0.0.1", 26379)], himport_schemas={"s": ["a"]})
+        assert s.connection_kwargs.get("himport_schemas") == {"s": ["a"]}
+        pool = SentinelConnectionPool("mymaster", s, himport_schemas={"s": ["a"]})
+        assert pool.himport_config.get("s").fields == ("a",)
+
+
+@pytest.mark.fixed_client
+class TestHImportPropagationAsync:
+    """Async mirror of the standalone propagation checks."""
+
+    def test_async_pool_and_client(self):
+        async def run():
+            pool = AsyncConnectionPool(himport_schemas={"s": ["a", "b"]})
+            assert pool.himport_config.get("s").fields == ("a", "b")
+            conn = pool.make_connection()
+            assert conn.himport_config is pool.himport_config
+            assert conn._himport_prepared == {}
+            assert conn._himport_reconciled_revision == 0
+
+            r = AsyncRedis(himport_schemas={"s": ["a"]})
+            assert r.himport_config is r.connection_pool.himport_config
+            assert r.himport_config.get("s").fields == ("a",)
+
+            assert AsyncRedis().himport_config is None
+
+        asyncio.run(run())
+
+
+@pytest.mark.fixed_client
+class TestHImportClusterWiring:
+    """Cluster wiring guards (offline). Full topology behavior is covered by the
+    cluster suite; here we assert the plumbing that makes propagation possible."""
+
+    def test_nodes_manager_accepts_shared_config(self):
+        # The one shared config is threaded to nodes via NodesManager (and injected
+        # onto each node pool), not through connection_kwargs.
+        params = inspect.signature(cluster_mod.NodesManager.__init__).parameters
+        assert "himport_config" in params
+
+    def test_sync_cluster_single_public_param(self):
+        params = inspect.signature(cluster_mod.RedisCluster.__init__).parameters
+        assert "himport_schemas" in params
+        assert "himport_config" not in params
+
+    def test_async_cluster_single_public_param(self):
+        params = inspect.signature(async_cluster_mod.RedisCluster.__init__).parameters
+        assert "himport_schemas" in params
+        assert "himport_config" not in params
+
+    def test_async_cluster_has_himport_slot(self):
+        assert "himport_config" in async_cluster_mod.RedisCluster.__slots__

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -321,6 +321,33 @@ class _AsyncRecordingConn(_RecordingConn):
         pass
 
 
+class _CapturingConn(_RecordingConn):
+    """Recording connection that captures the wire writes in order.
+
+    ``writes`` records ``("packed", [cmd, ...])`` for each ``send_packed_command``
+    and ``("cmd", (args...))`` for each ``send_command`` so tests can assert the
+    exact command ordering (e.g. that ASKING is packed immediately before the SET).
+    """
+
+    def __init__(self, cfg, prepared=None):
+        super().__init__(cfg, prepared)
+        self.writes = []
+
+    def send_packed_command(self, packed, **kwargs):
+        self.writes.append(("packed", list(packed)))
+
+    def send_command(self, *args, **kwargs):
+        self.writes.append(("cmd", args))
+
+
+class _AsyncCapturingConn(_CapturingConn):
+    async def send_packed_command(self, packed, **kwargs):
+        self.writes.append(("packed", list(packed)))
+
+    async def send_command(self, *args, **kwargs):
+        self.writes.append(("cmd", args))
+
+
 @pytest.mark.fixed_client
 class TestHImportBatchedReadDrain:
     """A per-command ResponseError inside a packed DISCARD/PREPARE batch must not
@@ -401,6 +428,174 @@ class TestHImportBatchedReadDrain:
         asyncio.run(run())
 
 
+PREPARE_FS_AB = ("HIMPORT", "PREPARE", "fs", "a", "b")
+ASKING = ("ASKING",)
+SET_K_FS = ("HIMPORT", "SET", "k", "fs", "v")
+
+
+DISCARD_GONE = ("HIMPORT", "DISCARD", "gone")
+
+
+@pytest.mark.fixed_client
+class TestHImportAskRedirectSync:
+    """An ASK-redirected ``HIMPORT SET`` must carry the ASKING allowance on the
+    same connection, immediately before the SET.
+
+    Redis clears the per-command ASKING flag after the next command, so any
+    session command (deferred DISCARD, lazy PREPARE) sent between ASKING and the
+    SET would consume the allowance and leave the slot-scoped SET to fail or
+    redirect again during migration. On the sync cluster the dispatch loop runs
+    ``RedisCluster._himport_prepare_for_asking`` (reconcile + lazy PREPARE) before
+    sending ASKING, so ASKING lands right before the bare SET the node then issues.
+    ``_himport_prepare_for_asking`` ignores ``self``; call it unbound for the test.
+    """
+
+    def test_prepare_for_asking_sends_bare_prepare(self):
+        cfg = HImportConfig({"fs": ["a", "b"]})
+        conn = _CapturingConn(cfg)
+        conn._himport_reconciled_revision = cfg.revision  # nothing to reconcile
+        redis_node = Redis()
+        with mock.patch.object(redis_node, "parse_response", side_effect=["OK"]) as pr:
+            cluster_mod.RedisCluster._himport_prepare_for_asking(
+                None, redis_node, conn, "fs"
+            )
+        # A single bare PREPARE (the caller sends ASKING itself, right after).
+        assert conn.writes == [("cmd", PREPARE_FS_AB)]
+        assert conn._himport_prepared["fs"] == cfg.get("fs").version
+        assert pr.call_count == 1
+
+    def test_prepare_for_asking_noop_when_already_prepared(self):
+        cfg = HImportConfig({"fs": ["a"]})
+        fieldset = cfg.get("fs")
+        conn = _CapturingConn(cfg, prepared={"fs": fieldset.version})
+        conn._himport_reconciled_revision = cfg.revision
+        redis_node = Redis()
+        cluster_mod.RedisCluster._himport_prepare_for_asking(
+            None, redis_node, conn, "fs"
+        )
+        assert conn.writes == []  # nothing sent before ASKING
+
+    def test_prepare_for_asking_reconciles_discards_first(self):
+        # A stale prepared fieldset is DISCARDed (session command, no allowance
+        # needed) ahead of everything; the already-prepared target needs no PREPARE.
+        cfg = HImportConfig({"fs": ["a"]})
+        cfg.prepare("gone", ["x"])
+        cfg.discard("gone")
+        fieldset = cfg.get("fs")
+        conn = _CapturingConn(cfg, prepared={"gone": 1, "fs": fieldset.version})
+        conn._himport_reconciled_revision = 0  # force a reconcile pass
+        redis_node = Redis()
+        with mock.patch.object(redis_node, "parse_response", side_effect=[1]):
+            cluster_mod.RedisCluster._himport_prepare_for_asking(
+                None, redis_node, conn, "fs"
+            )
+        assert conn.writes == [("packed", [DISCARD_GONE])]
+        assert "gone" not in conn._himport_prepared
+
+
+@pytest.mark.fixed_client
+class TestHImportAskRedirectAsyncCluster:
+    """The async cluster owns its own HIMPORT executor on ``ClusterNode``; there
+    the ASKING allowance is folded into the SET's own packed write (the ASKING is
+    not sent as a separately pooled command), so ASKING lands immediately before
+    the SET. The methods only touch ``self.parse_response`` /
+    ``self._himport_reconcile_discards``; a stub ``self`` exercises the real code.
+    """
+
+    def test_prepare_and_set_packs_prepare_asking_set(self):
+        async def run():
+            cfg = HImportConfig({"fs": ["a", "b"]})
+            conn = _AsyncCapturingConn(cfg)
+            fieldset = cfg.get("fs")
+            node = mock.Mock()
+            node.parse_response = mock.AsyncMock(side_effect=["OK", "OK", 1])
+            resp = await async_cluster_mod.ClusterNode._himport_prepare_and_set(
+                node, conn, "k", "fs", ["v"], fieldset, asking=True
+            )
+            assert resp == 1
+            assert conn.writes == [("packed", [PREPARE_FS_AB, ASKING, SET_K_FS])]
+            assert conn._himport_prepared["fs"] == fieldset.version
+            assert node.parse_response.call_count == 3
+
+        asyncio.run(run())
+
+    def test_prepare_and_set_without_asking_keeps_bundle(self):
+        # Regression guard: without an ASK redirect the batch stays [PREPARE, SET].
+        async def run():
+            cfg = HImportConfig({"fs": ["a", "b"]})
+            conn = _AsyncCapturingConn(cfg)
+            fieldset = cfg.get("fs")
+            node = mock.Mock()
+            node.parse_response = mock.AsyncMock(side_effect=["OK", 1])
+            await async_cluster_mod.ClusterNode._himport_prepare_and_set(
+                node, conn, "k", "fs", ["v"], fieldset
+            )
+            assert conn.writes == [("packed", [PREPARE_FS_AB, SET_K_FS])]
+
+        asyncio.run(run())
+
+    def test_bare_set_packs_asking_then_set(self):
+        async def run():
+            cfg = HImportConfig({"fs": ["a"]})
+            fieldset = cfg.get("fs")
+            conn = _AsyncCapturingConn(cfg, prepared={"fs": fieldset.version})
+            conn._himport_reconciled_revision = cfg.revision
+            node = mock.Mock()
+            node._himport_reconcile_discards = mock.AsyncMock()
+            node.parse_response = mock.AsyncMock(side_effect=["OK", 1])
+            resp = await async_cluster_mod.ClusterNode._himport_execute_set(
+                node, conn, "k", "fs", ["v"], asking=True
+            )
+            assert resp == 1
+            assert conn.writes == [("packed", [ASKING, SET_K_FS])]
+
+        asyncio.run(run())
+
+
+@pytest.mark.fixed_client
+class TestHImportSingleConnectionPrepareMaterializesFields:
+    """On a single-connection client the immediate wire PREPARE must send the
+    fully materialized fields even when the caller passes a one-shot iterable.
+
+    ``himport_config.prepare`` consumes the iterable into a tuple, so re-passing
+    the original ``fields`` to the wire call would forward an exhausted iterator
+    and PREPARE zero fields. The wire call must reuse the stored
+    ``HImportFieldset.fields`` returned by ``prepare`` instead.
+    """
+
+    def test_generator_fields_reach_wire_prepare(self):
+        client = Redis()
+        client._single_connection_client = True
+        conn = mock.Mock()
+        conn.is_connected = True
+        conn._himport_prepared = {}
+        client.connection = conn
+        with mock.patch.object(client, "himport_prepare_internal") as internal:
+            client.himport_prepare("fs", (f"f{i}" for i in range(3)))
+        internal.assert_called_once_with("fs", ("f0", "f1", "f2"))
+        assert conn._himport_prepared["fs"] == client.himport_config.get("fs").version
+
+    def test_async_generator_fields_reach_wire_prepare(self):
+        async def run():
+            client = AsyncRedis()
+            client.single_connection_client = True
+            client.initialize = mock.AsyncMock(return_value=client)
+            conn = mock.Mock()
+            conn.is_connected = True
+            conn._himport_prepared = {}
+            client.connection = conn
+            client.himport_prepare_internal = mock.AsyncMock()
+            await client.himport_prepare("fs", (f"f{i}" for i in range(3)))
+            client.himport_prepare_internal.assert_awaited_once_with(
+                "fs", ("f0", "f1", "f2")
+            )
+            assert (
+                conn._himport_prepared["fs"] == client.himport_config.get("fs").version
+            )
+
+        asyncio.run(run())
+
+
 @pytest.mark.fixed_client
 class TestHImportPropagationSync:
     """Data propagation: client -> pool -> connection (standalone + sentinel)."""
@@ -441,6 +636,16 @@ class TestHImportPropagationSync:
         assert r.himport_config is r.connection_pool.himport_config
         assert r.himport_config.get("shared").fields == ("name", "email")
 
+    def test_redis_unix_socket_propagates_schemas(self):
+        # Regression: himport_schemas must propagate for Unix-socket clients, not
+        # just TCP. Construction does not connect, so no socket is needed.
+        r = Redis(
+            unix_socket_path="/tmp/does-not-connect.sock",
+            himport_schemas={"shared": ["name", "email"]},
+        )
+        assert r.himport_config is r.connection_pool.himport_config
+        assert r.himport_config.get("shared").fields == ("name", "email")
+
     def test_redis_unconfigured_is_empty(self):
         cfg = Redis().himport_config
         assert isinstance(cfg, HImportConfig)
@@ -478,6 +683,27 @@ class TestHImportPropagationAsync:
             assert r.himport_config.get("s").fields == ("a",)
 
             assert len(AsyncRedis().himport_config) == 0
+
+        asyncio.run(run())
+
+
+@pytest.mark.fixed_client
+class TestHImportSetValueValidation:
+    """himport_set must reject bare string-like value iterables (str/bytes/
+    bytearray/memoryview): splatting them sends single chars/bytes as separate
+    positional values instead of one value. The guard runs before any connection
+    use, so no server is needed. Mirrors HImportConfig's field-list guard."""
+
+    @pytest.mark.parametrize("bad", ["abc", b"x", bytearray(b"x"), memoryview(b"x")])
+    def test_sync_rejects_string_like_values(self, bad):
+        with pytest.raises(DataError, match="must be a collection of values"):
+            Redis().himport_set("k", "fs", bad)
+
+    @pytest.mark.parametrize("bad", ["abc", b"x", bytearray(b"x"), memoryview(b"x")])
+    def test_async_rejects_string_like_values(self, bad):
+        async def run():
+            with pytest.raises(DataError, match="must be a collection of values"):
+                await AsyncRedis().himport_set("k", "fs", bad)
 
         asyncio.run(run())
 

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -13,8 +13,8 @@ from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool
 from redis.connection import BlockingConnectionPool, ConnectionPool
 from redis._parsers.base import BaseParser
 from redis.exceptions import DataError, NoSuchFieldsetError, ResponseError
-from redis.himport import HIMPORT_SET, FieldsetOrigin, HImportRegistry, HImportFieldset
-from redis.sentinel import Sentinel, SentinelConnectionPool
+from redis.himport import HIMPORT_SET, HImportRegistry, HImportFieldset
+from redis.sentinel import Sentinel
 
 
 @pytest.mark.fixed_client
@@ -30,24 +30,16 @@ class TestHImportRegistry:
         assert registry.get("missing") is None
         assert "missing" not in registry
 
-    def test_none_schemas_is_empty(self):
-        assert len(HImportRegistry(None)) == 0
-
-    def test_constructor_entries_are_init(self):
-        registry = HImportRegistry({"shared": ["name", "email", "age"]})
+    def test_prepared_entry_exposes_name_fields_version(self):
+        registry = HImportRegistry()
+        registry.prepare("shared", ["name", "email", "age"])
         fs = registry.get("shared")
         assert isinstance(fs, HImportFieldset)
         assert fs.name == "shared"
         assert fs.fields == ("name", "email", "age")
-        assert fs.origin is FieldsetOrigin.INIT
+        assert isinstance(fs.version, int)
         assert "shared" in registry
         assert registry.names() == ["shared"]
-
-    def test_multiple_constructor_entries(self):
-        registry = HImportRegistry({"a": ["x"], "b": ["y", "z"]})
-        assert len(registry) == 2
-        assert {name for name, _ in registry.items()} == {"a", "b"}
-        assert all(fs.origin is FieldsetOrigin.INIT for _, fs in registry.items())
 
     # -- field-order fidelity --------------------------------------------
 
@@ -73,7 +65,8 @@ class TestHImportRegistry:
     def test_empty_string_names_and_fields_allowed(self):
         # Empty strings are valid fieldset names and field names per the HLD;
         # the client must not reject them locally.
-        registry = HImportRegistry({"": [""]})
+        registry = HImportRegistry()
+        registry.prepare("", [""])
         assert registry.get("").fields == ("",)
         registry.prepare("fs", ["", "x", ""])
         assert registry.get("fs").fields == ("", "x", "")
@@ -84,10 +77,6 @@ class TestHImportRegistry:
         registry = HImportRegistry()
         with pytest.raises(DataError):
             registry.prepare("fs", [])
-
-    def test_empty_field_list_rejected_in_constructor(self):
-        with pytest.raises(DataError):
-            HImportRegistry({"fs": []})
 
     @pytest.mark.parametrize(
         "bad", ["name", b"name", bytearray(b"name"), memoryview(b"name")]
@@ -161,13 +150,6 @@ class TestHImportRegistry:
         assert registry.discard_all() == 0
         assert registry.revision == before
 
-    def test_revision_unchanged_when_discard_init_raises(self):
-        registry = HImportRegistry({"fs": ["a"]})
-        before = registry.revision
-        with pytest.raises(DataError):
-            registry.discard("fs")
-        assert registry.revision == before
-
     # -- names_to_discard -------------------------------------------------
 
     def test_names_to_discard_returns_removed_names(self):
@@ -179,7 +161,9 @@ class TestHImportRegistry:
         assert registry.names_to_discard(["a", "b"]) == ["a"]
 
     def test_names_to_discard_empty_when_all_registered(self):
-        registry = HImportRegistry({"a": ["x"], "b": ["y"]})
+        registry = HImportRegistry()
+        registry.prepare("a", ["x"])
+        registry.prepare("b", ["y"])
         assert registry.names_to_discard(["a", "b"]) == []
 
     def test_names_to_discard_preserves_input_order(self):
@@ -195,29 +179,9 @@ class TestHImportRegistry:
         registry.prepare("fs", ["a", "b"])
         assert registry.names_to_discard(["fs"]) == []
 
-    # -- origin semantics -------------------------------------------------
-
-    def test_prepare_new_name_is_runtime(self):
-        registry = HImportRegistry()
-        assert registry.prepare("fs", ["a"]).origin is FieldsetOrigin.RUNTIME
-
-    def test_reprepare_preserves_init_origin(self):
-        # Re-preparing an init fieldset must keep it INIT so discard protection
-        # cannot be bypassed.
-        registry = HImportRegistry({"fs": ["a"]})
-        updated = registry.prepare("fs", ["a", "b"])
-        assert updated.origin is FieldsetOrigin.INIT
-        with pytest.raises(DataError):
-            registry.discard("fs")
-
-    def test_reprepare_preserves_runtime_origin(self):
-        registry = HImportRegistry()
-        registry.prepare("fs", ["a"])
-        assert registry.prepare("fs", ["a", "b"]).origin is FieldsetOrigin.RUNTIME
-
     # -- discard ----------------------------------------------------------
 
-    def test_discard_runtime_removes_and_returns_true(self):
+    def test_discard_removes_and_returns_true(self):
         registry = HImportRegistry()
         registry.prepare("fs", ["a"])
         assert registry.discard("fs") is True
@@ -228,15 +192,17 @@ class TestHImportRegistry:
         registry = HImportRegistry()
         assert registry.discard("missing") is False
 
-    def test_discard_init_raises_and_keeps_entry(self):
-        registry = HImportRegistry({"fs": ["a"]})
-        with pytest.raises(DataError):
-            registry.discard("fs")
-        assert "fs" in registry
+    def test_discard_never_raises_and_removes_any_fieldset(self):
+        # There is no init/protected concept anymore: any prepared fieldset is
+        # freely discardable and discard never raises.
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
+        assert registry.discard("fs") is True
+        assert "fs" not in registry
 
     # -- discard_all ------------------------------------------------------
 
-    def test_discard_all_removes_runtime_and_returns_count(self):
+    def test_discard_all_removes_all_and_returns_count(self):
         registry = HImportRegistry()
         registry.prepare("a", ["x"])
         registry.prepare("b", ["y"])
@@ -246,35 +212,38 @@ class TestHImportRegistry:
     def test_discard_all_on_empty_returns_zero(self):
         assert HImportRegistry().discard_all() == 0
 
-    def test_discard_all_rejected_when_init_present(self):
-        registry = HImportRegistry({"init": ["a"]})
-        registry.prepare("runtime", ["b"])
-        with pytest.raises(DataError):
-            registry.discard_all()
-        # Registry left untouched by the rejection.
-        assert len(registry) == 2
-        assert "init" in registry
-        assert "runtime" in registry
+    def test_discard_all_never_raises_and_clears_everything(self):
+        # discard_all removes every fieldset and returns the count with no
+        # DataError, even for fieldsets that would formerly have been "init".
+        registry = HImportRegistry()
+        registry.prepare("a", ["x"])
+        registry.prepare("b", ["y"])
+        assert registry.discard_all() == 2
+        assert len(registry) == 0
+        assert "a" not in registry
+        assert "b" not in registry
 
     # -- read-only access / immutability ----------------------------------
 
     def test_fieldset_is_immutable(self):
-        registry = HImportRegistry({"fs": ["a"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
         fs = registry.get("fs")
         with pytest.raises(Exception):
             fs.fields = ("b",)
 
     def test_items_snapshot_does_not_mutate_registry(self):
-        registry = HImportRegistry({"fs": ["a"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
         items = registry.items()
         items.clear()
         assert "fs" in registry
 
     def test_repr_lists_entries(self):
-        registry = HImportRegistry({"fs": ["a", "b"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a", "b"])
         text = repr(registry)
         assert "fs" in text
-        assert "INIT" in text
 
     def test_concurrent_prepares_do_not_lose_revision_bumps(self):
         # A sync Redis instance (and its shared HImportRegistry) is routinely used
@@ -425,7 +394,9 @@ class TestHImportBatchedReadDrain:
         assert conn._himport_prepared == {}  # every stale name dropped regardless
 
     def test_prepare_pipeline_drains_all_replies_on_error(self):
-        registry = HImportRegistry({"a": ["f"], "b": ["f"]})
+        registry = HImportRegistry()
+        registry.prepare("a", ["f"])
+        registry.prepare("b", ["f"])
         conn = _RecordingConn(registry)
         conn._himport_reconciled_revision = registry.revision  # no discard to reconcile
         commands = [
@@ -461,7 +432,9 @@ class TestHImportBatchedReadDrain:
 
     def test_async_prepare_pipeline_drains_all_replies_on_error(self):
         async def run():
-            registry = HImportRegistry({"a": ["f"], "b": ["f"]})
+            registry = HImportRegistry()
+            registry.prepare("a", ["f"])
+            registry.prepare("b", ["f"])
             conn = _AsyncRecordingConn(registry)
             conn._himport_reconciled_revision = registry.revision
             commands = [
@@ -618,7 +591,8 @@ class TestHImportAskRedirectSync:
         _himport_prepare_and_set = cluster_mod.RedisCluster._himport_prepare_and_set
 
     def test_prepare_and_set_packs_prepare_asking_set(self):
-        registry = HImportRegistry({"fs": ["a", "b"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a", "b"])
         conn = _CapturingConn(registry)
         fieldset = registry.get("fs")
         node = mock.Mock()
@@ -633,7 +607,8 @@ class TestHImportAskRedirectSync:
 
     def test_prepare_and_set_without_asking_keeps_bundle(self):
         # Regression guard: without an ASK redirect the batch stays [PREPARE, SET].
-        registry = HImportRegistry({"fs": ["a", "b"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a", "b"])
         conn = _CapturingConn(registry)
         fieldset = registry.get("fs")
         node = mock.Mock()
@@ -644,7 +619,8 @@ class TestHImportAskRedirectSync:
         assert conn.writes == [("packed", [PREPARE_FS_AB, SET_K_FS])]
 
     def test_bare_set_packs_asking_then_set(self):
-        registry = HImportRegistry({"fs": ["a"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
         fieldset = registry.get("fs")
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
@@ -660,7 +636,8 @@ class TestHImportAskRedirectSync:
     def test_bare_set_recovers_with_asking_on_missing_fieldset(self):
         # The bare SET's ASKING allowance is consumed by the failed SET, so the
         # NoSuchFieldsetError recovery must re-arm ASKING: [PREPARE, ASKING, SET].
-        registry = HImportRegistry({"fs": ["a", "b"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a", "b"])
         fieldset = registry.get("fs")
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
@@ -688,7 +665,8 @@ class TestHImportAskRedirectSync:
 
     def test_bare_set_recovery_without_asking_keeps_bundle(self):
         # Regression: a non-ASK recovery still packs [PREPARE, SET] (no ASKING).
-        registry = HImportRegistry({"fs": ["a", "b"]})
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a", "b"])
         fieldset = registry.get("fs")
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
@@ -704,6 +682,27 @@ class TestHImportAskRedirectSync:
             ("packed", [PREPARE_FS_AB, SET_K_FS]),
         ]
 
+    def test_bare_set_asking_error_drains_set_reply(self):
+        # ASKING and SET are one packed write (two queued replies). If the ASKING
+        # reply errors, the SET reply must still be drained before the error is
+        # surfaced, or the connection returns to the pool with an unread reply.
+        registry = HImportRegistry()
+        registry.prepare("fs", ["a"])
+        fieldset = registry.get("fs")
+        conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
+        conn._himport_reconciled_revision = registry.revision
+        node = mock.Mock()
+        node._himport_reconcile_discards = mock.Mock()
+        node.parse_response = mock.Mock(
+            side_effect=[ResponseError("bad ASKING"), 1]  # ASKING errors, SET drained
+        )
+        with pytest.raises(ResponseError, match="bad ASKING"):
+            self._ClusterStub()._himport_execute_set(
+                node, conn, "k", "fs", ["v"], asking=True
+            )
+        assert node.parse_response.call_count == 2  # SET reply drained
+        assert conn.writes == [("packed", [ASKING, SET_K_FS])]  # no retry write
+
 
 @pytest.mark.fixed_client
 class TestHImportAskRedirectAsyncCluster:
@@ -716,7 +715,8 @@ class TestHImportAskRedirectAsyncCluster:
 
     def test_prepare_and_set_packs_prepare_asking_set(self):
         async def run():
-            registry = HImportRegistry({"fs": ["a", "b"]})
+            registry = HImportRegistry()
+            registry.prepare("fs", ["a", "b"])
             conn = _AsyncCapturingConn(registry)
             fieldset = registry.get("fs")
             node = mock.Mock()
@@ -734,7 +734,8 @@ class TestHImportAskRedirectAsyncCluster:
     def test_prepare_and_set_without_asking_keeps_bundle(self):
         # Regression guard: without an ASK redirect the batch stays [PREPARE, SET].
         async def run():
-            registry = HImportRegistry({"fs": ["a", "b"]})
+            registry = HImportRegistry()
+            registry.prepare("fs", ["a", "b"])
             conn = _AsyncCapturingConn(registry)
             fieldset = registry.get("fs")
             node = mock.Mock()
@@ -748,7 +749,8 @@ class TestHImportAskRedirectAsyncCluster:
 
     def test_bare_set_packs_asking_then_set(self):
         async def run():
-            registry = HImportRegistry({"fs": ["a"]})
+            registry = HImportRegistry()
+            registry.prepare("fs", ["a"])
             fieldset = registry.get("fs")
             conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
             conn._himport_reconciled_revision = registry.revision
@@ -767,7 +769,8 @@ class TestHImportAskRedirectAsyncCluster:
         # The bare SET's ASKING allowance is consumed by the failed SET, so the
         # NoSuchFieldsetError recovery must re-arm ASKING: [PREPARE, ASKING, SET].
         async def run():
-            registry = HImportRegistry({"fs": ["a", "b"]})
+            registry = HImportRegistry()
+            registry.prepare("fs", ["a", "b"])
             fieldset = registry.get("fs")
             conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
             conn._himport_reconciled_revision = registry.revision
@@ -801,7 +804,8 @@ class TestHImportAskRedirectAsyncCluster:
     def test_bare_set_recovery_without_asking_keeps_bundle(self):
         # Regression: a non-ASK recovery still packs [PREPARE, SET] (no ASKING).
         async def run():
-            registry = HImportRegistry({"fs": ["a", "b"]})
+            registry = HImportRegistry()
+            registry.prepare("fs", ["a", "b"])
             fieldset = registry.get("fs")
             conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
             conn._himport_reconciled_revision = registry.revision
@@ -821,6 +825,30 @@ class TestHImportAskRedirectAsyncCluster:
                 ("cmd", SET_K_FS),
                 ("packed", [PREPARE_FS_AB, SET_K_FS]),
             ]
+
+        asyncio.run(run())
+
+    def test_bare_set_asking_error_drains_set_reply(self):
+        # ASKING and SET are one packed write (two queued replies). If the ASKING
+        # reply errors, the SET reply must still be drained before the error is
+        # surfaced, or the connection returns to the pool with an unread reply.
+        async def run():
+            registry = HImportRegistry()
+            registry.prepare("fs", ["a"])
+            fieldset = registry.get("fs")
+            conn = _AsyncCapturingConn(registry, prepared={"fs": fieldset.version})
+            conn._himport_reconciled_revision = registry.revision
+            node = mock.Mock()
+            node._himport_reconcile_discards = mock.AsyncMock()
+            node.parse_response = mock.AsyncMock(
+                side_effect=[ResponseError("bad ASKING"), 1]  # ASKING errs, SET drained
+            )
+            with pytest.raises(ResponseError, match="bad ASKING"):
+                await async_cluster_mod.ClusterNode._himport_execute_set(
+                    node, conn, "k", "fs", ["v"], asking=True
+                )
+            assert node.parse_response.call_count == 2  # SET reply drained
+            assert conn.writes == [("packed", [ASKING, SET_K_FS])]  # no retry write
 
         asyncio.run(run())
 
@@ -874,20 +902,25 @@ class TestHImportSingleConnectionPrepareMaterializesFields:
 class TestHImportPropagationSync:
     """Data propagation: client -> pool -> connection (standalone + sentinel)."""
 
-    def test_pool_builds_registry_from_schemas(self):
-        pool = ConnectionPool(himport_schemas={"shared": ["a", "b"]})
+    def test_pool_registry_reaches_connection_via_runtime_prepare(self):
+        # A shared registry always exists on the pool; a runtime prepare on it is
+        # visible through the same object reached by every connection.
+        pool = ConnectionPool()
+        pool.himport_registry.prepare("shared", ["a", "b"])
         assert isinstance(pool.himport_registry, HImportRegistry)
         assert pool.himport_registry.get("shared").fields == ("a", "b")
         conn = pool.make_connection()
         # Same shared object reaches the connection, plus empty per-conn state.
         assert conn.himport_registry is pool.himport_registry
+        assert conn.himport_registry.get("shared").fields == ("a", "b")
         assert conn._himport_prepared == {}
         assert conn._himport_reconciled_revision == 0
 
     def test_pool_accepts_prebuilt_registry_internally(self):
         # Internal channel (used by the cluster to share one object): a pre-built
         # himport_registry passed via connection_kwargs is used as-is, not rebuilt.
-        registry = HImportRegistry({"x": ["1"]})
+        registry = HImportRegistry()
+        registry.prepare("x", ["1"])
         pool = ConnectionPool(himport_registry=registry)
         assert pool.himport_registry is registry
         assert pool.make_connection().himport_registry is registry
@@ -901,22 +934,23 @@ class TestHImportPropagationSync:
         assert pool.make_connection().himport_registry is pool.himport_registry
 
     def test_blocking_pool_resolves(self):
-        pool = BlockingConnectionPool(himport_schemas={"s": ["a"]})
+        pool = BlockingConnectionPool()
+        pool.himport_registry.prepare("s", ["a"])
         assert pool.himport_registry.get("s").fields == ("a",)
         assert pool.make_connection().himport_registry is pool.himport_registry
 
     def test_redis_property_and_propagation(self):
-        r = Redis(himport_schemas={"shared": ["name", "email"]})
+        r = Redis()
+        r.himport_prepare("shared", ["name", "email"])
         assert r.himport_registry is r.connection_pool.himport_registry
         assert r.himport_registry.get("shared").fields == ("name", "email")
 
-    def test_redis_unix_socket_propagates_schemas(self):
-        # Regression: himport_schemas must propagate for Unix-socket clients, not
-        # just TCP. Construction does not connect, so no socket is needed.
-        r = Redis(
-            unix_socket_path="/tmp/does-not-connect.sock",
-            himport_schemas={"shared": ["name", "email"]},
-        )
+    def test_redis_unix_socket_propagates_runtime_prepare(self):
+        # Regression: runtime himport_prepare must reach the shared pool registry for
+        # Unix-socket clients, not just TCP. Construction does not connect, so no
+        # socket is needed.
+        r = Redis(unix_socket_path="/tmp/does-not-connect.sock")
+        r.himport_prepare("shared", ["name", "email"])
         assert r.himport_registry is r.connection_pool.himport_registry
         assert r.himport_registry.get("shared").fields == ("name", "email")
 
@@ -925,18 +959,22 @@ class TestHImportPropagationSync:
         assert isinstance(registry, HImportRegistry)
         assert len(registry) == 0
 
-    def test_redis_has_no_public_himport_registry_param(self):
-        # himport_registry (the object) is internal-only; the sole public knob is the
-        # schemas dict, so the client never holds a caller-supplied mutable registry.
-        assert "himport_registry" not in inspect.signature(Redis.__init__).parameters
+    def test_redis_has_no_public_himport_param(self):
+        # Under the runtime-only model there is no HIMPORT constructor argument at
+        # all: himport_registry is internal-only and himport_schemas was removed.
+        # Fieldsets are declared exclusively via the runtime himport_prepare method.
+        params = inspect.signature(Redis.__init__).parameters
+        assert not any("himport" in name for name in params)
 
-    def test_sentinel_pool_resolves_via_connection_kwargs(self):
-        # Sentinel needs no edits: himport_schemas rides in connection_kwargs and
-        # the base pool (via SentinelConnectionPool) resolves it.
-        s = Sentinel([("127.0.0.1", 26379)], himport_schemas={"s": ["a"]})
-        assert s.connection_kwargs.get("himport_schemas") == {"s": ["a"]}
-        pool = SentinelConnectionPool("mymaster", s, himport_schemas={"s": ["a"]})
-        assert pool.himport_registry.get("s").fields == ("a",)
+    def test_sentinel_master_client_runtime_prepare(self):
+        # Sentinel needs no HIMPORT-specific wiring: a client from master_for exposes
+        # the runtime himport API and mutates its own pool's shared registry. Pure
+        # unit test: construction and himport_prepare do not connect.
+        s = Sentinel([("127.0.0.1", 26379)])
+        master = s.master_for("mymaster")
+        master.himport_prepare("s", ["a"])
+        assert master.himport_registry is master.connection_pool.himport_registry
+        assert master.himport_registry.get("s").fields == ("a",)
 
 
 @pytest.mark.fixed_client
@@ -945,14 +983,17 @@ class TestHImportPropagationAsync:
 
     def test_async_pool_and_client(self):
         async def run():
-            pool = AsyncConnectionPool(himport_schemas={"s": ["a", "b"]})
+            pool = AsyncConnectionPool()
+            pool.himport_registry.prepare("s", ["a", "b"])
             assert pool.himport_registry.get("s").fields == ("a", "b")
             conn = pool.make_connection()
             assert conn.himport_registry is pool.himport_registry
+            assert conn.himport_registry.get("s").fields == ("a", "b")
             assert conn._himport_prepared == {}
             assert conn._himport_reconciled_revision == 0
 
-            r = AsyncRedis(himport_schemas={"s": ["a"]})
+            r = AsyncRedis()
+            await r.himport_prepare("s", ["a"])
             assert r.himport_registry is r.connection_pool.himport_registry
             assert r.himport_registry.get("s").fields == ("a",)
 
@@ -993,15 +1034,15 @@ class TestHImportClusterWiring:
         params = inspect.signature(cluster_mod.NodesManager.__init__).parameters
         assert "himport_registry" in params
 
-    def test_sync_cluster_single_public_param(self):
+    def test_sync_cluster_has_no_public_himport_param(self):
         params = inspect.signature(cluster_mod.RedisCluster.__init__).parameters
-        assert "himport_schemas" in params
-        assert "himport_registry" not in params
+        # Runtime-only model: no HIMPORT constructor knob is public (the shared
+        # registry is threaded internally, and the old schemas dict was removed).
+        assert not any("himport" in name for name in params)
 
-    def test_async_cluster_single_public_param(self):
+    def test_async_cluster_has_no_public_himport_param(self):
         params = inspect.signature(async_cluster_mod.RedisCluster.__init__).parameters
-        assert "himport_schemas" in params
-        assert "himport_registry" not in params
+        assert not any("himport" in name for name in params)
 
     def test_async_cluster_has_himport_slot(self):
         # Private backing attribute lives in __slots__; the public name is a property.

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -1114,6 +1114,48 @@ class TestHImportClusterWiring:
             assert isinstance(attr, property), cls
             assert attr.fset is None, cls  # read-only: no setter
 
+    def test_sync_cluster_pipeline_shares_parent_registry(self):
+        # The pipeline inherits himport_prepare/discard/discard_all from RedisCluster;
+        # they mutate the one registry threaded through the NodesManager (and referenced
+        # by every node pool), so a fieldset declared on the pipeline is visible to the
+        # batched himport_set pre-flight exactly as on the parent client.
+        registry = HImportRegistry()
+        nodes_manager = mock.Mock()
+        nodes_manager.himport_registry = registry
+        pipe = cluster_mod.ClusterPipeline(
+            nodes_manager=nodes_manager, commands_parser=mock.Mock()
+        )
+
+        assert pipe.himport_registry is registry
+        assert pipe.himport_prepare("fs", ["a", "b"]) is True
+        assert registry.get("fs") is not None  # mutated the shared object
+        assert pipe.himport_discard("fs") == 1
+        assert registry.get("fs") is None
+        assert pipe.himport_discard_all() == 0
+
+    def test_async_cluster_pipeline_delegates_to_parent_registry(self):
+        # The async pipeline holds only a client reference, so its HIMPORT lifecycle
+        # methods delegate to the parent client, mutating the one shared registry.
+        registry = HImportRegistry()
+        client = mock.Mock()
+        client.himport_registry = registry
+        client.himport_prepare = mock.AsyncMock(return_value=True)
+        client.himport_discard = mock.AsyncMock(return_value=1)
+        client.himport_discard_all = mock.AsyncMock(return_value=0)
+        pipe = async_cluster_mod.ClusterPipeline(client)
+
+        assert pipe.himport_registry is registry
+
+        async def run():
+            assert await pipe.himport_prepare("fs", ["a", "b"]) is True
+            assert await pipe.himport_discard("fs") == 1
+            assert await pipe.himport_discard_all() == 0
+
+        asyncio.run(run())
+        client.himport_prepare.assert_awaited_once_with("fs", ["a", "b"])
+        client.himport_discard.assert_awaited_once_with("fs")
+        client.himport_discard_all.assert_awaited_once_with()
+
 
 @pytest.mark.fixed_client
 class TestNoSuchFieldsetErrorMapping:

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -1024,6 +1024,60 @@ class TestHImportSetValueValidation:
 
 
 @pytest.mark.fixed_client
+class TestHImportSetRawArityFallThrough:
+    """A raw ``execute_command`` for HIMPORT SET with too few args must fall through
+    to the normal send path so the server returns its arity error, instead of the
+    client raising IndexError while slicing key/fieldset_name out of ``args``.
+    ``himport_set`` itself always supplies key + fieldset_name (len(args) >= 3), so
+    the real command path is unaffected."""
+
+    def test_sync_too_few_args_falls_through_to_send(self):
+        conn = _CapturingConn(HImportRegistry())
+        r = Redis()
+        r._himport_execute_set = mock.Mock(
+            side_effect=AssertionError("must not take the HIMPORT executor path")
+        )
+        r.parse_response = mock.Mock(return_value="server-arity-error")
+        # (HIMPORT_SET, key) — no fieldset_name; must not raise IndexError.
+        r._send_command_parse_response(conn, HIMPORT_SET, HIMPORT_SET, "k")
+        assert conn.writes == [("cmd", (HIMPORT_SET, "k"))]
+
+    def test_sync_well_formed_uses_himport_executor(self):
+        conn = _CapturingConn(HImportRegistry())
+        r = Redis()
+        r._himport_execute_set = mock.Mock(return_value="OK")
+        r._send_command_parse_response(conn, HIMPORT_SET, HIMPORT_SET, "k", "fs", "v")
+        r._himport_execute_set.assert_called_once_with(conn, "k", "fs", ["v"])
+        assert conn.writes == []  # did not fall through to a plain send
+
+    def test_async_too_few_args_falls_through_to_send(self):
+        async def run():
+            conn = _AsyncCapturingConn(HImportRegistry())
+            r = AsyncRedis()
+            r._himport_execute_set = mock.AsyncMock(
+                side_effect=AssertionError("must not take the HIMPORT executor path")
+            )
+            r.parse_response = mock.AsyncMock(return_value="server-arity-error")
+            await r._send_command_parse_response(conn, HIMPORT_SET, HIMPORT_SET, "k")
+            assert conn.writes == [("cmd", (HIMPORT_SET, "k"))]
+
+        asyncio.run(run())
+
+    def test_async_well_formed_uses_himport_executor(self):
+        async def run():
+            conn = _AsyncCapturingConn(HImportRegistry())
+            r = AsyncRedis()
+            r._himport_execute_set = mock.AsyncMock(return_value="OK")
+            await r._send_command_parse_response(
+                conn, HIMPORT_SET, HIMPORT_SET, "k", "fs", "v"
+            )
+            r._himport_execute_set.assert_awaited_once_with(conn, "k", "fs", ["v"])
+            assert conn.writes == []
+
+        asyncio.run(run())
+
+
+@pytest.mark.fixed_client
 class TestHImportClusterWiring:
     """Cluster wiring guards (offline). Full topology behavior is covered by the
     cluster suite; here we assert the plumbing that makes propagation possible."""

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -18,6 +18,7 @@ from redis.himport import (
     HImportFieldset,
     HImportRegistry,
     is_himport_set_command,
+    parse_himport_set_args,
 )
 from redis.sentinel import Sentinel
 
@@ -614,6 +615,45 @@ class TestIsHImportSetCommand:
     )
     def test_rejects_other_commands_and_non_strings(self, name):
         assert is_himport_set_command(name) is False
+
+
+@pytest.mark.fixed_client
+class TestParseHImportSetArgs:
+    """``parse_himport_set_args`` recognises both wire-equivalent raw forms of
+    HIMPORT SET and returns the operands at the right offsets for either.
+    """
+
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            # Joined form: args[0] == "HIMPORT SET".
+            (("HIMPORT SET", "k", "fs", "v1", "v2"), ("k", "fs", ["v1", "v2"])),
+            (("himport set", "k", "fs", "v1"), ("k", "fs", ["v1"])),
+            ((b"HIMPORT SET", "k", "fs"), ("k", "fs", [])),  # no values
+            # Split form: args[0] == "HIMPORT", args[1] == "SET".
+            (("HIMPORT", "SET", "k", "fs", "v1", "v2"), ("k", "fs", ["v1", "v2"])),
+            (("himport", "set", "k", "fs", "v1"), ("k", "fs", ["v1"])),
+            ((b"HImPoRt", b"SeT", "k", "fs", "v1"), ("k", "fs", ["v1"])),
+        ],
+    )
+    def test_parses_both_forms(self, args, expected):
+        assert parse_himport_set_args(args) == expected
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            (),  # empty
+            ("HIMPORT",),  # bare, no subcommand
+            ("HIMPORT SET",),  # joined, too few operands
+            ("HIMPORT", "SET", "k"),  # split, missing fieldset
+            ("HIMPORT", "PREPARE", "fs", "a"),  # different subcommand
+            ("HIMPORT", "DISCARD", "fs"),
+            ("GET", "k"),  # unrelated command
+            ("HSET", "k", "f", "v"),
+        ],
+    )
+    def test_returns_none_for_non_set_or_too_few(self, args):
+        assert parse_himport_set_args(args) is None
 
 
 class TestHImportAskRedirectSync:

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -68,6 +68,35 @@ class TestHImportRegistry:
         assert registry.get("tuple").fields == ("a", "b")
         assert registry.get("gen").fields == ("f0", "f1", "f2")
 
+    def test_prepare_with_registry_reentrant_generator_does_not_deadlock(self):
+        # The field iterable is materialized *before* the mutation lock, so a
+        # generator that consults the same registry mid-iteration (yield, then a
+        # locked read) must not deadlock on the non-reentrant lock. Run under a
+        # join timeout so a regression fails deterministically instead of hanging.
+        registry = HImportRegistry()
+        registry.prepare("existing", ["a"])
+        seen = []
+
+        def fields():
+            yield "f1"
+            seen.extend(registry.names())  # locked read while being consumed
+            yield "f2"
+
+        done = threading.Event()
+
+        def run():
+            registry.prepare("gen", fields())
+            done.set()
+
+        thread = threading.Thread(target=run)
+        thread.start()
+        thread.join(timeout=5)
+        assert done.is_set(), (
+            "prepare() deadlocked materializing a registry-re-entrant generator"
+        )
+        assert registry.get("gen").fields == ("f1", "f2")
+        assert "existing" in seen
+
     def test_empty_string_names_and_fields_allowed(self):
         # Empty strings are valid fieldset names and field names per the HLD;
         # the client must not reject them locally.

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -13,7 +13,12 @@ from redis.asyncio.connection import ConnectionPool as AsyncConnectionPool
 from redis.connection import BlockingConnectionPool, ConnectionPool
 from redis._parsers.base import BaseParser
 from redis.exceptions import DataError, NoSuchFieldsetError, ResponseError
-from redis.himport import HIMPORT_SET, HImportRegistry, HImportFieldset
+from redis.himport import (
+    HIMPORT_SET,
+    HImportFieldset,
+    HImportRegistry,
+    is_himport_set_command,
+)
 from redis.sentinel import Sentinel
 
 
@@ -570,6 +575,47 @@ SET_K_FS = ("HIMPORT", "SET", "k", "fs", "v")
 
 
 @pytest.mark.fixed_client
+@pytest.mark.fixed_client
+class TestIsHImportSetCommand:
+    """``is_himport_set_command`` selects the connection-state-aware HIMPORT SET
+    path for the raw ``execute_command`` API, where the caller controls the
+    command-name spelling and encoding. An exact comparison would miss
+    case/byte variants and send a bare SET that fails ``no such fieldset``.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "HIMPORT SET",
+            "himport set",
+            "Himport Set",
+            b"HIMPORT SET",
+            b"himport set",
+            bytearray(b"himport set"),
+            memoryview(b"HIMPORT SET"),
+        ],
+    )
+    def test_matches_case_and_encoding_variants(self, name):
+        assert is_himport_set_command(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "HIMPORT PREPARE",
+            "HIMPORT DISCARD",
+            "SET",
+            "himport setx",  # length differs -> no upper() needed, still rejected
+            "himport se",
+            "",
+            b"GET",
+            None,
+            123,
+        ],
+    )
+    def test_rejects_other_commands_and_non_strings(self, name):
+        assert is_himport_set_command(name) is False
+
+
 class TestHImportAskRedirectSync:
     """An ASK-redirected ``HIMPORT SET`` must carry the ASKING allowance on the
     same connection, immediately before the SET.

--- a/tests/test_himport.py
+++ b/tests/test_himport.py
@@ -581,14 +581,19 @@ class TestHImportAskRedirectSync:
     executor on ``RedisCluster`` (mirroring the async ``ClusterNode``): the ASKING
     allowance is folded into the SET's own packed write so it lands immediately
     before the SET. ``_himport_prepare_and_set`` ignores ``self`` (call it unbound);
-    ``_himport_execute_set`` dispatches to it via ``self``, so a stub ``self``
-    carrying the real methods exercises the real code. ``parse_response`` /
-    ``_himport_reconcile_discards`` are taken from the ``redis_node`` argument.
+    ``_himport_execute_set`` dispatches to ``_himport_prepare_and_set`` and
+    ``_himport_reconcile_discards`` via ``self``, so a stub ``self`` carrying the
+    real ``RedisCluster`` methods exercises the real code. ``parse_response`` is
+    taken from the ``redis_node`` argument (the reconcile helper drains its own
+    replies through that same ``redis_node``).
     """
 
     class _ClusterStub:
         _himport_execute_set = cluster_mod.RedisCluster._himport_execute_set
         _himport_prepare_and_set = cluster_mod.RedisCluster._himport_prepare_and_set
+        _himport_reconcile_discards = (
+            cluster_mod.RedisCluster._himport_reconcile_discards
+        )
 
     def test_prepare_and_set_packs_prepare_asking_set(self):
         registry = HImportRegistry()
@@ -625,7 +630,6 @@ class TestHImportAskRedirectSync:
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
         node = mock.Mock()
-        node._himport_reconcile_discards = mock.Mock()
         node.parse_response = mock.Mock(side_effect=["OK", 1])
         resp = self._ClusterStub()._himport_execute_set(
             node, conn, "k", "fs", ["v"], asking=True
@@ -642,7 +646,6 @@ class TestHImportAskRedirectSync:
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
         node = mock.Mock()
-        node._himport_reconcile_discards = mock.Mock()
         node.parse_response = mock.Mock(
             side_effect=[
                 "OK",  # ASKING (bare)
@@ -671,7 +674,6 @@ class TestHImportAskRedirectSync:
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
         node = mock.Mock()
-        node._himport_reconcile_discards = mock.Mock()
         node.parse_response = mock.Mock(
             side_effect=[NoSuchFieldsetError("no such fieldset"), "OK", 1]
         )
@@ -692,7 +694,6 @@ class TestHImportAskRedirectSync:
         conn = _CapturingConn(registry, prepared={"fs": fieldset.version})
         conn._himport_reconciled_revision = registry.revision
         node = mock.Mock()
-        node._himport_reconcile_discards = mock.Mock()
         node.parse_response = mock.Mock(
             side_effect=[ResponseError("bad ASKING"), 1]  # ASKING errors, SET drained
         )

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -349,6 +349,22 @@ class TestHImportIntegration:
         assert not any(isinstance(r, Exception) for r in result)
         assert hr.hget("h:{u}:pl1", "y") == b"2"
 
+    def test_pipeline_watch_immediate_himport_set(self, hr):
+        # An HIMPORT SET issued after WATCH (before MULTI) runs on the immediate
+        # execution path, not the batched one. That path must lazily PREPARE the
+        # fieldset on the watched connection like the normal and batched paths
+        # do; otherwise the bare HIMPORT SET fails with "no such fieldset".
+        key = "h:{u}:w1"
+        pipe = hr.pipeline(transaction=True)
+        try:
+            pipe.watch(key)
+            # Executed immediately on the watched connection.
+            pipe.himport_set(key, "shared", ["alice", "alice@x", "25"])
+        finally:
+            pipe.reset()
+        assert hr.hget(key, "name") == b"alice"
+        assert hr.hget(key, "age") == b"25"
+
     @pytest.mark.onlycluster
     def test_cluster_multi_slot(self, hr):
         # Distinct hash tags spread keys across slots/nodes; each node prepares lazily.

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -165,7 +165,7 @@ def test_discard_on_disconnected_single_connection(request):
             assert client.himport_discard("tmp") == 1
             discard_wire.assert_not_called()
         assert conn.is_connected is False
-        assert "tmp" not in client.himport_config
+        assert "tmp" not in client.himport_registry
         # A later himport_set still works: the prepare (while still disconnected)
         # sends nothing, and the set reconnects and bundles PREPARE lazily.
         with track_himport_wire(conn) as events:

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -309,14 +309,6 @@ class TestHImportIntegration:
         # Keys already written through it are unaffected.
         assert hr.hget("h:{u}:t", "f1") == b"1"
 
-    def test_discard_init_raises(self, hr):
-        with pytest.raises(redis.DataError):
-            hr.himport_discard("shared")
-
-    def test_discard_all_rejected_when_init_present(self, hr):
-        with pytest.raises(redis.DataError):
-            hr.himport_discard_all()
-
     def test_pool_churn_lazy_prepare(self, hr):
         # Each connection the pool hands out prepares the fieldset once, lazily.
         n = 25

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -83,8 +83,10 @@ def hr(request):
         redis.Redis,
         request,
         single_connection_client=False,
-        himport_schemas=dict(SCHEMAS),
     ) as client:
+        # Populate the registry directly (mirrors what init schemas did) without an
+        # eager PREPARE, so lazy-bundling wire assertions in the tests still hold.
+        client.himport_registry.prepare("shared", SCHEMAS["shared"])
         yield client
 
 
@@ -96,8 +98,8 @@ def test_dedicated_connection_prepare_immediate(request):
         redis.Redis,
         request,
         single_connection_client=True,
-        himport_schemas=dict(SCHEMAS),
     ) as client:
+        client.himport_registry.prepare("shared", SCHEMAS["shared"])
         conn = client.connection
         client.himport_set("himport:{probe}", "shared", ["p", "p@x", "1"])
         client.delete("himport:{probe}", "d:{u}:1")
@@ -111,7 +113,7 @@ def test_dedicated_connection_prepare_immediate(request):
 
 
 def test_runtime_prepare_without_init_schemas(request):
-    """A client built with no himport_schemas can still declare + use fieldsets."""
+    """A client that declares nothing up front can still declare + use fieldsets."""
     with _get_client(redis.Redis, request, single_connection_client=False) as client:
         client.himport_prepare("ronly", ["a", "b"])
         client.delete("r:{u}:1")
@@ -127,8 +129,8 @@ def test_disconnect_clears_prepared_state(request):
         redis.Redis,
         request,
         single_connection_client=True,
-        himport_schemas=dict(SCHEMAS),
     ) as client:
+        client.himport_registry.prepare("shared", SCHEMAS["shared"])
         conn = client.connection
         with track_himport_wire(conn) as events:
             # First use of the fieldset bundles PREPARE with SET; the second reuses
@@ -184,9 +186,9 @@ def test_himport_set_retries_and_reprepares(request):
         redis.Redis,
         request,
         single_connection_client=True,
-        himport_schemas=dict(SCHEMAS),
         retry=Retry(NoBackoff(), 1),
     ) as client:
+        client.himport_registry.prepare("shared", SCHEMAS["shared"])
         # Warm the pinned connection so "shared" is already prepared on it.
         client.himport_set("h:{u}:warm", "shared", ["w", "w@x", "0"])
         conn = client.connection
@@ -217,8 +219,8 @@ def test_himport_set_recovers_when_fieldset_lost_midconnection(request):
         redis.Redis,
         request,
         single_connection_client=True,
-        himport_schemas=dict(SCHEMAS),
     ) as client:
+        client.himport_registry.prepare("shared", SCHEMAS["shared"])
         client.himport_set("rst:{u}:1", "shared", ["a", "a@x", "1"])
         conn = client.connection
         assert "shared" in conn._himport_prepared
@@ -247,8 +249,8 @@ def test_himport_with_client_side_caching(request):
         single_connection_client=False,
         protocol=3,
         cache_config=CacheConfig(),
-        himport_schemas=dict(SCHEMAS),
     ) as client:
+        client.himport_registry.prepare("shared", SCHEMAS["shared"])
         client.himport_set("csc:{u}:1", "shared", ["a", "a@x", "1"])
         assert client.hget("csc:{u}:1", "name") == b"a"
         # create-or-replace still works through the proxy-wrapped connection

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -1,0 +1,365 @@
+"""Integration tests for the HIMPORT command family against a real server.
+
+Runs against whatever topology the suite targets: standalone under
+``invoke standalone-tests`` and cluster under ``invoke cluster-tests`` (the
+``_get_client`` helper builds the matching client). HIMPORT was introduced in
+Redis 8.9.0, so the whole module is gated on that server version.
+
+Keys use a shared hash tag (``{u}``) so a single test stays within one slot on
+cluster; the cross-slot behavior is exercised by a dedicated ``onlycluster`` test.
+"""
+
+import contextlib
+from unittest import mock
+
+import pytest
+
+import redis
+from redis.backoff import NoBackoff
+from redis.retry import Retry
+from tests.conftest import _get_client, skip_if_server_version_lt
+
+SCHEMAS = {"shared": ["name", "email", "age"]}
+
+# HIMPORT (Hinted Hash Templates) landed in Redis 8.9.0; gate the whole module.
+pytestmark = skip_if_server_version_lt("8.9.0")
+
+
+def _himport_verb(parts):
+    """Return the HIMPORT subcommand for a command's leading tokens, or ``None``.
+
+    Handles both wire forms: the joined ``"HIMPORT SET"`` produced by
+    ``execute_command`` and the split ``("HIMPORT", "SET")`` produced by the
+    command builders used in the bundled path.
+    """
+    joined = " ".join(str(p) for p in list(parts)[:2])
+    for verb in ("PREPARE", "SET", "DISCARDALL", "DISCARD"):
+        if joined.startswith(f"HIMPORT {verb}"):
+            return verb
+    return None
+
+
+@contextlib.contextmanager
+def track_himport_wire(conn):
+    """Record how each HIMPORT write reached the socket, in order.
+
+    Wraps ``conn``'s write primitives (calling through to the real ones, so the
+    exchange still happens for real) and yields a list of markers:
+
+    - ``"PREPARE+SET"`` — lazy PREPARE bundled with the SET in one packed write
+    - ``"SET"``         — bare SET (fieldset already prepared on this connection)
+    - ``"PREPARE"`` / ``"DISCARD"`` — a standalone command
+    - ``"DISCARD*N"``   — a deferred-discard reconcile of ``N`` fieldsets
+    """
+    events = []
+    real_pack = conn.pack_commands
+    real_send = conn.send_command
+
+    def pack(commands, *args, **kwargs):
+        verbs = [_himport_verb(cmd) for cmd in commands]
+        if "PREPARE" in verbs:
+            events.append("PREPARE+SET")
+        elif verbs and all(v == "DISCARD" for v in verbs):
+            events.append(f"DISCARD*{len(verbs)}")
+        return real_pack(commands, *args, **kwargs)
+
+    def send(*args, **kwargs):
+        verb = _himport_verb(args)
+        if verb is not None:
+            events.append(verb)
+        return real_send(*args, **kwargs)
+
+    with (
+        mock.patch.object(conn, "pack_commands", new=pack),
+        mock.patch.object(conn, "send_command", new=send),
+    ):
+        yield events
+
+
+@pytest.fixture()
+def hr(request):
+    """A pooled client (standalone or cluster) with a declared HIMPORT schema."""
+    with _get_client(
+        redis.Redis,
+        request,
+        single_connection_client=False,
+        himport_schemas=dict(SCHEMAS),
+    ) as client:
+        yield client
+
+
+@pytest.mark.onlynoncluster
+def test_dedicated_connection_prepare_immediate(request):
+    """On a single-connection client, himport_prepare runs on the pinned socket
+    immediately, so the following himport_set is a bare SET (no re-prepare)."""
+    with _get_client(
+        redis.Redis,
+        request,
+        single_connection_client=True,
+        himport_schemas=dict(SCHEMAS),
+    ) as client:
+        conn = client.connection
+        client.himport_set("himport:{probe}", "shared", ["p", "p@x", "1"])
+        client.delete("himport:{probe}", "d:{u}:1")
+        with track_himport_wire(conn) as events:
+            assert client.himport_prepare("ded", ["x", "y"]) is True
+            client.himport_set("d:{u}:1", "ded", ["1", "2"])
+        # PREPARE goes out eagerly on its own; the SET then finds the fieldset
+        # already prepared and sends bare (not another PREPARE+SET bundle).
+        assert events == ["PREPARE", "SET"]
+        assert client.hget("d:{u}:1", "y") == b"2"
+
+
+def test_runtime_prepare_without_init_schemas(request):
+    """A client built with no himport_schemas can still declare + use fieldsets."""
+    with _get_client(redis.Redis, request, single_connection_client=False) as client:
+        client.himport_prepare("ronly", ["a", "b"])
+        client.delete("r:{u}:1")
+        client.himport_set("r:{u}:1", "ronly", ["1", "2"])
+        assert client.hget("r:{u}:1", "b") == b"2"
+
+
+@pytest.mark.onlynoncluster
+def test_disconnect_clears_prepared_state(request):
+    """A disconnect drops the server session, so per-connection prepared state
+    is cleared and the next himport_set transparently re-prepares."""
+    with _get_client(
+        redis.Redis,
+        request,
+        single_connection_client=True,
+        himport_schemas=dict(SCHEMAS),
+    ) as client:
+        conn = client.connection
+        with track_himport_wire(conn) as events:
+            # First use of the fieldset bundles PREPARE with SET; the second reuses
+            # the already-prepared connection and sends bare.
+            client.himport_set("d:{u}:1", "shared", ["a", "a@x", "1"])
+            client.himport_set("d:{u}:x", "shared", ["c", "c@x", "3"])
+        assert events == ["PREPARE+SET", "SET"]
+        assert "shared" in conn._himport_prepared
+        conn.disconnect()
+        assert conn._himport_prepared == {}
+        # The reconnected socket has no session state, so the next set re-bundles.
+        with track_himport_wire(conn) as events:
+            client.himport_set("d:{u}:2", "shared", ["b", "b@x", "2"])
+        assert events == ["PREPARE+SET"]
+        assert client.hget("d:{u}:2", "name") == b"b"
+
+
+@pytest.mark.onlynoncluster
+def test_discard_on_disconnected_single_connection(request):
+    """Discarding on a single-connection client whose socket is not connected
+    updates the registry without reconnecting or issuing a server DISCARD (a fresh
+    connection re-prepares lazily on the next himport_set)."""
+    with _get_client(redis.Redis, request, single_connection_client=True) as client:
+        client.himport_prepare("tmp", ["a", "b"])
+        client.himport_set("z:{u}:1", "tmp", ["1", "2"])
+        conn = client.connection
+        assert "tmp" in conn._himport_prepared
+        conn.disconnect()
+        assert conn.is_connected is False
+        # While disconnected the branch must skip the wire DISCARD entirely: spy the
+        # internal command to prove it is never issued, and confirm the socket stays
+        # closed (a DISCARD would have reconnected it).
+        with mock.patch.object(client, "himport_discard_internal") as discard_wire:
+            assert client.himport_discard("tmp") == 1
+            discard_wire.assert_not_called()
+        assert conn.is_connected is False
+        assert "tmp" not in client.himport_config
+        # A later himport_set still works: the prepare (while still disconnected)
+        # sends nothing, and the set reconnects and bundles PREPARE lazily.
+        with track_himport_wire(conn) as events:
+            client.himport_prepare("tmp2", ["c", "d"])
+            client.himport_set("z:{u}:2", "tmp2", ["3", "4"])
+        assert events == ["PREPARE+SET"]
+        assert client.hget("z:{u}:2", "d") == b"4"
+
+
+@pytest.mark.onlynoncluster
+def test_himport_set_retries_and_reprepares(request):
+    """himport_set uses the normal command path, so a retryable error triggers the
+    standard reconnect-and-retry: the dropped socket clears the prepared state and
+    the retry re-prepares the fieldset before the SET."""
+    with _get_client(
+        redis.Redis,
+        request,
+        single_connection_client=True,
+        himport_schemas=dict(SCHEMAS),
+        retry=Retry(NoBackoff(), 1),
+    ) as client:
+        # Warm the pinned connection so "shared" is already prepared on it.
+        client.himport_set("h:{u}:warm", "shared", ["w", "w@x", "0"])
+        conn = client.connection
+        real_parse = client.parse_response
+        injected = {"done": False}
+
+        def flaky(connection, command_name, **options):
+            # Drop the connection once, while reading the first SET reply.
+            if command_name == "HIMPORT SET" and not injected["done"]:
+                injected["done"] = True
+                raise redis.ConnectionError("simulated drop")
+            return real_parse(connection, command_name, **options)
+
+        with mock.patch.object(client, "parse_response", side_effect=flaky):
+            assert client.himport_set("h:{u}:r", "shared", ["a", "a@x", "1"]) is True
+        assert injected["done"] is True  # the failure actually fired
+        # The command still succeeded and the reconnected socket was re-prepared.
+        assert client.hget("h:{u}:r", "email") == b"a@x"
+        assert "shared" in conn._himport_prepared
+
+
+@pytest.mark.onlynoncluster
+def test_himport_set_recovers_when_fieldset_lost_midconnection(request):
+    """If the server drops a prepared fieldset mid-connection (e.g. RESET or
+    maxmemory-clients eviction) without dropping the socket, the next himport_set
+    re-prepares on the same connection and retries the SET once — no reconnect."""
+    with _get_client(
+        redis.Redis,
+        request,
+        single_connection_client=True,
+        himport_schemas=dict(SCHEMAS),
+    ) as client:
+        client.himport_set("rst:{u}:1", "shared", ["a", "a@x", "1"])
+        conn = client.connection
+        assert "shared" in conn._himport_prepared
+        # Drop the fieldset server-side on this exact socket without touching the
+        # client's tracking, simulating a mid-connection loss.
+        client.execute_command("HIMPORT", "DISCARD", "shared")
+        assert "shared" in conn._himport_prepared  # client still believes it exists
+        assert conn.is_connected is True
+        with track_himport_wire(conn) as events:
+            assert client.himport_set("rst:{u}:2", "shared", ["b", "b@x", "2"]) is True
+        # The bare SET fails with NoSuchFieldsetError, then a PREPARE+SET recovers it.
+        assert events == ["SET", "PREPARE+SET"]
+        assert conn.is_connected is True  # recovery never reconnected
+        assert client.hget("rst:{u}:2", "name") == b"b"
+
+
+@pytest.mark.onlynoncluster
+def test_himport_with_client_side_caching(request):
+    """HIMPORT is non-cacheable and bypasses the CSC proxy, so it works with
+    client-side caching enabled while normal reads stay cacheable."""
+    from redis.cache import CacheConfig
+
+    with _get_client(
+        redis.Redis,
+        request,
+        single_connection_client=False,
+        protocol=3,
+        cache_config=CacheConfig(),
+        himport_schemas=dict(SCHEMAS),
+    ) as client:
+        client.himport_set("csc:{u}:1", "shared", ["a", "a@x", "1"])
+        assert client.hget("csc:{u}:1", "name") == b"a"
+        # create-or-replace still works through the proxy-wrapped connection
+        client.himport_set("csc:{u}:1", "shared", ["b", "b@x", "2"])
+        assert client.hget("csc:{u}:1", "name") == b"b"
+        # Client-side caching remains active for normal reads.
+        client.set("csc:{u}:k", "v")
+        client.get("csc:{u}:k")
+        client.get("csc:{u}:k")
+        assert client.get_cache().size > 0
+
+
+class TestHImportIntegration:
+    def test_prepare_set_readback(self, hr):
+        hr.himport_set("h:{u}:1", "shared", ["alice", "alice@x", "25"])
+        hr.himport_set("h:{u}:2", "shared", ["bob", "bob@x", "30"])
+        assert hr.hget("h:{u}:1", "name") == b"alice"
+        assert hr.hget("h:{u}:2", "email") == b"bob@x"
+        assert hr.hgetall("h:{u}:1") == {
+            b"name": b"alice",
+            b"email": b"alice@x",
+            b"age": b"25",
+        }
+
+    def test_positional_value_mapping(self, hr):
+        # ``age`` is the 3rd prepared field; the 3rd value maps to it.
+        hr.himport_set("h:{u}:p", "shared", ["x", "y", "99"])
+        assert hr.hget("h:{u}:p", "age") == b"99"
+
+    def test_create_or_replace(self, hr):
+        hr.himport_set("h:{u}:r", "shared", ["a", "a@x", "1"])
+        hr.himport_set("h:{u}:r", "shared", ["b", "b@x", "2"])
+        assert hr.hget("h:{u}:r", "name") == b"b"
+        assert hr.hget("h:{u}:r", "age") == b"2"
+
+    def test_wrongtype_on_non_hash_key(self, hr):
+        hr.set("h:{u}:str", "notahash")
+        with pytest.raises(redis.ResponseError):
+            hr.himport_set("h:{u}:str", "shared", ["a", "a@x", "1"])
+
+    def test_value_count_mismatch_propagates(self, hr):
+        with pytest.raises(redis.ResponseError):
+            hr.himport_set("h:{u}:bad", "shared", ["only-one-value"])
+
+    def test_runtime_prepare_then_set(self, hr):
+        assert hr.himport_prepare("ord", ["a", "b", "c"]) is True
+        hr.himport_set("h:{u}:o", "ord", ["va", "vb", "vc"])
+        assert hr.hget("h:{u}:o", "b") == b"vb"
+
+    def test_discard_runtime(self, hr):
+        hr.himport_prepare("tmp", ["f1", "f2"])
+        hr.himport_set("h:{u}:t", "tmp", ["1", "2"])
+        assert hr.himport_discard("tmp") == 1
+        # No longer registered.
+        assert hr.himport_discard("tmp") == 0
+        # Keys already written through it are unaffected.
+        assert hr.hget("h:{u}:t", "f1") == b"1"
+
+    def test_discard_init_raises(self, hr):
+        with pytest.raises(redis.DataError):
+            hr.himport_discard("shared")
+
+    def test_discard_all_rejected_when_init_present(self, hr):
+        with pytest.raises(redis.DataError):
+            hr.himport_discard_all()
+
+    def test_pool_churn_lazy_prepare(self, hr):
+        # Each connection the pool hands out prepares the fieldset once, lazily.
+        n = 25
+        for i in range(n):
+            hr.himport_set(f"h:{{u}}:c{i}", "shared", [f"n{i}", f"e{i}@x", str(i)])
+        for i in range(n):
+            assert hr.hget(f"h:{{u}}:c{i}", "name") == f"n{i}".encode()
+
+    def test_pipeline_non_transaction(self, hr):
+        # A pipeline bypasses the per-command lazy prepare; the fieldset is
+        # prepared on the pipeline connection as a pre-flight before the batch.
+        pipe = hr.pipeline(transaction=False)
+        pipe.himport_set("h:{u}:np1", "shared", ["a", "a@x", "1"])
+        pipe.himport_set("h:{u}:np2", "shared", ["b", "b@x", "2"])
+        pipe.hget("h:{u}:np1", "name")
+        result = pipe.execute()
+        assert not any(isinstance(r, Exception) for r in result)
+        assert result[-1] == b"a"
+        assert hr.hget("h:{u}:np2", "email") == b"b@x"
+
+    def test_pipeline_transaction(self, hr):
+        # Same fieldset inside MULTI/EXEC; PREPARE is pre-flighted before MULTI.
+        pipe = hr.pipeline(transaction=True)
+        pipe.himport_set("h:{u}:tp1", "shared", ["c", "c@x", "3"])
+        pipe.himport_set("h:{u}:tp2", "shared", ["d", "d@x", "4"])
+        pipe.hget("h:{u}:tp1", "age")
+        result = pipe.execute()
+        assert not any(isinstance(r, Exception) for r in result)
+        assert result[-1] == b"3"
+        assert hr.hget("h:{u}:tp2", "name") == b"d"
+
+    def test_pipeline_runtime_prepared_fieldset(self, hr):
+        # A fieldset declared at runtime is also pre-flighted for the pipeline.
+        hr.himport_prepare("pl", ["x", "y"])
+        pipe = hr.pipeline(transaction=False)
+        pipe.himport_set("h:{u}:pl1", "pl", ["1", "2"])
+        result = pipe.execute()
+        assert not any(isinstance(r, Exception) for r in result)
+        assert hr.hget("h:{u}:pl1", "y") == b"2"
+
+    @pytest.mark.onlycluster
+    def test_cluster_multi_slot(self, hr):
+        # Distinct hash tags spread keys across slots/nodes; each node prepares lazily.
+        keys = [f"h:{{s{i}}}:k" for i in range(8)]
+        for i, k in enumerate(keys):
+            hr.himport_set(k, "shared", [f"n{i}", f"e{i}@x", str(i)])
+        for i, k in enumerate(keys):
+            assert hr.hget(k, "name") == f"n{i}".encode()

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -418,6 +418,21 @@ class TestHImportIntegration:
         assert hr.hget("pf:{u}:1", "x") == b"1"
         assert hr.hget("pf:{u}:2", "y") == b"4"
 
+    @pytest.mark.onlynoncluster
+    def test_pipeline_raw_case_insensitive_himport_set_is_preflighted(self, hr):
+        # A raw, case/encoding-insensitive HIMPORT SET buffered in a pipeline must be
+        # detected by the pre-flight so its fieldset is PREPAREd before the batch --
+        # matching the per-command path. Otherwise the batched SET fails "no such
+        # fieldset" (the fieldset is only in the client registry, not on the socket).
+        hr.himport_prepare("plraw", ["x", "y"])
+        pipe = hr.pipeline(transaction=False)
+        pipe.execute_command("himport set", "plraw:{u}:1", "plraw", "1", "2")
+        pipe.execute_command(b"HImPoRt SeT", "plraw:{u}:2", "plraw", "3", "4")
+        result = pipe.execute()
+        assert not any(isinstance(r, Exception) for r in result)
+        assert hr.hget("plraw:{u}:1", "x") == b"1"
+        assert hr.hget("plraw:{u}:2", "y") == b"4"
+
     def test_pipeline_watch_immediate_himport_set(self, hr):
         # An HIMPORT SET issued after WATCH (before MULTI) runs on the immediate
         # execution path, not the batched one. That path must lazily PREPARE the

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -40,6 +40,40 @@ def _himport_verb(parts):
 
 
 @contextlib.contextmanager
+def capture_himport_packed_writes(pool):
+    """Yield a list of every HIMPORT-carrying packed write on connections the pool
+    hands out while the context is active. Used to prove the pipeline folds its
+    PREPARE into a single ``send_packed_command`` rather than a separate exchange.
+    """
+    blobs = []
+    real_get = pool.get_connection
+
+    def get_connection(*args, **kwargs):
+        conn = real_get(*args, **kwargs)
+        if not getattr(conn, "_himport_write_spy", False):
+            conn._himport_write_spy = True
+            real_send = conn.send_packed_command
+
+            def send_packed_command(*a, **k):
+                blob = a[0] if a else k.get("command", b"")
+                # pack_commands() returns a list of byte chunks; a single command
+                # is bytes. Normalise both to one bytestring for inspection.
+                if isinstance(blob, (list, tuple)):
+                    data = b"".join(bytes(x) for x in blob)
+                else:
+                    data = bytes(blob)
+                if b"HIMPORT" in data:
+                    blobs.append(data)
+                return real_send(*a, **k)
+
+            conn.send_packed_command = send_packed_command
+        return conn
+
+    with mock.patch.object(pool, "get_connection", side_effect=get_connection):
+        yield blobs
+
+
+@contextlib.contextmanager
 def track_himport_wire(conn):
     """Record how each HIMPORT write reached the socket, in order.
 
@@ -88,6 +122,21 @@ def hr(request):
         # eager PREPARE, so lazy-bundling wire assertions in the tests still hold.
         client.himport_registry.prepare("shared", SCHEMAS["shared"])
         yield client
+
+
+@pytest.mark.onlynoncluster
+def test_raw_case_insensitive_himport_set_is_intercepted(hr):
+    # A registered-but-not-yet-prepared fieldset used through the raw, case- and
+    # encoding-insensitive command name must still take the connection-state-aware
+    # path (lazy PREPARE), not send a bare SET that fails ``no such fieldset``.
+    hr.himport_prepare("rawcmd", ["name", "email"])
+    hr.delete("raw:{u}:1", "raw:{u}:2")
+    # Lowercase str name.
+    assert hr.execute_command("himport set", "raw:{u}:1", "rawcmd", "alice", "a@x")
+    assert hr.hget("raw:{u}:1", "name") == b"alice"
+    # Mixed-case bytes name.
+    assert hr.execute_command(b"HImPoRt SeT", "raw:{u}:2", "rawcmd", "bob", "b@x")
+    assert hr.hget("raw:{u}:2", "email") == b"b@x"
 
 
 @pytest.mark.onlynoncluster
@@ -348,6 +397,26 @@ class TestHImportIntegration:
         result = pipe.execute()
         assert not any(isinstance(r, Exception) for r in result)
         assert hr.hget("h:{u}:pl1", "y") == b"2"
+
+    @pytest.mark.onlynoncluster
+    def test_pipeline_folds_prepare_into_single_write(self, hr):
+        # First pipeline use of a registered-but-not-yet-prepared fieldset must fold
+        # the PREPARE into the single batched write, not do a separate PREPARE round
+        # trip first. Spy every connection the pool hands out and assert exactly one
+        # HIMPORT-carrying packed write, containing both the PREPARE and the SETs.
+        hr.himport_prepare("pfold", ["x", "y"])
+        pipe = hr.pipeline(transaction=False)
+        pipe.himport_set("pf:{u}:1", "pfold", ["1", "2"])
+        pipe.himport_set("pf:{u}:2", "pfold", ["3", "4"])
+        with capture_himport_packed_writes(hr.connection_pool) as blobs:
+            pipe.execute()
+        assert len(blobs) == 1, (
+            "PREPARE must be folded into the single pipeline write, "
+            f"got {len(blobs)} HIMPORT writes"
+        )
+        assert b"PREPARE" in blobs[0] and b"SET" in blobs[0]
+        assert hr.hget("pf:{u}:1", "x") == b"1"
+        assert hr.hget("pf:{u}:2", "y") == b"4"
 
     def test_pipeline_watch_immediate_himport_set(self, hr):
         # An HIMPORT SET issued after WATCH (before MULTI) runs on the immediate

--- a/tests/test_himport_integration.py
+++ b/tests/test_himport_integration.py
@@ -137,6 +137,11 @@ def test_raw_case_insensitive_himport_set_is_intercepted(hr):
     # Mixed-case bytes name.
     assert hr.execute_command(b"HImPoRt SeT", "raw:{u}:2", "rawcmd", "bob", "b@x")
     assert hr.hget("raw:{u}:2", "email") == b"b@x"
+    # Split-token wire-equivalent form: ("HIMPORT", "SET", key, fieldset, *values).
+    assert hr.execute_command("HIMPORT", "SET", "raw:{u}:3", "rawcmd", "cara", "c@x")
+    assert hr.hget("raw:{u}:3", "name") == b"cara"
+    assert hr.execute_command(b"himport", b"set", "raw:{u}:4", "rawcmd", "dan", "d@x")
+    assert hr.hget("raw:{u}:4", "email") == b"d@x"
 
 
 @pytest.mark.onlynoncluster
@@ -428,10 +433,13 @@ class TestHImportIntegration:
         pipe = hr.pipeline(transaction=False)
         pipe.execute_command("himport set", "plraw:{u}:1", "plraw", "1", "2")
         pipe.execute_command(b"HImPoRt SeT", "plraw:{u}:2", "plraw", "3", "4")
+        # Split-token form must also be recognised by the pre-flight.
+        pipe.execute_command("HIMPORT", "SET", "plraw:{u}:3", "plraw", "5", "6")
         result = pipe.execute()
         assert not any(isinstance(r, Exception) for r in result)
         assert hr.hget("plraw:{u}:1", "x") == b"1"
         assert hr.hget("plraw:{u}:2", "y") == b"4"
+        assert hr.hget("plraw:{u}:3", "y") == b"6"
 
     def test_pipeline_watch_immediate_himport_set(self, hr):
         # An HIMPORT SET issued after WATCH (before MULTI) runs on the immediate

--- a/tests/test_multidb/test_pipeline.py
+++ b/tests/test_multidb/test_pipeline.py
@@ -5,8 +5,9 @@ import pybreaker
 import pytest
 
 from redis.client import Pipeline
+from redis.exceptions import DataError
 from redis.multidb.circuit import State as CBState, PBCircuitBreakerAdapter
-from redis.multidb.client import MultiDBClient
+from redis.multidb.client import MultiDBClient, Pipeline as MultiDBPipeline
 from redis.multidb.config import InitialHealthCheck
 from redis.multidb.failover import (
     WeightBasedFailoverStrategy,
@@ -539,3 +540,21 @@ class TestTransaction:
                 assert client.transaction(callback) == ["OK1", "value"]
             finally:
                 client.close()
+
+
+@pytest.mark.fixed_client
+class TestPipelineHImportUnsupported:
+    """HIMPORT is unsupported on the multi-database client. The lifecycle methods
+    are blocked on ``MultiDBClient``; the pipeline inherits ``himport_set`` from
+    ``CoreCommands`` and would otherwise queue it silently, so it must be blocked
+    there too. The overrides raise before touching the client, so no config or
+    server is needed."""
+
+    @pytest.mark.parametrize(
+        "method",
+        ["himport_prepare", "himport_set", "himport_discard", "himport_discard_all"],
+    )
+    def test_pipeline_himport_methods_raise(self, method):
+        pipe = MultiDBPipeline(Mock(spec=MultiDBClient))
+        with pytest.raises(DataError, match="not supported on the multi-database"):
+            getattr(pipe, method)("users", ["a"])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4726,7 +4726,11 @@ class TestSearchWithVamana(SearchTestsBase):
 
 class TestHybridSearch(SearchTestsBase):
     _HYBRID_TIMEOUT_DIM = 8192
-    _HYBRID_TIMEOUT_DOCS = 1500
+    # The 1ms timeout only fires once the query runs long enough to hit a
+    # server timeout checkpoint; smaller data sets slip through and return no
+    # warnings. 6000 docs keeps the query comfortably above the 1ms limit so
+    # the timeout reliably triggers across hardware.
+    _HYBRID_TIMEOUT_DOCS = 6000
 
     def _create_hybrid_search_index(self, client, dim=4):
         client.ft().create_index(

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -497,3 +497,67 @@ def test_sentinel_commands_with_strict_redis_client(request):
     assert isinstance(client.sentinel_ckquorum("redis-py-test"), bool)
 
     client.close()
+
+
+# ---------------------------------------------------------------------------
+# HIMPORT on Sentinel
+# ---------------------------------------------------------------------------
+# HIMPORT needs no Sentinel-specific code: the client returned by ``master_for``
+# is a normal ``Redis`` whose ``SentinelConnectionPool`` inherits the shared
+# ``HImportRegistry`` from ``ConnectionPool``. Fieldsets are declared at runtime
+# with ``himport_prepare`` and survive failover because the registry lives on the
+# long-lived pool while the per-connection PREPARE is reset on reconnect and
+# re-applied lazily on the next ``himport_set``.
+
+
+@pytest.mark.onlynoncluster
+def test_himport_master_for_exposes_runtime_prepare(sentinel):
+    """``master_for`` returns a client exposing the HIMPORT family; runtime
+    ``himport_prepare`` populates the client's registry with no init argument, and
+    discard is never forbidden."""
+    master = sentinel.master_for("mymaster", db=9)
+    assert master.himport_prepare("users", ["name", "email", "age"]) is True
+    fs = master.himport_registry.get("users")
+    assert fs is not None
+    assert fs.fields == ("name", "email", "age")
+    # Discard is always allowed under the runtime-only model.
+    assert master.himport_discard("users") == 1
+    assert master.himport_registry.get("users") is None
+
+
+@pytest.mark.onlynoncluster
+def test_himport_registry_shared_with_pool_connections(sentinel):
+    """The runtime-prepared fieldset lives on the pool-level registry object that is
+    injected into every connection via ``connection_kwargs``, so a connection created
+    after a Sentinel failover (pool re-point) still sees it."""
+    master = sentinel.master_for("mymaster", db=9)
+    master.himport_prepare("shared", ["a", "b"])
+    pool = master.connection_pool
+    # The same registry object reaches every connection the pool creates.
+    assert pool.connection_kwargs["himport_registry"] is pool.himport_registry
+    assert "shared" in pool.himport_registry
+
+
+@pytest.mark.onlynoncluster
+def test_himport_prepare_set_survives_reconnect(deployed_sentinel):
+    """Runtime ``himport_prepare`` on a reused ``master_for`` client survives a
+    connection drop (the Sentinel-failover analog): the per-connection PREPARE is
+    reset on reconnect and re-applied lazily on the next ``himport_set`` against the
+    re-pointed pool. Requires a deployed Sentinel and Redis >= 8.9.0."""
+    master = deployed_sentinel.master_for("redis-py-test", db=0)
+    try:
+        master.himport_prepare("users", ["name", "email"])
+        master.delete("himport:sentinel:1")
+        master.himport_set("himport:sentinel:1", "users", ["alice", "a@x.com"])
+    except exceptions.ResponseError as exc:
+        if "unknown command" in str(exc).lower() or "no such fieldset" in str(exc):
+            pytest.skip("server does not support HIMPORT")
+        raise
+    assert master.hget("himport:sentinel:1", "name") == "alice"
+    # Drop the pooled connection to simulate the failover reconnect, then reuse the
+    # same client: the fieldset is re-prepared lazily on the next himport_set.
+    for conn in list(master.connection_pool._available_connections):
+        conn.disconnect()
+    master.delete("himport:sentinel:2")
+    master.himport_set("himport:sentinel:2", "users", ["bob", "b@x.com"])
+    assert master.hget("himport:sentinel:2", "email") == "b@x.com"


### PR DESCRIPTION
## Change summary

This pull request adds support for the Redis 8.10 `HIMPORT` command family, which
lets an application register an ordered list of hash field names once (a
*fieldset*) and then create many hashes by sending only their values. It
introduces the public client methods `himport_prepare`, `himport_set`,
`himport_discard`, and `himport_discard_all`, mirrored across the sync and async
standalone, cluster, and Sentinel clients.

The core challenge is that a fieldset is per-connection server session state:
`PREPARE` binds field names to a single physical connection and is lost on
disconnect/`RESET`, whereas redis-py pools connections. The design decouples the
two. A new `redis/himport.py` holds `HImportRegistry` — a lock-guarded, in-memory,
sync/async-shared registry of declared fieldsets keyed by name with a monotonic
revision clock. `himport_prepare` only mutates this registry; the server-side
`PREPARE` is applied lazily, bundled into the first `himport_set` on each borrowed
connection (`_himport_execute_set` / `_himport_prepare_and_set`), and discards are
reconciled per connection via the revision counter (`_himport_reconcile_discards`)
when a connection is next used. `himport_set` is intercepted in `execute_command`
(the only seam where the concrete connection is known) so it reuses the full
retry / disconnect-on-error / routing machinery. Connection-level tracking
(`_himport_prepared`, `_himport_reconciled_revision`) is reset on connect/disconnect,
and `CacheProxyConnection` transparently delegates it to the wrapped connection.

Key edge cases handled: lazy PREPARE+SET is sent as one packed write; a
mid-connection fieldset loss surfaces as the new `NoSuchFieldsetError` (mapped from
the server's `no such fieldset` reply) and triggers a single automatic re-prepare
and retry on the same socket — for direct calls only; pipelines/transactions
pre-flight one `PREPARE` per referenced fieldset before the batch instead. Cluster
routes `himport_set` by key slot with a shared cluster-wide registry and preserves
ASK/MOVED handling; Sentinel fieldsets survive failover via the long-lived client's
registry. On the multi-database (Active-Active) client all HIMPORT methods (and its
pipeline) raise `DataError` early, since per-connection session state cannot be kept
coherent across independent database clients.

Backward-compatibility notes: this is purely additive to the public API. A new
`himport_registry` connection kwarg is injected unconditionally by the pool (custom
`connection_class` implementations must accept `**kwargs`, as the built-ins do) and
is omitted from `ConnectionPool.__repr__`. The `redis/exceptions.py` diff is a
cosmetic type-hint modernization (`str = None` → `str | None = None`) with no
behavior change. The feature requires a Redis 8.10 server; the CI image map is
bumped to `8.10-rc2`. An unrelated flaky-test stabilization is bundled in
(`TestHybridSearch` doc count raised to 6000 so the 1 ms timeout reliably fires),
along with the `HIMPORT`-related additions to `.github/wordlist.txt`.

## Test coverage

`tests/test_himport.py` adds 78 unit tests covering the registry (ordering,
dedup/version semantics, validation, thread-safe mutation, `names_to_discard`),
plus orchestration behaviors driven through recording/capturing fake connections:
lazy PREPARE+SET bundling, batched-reply draining on error, reconcile-revision
stamping, ASK-redirect handling (sync and async cluster), single-connection
materialization, propagation, value/arity validation, cluster wiring, and the
`NoSuchFieldsetError` mapping. Integration suites (`tests/test_himport_integration.py`,
20 tests, and its async mirror, 18) exercise the full client against a live server,
and HIMPORT cases were added to the cluster, Sentinel, async connection-pool, and
multidb-pipeline (unsupported-guard) test suites. Sync and async paths are covered
symmetrically; no existing assertions were weakened.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, cross-cutting change to command dispatch, pooling, and cluster redirect handling; behavior is subtle around pipelines vs direct calls and custom connection classes must accept the injected `himport_registry` kwarg.
> 
> **Overview**
> Adds **Redis 8.10 HIMPORT** support: public `himport_prepare`, `himport_set`, `himport_discard`, and `himport_discard_all` on sync/async **standalone**, **cluster**, and **Sentinel** clients (marked experimental).
> 
> Fieldsets are **connection-session state**, so the PR introduces `HImportRegistry` in `redis/himport.py` and wires it through pools and connections. `himport_prepare` only updates the registry; **`PREPARE` is sent lazily** on the connection that serves each `himport_set`, with **deferred `DISCARD`** reconciliation via a revision counter. `himport_set` is handled in `execute_command` so retries, disconnect-on-error, and cluster **ASK/MOVED** (including ASK folded into the SET write) stay on the normal path. Shared executors in `redis/_himport_exec.py` and `redis/asyncio/_himport_exec.py` cover packed writes, reply draining, pipeline pre-flight, and one-shot recovery from **`NoSuchFieldsetError`**.
> 
> **Pipelines/transactions** pre-flight PREPAREs (folded into one write where possible). **Multi-database (Active-Active)** clients and pipelines raise `DataError` for all HIMPORT methods. README documents usage; CI bumps Redis **8.10-rc2**; tests add unit/integration coverage plus a small unrelated hybrid-search timeout stabilization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a200a4363dee961368a169d5f08f2680cc65cba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->