### PR TITLE
feat(ssl): support custom SSLContext

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -97,8 +97,9 @@ from redis.utils import (
 )
 
 if TYPE_CHECKING and SSL_AVAILABLE:
-    from ssl import TLSVersion, VerifyFlags, VerifyMode
+    from ssl import SSLContext, TLSVersion, VerifyFlags, VerifyMode
 else:
+    SSLContext = None
     TLSVersion = None
     VerifyMode = None
     VerifyFlags = None
@@ -293,6 +294,7 @@ class Redis(
         ssl_min_version: "TLSVersion | None" = None,
         ssl_ciphers: str | None = None,
         ssl_password: str | None = None,
+        ssl_context: "SSLContext | None" = None,
         max_connections: int | None = None,
         single_connection_client: bool = False,
         health_check_interval: int = 0,
@@ -449,6 +451,7 @@ class Redis(
                             "ssl_min_version": ssl_min_version,
                             "ssl_ciphers": ssl_ciphers,
                             "ssl_password": ssl_password,
+                            "ssl_context": ssl_context,
                         }
                     )
             maint_notifications_enabled = (

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -133,8 +133,9 @@ from redis.utils import (
 )
 
 if SSL_AVAILABLE:
-    from ssl import TLSVersion, VerifyFlags, VerifyMode
+    from ssl import SSLContext, TLSVersion, VerifyFlags, VerifyMode
 else:
+    SSLContext = None
     TLSVersion = None
     VerifyMode = None
     VerifyFlags = None
@@ -443,6 +444,7 @@ class RedisCluster(
         ssl_keyfile: str | None = None,
         ssl_min_version: "TLSVersion | None" = None,
         ssl_ciphers: str | None = None,
+        ssl_context: "SSLContext | None" = None,
         protocol: int | None = None,
         legacy_responses: bool = True,
         address_remap: Callable[[Tuple[str, int]], Tuple[str, int]] | None = None,
@@ -510,6 +512,7 @@ class RedisCluster(
                     "ssl_keyfile": ssl_keyfile,
                     "ssl_min_version": ssl_min_version,
                     "ssl_ciphers": ssl_ciphers,
+                    "ssl_context": ssl_context,
                 }
             )
 

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1507,6 +1507,7 @@ class SSLConnection(Connection):
         ssl_min_version: Optional[TLSVersion] = None,
         ssl_ciphers: Optional[str] = None,
         ssl_password: Optional[str] = None,
+        ssl_context: Optional[SSLContext] = None,
         **kwargs,
     ):
         if not SSL_AVAILABLE:
@@ -1525,6 +1526,7 @@ class SSLConnection(Connection):
             min_version=ssl_min_version,
             ciphers=ssl_ciphers,
             password=ssl_password,
+            context=ssl_context,
         )
         super().__init__(**kwargs)
 
@@ -1601,6 +1603,7 @@ class RedisSSLContext:
         min_version: Optional[TLSVersion] = None,
         ciphers: Optional[str] = None,
         password: Optional[str] = None,
+        context: Optional[SSLContext] = None,
     ):
         if not SSL_AVAILABLE:
             raise RedisError("Python wasn't built with SSL support")
@@ -1632,10 +1635,10 @@ class RedisSSLContext:
         self.min_version = min_version
         self.ciphers = ciphers
         self.password = password
-        self.context: Optional[SSLContext] = None
+        self.context: Optional[SSLContext] = context
 
     def get(self) -> SSLContext:
-        if not self.context:
+        if self.context is None:
             context = ssl.create_default_context()
             context.check_hostname = self.check_hostname
             context.verify_mode = self.cert_reqs

--- a/redis/client.py
+++ b/redis/client.py
@@ -315,6 +315,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         maint_notifications_config: MaintNotificationsConfig | None = None,
         oss_cluster_maint_notifications_handler: OSSMaintNotificationsHandler
         | None = None,
+        ssl_context: "ssl.SSLContext | None" = None,
     ) -> None:
         """
         Initialize a new Redis client.
@@ -464,6 +465,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                             "ssl_ocsp_expected_cert": ssl_ocsp_expected_cert,
                             "ssl_min_version": ssl_min_version,
                             "ssl_ciphers": ssl_ciphers,
+                            "ssl_context": ssl_context,
                         }
                     )
                 if (cache_config or cache) and check_protocol_version(protocol, 3):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -302,6 +302,7 @@ REDIS_ALLOWED_KEYS = (
     "ssl_exclude_verify_flags",
     "ssl_keyfile",
     "ssl_password",
+    "ssl_context",
     "ssl_check_hostname",
     "unix_socket_path",
     "username",

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2035,6 +2035,7 @@ class SSLConnection(Connection):
         ssl_ocsp_expected_cert=None,
         ssl_min_version=None,
         ssl_ciphers=None,
+        ssl_context=None,
         **kwargs,
     ):
         """Constructor
