### PR TITLE
Avoid retrying client-initiated SHUTDOWN

### DIFF
--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -872,6 +872,7 @@ class Redis(
         await self.initialize()
         pool = self.connection_pool
         command_name = args[0]
+        no_retry = options.pop("_no_retry", False)
         conn = self.connection or await pool.get_connection()
 
         # Start timing for observability
@@ -889,13 +890,26 @@ class Redis(
         if self.single_connection_client:
             await self._single_conn_lock.acquire()
         try:
-            result = await conn.retry.call_with_retry(
-                lambda: self._send_command_parse_response(
-                    conn, command_name, *args, **options
-                ),
-                failure_callback,
-                with_failure_count=True,
-            )
+            if no_retry:
+                # SHUTDOWN closes the server-side connection, so retrying the
+                # resulting connection error only delays the expected outcome.
+                try:
+                    result = await self._send_command_parse_response(
+                        conn, command_name, *args, **options
+                    )
+                except (ConnectionError, TimeoutError) as error:
+                    await self._close_connection(
+                        conn, error, 0, start_time, command_name
+                    )
+                    raise
+            else:
+                result = await conn.retry.call_with_retry(
+                    lambda: self._send_command_parse_response(
+                        conn, command_name, *args, **options
+                    ),
+                    failure_callback,
+                    with_failure_count=True,
+                )
 
             await record_operation_duration(
                 command_name=command_name,

--- a/redis/client.py
+++ b/redis/client.py
@@ -818,6 +818,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         """Execute a command and return a parsed response"""
         pool = self.connection_pool
         command_name = args[0]
+        no_retry = options.pop("_no_retry", False)
         conn = self.connection or pool.get_connection()
 
         # Start timing for observability
@@ -834,13 +835,24 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         if self._single_connection_client:
             self.single_connection_lock.acquire()
         try:
-            result = conn.retry.call_with_retry(
-                lambda: self._send_command_parse_response(
-                    conn, command_name, *args, **options
-                ),
-                failure_callback,
-                with_failure_count=True,
-            )
+            if no_retry:
+                # SHUTDOWN closes the server-side connection, so retrying the
+                # resulting connection error only delays the expected outcome.
+                try:
+                    result = self._send_command_parse_response(
+                        conn, command_name, *args, **options
+                    )
+                except (ConnectionError, TimeoutError) as error:
+                    self._close_connection(conn, error, 0, start_time, command_name)
+                    raise
+            else:
+                result = conn.retry.call_with_retry(
+                    lambda: self._send_command_parse_response(
+                        conn, command_name, *args, **options
+                    ),
+                    failure_callback,
+                    with_failure_count=True,
+                )
 
             record_operation_duration(
                 command_name=command_name,

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -2116,6 +2116,7 @@ class ManagementCommands(CommandsProtocol):
         if abort:
             args.append("ABORT")
         try:
+            kwargs["_no_retry"] = True
             self.execute_command(*args, **kwargs)
         except ConnectionError:
             # a ConnectionError here is expected
@@ -2471,6 +2472,7 @@ class AsyncManagementCommands(ManagementCommands):
         if abort:
             args.append("ABORT")
         try:
+            kwargs["_no_retry"] = True
             await self.execute_command(*args, **kwargs)
         except ConnectionError:
             # a ConnectionError here is expected

--- a/tests/test_asyncio/test_client.py
+++ b/tests/test_asyncio/test_client.py
@@ -10,6 +10,8 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import redis.asyncio as redis
+from redis.asyncio.retry import Retry
+from redis.backoff import NoBackoff
 from redis.asyncio.observability import recorder as async_recorder
 from redis.observability.attributes import (
     SERVER_ADDRESS,
@@ -361,6 +363,22 @@ class TestAsyncRedisClientErrorMetricsRecording:
             assert attrs["error.type"] == "ConnectionError"
 
         async_recorder.reset_collector()
+
+    async def test_no_retry_option_executes_command_once(
+        self, mock_async_connection_pool
+    ):
+        mock_async_connection = mock_async_connection_pool.get_connection.return_value
+        mock_async_connection.retry = Retry(NoBackoff(), retries=3)
+        mock_async_connection.disconnect = AsyncMock()
+        client = redis.Redis(connection_pool=mock_async_connection_pool)
+        send_command = AsyncMock(side_effect=redis.ConnectionError("shutdown"))
+        client._send_command_parse_response = send_command
+
+        with pytest.raises(redis.ConnectionError, match="shutdown"):
+            await client.execute_command("SHUTDOWN", _no_retry=True)
+
+        assert send_command.call_count == 1
+        assert send_command.call_args.kwargs == {}
 
     async def test_timeout_error_records_error_count(
         self, mock_async_connection_pool, mock_async_connection, mock_error_meter

--- a/tests/test_asyncio/test_commands.py
+++ b/tests/test_asyncio/test_commands.py
@@ -791,6 +791,16 @@ class TestRedisCommands:
     async def test_ping(self, r: redis.Redis):
         assert await r.ping()
 
+    async def test_shutdown_disables_command_retries(self):
+        client = redis.Redis()
+        client.execute_command = AsyncMock(side_effect=redis.ConnectionError)
+
+        await client.shutdown(nosave=True)
+
+        client.execute_command.assert_awaited_once_with(
+            "SHUTDOWN", "NOSAVE", _no_retry=True
+        )
+
     @pytest.mark.onlynoncluster
     async def test_slowlog_get(self, r: redis.Redis, slowlog):
         assert await r.slowlog_reset()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,12 +3,14 @@ from unittest import mock
 import pytest
 
 import redis
+from redis.backoff import NoBackoff
 from redis.event import (
     EventDispatcher,
 )
 from redis.observability import recorder
 from redis.observability.config import OTelConfig, MetricGroup
 from redis.observability.metrics import RedisMetricsCollector
+from redis.retry import Retry
 
 
 class TestRedisClientMetricsRecording:
@@ -470,6 +472,7 @@ class TestRedisClientMetricsRecording:
         mock_connection_pool.get_connection.return_value = mock_connection
 
         recorder.reset_collector()
+
         # Enable both COMMAND and RESILIENCY metric groups
         config = OTelConfig(metric_groups=[MetricGroup.COMMAND, MetricGroup.RESILIENCY])
 
@@ -513,3 +516,16 @@ class TestRedisClientMetricsRecording:
             assert "error.type" in error_attrs
 
         recorder.reset_collector()
+
+    def test_no_retry_option_executes_command_once(self, mock_connection_pool):
+        mock_connection = mock_connection_pool.get_connection.return_value
+        mock_connection.retry = Retry(NoBackoff(), retries=3)
+        client = redis.Redis(connection_pool=mock_connection_pool)
+        send_command = mock.MagicMock(side_effect=redis.ConnectionError("shutdown"))
+        client._send_command_parse_response = send_command
+
+        with pytest.raises(redis.ConnectionError, match="shutdown"):
+            client.execute_command("SHUTDOWN", _no_retry=True)
+
+        assert send_command.call_count == 1
+        assert send_command.call_args.kwargs == {}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8442,17 +8442,27 @@ class TestRedisCommands:
         assert r.replicaof("NO", "ONE")
 
     def test_shutdown(self, r: redis.Redis):
-        r.execute_command = mock.MagicMock()
-        r.execute_command("SHUTDOWN", "NOSAVE")
-        r.execute_command.assert_called_once_with("SHUTDOWN", "NOSAVE")
+        def execute_command(command, *args, **kwargs):
+            if command == "SHUTDOWN":
+                raise redis.ConnectionError
+
+        r.execute_command = mock.MagicMock(side_effect=execute_command)
+        r.shutdown(nosave=True)
+        r.execute_command.assert_called_once_with("SHUTDOWN", "NOSAVE", _no_retry=True)
 
     @skip_if_server_version_lt("7.0.0")
     def test_shutdown_with_params(self, r: redis.Redis):
-        r.execute_command = mock.MagicMock()
-        r.execute_command("SHUTDOWN", "SAVE", "NOW", "FORCE")
-        r.execute_command.assert_called_once_with("SHUTDOWN", "SAVE", "NOW", "FORCE")
-        r.execute_command("SHUTDOWN", "ABORT")
-        r.execute_command.assert_called_with("SHUTDOWN", "ABORT")
+        def execute_command(command, *args, **kwargs):
+            if command == "SHUTDOWN":
+                raise redis.ConnectionError
+
+        r.execute_command = mock.MagicMock(side_effect=execute_command)
+        r.shutdown(save=True, now=True, force=True)
+        r.execute_command.assert_called_once_with(
+            "SHUTDOWN", "SAVE", "NOW", "FORCE", _no_retry=True
+        )
+        r.shutdown(abort=True)
+        r.execute_command.assert_called_with("SHUTDOWN", "ABORT", _no_retry=True)
 
     @pytest.mark.replica
     @pytest.mark.xfail(strict=False)


### PR DESCRIPTION
Fixes #3704

## Motivation

When Redis shuts down, the connection used to send `SHUTDOWN` is expected to close. The default connection retry policy currently retries the resulting `ConnectionError`, which delays `Redis.shutdown()` by the configured backoff/retry period.

## Solution

- Add an internal per-command no-retry option to the synchronous and asynchronous clients.
- Use it only for `shutdown()`, leaving retry behavior for all other commands unchanged.
- Preserve the existing `ConnectionError` handling that treats the expected disconnect as a successful shutdown.
- Close the failed connection and keep existing operation/error metrics behavior.

## Tests

- Verify sync and async `shutdown()` pass the internal option for NOSAVE, SAVE/NOW/FORCE, and ABORT.
- Verify sync and async command execution performs exactly one attempt even when the connection retry policy allows retries.
- Existing client retry and metrics tests remain green.

Validation:
- `pytest -q tests/test_commands.py -k 'test_shutdown'`
- `pytest -q tests/test_asyncio/test_commands.py -k 'shutdown_disables_command_retries'`
- `pytest -q tests/test_client.py`
- `pytest -q tests/test_asyncio/test_client.py`
- `invoke linters`
- `python -m compileall -q redis ...`