### PR TITLE
fix: Fixed double decoding issue with unquote()

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1749,7 +1749,10 @@ def parse_url(url: str) -> ConnectKwargs:
 
     for name, value_list in parse_qs(parsed.query).items():
         if value_list and len(value_list) > 0:
-            value = unquote(value_list[0])
+            # parse_qs() already percent-decodes query values, so use the value
+            # as-is; unquoting again here would double-decode (e.g. "%2520" ->
+            # "%20" -> " "). See issue #4208.
+            value = value_list[0]
             parser = URL_QUERY_ARGUMENT_PARSERS.get(name)
             if parser:
                 try:

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2291,7 +2291,10 @@ def parse_url(url):
 
     for name, value in parse_qs(url.query).items():
         if value and len(value) > 0:
-            value = unquote(value[0])
+            # parse_qs() already percent-decodes query values, so use the value
+            # as-is; unquoting again here would double-decode (e.g. "%2520" ->
+            # "%20" -> " "). See issue #4208.
+            value = value[0]
             parser = URL_QUERY_ARGUMENT_PARSERS.get(name)
             if parser:
                 try:

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -617,6 +617,21 @@ class TestConnectionPoolURLParsing:
         pool = redis.ConnectionPool.from_url("redis://location?client_name=test-client")
         assert pool.connection_kwargs["client_name"] == "test-client"
 
+    def test_querystring_value_percent_decoded_once(self):
+        # A single percent-encoded sequence is decoded exactly once.
+        pool = redis.ConnectionPool.from_url(
+            "redis://location?client_name=worker%20name"
+        )
+        assert pool.connection_kwargs["client_name"] == "worker name"
+
+    def test_querystring_value_not_double_percent_decoded(self):
+        # A literal percent sign in a query value (encoded as %2520) must survive
+        # as "%20" rather than being decoded a second time into a space. See #4208.
+        pool = redis.ConnectionPool.from_url(
+            "redis://location?client_name=worker%2520name"
+        )
+        assert pool.connection_kwargs["client_name"] == "worker%20name"
+
     def test_invalid_extra_typed_querystring_options(self):
         with pytest.raises(ValueError):
             redis.ConnectionPool.from_url(

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -515,6 +515,21 @@ class TestConnectionPoolURLParsing:
         pool = redis.ConnectionPool.from_url("redis://location?client_name=test-client")
         assert pool.connection_kwargs["client_name"] == "test-client"
 
+    def test_querystring_value_percent_decoded_once(self):
+        # A single percent-encoded sequence is decoded exactly once.
+        pool = redis.ConnectionPool.from_url(
+            "redis://location?client_name=worker%20name"
+        )
+        assert pool.connection_kwargs["client_name"] == "worker name"
+
+    def test_querystring_value_not_double_percent_decoded(self):
+        # A literal percent sign in a query value (encoded as %2520) must survive
+        # as "%20" rather than being decoded a second time into a space. See #4208.
+        pool = redis.ConnectionPool.from_url(
+            "redis://location?client_name=worker%2520name"
+        )
+        assert pool.connection_kwargs["client_name"] == "worker%20name"
+
     def test_invalid_extra_typed_querystring_options(self):
         with pytest.raises(ValueError):
             redis.ConnectionPool.from_url(


### PR DESCRIPTION
### Description of change

`ConnectionPool.from_url` (and everything that routes through parse_url — Redis.from_url, the sync/async cluster clients, and Sentinel) percent-decodes URL query values twice, corrupting any value that contains a literal percent-encoded sequence.

`urllib.parse.parse_qs()` already percent-decodes the values it returns, but parse_url then called `urllib.parse.unquote()` on the result a second time:
                                                           
```                                                                                                                                                                                                                 
for name, value in parse_qs(url.query).items():                                                                                                                                                                
    if value and len(value) > 0:                                                                                                                                                                               
        value = unquote(value[0])   # ← second, erroneous decode
```

### Fix

Drop the redundant second decode in both stacks and use the value parse_qs already returned:                                                                                                                   
                                                                                                                                                                                                               
- redis/connection.py — parse_url()                                                                                                                                                                            
- redis/asyncio/connection.py — parse_url()                                                                                                                                                                    
                                                                                                                                                                                                                 
The unquote() calls on username, password, path, and hostname are intentionally left unchanged: urlparse() does not decode those components, so those are the correct single decode. + handling is also unaffected — parse_qs already applies form-encoding semantics (+ → space), and unquote never touched +.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow URL parsing fix with targeted tests; behavior change only for query values that were incorrectly double-decoded.
> 
> **Overview**
> **Fixes double percent-decoding of query-string values** in `parse_url()` for sync and async connection URLs (`redis://`, `rediss://`, `unix://`), including `ConnectionPool.from_url` / `Redis.from_url` and other callers of that helper (#4208).
> 
> Query parameters were passed through `urllib.parse.unquote()` after `parse_qs()` had already decoded them, so values like `client_name=worker%2520name` became a space instead of the intended literal `%20`. The redundant `unquote` is removed; **username, password, path, and hostname** still use `unquote` because `urlparse` does not decode those parts.
> 
> Sync and asyncio connection-pool tests cover single decode (`worker%20name` → space) and no second decode (`worker%2520name` → `worker%20name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af8435108e9d3b6638fc57444124236704f5cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->