### PR TITLE
Make cluster scans best-effort with partial coverage

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1069,6 +1069,10 @@ class RedisCluster(
         command = args[0]
         target_nodes = []
         target_nodes_specified = False
+        best_effort = (
+            kwargs.pop("_best_effort", False)
+            and not self.nodes_manager.require_full_coverage
+        )
         retry_attempts = self.retry.get_retries()
 
         passed_targets = kwargs.pop("target_nodes", None)
@@ -1137,7 +1141,18 @@ class RedisCluster(
 
                 if len(target_nodes) == 1:
                     # Return the processed result
-                    ret = await self._execute_command(target_nodes[0], *args, **kwargs)
+                    try:
+                        ret = await self._execute_command(
+                            target_nodes[0], *args, **kwargs
+                        )
+                    except (ConnectionError, TimeoutError):
+                        if not best_effort:
+                            raise
+                        if command in self.result_callbacks:
+                            return self.result_callbacks[command](command, {}, **kwargs)
+                        return self._policies_callback_mapping[
+                            command_policies.response_policy
+                        ]({})
                     if command in self.result_callbacks:
                         ret = self.result_callbacks[command](
                             command, {target_nodes[0].name: ret}, **kwargs
@@ -1153,15 +1168,27 @@ class RedisCluster(
                                 self._execute_command(node, *args, **kwargs)
                             )
                             for node in target_nodes
-                        )
+                        ),
+                        return_exceptions=best_effort,
                     )
