### PR TITLE
Fix FIELDNAME alias dropping first character of un-prefixed fields

### DIFF
--- a/redis/commands/search/aggregation.py
+++ b/redis/commands/search/aggregation.py
@@ -50,8 +50,8 @@ class Reducer:
             if not self._field:
                 raise ValueError("Cannot use FIELDNAME alias with no field")
             else:
-                # Chop off initial '@'
-                alias = self._field[1:]
+                # Chop off initial '@', which is optional in field names
+                alias = self._field.removeprefix("@")
         self._alias = alias
         return self
 

--- a/tests/test_search_aggregation.py
+++ b/tests/test_search_aggregation.py
@@ -1,0 +1,34 @@
+"""Unit tests for search aggregation request building.
+
+These tests exercise the pure-Python argument building logic and do not
+require a running Redis server, so they live in the ``fixed_client`` test
+group.
+"""
+
+import pytest
+
+from redis.commands.search import reducers
+from redis.commands.search.aggregation import FIELDNAME, AggregateRequest
+
+
+@pytest.mark.fixed_client
+class TestReducerAlias:
+    def test_fieldname_alias_with_at_prefix(self):
+        reducer = reducers.sum("@paid").alias(FIELDNAME)
+        assert reducer._alias == "paid"
+
+    def test_fieldname_alias_without_at_prefix(self):
+        # The '@' prefix is optional, so the name must be used as-is rather
+        # than having its first character removed.
+        reducer = reducers.sum("paid").alias(FIELDNAME)
+        assert reducer._alias == "paid"
+
+    def test_fieldname_alias_without_at_prefix_in_args(self):
+        request = AggregateRequest("*").group_by(
+            "@id", reducers.sum("paid").alias(FIELDNAME)
+        )
+        assert request.build_args()[-3:] == ["paid", "AS", "paid"]
+
+    def test_fieldname_alias_without_field(self):
+        with pytest.raises(ValueError, match="Cannot use FIELDNAME alias"):
+            reducers.count().alias(FIELDNAME)


### PR DESCRIPTION
### Description of change

`Reducer.alias(FIELDNAME)` removes the first character of the field name to
strip a leading `@`, but the `@` prefix is optional, so a bare field name loses
its first letter:

```python
>>> reducers.sum("@paid").alias(FIELDNAME)._alias
'paid'
>>> reducers.sum("paid").alias(FIELDNAME)._alias
'aid'
```

This builds `REDUCE SUM 1 paid AS aid`, so the results come back under a
mangled key instead of failing.

Bare names are supported elsewhere — `reducers.stddev("random_num")` is used in
`tests/test_search.py`, and `reducers._ensure_at_prefix()` exists to normalize
them — so this uses `removeprefix("@")` instead.

`FIELDNAME` had no test coverage, so I added server-free tests for it following
`tests/test_search_result.py`.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to aggregation alias string handling with new unit tests; no auth, data, or API surface changes beyond correct behavior.
> 
> **Overview**
> Fixes **`Reducer.alias(FIELDNAME)`** so the alias matches the field name when the `@` prefix is omitted. Previously the code always dropped the first character (`field[1:]`), so a bare name like `paid` became `aid` in the built `REDUCE ... AS` clause.
> 
> The alias now uses **`removeprefix("@")`**, stripping only a leading `@` when present and leaving unprefixed names unchanged.
> 
> Adds **`tests/test_search_aggregation.py`** (fixed-client) covering `@`-prefixed and bare fields, aggregate `build_args()`, and the existing error when `FIELDNAME` is used without a field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3ded5e92f91be902af159e3435ebf4e787c390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->