### PR TITLE
Add a separate timeout for Redis Cluster topology discovery

### DIFF
--- a/docs/clustering.rst
+++ b/docs/clustering.rst
@@ -61,6 +61,11 @@ commands cache contains all the server supported commands that were
 retrieved using the Redis ‘COMMAND’ output. See *RedisCluster specific
 options* below for more.
 
+The ``cluster_slots_timeout`` option can be used when topology discovery is
+expected to take longer than regular application commands. It overrides the
+read timeout only for ``CLUSTER SLOTS`` during initialization and topology
+refreshes; when omitted, ``socket_timeout`` continues to apply.
+
 RedisCluster instance can be directly used to execute Redis commands.
 When a command is being executed through the cluster instance, the
 target node(s) will be internally determined. When using a key-based

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -449,6 +449,8 @@ class RedisCluster(
         event_dispatcher: EventDispatcher | None = None,
         policy_resolver: AsyncPolicyResolver = AsyncStaticPolicyResolver(),
         maint_notifications_config: MaintNotificationsConfig | None = None,
+        # Read timeout used only for CLUSTER SLOTS topology discovery.
+        cluster_slots_timeout: float | None = None,
     ) -> None:
         if db:
             raise RedisClusterException(
@@ -586,6 +588,7 @@ class RedisCluster(
             dynamic_startup_nodes=dynamic_startup_nodes,
             address_remap=address_remap,
             event_dispatcher=self._event_dispatcher,
+            cluster_slots_timeout=cluster_slots_timeout,
         )
         AsyncMaintNotificationsAbstractRedisCluster.__init__(
             self,
@@ -1756,12 +1759,23 @@ class ClusterNode:
     async def parse_response(
         self, connection: Connection, command: str, **kwargs: Any
     ) -> Any:
+        # Used internally by RedisCluster for topology discovery reads.
+        read_timeout = kwargs.pop("_read_timeout", None)
         try:
             if NEVER_DECODE in kwargs:
-                response = await connection.read_response(disable_decoding=True)
+                read_options = {"disable_decoding": True}
                 kwargs.pop(NEVER_DECODE)
             else:
-                response = await connection.read_response()
+                read_options = {}
+            if read_timeout is not None:
+                original_socket_timeout = connection.socket_timeout
+                connection.socket_timeout = read_timeout
+                try:
+                    response = await connection.read_response(**read_options)
+                finally:
+                    connection.socket_timeout = original_socket_timeout
+            else:
+                response = await connection.read_response(**read_options)
         except ResponseError:
             if EMPTY_RESPONSE in kwargs:
                 return kwargs[EMPTY_RESPONSE]
@@ -1872,6 +1886,7 @@ class NodesManager:
         "slots_cache",
         "startup_nodes",
         "address_remap",
+        "cluster_slots_timeout",
     )
 
     def __init__(
@@ -1882,11 +1897,13 @@ class NodesManager:
         dynamic_startup_nodes: bool = True,
         address_remap: Optional[Callable[[Tuple[str, int]], Tuple[str, int]]] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
+        cluster_slots_timeout: float | None = None,
     ) -> None:
         self.startup_nodes = {node.name: node for node in startup_nodes}
         self.require_full_coverage = require_full_coverage
         self.connection_kwargs = connection_kwargs
         self.address_remap = address_remap
+        self.cluster_slots_timeout = cluster_slots_timeout
 
         self.default_node: "ClusterNode" = None
         self.nodes_cache: Dict[str, "ClusterNode"] = {}
@@ -2130,6 +2147,9 @@ class NodesManager:
                             deferred_failed_nodes.append(node)
                         additional_startup_nodes.pop(index)
                         break
+            cluster_slots_options = {}
+            if self.cluster_slots_timeout is not None:
+                cluster_slots_options["_read_timeout"] = self.cluster_slots_timeout
             for startup_node in chain(
                 startup_nodes,
                 additional_startup_nodes,
@@ -2145,7 +2165,7 @@ class NodesManager:
                             )
                         )
                         cluster_slots = await startup_node.execute_command(
-                            "CLUSTER SLOTS"
+                            "CLUSTER SLOTS", **cluster_slots_options
                         )
                     except ResponseError:
                         raise RedisClusterException(

--- a/redis/client.py
+++ b/redis/client.py
@@ -875,12 +875,17 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
 
     def parse_response(self, connection, command_name, **options):
         """Parses a response from the Redis server"""
+        # Used internally by RedisCluster for topology discovery reads.
+        read_timeout = options.pop("_read_timeout", None)
         try:
             if NEVER_DECODE in options:
-                response = connection.read_response(disable_decoding=True)
+                read_options = {"disable_decoding": True}
                 options.pop(NEVER_DECODE)
             else:
-                response = connection.read_response()
+                read_options = {}
+            if read_timeout is not None:
+                read_options["timeout"] = read_timeout
+            response = connection.read_response(**read_options)
         except ResponseError:
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -712,6 +712,7 @@ class RedisCluster(
         event_dispatcher: Optional[EventDispatcher] = None,
         policy_resolver: PolicyResolver = StaticPolicyResolver(),
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
+        cluster_slots_timeout: Optional[float] = None,
         **kwargs,
     ):
         """
@@ -751,6 +752,10 @@ class RedisCluster(
             listed in the CLUSTER SLOTS output.
             If you use dynamic DNS endpoints for startup nodes but CLUSTER SLOTS lists
             specific IP addresses, it is best to set it to false.
+        :param cluster_slots_timeout:
+            Optional read timeout, in seconds, used only for ``CLUSTER SLOTS``
+            topology discovery and refreshes. If not set, ``socket_timeout`` is
+            used as before.
         :param cluster_error_retry_attempts:
             @deprecated - Please configure the 'retry' object instead
             In case 'retry' object is set - this argument is ignored!
@@ -833,6 +838,9 @@ class RedisCluster(
                     "A ``db`` querystring option can only be 0 in cluster mode"
                 )
             kwargs.update(url_options)
+            cluster_slots_timeout = kwargs.pop(
+                "cluster_slots_timeout", cluster_slots_timeout
+            )
             host = kwargs.get("host")
             port = kwargs.get("port", port)
             startup_nodes.append(ClusterNode(host, port))
@@ -909,6 +917,7 @@ class RedisCluster(
             cache_config=cache_config,
             event_dispatcher=self._event_dispatcher,
             maint_notifications_config=maint_notifications_config,
+            cluster_slots_timeout=cluster_slots_timeout,
             **kwargs,
         )
 
@@ -2121,6 +2130,7 @@ class NodesManager:
         cache_factory: Optional[CacheFactoryInterface] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
+        cluster_slots_timeout: Optional[float] = None,
         **kwargs,
     ):
         self.nodes_cache: dict[str, ClusterNode] = {}
@@ -2141,6 +2151,7 @@ class NodesManager:
         elif cache_config is not None:
             self._cache = CacheFactory(cache_config).get_cache()
         self.connection_kwargs = kwargs
+        self.cluster_slots_timeout = cluster_slots_timeout
         self.read_load_balancer = LoadBalancer()
 
         # nodes_cache / slots_cache / startup_nodes / default_node are protected by _lock
@@ -2469,6 +2480,9 @@ class NodesManager:
         startup_nodes_reachable = False
         fully_covered = False
         kwargs = self.connection_kwargs
+        cluster_slots_options = {}
+        if self.cluster_slots_timeout is not None:
+            cluster_slots_options["_read_timeout"] = self.cluster_slots_timeout
         exception = None
         epoch = self._get_epoch()
         if additional_startup_nodes_info is None:
@@ -2551,7 +2565,9 @@ class NodesManager:
                             startup_node.redis_connection = r
                     try:
                         # Make sure cluster mode is enabled on this node
-                        cluster_slots = str_if_bytes(r.execute_command("CLUSTER SLOTS"))
+                        cluster_slots = str_if_bytes(
+                            r.execute_command("CLUSTER SLOTS", **cluster_slots_options)
+                        )
                         if disconnect_startup_nodes_pools:
                             with r.connection_pool._lock:
                                 # take care to clear connections before we move on

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2904,6 +2904,54 @@ class TestNodesManager:
         )
 
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("cluster_slots_timeout", [None, 5.0])
+    async def test_initialize_uses_cluster_slots_timeout(
+        self, cluster_slots_timeout: float | None
+    ) -> None:
+        rc = await get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            cluster_slots_timeout=cluster_slots_timeout,
+        )
+
+        async def execute_command(node, command, *args, **kwargs):
+            if command == "CLUSTER SLOTS":
+                return default_cluster_slots
+            raise AssertionError(f"Unexpected command: {command}")
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            autospec=True,
+            side_effect=execute_command,
+        ) as execute_command_mock:
+            await rc.nodes_manager.initialize()
+
+        cluster_slots_calls = [
+            call
+            for call in execute_command_mock.call_args_list
+            if call.args[1] == "CLUSTER SLOTS"
+        ]
+        assert cluster_slots_calls
+        if cluster_slots_timeout is None:
+            assert "_read_timeout" not in cluster_slots_calls[-1].kwargs
+        else:
+            assert (
+                cluster_slots_calls[-1].kwargs["_read_timeout"] == cluster_slots_timeout
+            )
+
+    @pytest.mark.fixed_client
+    async def test_parse_response_uses_internal_read_timeout(self):
+        node = ClusterNode(default_host, default_port)
+        connection = mock.AsyncMock(spec=Connection)
+        connection.socket_timeout = 0.1
+        connection.read_response.return_value = b"OK"
+
+        assert await node.parse_response(connection, "GET", _read_timeout=5.0) == b"OK"
+        assert connection.socket_timeout == 0.1
+        connection.read_response.assert_awaited_once_with()
+
+    @pytest.mark.fixed_client
     async def test_init_slots_cache_cluster_mode_disabled(self) -> None:
         """
         Test that creating a RedisCluster failes if one of the startup nodes

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2958,6 +2958,49 @@ class TestNodesManager:
         execute_command.assert_any_call("CLUSTER SLOTS")
 
     @pytest.mark.fixed_client
+    @pytest.mark.parametrize("cluster_slots_timeout", [None, 5.0])
+    def test_initialize_uses_cluster_slots_timeout(self, cluster_slots_timeout):
+        rc = get_mocked_redis_client(
+            host=default_host,
+            port=default_port,
+            cluster_slots_timeout=cluster_slots_timeout,
+        )
+
+        with patch.object(Redis, "execute_command", autospec=True) as execute_command:
+
+            def execute_command_side_effect(_redis, command, *args, **kwargs):
+                if command == "CLUSTER SLOTS":
+                    return default_cluster_slots
+                raise AssertionError(f"Unexpected command: {command}")
+
+            execute_command.side_effect = execute_command_side_effect
+            rc.nodes_manager.initialize(disconnect_startup_nodes_pools=False)
+
+        cluster_slots_calls = [
+            call
+            for call in execute_command.call_args_list
+            if call.args[1] == "CLUSTER SLOTS"
+        ]
+        assert cluster_slots_calls
+        if cluster_slots_timeout is None:
+            assert "_read_timeout" not in cluster_slots_calls[-1].kwargs
+        else:
+            assert (
+                cluster_slots_calls[-1].kwargs["_read_timeout"] == cluster_slots_timeout
+            )
+
+    @pytest.mark.fixed_client
+    def test_parse_response_uses_internal_read_timeout(self):
+        redis_client = Redis()
+        connection = Mock()
+        connection.read_response.return_value = b"OK"
+
+        assert (
+            redis_client.parse_response(connection, "GET", _read_timeout=5.0) == b"OK"
+        )
+        connection.read_response.assert_called_once_with(timeout=5.0)
+
+    @pytest.mark.fixed_client
     def test_init_promote_server_type_for_node_in_cache(self):
         """
         When replica is promoted to master, nodes_cache must change the server type


### PR DESCRIPTION
## Summary

Fixes #3800.

Redis Cluster topology discovery currently uses the regular command/socket read timeout for `CLUSTER SLOTS`. A short application timeout can therefore abort a slow topology response and cause repeated connection attempts.

This change adds `cluster_slots_timeout` to both synchronous and asyncio `RedisCluster` clients. When configured, it applies only to `CLUSTER SLOTS` during initial discovery and topology refreshes. Application commands continue to use `socket_timeout`, and the default behavior is unchanged.

## Testing

- Added sync and asyncio regression tests for the configured and default paths.
- Added read-timeout propagation tests for both parser paths.
- `pytest -m fixed_client tests/test_cluster.py tests/test_asyncio/test_cluster.py`: 71 passed.
- `pytest tests/test_connection.py tests/test_asyncio/test_connection.py`: 153 passed, 4 skipped.
- `pytest tests/test_client.py`: 10 passed.
- `ruff check`, `compileall`, and `git diff --check` passed.

The local environment does not provide the Redis Cluster fixture, so the tests marked `onlycluster` were not used for validation.