### PR TITLE
Handle ASK redirects to slotless nodes during resharding

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1198,7 +1198,7 @@ class RedisCluster(
         self, target_node: "ClusterNode", *args: Union[KeyT, EncodableT], **kwargs: Any
     ) -> Any:
         asking = moved = False
-        redirect_addr = None
+        redirected_node = None
         ttl = self.RedisClusterRequestTTL
         command = args[0]
         start_time = time.monotonic()
@@ -1207,7 +1207,7 @@ class RedisCluster(
             ttl -= 1
             try:
                 if asking:
-                    target_node = self.get_node(node_name=redirect_addr)
+                    target_node = redirected_node
                     await target_node.execute_command("ASKING")
                     asking = False
                 elif moved:
@@ -1327,7 +1327,11 @@ class RedisCluster(
                     connection=target_node,
                 )
             except AskError as e:
-                redirect_addr = get_node_name(host=e.host, port=e.port)
+                redirected_node = self.get_node(host=e.host, port=e.port)
+                if redirected_node is None:
+                    redirected_node = ClusterNode(
+                        e.host, e.port, PRIMARY, **self.nodes_manager.connection_kwargs
+                    )
                 asking = True
                 await self._record_command_metric(
                     command_name=command,

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1634,7 +1634,7 @@ class RedisCluster(
         command = args[0]
         redis_node = None
         connection = None
-        redirect_addr = None
+        redirected_node = None
         asking = False
         moved = False
         ttl = int(self.RedisClusterRequestTTL)
@@ -1646,7 +1646,7 @@ class RedisCluster(
             ttl -= 1
             try:
                 if asking:
-                    target_node = self.get_node(node_name=redirect_addr)
+                    target_node = redirected_node
                 elif moved:
                     # MOVED occurred and the slots cache was updated,
                     # refresh the target node
@@ -1818,7 +1818,9 @@ class RedisCluster(
                         f"ASK error received for command {args_log_str}, on node {target_node.name}, "
                         f"and connection: {connection} using local socket address: {socket_address}, error: {e}"
                     )
-                redirect_addr = get_node_name(host=e.host, port=e.port)
+                redirected_node = self.get_node(host=e.host, port=e.port)
+                if redirected_node is None:
+                    redirected_node = ClusterNode(e.host, e.port, PRIMARY)
                 asking = True
 
                 self._record_command_metric(

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -656,6 +656,35 @@ class TestRedisClusterObj:
 
             assert await r.execute_command("SET", "foo", "bar") == "MOCK_OK"
 
+    async def test_ask_redirection_to_node_without_slots(self) -> None:
+        r = await get_mocked_redis_client(host=default_host, port=default_port)
+        redirect_host = "127.0.0.1"
+        redirect_port = 7009
+
+        async def ask_redirect_effect(node, *args, **_options):
+            if args[0] == "SET" and node.port != redirect_port:
+                raise AskError(f"12182 {redirect_host}:{redirect_port}")
+            if args[0] == "ASKING":
+                assert node.port == redirect_port
+                return "OK"
+            assert node.port == redirect_port
+            return "MOCK_OK"
+
+        with mock.patch.object(
+            ClusterNode, "execute_command", autospec=True
+        ) as execute_command:
+            execute_command.side_effect = ask_redirect_effect
+
+            assert (
+                await r.execute_command(
+                    "SET", "foo", "bar", target_nodes=r.get_primaries()[0]
+                )
+                == "MOCK_OK"
+            )
+        assert r.get_node(host=redirect_host, port=redirect_port) is None
+
+        await r.aclose()
+
     async def test_moved_redirection(
         self, create_redis: Callable[..., RedisCluster]
     ) -> None:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -501,6 +501,36 @@ class TestRedisClusterObj:
 
             assert r.execute_command("SET", "foo", "bar") == "MOCK_OK"
 
+    def test_ask_redirection_to_node_without_slots(self):
+        r = get_mocked_redis_client(host=default_host, port=default_port)
+        redirect_host = "127.0.0.1"
+        redirect_port = 7009
+
+        def get_redis_connection(node):
+            connection = Mock(host=node.host, port=node.port)
+            redis_node = Mock(connection=connection)
+
+            def parse_response(_connection, command, **_kwargs):
+                if command == "SET" and node.port != redirect_port:
+                    raise AskError(f"12182 {redirect_host}:{redirect_port}")
+                if command == "ASKING":
+                    assert node.port == redirect_port
+                    return "OK"
+                assert node.port == redirect_port
+                return "MOCK_OK"
+
+            redis_node.parse_response.side_effect = parse_response
+            return redis_node
+
+        with patch.object(r, "get_redis_connection", side_effect=get_redis_connection):
+            assert (
+                r.execute_command(
+                    "SET", "foo", "bar", target_nodes=r.get_primaries()[0]
+                )
+                == "MOCK_OK"
+            )
+        assert r.get_node(host=redirect_host, port=redirect_port) is None
+
     def test_handling_cluster_failover_to_a_replica(self, r):
         # Set the key we'll test for
         key = "key"


### PR DESCRIPTION
Fixes #4015

## What changed

- Preserve an ASK redirect target for the current retry even when it is absent from the refreshed slots cache.
- Create a temporary primary `ClusterNode` only when the redirect target is unknown.
- Keep the existing ASK sequence unchanged: send `ASKING`, then retry the original command.
- Do not patch slot ownership or retain the temporary node in `nodes_cache`.
- Apply the same behavior to synchronous and asynchronous cluster clients.
- Add deterministic regression tests for an ASK target with no slots.

## Verification

- `pytest -q tests/test_cluster.py -m onlycluster -k 'ask_redirection_to_node_without_slots'` — 1 passed
- `pytest -q tests/test_asyncio/test_cluster.py -k 'ask_redirection_to_node_without_slots'` — 1 passed
- `invoke linters`
- `ruff format --check`
- `git diff --check`
- `python -m compileall`

The full Redis Cluster integration suite requires local Redis cluster services, which are not available in this workspace.