### PR TITLE
Wait for pending async cluster pool cleanup

### DIFF
--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1687,8 +1687,13 @@ class ClusterNode:
                 self._connection_available_event.clear()
                 return connection
             except MaxConnectionsError:
-                pending_cleanup = tuple(self._background_tasks)
+                pending_cleanup = tuple(
+                    task for task in self._background_tasks if not task.done()
+                )
                 if not pending_cleanup:
+                    if self._background_tasks:
+                        self._background_tasks.clear()
+                        continue
                     raise
                 await self._connection_available_event.wait()
                 self._connection_available_event.clear()

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1686,8 +1686,9 @@ class ClusterNode:
                 pending_cleanup = tuple(self._background_tasks)
                 if not pending_cleanup:
                     raise
-                await asyncio.gather(
-                    *(asyncio.shield(task) for task in pending_cleanup)
+                await asyncio.wait(
+                    [asyncio.shield(task) for task in pending_cleanup],
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
 
     async def disconnect_if_needed(self, connection: Connection) -> None:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1563,6 +1563,7 @@ class ClusterNode:
     __slots__ = (
         "_background_tasks",
         "_connections",
+        "_connection_available_event",
         "_free",
         "_lock",
         "_event_dispatcher",
@@ -1602,6 +1603,7 @@ class ClusterNode:
         self.response_callbacks = connection_kwargs.pop("response_callbacks", {})
 
         self._connections: List[Connection] = []
+        self._connection_available_event = asyncio.Event()
         self._free: Deque[Connection] = collections.deque(maxlen=self.max_connections)
         self._background_tasks: Set[asyncio.Task] = set()
         self._event_dispatcher = self.connection_kwargs.get("event_dispatcher", None)
@@ -1678,18 +1680,18 @@ class ClusterNode:
             raise MaxConnectionsError()
 
     async def acquire_connection_async(self) -> Connection:
-        """Acquire a connection after pending reconnect cleanup completes."""
+        """Acquire a connection after a pending release makes one available."""
         while True:
             try:
-                return self.acquire_connection()
+                connection = self.acquire_connection()
+                self._connection_available_event.clear()
+                return connection
             except MaxConnectionsError:
                 pending_cleanup = tuple(self._background_tasks)
                 if not pending_cleanup:
                     raise
-                await asyncio.wait(
-                    [asyncio.shield(task) for task in pending_cleanup],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
+                await self._connection_available_event.wait()
+                self._connection_available_event.clear()
 
     async def disconnect_if_needed(self, connection: Connection) -> None:
         """
@@ -1712,6 +1714,7 @@ class ClusterNode:
             task.add_done_callback(self._background_tasks.discard)
             return
         self._free.append(connection)
+        self._connection_available_event.set()
 
     async def _disconnect_and_release(self, connection: Connection) -> None:
         try:
@@ -1726,9 +1729,11 @@ class ClusterNode:
                 self._connections.remove(connection)
             except ValueError:
                 pass
+            self._connection_available_event.set()
             return
 
         self._free.append(connection)
+        self._connection_available_event.set()
 
     def get_encoder(self) -> Encoder:
         """Return an :class:`Encoder` derived from this node's connection kwargs."""

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -631,10 +631,8 @@ class RedisCluster(
         self.command_flags = self.__class__.COMMAND_FLAGS.copy()
         self.response_callbacks = kwargs["response_callbacks"]
         self.result_callbacks = self.__class__.RESULT_CALLBACKS.copy()
-        self.result_callbacks["CLUSTER SLOTS"] = (
-            lambda cmd, res, **kwargs: parse_cluster_slots(
-                list(res.values())[0], **kwargs
-            )
+        self.result_callbacks["CLUSTER SLOTS"] = lambda cmd, res, **kwargs: (
+            parse_cluster_slots(list(res.values())[0], **kwargs)
         )
 
         self._initialize = True
@@ -1688,7 +1686,9 @@ class ClusterNode:
                 pending_cleanup = tuple(self._background_tasks)
                 if not pending_cleanup:
                     raise
-                await asyncio.gather(*pending_cleanup)
+                await asyncio.gather(
+                    *(asyncio.shield(task) for task in pending_cleanup)
+                )
 
     async def disconnect_if_needed(self, connection: Connection) -> None:
         """

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1679,6 +1679,17 @@ class ClusterNode:
 
             raise MaxConnectionsError()
 
+    async def acquire_connection_async(self) -> Connection:
+        """Acquire a connection after pending reconnect cleanup completes."""
+        while True:
+            try:
+                return self.acquire_connection()
+            except MaxConnectionsError:
+                pending_cleanup = tuple(self._background_tasks)
+                if not pending_cleanup:
+                    raise
+                await asyncio.gather(*pending_cleanup)
+
     async def disconnect_if_needed(self, connection: Connection) -> None:
         """
         Disconnect a connection if it's marked for reconnect.
@@ -1781,7 +1792,7 @@ class ClusterNode:
 
     async def execute_command(self, *args: Any, **kwargs: Any) -> Any:
         # Acquire connection
-        connection = self.acquire_connection()
+        connection = await self.acquire_connection_async()
         try:
             # Handle lazy disconnect for connections marked for reconnect
             await self.disconnect_if_needed(connection)
@@ -1800,7 +1811,7 @@ class ClusterNode:
 
     async def execute_pipeline(self, commands: List["PipelineCommand"]) -> bool:
         # Acquire connection
-        connection = self.acquire_connection()
+        connection = await self.acquire_connection_async()
         try:
             # Handle lazy disconnect for connections marked for reconnect
             await self.disconnect_if_needed(connection)
@@ -2925,7 +2936,7 @@ class TransactionStrategy(AbstractStrategy):
             RedisCluster.ERRORS_ALLOW_RETRY + self.SLOT_REDIRECT_ERRORS
         )
 
-    def _get_client_and_connection_for_transaction(
+    async def _get_client_and_connection_for_transaction(
         self,
     ) -> Tuple[ClusterNode, Connection]:
         """
@@ -2947,7 +2958,9 @@ class TransactionStrategy(AbstractStrategy):
         self._transaction_node = node
 
         if not self._transaction_connection:
-            connection: Connection = self._transaction_node.acquire_connection()
+            connection: Connection = (
+                await self._transaction_node.acquire_connection_async()
+            )
             self._transaction_connection = connection
 
         return self._transaction_node, self._transaction_connection
@@ -3024,7 +3037,7 @@ class TransactionStrategy(AbstractStrategy):
         )
 
     async def _get_connection_and_send_command(self, *args, **options):
-        redis_node, connection = self._get_client_and_connection_for_transaction()
+        redis_node, connection = await self._get_client_and_connection_for_transaction()
         # Only disconnect if not watching - disconnecting would lose WATCH state
         if not self._watching:
             await redis_node.disconnect_if_needed(connection)
@@ -3172,7 +3185,7 @@ class TransactionStrategy(AbstractStrategy):
 
         self._executing = True
 
-        redis_node, connection = self._get_client_and_connection_for_transaction()
+        redis_node, connection = await self._get_client_and_connection_for_transaction()
         # Only disconnect if not watching - disconnecting would lose WATCH state
         if not self._watching:
             await redis_node.disconnect_if_needed(connection)
@@ -3388,7 +3401,7 @@ class _ClusterNodePoolAdapter(ConnectionPoolInterface):
     async def get_connection(
         self, command_name: Optional[str] = None, *keys: Any, **options: Any
     ) -> AbstractConnection:
-        connection = self._node.acquire_connection()
+        connection = await self._node.acquire_connection_async()
         try:
             await connection.connect()
         except BaseException:

--- a/redis/asyncio/cluster.py
+++ b/redis/asyncio/cluster.py
@@ -1698,6 +1698,10 @@ class ClusterNode:
                 await self._connection_available_event.wait()
                 self._connection_available_event.clear()
 
+    def _connection_cleanup_done(self, task: asyncio.Task) -> None:
+        self._background_tasks.discard(task)
+        self._connection_available_event.set()
+
     async def disconnect_if_needed(self, connection: Connection) -> None:
         """
         Disconnect a connection if it's marked for reconnect.
@@ -1716,7 +1720,7 @@ class ClusterNode:
         if connection.should_reconnect():
             task = asyncio.create_task(self._disconnect_and_release(connection))
             self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(self._connection_cleanup_done)
             return
         self._free.append(connection)
         self._connection_available_event.set()
@@ -1734,11 +1738,9 @@ class ClusterNode:
                 self._connections.remove(connection)
             except ValueError:
                 pass
-            self._connection_available_event.set()
             return
 
         self._free.append(connection)
-        self._connection_available_event.set()
 
     def get_encoder(self) -> Encoder:
         """Return an :class:`Encoder` derived from this node's connection kwargs."""

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3414,6 +3414,52 @@ class TestClusterNodeConnectionHandling:
         await cleanup_task
         assert await node.acquire_connection_async() is connection
 
+    async def test_acquire_connection_async_retries_after_any_cleanup(self) -> None:
+        node = ClusterNode(default_host, 7000, max_connections=2)
+        first_connection = mock.AsyncMock(spec=Connection)
+        second_connection = mock.AsyncMock(spec=Connection)
+        for connection in (first_connection, second_connection):
+            connection.is_connected = True
+            connection.reconnect = True
+            connection.should_reconnect.side_effect = (
+                lambda connection=connection: connection.reconnect
+            )
+            node._connections.append(connection)
+
+        first_disconnect_started = asyncio.Event()
+        second_disconnect_started = asyncio.Event()
+        allow_first_disconnect = asyncio.Event()
+        allow_second_disconnect = asyncio.Event()
+
+        async def disconnect_first() -> None:
+            first_disconnect_started.set()
+            await allow_first_disconnect.wait()
+            first_connection.reconnect = False
+            first_connection.is_connected = False
+
+        async def disconnect_second() -> None:
+            second_disconnect_started.set()
+            await allow_second_disconnect.wait()
+            second_connection.reconnect = False
+            second_connection.is_connected = False
+
+        first_connection.disconnect.side_effect = disconnect_first
+        second_connection.disconnect.side_effect = disconnect_second
+        node.release(first_connection)
+        node.release(second_connection)
+        await asyncio.gather(
+            first_disconnect_started.wait(), second_disconnect_started.wait()
+        )
+
+        waiter = asyncio.create_task(node.acquire_connection_async())
+        await asyncio.sleep(0)
+        allow_first_disconnect.set()
+
+        assert await asyncio.wait_for(waiter, timeout=1) is first_connection
+
+        allow_second_disconnect.set()
+        await asyncio.gather(*node._background_tasks)
+
     class WriteFailingConnection:
         def __init__(self, **kwargs: Any) -> None:
             self.host = kwargs["host"]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3342,6 +3342,44 @@ class TestNodesManager:
 class TestClusterNodeConnectionHandling:
     """Tests for ClusterNode connection handling methods."""
 
+    async def test_execute_command_waits_for_pending_reconnect_cleanup(self) -> None:
+        node = ClusterNode(default_host, 7000, max_connections=1)
+        connection = mock.AsyncMock(spec=Connection)
+        connection.reconnect = True
+        connection.should_reconnect.side_effect = lambda: connection.reconnect
+        connection.pack_command.return_value = b"packed"
+        connection.read_response.return_value = b"OK"
+
+        disconnect_started = asyncio.Event()
+        allow_disconnect = asyncio.Event()
+
+        async def disconnect() -> None:
+            disconnect_started.set()
+            await allow_disconnect.wait()
+            connection.reconnect = False
+            connection.is_connected = False
+
+        connection.disconnect.side_effect = disconnect
+        node._connections.append(connection)
+        node.release(connection)
+
+        await disconnect_started.wait()
+        command = asyncio.create_task(node.execute_command("GET", "key"))
+        await asyncio.sleep(0)
+        assert not command.done()
+
+        allow_disconnect.set()
+        assert await command == b"OK"
+
+    async def test_acquire_connection_async_preserves_pool_exhaustion(self) -> None:
+        node = ClusterNode(default_host, 7000, max_connections=1)
+        connection = mock.AsyncMock(spec=Connection)
+        connection.is_connected = False
+        node._connections.append(connection)
+
+        with pytest.raises(MaxConnectionsError):
+            await node.acquire_connection_async()
+
     class WriteFailingConnection:
         def __init__(self, **kwargs: Any) -> None:
             self.host = kwargs["host"]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3460,6 +3460,40 @@ class TestClusterNodeConnectionHandling:
         allow_second_disconnect.set()
         await asyncio.gather(*node._background_tasks)
 
+    async def test_acquire_connection_async_wakes_on_normal_release(self) -> None:
+        node = ClusterNode(default_host, 7000, max_connections=2)
+        reconnecting_connection = mock.AsyncMock(spec=Connection)
+        released_connection = mock.AsyncMock(spec=Connection)
+        reconnecting_connection.is_connected = False
+        released_connection.is_connected = False
+        reconnecting_connection.reconnect = True
+        reconnecting_connection.should_reconnect.return_value = True
+        released_connection.reconnect = False
+        released_connection.should_reconnect.return_value = False
+        node._connections.extend([reconnecting_connection, released_connection])
+
+        disconnect_started = asyncio.Event()
+        allow_disconnect = asyncio.Event()
+
+        async def disconnect() -> None:
+            disconnect_started.set()
+            await allow_disconnect.wait()
+            reconnecting_connection.reconnect = False
+
+        reconnecting_connection.disconnect.side_effect = disconnect
+        node.release(reconnecting_connection)
+        await disconnect_started.wait()
+
+        waiter = asyncio.create_task(node.acquire_connection_async())
+        await asyncio.sleep(0)
+        node.release(released_connection)
+
+        try:
+            assert await asyncio.wait_for(waiter, timeout=1) is released_connection
+        finally:
+            allow_disconnect.set()
+            await asyncio.gather(*node._background_tasks)
+
     class WriteFailingConnection:
         def __init__(self, **kwargs: Any) -> None:
             self.host = kwargs["host"]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3380,6 +3380,40 @@ class TestClusterNodeConnectionHandling:
         with pytest.raises(MaxConnectionsError):
             await node.acquire_connection_async()
 
+    async def test_acquire_connection_async_does_not_cancel_cleanup(self) -> None:
+        node = ClusterNode(default_host, 7000, max_connections=1)
+        connection = mock.AsyncMock(spec=Connection)
+        connection.is_connected = True
+        connection.reconnect = True
+        connection.should_reconnect.side_effect = lambda: connection.reconnect
+
+        disconnect_started = asyncio.Event()
+        allow_disconnect = asyncio.Event()
+
+        async def disconnect() -> None:
+            disconnect_started.set()
+            await allow_disconnect.wait()
+            connection.reconnect = False
+            connection.is_connected = False
+
+        connection.disconnect.side_effect = disconnect
+        node._connections.append(connection)
+        node.release(connection)
+        await disconnect_started.wait()
+
+        waiter = asyncio.create_task(node.acquire_connection_async())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        cleanup_task = next(iter(node._background_tasks))
+        assert cleanup_task.cancelled() is False
+
+        allow_disconnect.set()
+        await cleanup_task
+        assert await node.acquire_connection_async() is connection
+
     class WriteFailingConnection:
         def __init__(self, **kwargs: Any) -> None:
             self.host = kwargs["host"]

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -3460,6 +3460,37 @@ class TestClusterNodeConnectionHandling:
         allow_second_disconnect.set()
         await asyncio.gather(*node._background_tasks)
 
+    async def test_acquire_connection_async_rechecks_completed_cleanup(self) -> None:
+        node = ClusterNode(default_host, 7000, max_connections=1)
+        connection = mock.AsyncMock(spec=Connection)
+        connection.is_connected = False
+        connection.reconnect = True
+        connection.should_reconnect.return_value = True
+        node._connections.append(connection)
+
+        disconnect_started = asyncio.Event()
+        allow_disconnect = asyncio.Event()
+
+        async def disconnect() -> None:
+            disconnect_started.set()
+            await allow_disconnect.wait()
+            connection.reconnect = False
+
+        connection.disconnect.side_effect = disconnect
+        node.release(connection)
+        await disconnect_started.wait()
+
+        first_waiter = asyncio.create_task(node.acquire_connection_async())
+        second_waiter = asyncio.create_task(node.acquire_connection_async())
+        await asyncio.sleep(0)
+
+        allow_disconnect.set()
+        assert await asyncio.wait_for(first_waiter, timeout=1) is connection
+        with pytest.raises(MaxConnectionsError):
+            await asyncio.wait_for(second_waiter, timeout=1)
+
+        await asyncio.gather(*node._background_tasks)
+
     async def test_acquire_connection_async_wakes_on_normal_release(self) -> None:
         node = ClusterNode(default_host, 7000, max_connections=2)
         reconnecting_connection = mock.AsyncMock(spec=Connection)


### PR DESCRIPTION
## Summary

Fixes #3929.

During an async Redis Cluster topology refresh, in-use connections are marked for reconnect. When those commands finish, ClusterNode.release() schedules asynchronous cleanup, but the connections remain counted toward the node's pool limit until that cleanup completes. Under concurrency, requests can receive MaxConnectionsError during this transient window and the cluster may appear unrecoverable.

This change adds an async acquisition path used by cluster commands, transactions, pipelines, and cluster PubSub. If the pool is full and reconnect cleanup is pending, it waits for that cleanup and retries acquisition. Ordinary pool exhaustion without pending cleanup still raises MaxConnectionsError immediately.

## Testing

- Added a deterministic regression test for pending reconnect cleanup.
- Added a regression test preserving immediate pool exhaustion errors.
- pytest -m fixed_client tests/test_asyncio/test_cluster.py: 38 passed.
- Targeted regression tests: 2 passed.
- ruff check, compileall, and git diff --check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async cluster connection pooling and concurrency around topology refresh; behavior change is narrowly scoped to the transient full-pool window, with regression tests covering the main race scenarios.
> 
> **Overview**
> Fixes false **MaxConnectionsError** during async cluster topology refresh when connections are still counted in the pool while **lazy reconnect cleanup** runs after `release()`.
> 
> **ClusterNode** now exposes **`acquire_connection_async()`**, which retries acquisition when the pool looks full but background `_disconnect_and_release` tasks are still running, using an **`asyncio.Event`** signaled on normal release and when cleanup finishes. Synchronous **`acquire_connection()`** is unchanged; true exhaustion with no pending cleanup still fails immediately.
> 
> All async callers that borrowed connections synchronously now **`await acquire_connection_async()`**: node **`execute_command`** / **`execute_pipeline`**, cluster pipeline **transaction** connection setup (method made **`async`**), and **`_ClusterNodePoolAdapter.get_connection`** for cluster PubSub.
> 
> Adds deterministic asyncio tests for waiting on cleanup, preserving immediate exhaustion, cancellation not cancelling cleanup, and wakeups on normal release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46950ef897fcb5a977ccb19ec8de52cb1ac5c041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->