### PR TITLE
Add configurable encoder classes to standalone clients

### DIFF
--- a/docs/advanced_features.rst
+++ b/docs/advanced_features.rst
@@ -23,6 +23,32 @@ a separate connection pool) for each database.
 
 It is not safe to pass PubSub or Pipeline objects between threads.
 
+Custom encoders
+---------------
+
+Redis clients use an ``Encoder`` to serialize command arguments
+and deserialize responses. Applications that need to support additional
+Python value types can provide an ``encoder_class``. The class is
+instantiated separately for each connection, so it must accept the same
+``encoding``, ``encoding_errors``, and ``decode_responses`` arguments as the
+default encoder:
+
+.. code:: python
+
+   from redis import Encoder, Redis
+
+   class ApplicationEncoder(Encoder):
+       def encode(self, value):
+           if isinstance(value, ApplicationValue):
+               return value.to_bytes()
+           return super().encode(value)
+
+   client = Redis(encoder_class=ApplicationEncoder)
+
+The same option is available on ``redis.asyncio.Redis`` and both standalone
+connection-pool classes. Passing an encoder class, rather than a shared
+encoder instance, keeps connection-specific encoder state isolated.
+
 Pipelines
 ---------
 

--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -2,6 +2,7 @@ from redis import asyncio  # noqa
 from redis.backoff import default_backoff
 from redis.client import Redis, StrictRedis
 from redis.driver_info import DriverInfo