+                    if best_effort:
+                        successful_values = {}
+                        for node, value in zip(target_nodes, values):
+                            if isinstance(value, (ConnectionError, TimeoutError)):
+                                continue
+                            if isinstance(value, Exception):
+                                raise value
+                            successful_values[node.name] = value
+                        values = successful_values
                     if command in self.result_callbacks:
                         return self.result_callbacks[command](
-                            command, dict(zip(keys, values)), **kwargs
+                            command,
+                            values if best_effort else dict(zip(keys, values)),
+                            **kwargs,
                         )
                     return self._policies_callback_mapping[
                         command_policies.response_policy
-                    ](dict(zip(keys, values)))
+                    ](values if best_effort else dict(zip(keys, values)))
             except Exception as e:
                 if retry_attempts > 0 and type(e) in self.__class__.ERRORS_ALLOW_RETRY:
                     # The nodes and slots cache were should be reinitialized.

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1505,6 +1505,10 @@ class RedisCluster(
         target_nodes_specified = False
         is_default_node = False
         target_nodes = None
+        best_effort = (
+            kwargs.pop("_best_effort", False)
+            and not self.nodes_manager.require_full_coverage
+        )
         passed_targets = kwargs.pop("target_nodes", None)
         command_policies = self._policy_resolver.resolve(args[0].lower())
 
@@ -1580,7 +1584,11 @@ class RedisCluster(
                     ):
                         is_default_node = True
                 for node in target_nodes:
-                    res[node.name] = self._execute_command(node, *args, **kwargs)
+                    try:
+                        res[node.name] = self._execute_command(node, *args, **kwargs)
+                    except (ConnectionError, TimeoutError):
+                        if not best_effort:
+                            raise
 
                     if command_policies.response_policy == ResponsePolicy.ONE_SUCCEEDED:
                         break
@@ -2187,6 +2195,10 @@ class NodesManager:
                 return self.nodes_cache.get(node_name)
         else:
             return None
+
+    @property
+    def require_full_coverage(self) -> bool:
+        return self._require_full_coverage
 
     def move_slot(self, e: Union[AskError, MovedError]):
         """

--- a/redis/commands/cluster.py
+++ b/redis/commands/cluster.py
@@ -18,7 +18,12 @@ from typing import (
 )
 
 from redis.crc import key_slot
-from redis.exceptions import RedisClusterException, RedisError
+from redis.exceptions import (
+    ConnectionError,
+    RedisClusterException,
+    RedisError,
+    TimeoutError,
+)
 from redis.typing import (
     AnyKeyT,
     AsyncClientProtocol,
@@ -1407,8 +1412,15 @@ class ClusterDataAccessCommands(DataAccessCommands):
         _type: str | None = None,
         **kwargs,
     ) -> Iterator:
+        best_effort = not self.nodes_manager.require_full_coverage
+        initial_kwargs = dict(kwargs)
+        if best_effort:
+            initial_kwargs["_best_effort"] = True
+
         # Do the first query with cursor=0 for all nodes
-        cursors, data = self.scan(match=match, count=count, _type=_type, **kwargs)
+        cursors, data = self.scan(
+            match=match, count=count, _type=_type, **initial_kwargs
+        )
         yield from data
 
         cursors = {name: cursor for name, cursor in cursors.items() if cursor != 0}
@@ -1419,15 +1431,21 @@ class ClusterDataAccessCommands(DataAccessCommands):
             # Iterate over each node till its cursor is 0
             kwargs.pop("target_nodes", None)
             while cursors:
-                for name, cursor in cursors.items():
-                    cur, data = self.scan(
-                        cursor=cursor,
-                        match=match,
-                        count=count,
-                        _type=_type,
-                        target_nodes=nodes[name],
-                        **kwargs,
-                    )
+                for name, cursor in list(cursors.items()):
+                    try:
+                        cur, data = self.scan(
+                            cursor=cursor,
+                            match=match,
+                            count=count,
+                            _type=_type,
+                            target_nodes=nodes[name],
+                            **kwargs,
+                        )
+                    except (ConnectionError, TimeoutError):
+                        if not best_effort:
+                            raise
+                        del cursors[name]
+                        continue
                     yield from data
                     cursors[name] = cur[name]
 
@@ -1453,8 +1471,15 @@ class AsyncClusterDataAccessCommands(
         _type: str | None = None,
         **kwargs,
     ) -> AsyncIterator:
+        best_effort = not self.nodes_manager.require_full_coverage
+        initial_kwargs = dict(kwargs)
+        if best_effort:
+            initial_kwargs["_best_effort"] = True
+
         # Do the first query with cursor=0 for all nodes
-        cursors, data = await self.scan(match=match, count=count, _type=_type, **kwargs)
+        cursors, data = await self.scan(
+            match=match, count=count, _type=_type, **initial_kwargs
+        )
         for value in data:
             yield value
 
@@ -1466,15 +1491,21 @@ class AsyncClusterDataAccessCommands(
             # Iterate over each node till its cursor is 0
             kwargs.pop("target_nodes", None)
             while cursors:
-                for name, cursor in cursors.items():
-                    cur, data = await self.scan(
-                        cursor=cursor,
-                        match=match,
-                        count=count,
-                        _type=_type,
-                        target_nodes=nodes[name],
-                        **kwargs,
-                    )
+                for name, cursor in list(cursors.items()):
+                    try:
+                        cur, data = await self.scan(
+                            cursor=cursor,
+                            match=match,
+                            count=count,
+                            _type=_type,
+                            target_nodes=nodes[name],
+                            **kwargs,
+                        )
+                    except (ConnectionError, TimeoutError):
+                        if not best_effort:
+                            raise
+                        del cursors[name]
+                        continue
                     for value in data:
                         yield value
                     cursors[name] = cur[name]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -77,6 +77,58 @@ default_cluster_slots = [
 ]
 
 
+@pytest.mark.asyncio
+async def test_async_cluster_scan_iter_skips_unavailable_node_without_full_coverage():
+    client = object.__new__(RedisCluster)
+    client.nodes_manager = mock.Mock(require_full_coverage=False)
+    client.get_node = mock.Mock(side_effect=lambda node_name: node_name)
+    client.scan = mock.AsyncMock(
+        side_effect=[
+            ({"available": 1, "unavailable": 1}, [b"first"]),
+            ({"available": 0}, [b"second"]),
+            ConnectionError("node unavailable"),
+        ]
+    )
+
+    values = [value async for value in client.scan_iter(count=10)]
+
+    assert values == [b"first", b"second"]
+
+
+@pytest.mark.asyncio
+async def test_async_cluster_scan_iter_preserves_fail_fast_with_full_coverage():
+    client = object.__new__(RedisCluster)
+    client.nodes_manager = mock.Mock(require_full_coverage=True)
+    client.get_node = mock.Mock(side_effect=lambda node_name: node_name)
+    client.scan = mock.AsyncMock(
+        side_effect=[
+            ({"unavailable": 1}, []),
+            ConnectionError("node unavailable"),
+        ]
+    )
+
+    with pytest.raises(ConnectionError, match="node unavailable"):
+        async for _ in client.scan_iter():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_async_cluster_scan_iter_does_not_hide_redis_errors():
+    client = object.__new__(RedisCluster)
+    client.nodes_manager = mock.Mock(require_full_coverage=False)
+    client.get_node = mock.Mock(side_effect=lambda node_name: node_name)
+    client.scan = mock.AsyncMock(
+        side_effect=[
+            ({"node": 1}, []),
+            ResponseError("invalid scan request"),
+        ]
+    )
+
+    with pytest.raises(ResponseError, match="invalid scan request"):
+        async for _ in client.scan_iter():
+            pass
+
+
 class NodeProxy:
     """A class to proxy a node connection to a different port"""
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -4,6 +4,7 @@ import select
 import socket
 import socketserver
 import threading
+from types import SimpleNamespace
 from typing import List
 import warnings
 from queue import LifoQueue, Queue
@@ -73,6 +74,51 @@ default_cluster_slots = [
     [0, 8191, ["127.0.0.1", 7000, "node_0"], ["127.0.0.1", 7003, "node_3"]],
     [8192, 16383, ["127.0.0.1", 7001, "node_1"], ["127.0.0.1", 7002, "node_2"]],
 ]
+
+
+def test_cluster_scan_iter_skips_unavailable_node_without_full_coverage():
+    client = object.__new__(RedisCluster)
+    client.nodes_manager = SimpleNamespace(require_full_coverage=False)
+    client.get_node = Mock(side_effect=lambda node_name: node_name)
+    client.scan = Mock(
+        side_effect=[
+            ({"available": 1, "unavailable": 1}, [b"first"]),
+            ({"available": 0}, [b"second"]),
+            ConnectionError("node unavailable"),
+        ]
+    )
+
+    assert list(client.scan_iter(count=10)) == [b"first", b"second"]
+
+
+def test_cluster_scan_iter_preserves_fail_fast_with_full_coverage():
+    client = object.__new__(RedisCluster)
+    client.nodes_manager = SimpleNamespace(require_full_coverage=True)
+    client.get_node = Mock(side_effect=lambda node_name: node_name)
+    client.scan = Mock(
+        side_effect=[
+            ({"unavailable": 1}, []),
+            ConnectionError("node unavailable"),
+        ]
+    )
+
+    with pytest.raises(ConnectionError, match="node unavailable"):
+        list(client.scan_iter())
+
+
+def test_cluster_scan_iter_does_not_hide_redis_errors():
+    client = object.__new__(RedisCluster)
+    client.nodes_manager = SimpleNamespace(require_full_coverage=False)
+    client.get_node = Mock(side_effect=lambda node_name: node_name)
+    client.scan = Mock(
+        side_effect=[
+            ({"node": 1}, []),
+            ResponseError("invalid scan request"),
+        ]
+    )
+
+    with pytest.raises(ResponseError, match="invalid scan request"):
+        list(client.scan_iter())
 
 
 class ProxyRequestHandler(socketserver.BaseRequestHandler):


### PR DESCRIPTION
Fixes #3411

## What changed

- Make cluster `scan_iter()` best-effort when `require_full_coverage=False`.
- Skip only per-node `ConnectionError` and `TimeoutError` failures while continuing to scan reachable nodes.
- Preserve fail-fast behavior when `require_full_coverage=True`.
- Continue to propagate Redis command errors such as `ResponseError`.
- Keep synchronous and asynchronous cluster clients consistent.
- Add regression tests for both clients and the failure boundaries.

## Verification

- `pytest -q tests/test_cluster.py -k 'cluster_scan_iter'` — 4 passed
- `pytest -q tests/test_asyncio/test_cluster.py -k 'cluster_scan_iter'` — 5 passed
- `invoke linters`
- `ruff format --check`
- `git diff --check`
- `python -m compileall`

The full Redis Cluster integration suite requires local Redis cluster services, which are not available in this workspace.