@@ -2058,6 +2059,9 @@ class SSLConnection(Connection):
             ssl_ocsp_expected_cert: A PEM armoured string containing the expected certificate to be returned from the ocsp verification service.
             ssl_min_version: The lowest supported SSL version. It affects the supported SSL versions of the SSLContext. None leaves the default provided by ssl module.
             ssl_ciphers: A string listing the ciphers that are allowed to be used. Defaults to None, which means that the default ciphers are used. See https://docs.python.org/3/library/ssl.html#ssl.SSLContext.set_ciphers for more information.
+            ssl_context: A pre-configured ``ssl.SSLContext`` to use for the
+                connection. If provided, it takes precedence over the other
+                SSL configuration options.
 
         Raises:
             RedisError
@@ -2096,6 +2100,7 @@ class SSLConnection(Connection):
         self.ssl_ocsp_expected_cert = ssl_ocsp_expected_cert
         self.ssl_min_version = ssl_min_version
         self.ssl_ciphers = ssl_ciphers
+        self.ssl_context = ssl_context
         super().__init__(**kwargs)
 
     def _connect(self):
@@ -2119,33 +2124,36 @@ class SSLConnection(Connection):
         Returns:
             An SSL wrapped socket.
         """
-        context = ssl.create_default_context()
-        context.check_hostname = self.check_hostname
-        context.verify_mode = self.cert_reqs
-        if self.ssl_include_verify_flags:
-            for flag in self.ssl_include_verify_flags:
-                context.verify_flags |= flag
-        if self.ssl_exclude_verify_flags:
-            for flag in self.ssl_exclude_verify_flags:
-                context.verify_flags &= ~flag
-        if self.certfile or self.keyfile:
-            context.load_cert_chain(
-                certfile=self.certfile,
-                keyfile=self.keyfile,
-                password=self.certificate_password,
-            )
-        if (
-            self.ca_certs is not None
-            or self.ca_path is not None
-            or self.ca_data is not None
-        ):
-            context.load_verify_locations(
-                cafile=self.ca_certs, capath=self.ca_path, cadata=self.ca_data
-            )
-        if self.ssl_min_version is not None:
-            context.minimum_version = self.ssl_min_version
-        if self.ssl_ciphers:
-            context.set_ciphers(self.ssl_ciphers)
+        if self.ssl_context is None:
+            context = ssl.create_default_context()
+            context.check_hostname = self.check_hostname
+            context.verify_mode = self.cert_reqs
+            if self.ssl_include_verify_flags:
+                for flag in self.ssl_include_verify_flags:
+                    context.verify_flags |= flag
+            if self.ssl_exclude_verify_flags:
+                for flag in self.ssl_exclude_verify_flags:
+                    context.verify_flags &= ~flag
+            if self.certfile or self.keyfile:
+                context.load_cert_chain(
+                    certfile=self.certfile,
+                    keyfile=self.keyfile,
+                    password=self.certificate_password,
+                )
+            if (
+                self.ca_certs is not None
+                or self.ca_path is not None
+                or self.ca_data is not None
+            ):
+                context.load_verify_locations(
+                    cafile=self.ca_certs, capath=self.ca_path, cadata=self.ca_data
+                )
+            if self.ssl_min_version is not None:
+                context.minimum_version = self.ssl_min_version
+            if self.ssl_ciphers:
+                context.set_ciphers(self.ssl_ciphers)
+        else:
+            context = self.ssl_context
         if self.ssl_validate_ocsp is True and CRYPTOGRAPHY_AVAILABLE is False:
             raise RedisError("cryptography is not installed.")
 

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -77,6 +77,17 @@ default_cluster_slots = [
 ]
 
 
+def test_cluster_preserves_custom_ssl_context():
+    context = ssl.create_default_context()
+    cluster = RedisCluster(
+        startup_nodes=[ClusterNode("localhost", 6379)],
+        ssl=True,
+        ssl_context=context,
+    )
+
+    assert cluster.connection_kwargs["ssl_context"] is context
+
+
 class NodeProxy:
     """A class to proxy a node connection to a different port"""
 

--- a/tests/test_asyncio/test_connect.py
+++ b/tests/test_asyncio/test_connect.py
@@ -4,6 +4,7 @@ import socket
 import ssl
 
 import pytest
+import redis.asyncio as redis
 from redis.asyncio.connection import (
     Connection,
     SSLConnection,
@@ -51,6 +52,26 @@ async def test_uds_connect(uds_address):
         path=path, client_name=_CLIENT_NAME, socket_timeout=10
     )
     await _assert_connect(conn, path)
+
+
+@pytest.mark.ssl
+async def test_tcp_ssl_uses_custom_context(tcp_address):
+    context = ssl.create_default_context()
+    conn = SSLConnection(host="localhost", port=tcp_address[1], ssl_context=context)
+
+    assert conn.ssl_context.get() is context
+
+
+@pytest.mark.ssl
+async def test_redis_passes_custom_context_to_ssl_connection():
+    context = ssl.create_default_context()
+    client = redis.Redis(ssl=True, ssl_context=context)
+
+    try:
+        connection = client.connection_pool.make_connection()
+        assert connection.ssl_context.get() is context
+    finally:
+        await client.aclose()
 
 
 @pytest.mark.ssl

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -753,6 +753,19 @@ class TestSSLConnectionURLParsing:
         assert pool.connection_class == redis.SSLConnection
         assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
+    def test_custom_ssl_context(self):
+        import ssl
+
+        context = ssl.create_default_context()
+
+        class DummyConnectionPool(redis.ConnectionPool):
+            def get_connection(self):
+                return self.make_connection()
+
+        pool = DummyConnectionPool.from_url("rediss://my.host", ssl_context=context)
+
+        assert pool.get_connection().ssl_context.get() is context
+
     def test_cert_reqs_options(self):
         import ssl
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3,6 +3,7 @@ import datetime
 import select
 import socket
 import socketserver
+import ssl
 import threading
 from typing import List
 import warnings
@@ -73,6 +74,22 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+def test_cluster_preserves_custom_ssl_context():
+    context = ssl.create_default_context()
+
+    with (
+        patch.object(NodesManager, "initialize"),
+        patch.object(CommandsParser, "initialize"),
+    ):
+        cluster = RedisCluster(
+            startup_nodes=[ClusterNode("localhost", 6379)],
+            ssl=True,
+            ssl_context=context,
+        )
+
+    assert cluster.get_connection_kwargs()["ssl_context"] is context
 
 
 class ProxyRequestHandler(socketserver.BaseRequestHandler):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -3,8 +3,10 @@ import socket
 import socketserver
 import ssl
 import threading
+import unittest.mock
 
 import pytest
+import redis
 from redis.connection import Connection, SSLConnection, UnixDomainSocketConnection
 from redis.exceptions import RedisError
 
@@ -46,6 +48,29 @@ def test_uds_connect(uds_address):
     path = str(uds_address)
     conn = UnixDomainSocketConnection(path, client_name=_CLIENT_NAME, socket_timeout=10)
     _assert_connect(conn, path)
+
+
+@pytest.mark.ssl
+def test_tcp_ssl_uses_custom_context(tcp_address):
+    context = unittest.mock.Mock(spec=ssl.SSLContext)
+    wrapped_socket = unittest.mock.Mock()
+    context.wrap_socket.return_value = wrapped_socket
+    conn = SSLConnection(host="localhost", port=tcp_address[1], ssl_context=context)
+
+    assert conn._wrap_socket_with_ssl(unittest.mock.Mock()) is wrapped_socket
+    context.wrap_socket.assert_called_once()
+
+
+@pytest.mark.ssl
+def test_redis_passes_custom_context_to_ssl_connection():
+    context = unittest.mock.Mock(spec=ssl.SSLContext)
+    client = redis.Redis(ssl=True, ssl_context=context)
+
+    try:
+        connection = client.connection_pool.make_connection()
+        assert connection.ssl_context is context
+    finally:
+        client.close()
 
 
 @pytest.mark.ssl

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -849,6 +849,17 @@ class TestSSLConnectionURLParsing:
         assert pool.connection_class == redis.SSLConnection
         assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
+    def test_custom_ssl_context(self):
+        context = ssl.create_default_context()
+
+        class DummyConnectionPool(redis.ConnectionPool):
+            def get_connection(self):
+                return self.make_connection()
+
+        pool = DummyConnectionPool.from_url("rediss://my.host", ssl_context=context)
+
+        assert pool.get_connection().ssl_context is context
+
     def test_connection_class_override(self):
         class MyConnection(redis.SSLConnection):
             pass


### PR DESCRIPTION
## Summary

redis-py currently exposes SSL configuration as individual keyword arguments, which prevents applications from supplying a pre-configured `ssl.SSLContext`. This is required for deployments that need TLS settings not represented by the current keyword arguments, such as custom certificate stores or private CA handling.

This change:

- accepts a pre-configured `SSLContext` for synchronous and asynchronous connections
- propagates it through standalone, URL-based, and cluster clients
- uses the supplied context without mutating it
- preserves the existing context-building path when no custom context is provided
- adds focused regression tests for direct clients, URL connection pools, and cluster configuration

Fixes #3599.

## Validation

- TDD regression tests failed before the implementation and passed afterward
- custom-context coverage: 8 passed
- existing SSL URL parsing regression coverage: 9 passed
- `invoke linters`: passed
- `python -m compileall -q redis tests`: passed
- `git diff --check`: passed

The full TLS/integration matrix was not completed because this checkout has no TLS fixture certificates and the local Redis instance does not enable the `DEBUG` command used by several unrelated connection tests.