### PR TITLE
Fix lat/lon swap in search querystring geo() helper

### DIFF
--- a/redis/commands/search/querystring.py
+++ b/redis/commands/search/querystring.py
@@ -57,7 +57,7 @@ def geo(lat, lon, radius, unit="km"):
     """
     Indicate that value is a geo region
     """
-    return GeoValue(lat, lon, radius, unit)
+    return GeoValue(lon, lat, radius, unit)
 
 
 class Value:

--- a/tests/test_search_querystring.py
+++ b/tests/test_search_querystring.py
@@ -1,0 +1,37 @@
+"""Unit tests for the search query string builders.
+
+These tests exercise the pure-Python query building logic and do not require a
+running Redis server, so they live in the ``fixed_client`` test group.
+"""
+
+import pytest
+
+from redis.commands.search.querystring import GeoValue, geo, intersect
+
+
+@pytest.mark.fixed_client
+class TestGeoValue:
+    """``geo()`` must render longitude before latitude.
+
+    RediSearch expects geo filters as ``[lon lat radius unit]``, which is also
+    the order used by ``GeoValue`` and ``query.GeoFilter``.
+    """
+
+    def test_geo_renders_longitude_before_latitude(self):
+        assert geo(lat=51.45, lon=-0.44, radius=10).to_string() == "[-0.44 51.45 10 km]"
+
+    def test_geo_matches_geovalue_built_directly(self):
+        assert (
+            geo(lat=51.45, lon=-0.44, radius=10).to_string()
+            == GeoValue(-0.44, 51.45, 10).to_string()
+        )
+
+    def test_geo_keeps_the_requested_unit(self):
+        assert (
+            geo(lat=51.45, lon=-0.44, radius=10, unit="mi").to_string()
+            == "[-0.44 51.45 10 mi]"
+        )
+
+    def test_geo_in_a_query(self):
+        query = intersect(location=geo(lat=51.45, lon=-0.44, radius=10))
+        assert query.to_string() == "@location:[-0.44 51.45 10 km]"


### PR DESCRIPTION
### Description of change

`geo()` in `redis/commands/search/querystring.py` is declared as
`geo(lat, lon, radius, unit="km")` but forwards its arguments positionally to
`GeoValue(lon, lat, radius, unit)`, so latitude and longitude end up swapped in
the generated query:

```python
>>> geo(lat=51.45, lon=-0.44, radius=10).to_string()
'[51.45 -0.44 10 km]'   # expected '[-0.44 51.45 10 km]'
```

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized query-building fix with tests; behavior change only affects callers of `geo()` who were previously getting incorrect coordinates.
> 
> **Overview**
> Fixes a bug where **`geo(lat, lon, ...)`** passed arguments into **`GeoValue`** in the wrong order, so generated RediSearch geo filters used **`[lat lon …]`** instead of the required **`[lon lat radius unit]`**.
> 
> The helper now forwards **`lon`** and **`lat`** consistently with **`GeoValue`** and **`GeoFilter`**. New **`fixed_client`** unit tests lock in rendering, units, and use inside **`intersect()`** queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97856db7df25b3219a5e7b4d4a3ec8e3a9870de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->