+from redis._parsers import Encoder
 from redis.cluster import RedisCluster
 from redis.connection import (
     BlockingConnectionPool,
@@ -84,6 +85,7 @@ __all__ = [
     "CrossSlotTransactionError",
     "DataError",
     "DriverInfo",
+    "Encoder",
     "EventType",
     "from_url",
     "default_backoff",

--- a/redis/asyncio/__init__.py
+++ b/redis/asyncio/__init__.py
@@ -1,3 +1,4 @@
+from redis._parsers import Encoder
 from redis.asyncio.client import Redis, StrictRedis
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import (
@@ -51,6 +52,7 @@ __all__ = [
     "ConnectionError",
     "ConnectionPool",
     "DataError",
+    "Encoder",
     "from_url",
     "default_backoff",
     "InvalidResponse",

--- a/redis/asyncio/client.py
+++ b/redis/asyncio/client.py
@@ -36,6 +36,7 @@ from redis._defaults import (
     DEFAULT_SOCKET_READ_SIZE,
     DEFAULT_SOCKET_TIMEOUT,
 )
+from redis._parsers.encoders import Encoder
 from redis._parsers.helpers import bool_ok, get_response_callbacks
 from redis.asyncio.connection import (
     Connection,
@@ -308,6 +309,7 @@ class Redis(
         legacy_responses: bool = True,
         event_dispatcher: EventDispatcher | None = None,
         maint_notifications_config: MaintNotificationsConfig | None = None,
+        encoder_class: Type[Encoder] = Encoder,
     ):
         """
         Initialize a new Redis client.
@@ -350,6 +352,10 @@ class Redis(
             If not provided and protocol is RESP3, the maintenance notifications
             will be enabled by default (logic is included in the connection pool
             initialization).
+            Argument is ignored when connection_pool is provided.
+        encoder_class:
+            The encoder class used to create an encoder for each connection.
+            Custom encoder classes must accept the same arguments as `Encoder`.
             Argument is ignored when connection_pool is provided.
         """
         kwargs: Dict[str, Any]
@@ -401,6 +407,7 @@ class Redis(
                 "redis_connect_func": redis_connect_func,
                 "protocol": protocol,
                 "legacy_responses": legacy_responses,
+                "encoder_class": encoder_class,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/client.py
+++ b/redis/client.py
@@ -315,6 +315,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
         maint_notifications_config: MaintNotificationsConfig | None = None,
         oss_cluster_maint_notifications_handler: OSSMaintNotificationsHandler
         | None = None,
+        encoder_class: Type[Encoder] = Encoder,
     ) -> None:
         """
         Initialize a new Redis client.
@@ -355,6 +356,10 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
             instance use is not thread safe.
         decode_responses:
             if `True`, the response will be decoded to utf-8.
+            Argument is ignored when connection_pool is provided.
+        encoder_class:
+            The encoder class used to create an encoder for each connection.
+            Custom encoder classes must accept the same arguments as `Encoder`.
             Argument is ignored when connection_pool is provided.
         driver_info:
             Optional DriverInfo object to identify upstream libraries.
@@ -412,6 +417,7 @@ class Redis(RedisModuleCommands, CoreCommands, SentinelCommands):
                 "credential_provider": credential_provider,
                 "protocol": protocol,
                 "legacy_responses": legacy_responses,
+                "encoder_class": encoder_class,
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -830,6 +830,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         command_packer: Optional[Callable[[], None]] = None,
         event_dispatcher: Optional[EventDispatcher] = None,
         maint_notifications_config: Optional[MaintNotificationsConfig] = None,
+        encoder_class: Type[Encoder] = Encoder,
         maint_notifications_pool_handler: Optional[
             MaintNotificationsPoolHandler
         ] = None,
@@ -909,7 +910,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
         self.health_check_interval = health_check_interval
         self.next_health_check = 0
         self.redis_connect_func = redis_connect_func
-        self.encoder = Encoder(encoding, encoding_errors, decode_responses)
+        self.encoder = encoder_class(encoding, encoding_errors, decode_responses)
         self.handshake_metadata = None
         self._sock = None
         self._socket_read_size = socket_read_size
@@ -3236,7 +3237,8 @@ class ConnectionPool(MaintNotificationsAbstractConnectionPool, ConnectionPoolInt
     def get_encoder(self) -> Encoder:
         "Return an encoder based on encoding settings"
         kwargs = self.connection_kwargs
-        return Encoder(
+        encoder_class = kwargs.get("encoder_class", Encoder)
+        return encoder_class(
             encoding=kwargs.get("encoding", "utf-8"),
             encoding_errors=kwargs.get("encoding_errors", "strict"),
             decode_responses=kwargs.get("decode_responses", False),

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -15,7 +15,7 @@ from redis._parsers import (
     _AsyncRESPBase,
 )
 from redis._parsers.hiredis import NOT_ENOUGH_DATA
-from redis.asyncio import ConnectionPool, Redis
+from redis.asyncio import ConnectionPool, Encoder, Redis
 from redis.asyncio.connection import (
     Connection,
     SSLConnection,
@@ -29,6 +29,18 @@ from redis.utils import HIREDIS_AVAILABLE
 from tests.conftest import skip_if_server_version_lt
 
 from .mocks import MockStream
+
+
+class CustomEncoder(Encoder):
+    def encode(self, value):
+        if value == "custom":
+            return b"encoded-custom"
+        return super().encode(value)
+
+    def decode(self, value, force=False):
+        if value == b"encoded-custom":
+            return "decoded-custom"
+        return super().decode(value, force=force)
 
 
 class DummyHiredisReader:
@@ -99,6 +111,34 @@ async def test_async_hiredis_can_read_uses_buffer_without_reading(
 
     assert await parser.can_read() is expected
     assert stream.read_called is False
+
+
+async def test_uses_custom_encoder_for_connections_and_pool_helpers():
+    connection_pool = ConnectionPool(encoder_class=CustomEncoder)
+
+    connection = connection_pool.make_connection()
+    try:
+        assert isinstance(connection.encoder, CustomEncoder)
+        assert connection.encoder.encode("custom") == b"encoded-custom"
+        assert connection.encoder.decode(b"encoded-custom") == "decoded-custom"
+        pool_encoder = connection_pool.get_encoder()
+        assert isinstance(pool_encoder, CustomEncoder)
+        assert pool_encoder is not connection.encoder
+    finally:
+        await connection.disconnect()
+        await connection_pool.disconnect()
+
+
+async def test_redis_client_passes_custom_encoder_to_pool():
+    client = Redis(encoder_class=CustomEncoder)
+
+    try:
+        assert isinstance(client.get_encoder(), CustomEncoder)
+        assert (
+            client.connection_pool.connection_kwargs["encoder_class"] is CustomEncoder
+        )
+    finally:
+        await client.aclose()
 
 
 async def test_async_hiredis_can_read_detects_reader_response():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -15,7 +15,7 @@ from unittest.mock import call, patch, MagicMock, Mock
 
 import pytest
 import redis
-from redis import ConnectionPool, Redis
+from redis import ConnectionPool, Encoder, Redis
 from redis._parsers import _HiredisParser, _RESP2Parser, _RESP3Parser
 from redis._parsers.hiredis import NOT_ENOUGH_DATA, _socket_can_read, _socket_is_closed
 from redis._parsers.socket import SocketBuffer
@@ -75,6 +75,18 @@ class DummyHiredisReader:
 
 class DummyPushNotification(list):
     pass
+
+
+class CustomEncoder(Encoder):
+    def encode(self, value):
+        if value == "custom":
+            return b"encoded-custom"
+        return super().encode(value)
+
+    def decode(self, value, force=False):
+        if value == b"encoded-custom":
+            return "decoded-custom"
+        return super().decode(value, force=force)
 
 
 def make_hiredis_parser(
@@ -902,6 +914,33 @@ def test_unix_socket_connection_failure():
 
 @pytest.mark.fixed_client
 class TestUnitConnectionPool:
+    def test_uses_custom_encoder_for_connections_and_pool_helpers(self):
+        connection_pool = ConnectionPool(encoder_class=CustomEncoder)
+
+        connection = connection_pool.make_connection()
+        try:
+            assert isinstance(connection.encoder, CustomEncoder)
+            assert connection.encoder.encode("custom") == b"encoded-custom"
+            assert connection.encoder.decode(b"encoded-custom") == "decoded-custom"
+            pool_encoder = connection_pool.get_encoder()
+            assert isinstance(pool_encoder, CustomEncoder)
+            assert pool_encoder is not connection.encoder
+        finally:
+            connection.disconnect()
+            connection_pool.disconnect()
+
+    def test_redis_client_passes_custom_encoder_to_pool(self):
+        client = Redis(encoder_class=CustomEncoder)
+
+        try:
+            assert isinstance(client.get_encoder(), CustomEncoder)
+            assert (
+                client.connection_pool.connection_kwargs["encoder_class"]
+                is CustomEncoder
+            )
+        finally:
+            client.close()
+
     @pytest.mark.parametrize(
         "max_conn", (-1, "str"), ids=("non-positive", "wrong type")
     )


### PR DESCRIPTION
## What

Adds support for configuring a custom `Encoder` subclass on standalone sync and asyncio clients and their connection pools.

Closes #3181

## Why

The default encoder rejects application-specific Python value types. Users can now implement custom serialization/deserialization while retaining redis-py's existing encoding configuration.

## Design

- Adds `encoder_class` to sync and asyncio `Redis` constructors.
- Propagates the class to the connection pool and connection instances.
- Instantiates an encoder per connection/helper instead of sharing mutable encoder instances.
- Exposes `Encoder` from `redis` and `redis.asyncio`.
- Preserves the default `Encoder` behavior when no custom class is supplied.
- Documents the connection-isolation contract.
- Limits this change to standalone clients and pools; Cluster/Sentinel behavior is unchanged.

## Tests

- Added sync and asyncio regression coverage for:
  - custom encoding and decoding
  - pool-created connection encoders
  - pool helper encoders being distinct instances
  - client-to-pool configuration propagation
- `157 passed, 4 skipped` for `tests/test_connection.py tests/test_asyncio/test_connection.py`
- `17 passed` for `tests/test_client.py tests/test_asyncio/test_client.py`
- Ruff check/format, compileall, and `git diff --check` pass.

This is a draft while CI and maintainer feedback run.