### PR TITLE
Fixed TS.NRANGE commands to correctly apply aggregators

### DIFF
--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -1201,13 +1201,15 @@ class TimeSeriesCommands:
                 Limits the number of returned rows, applied after the
                 merge in increasing-timestamp order.
             aggregators:
-                Optional aggregation. Requires exactly one aggregator per key,
-                emitted as separate tokens. A single aggregator string is
-                expanded to one token per key as a convenience; passing a list
-                whose length differs from ``keys`` raises ``DataError``. Valid
-                values: [`avg`, `sum`, `min`, `max`, `range`, `count`, `first`,
-                `last`, `std.p`, `std.s`, `var.p`, `var.s`, `twa`, `countNaN`,
-                `countAll`].
+                Optional aggregation, with exactly one spec token per key (a
+                single aggregator is never broadcast across keys). Each per-key
+                spec is a string and may list several comma-separated
+                aggregators, e.g. ``["avg,max", "sum"]`` builds
+                ``AGGREGATION avg,max sum`` for two keys. A bare string is the
+                spec for a single-key query; a number of specs that differs from
+                ``keys`` raises ``DataError``. Valid aggregators: [`avg`, `sum`,
+                `min`, `max`, `range`, `count`, `first`, `last`, `std.p`,
+                `std.s`, `var.p`, `var.s`, `twa`, `countNaN`, `countAll`].
             bucket_size_msec:
                 Time bucket for aggregation in milliseconds. Shared by all keys.
             filter_by_ts:
@@ -1329,13 +1331,15 @@ class TimeSeriesCommands:
                 Limits the number of returned rows, applied after the
                 merge in decreasing-timestamp order.
             aggregators:
-                Optional aggregation. Requires exactly one aggregator per key,
-                emitted as separate tokens. A single aggregator string is
-                expanded to one token per key as a convenience; passing a list
-                whose length differs from ``keys`` raises ``DataError``. Valid
-                values: [`avg`, `sum`, `min`, `max`, `range`, `count`, `first`,
-                `last`, `std.p`, `std.s`, `var.p`, `var.s`, `twa`, `countNaN`,
-                `countAll`].
+                Optional aggregation, with exactly one spec token per key (a
+                single aggregator is never broadcast across keys). Each per-key
+                spec is a string and may list several comma-separated
+                aggregators, e.g. ``["avg,max", "sum"]`` builds
+                ``AGGREGATION avg,max sum`` for two keys. A bare string is the
+                spec for a single-key query; a number of specs that differs from
+                ``keys`` raises ``DataError``. Valid aggregators: [`avg`, `sum`,
+                `min`, `max`, `range`, `count`, `first`, `last`, `std.p`,
+                `std.s`, `var.p`, `var.s`, `twa`, `countNaN`, `countAll`].
             bucket_size_msec:
                 Time bucket for aggregation in milliseconds. Shared by all keys.
             filter_by_ts:
@@ -2028,25 +2032,27 @@ class TimeSeriesCommands:
         bucket_size_msec: int | None,
         numkeys: int,
     ):
-        """Append AGGREGATION property for TS.NRANGE / TS.NREVRANGE.
+        """Append the AGGREGATION clause for TS.NRANGE / TS.NREVRANGE.
 
-        Unlike TS.RANGE, these commands require exactly one aggregator per
-        queried key, emitted as separate tokens (never a single comma-joined
-        token and never a single aggregator broadcast across keys). A single
-        aggregator string is expanded to one token per key as a convenience.
+        These commands take exactly one aggregation spec token per queried key;
+        a single aggregator is never broadcast across keys. A spec token may hold
+        several comma-separated aggregators, so the wire form is e.g.
+        ``AGGREGATION avg,max sum 1000`` for two keys -- key 0 aggregated by both
+        ``avg`` and ``max``, key 1 by ``sum``. Pass one spec string per key, each
+        optionally comma-joined (``["avg,max", "sum"]``); a bare string is the
+        spec for a single-key query. (Matches RedisTimeSeries PR #2079, which
+        replaced the earlier single comma-joined / broadcast token.)
         """
         if aggregators is None:
             return
-        if isinstance(aggregators, str):
-            aggregators = [aggregators] * numkeys
-        else:
-            aggregators = list(aggregators)
-        if len(aggregators) != numkeys:
+        specs = [aggregators] if isinstance(aggregators, str) else list(aggregators)
+        if len(specs) != numkeys:
             raise DataError(
-                "AGGREGATION requires exactly one aggregator per key "
-                f"(expected {numkeys}, got {len(aggregators)})."
+                "AGGREGATION requires exactly one aggregation spec per key "
+                f"(expected {numkeys}, got {len(specs)}); a spec may list "
+                "multiple comma-separated aggregators."
             )
-        params.extend(["AGGREGATION", *aggregators, bucket_size_msec])
+        params.extend(["AGGREGATION", *specs, bucket_size_msec])
 
     @staticmethod
     def _append_chunk_size(params: list[EncodableT], chunk_size: int | None):

--- a/redis/commands/timeseries/commands.py
+++ b/redis/commands/timeseries/commands.py
@@ -1174,11 +1174,17 @@ class TimeSeriesCommands:
         Query an explicit list of time-series over a range in forward direction
         and return timestamp-major rows ordered by increasing timestamp.
 
-        Each returned row is ``[timestamp, [value_for_key_0, value_for_key_1,
-        ...]]`` where the value array preserves the input ``keys`` order. A key
-        with no sample (or no aggregation bucket) at a row's timestamp is
-        reported as ``NaN``, which is indistinguishable from a stored or
-        aggregated ``NaN``.
+        Each returned row is ``[timestamp, [value, ...]]``. With no aggregation
+        -- or a single-aggregator spec per key -- the value array holds exactly
+        one value per queried key, in the input ``keys`` order. When a per-key
+        AGGREGATION spec lists several aggregators (e.g. ``"avg,max"``), that key
+        contributes one value per aggregator in the order the aggregators were
+        listed, and the row's value array is those per-key blocks concatenated in
+        ``keys`` order. For example ``keys=[a, b]`` with
+        ``aggregators=["avg,max", "sum"]`` yields ``[a_avg, a_max, b_sum]`` for
+        every row. A key (or aggregator column) with no sample or aggregation
+        bucket at a row's timestamp is reported as ``NaN``, which is
+        indistinguishable from a stored or aggregated ``NaN``.
 
         All keys must hash to the same slot when used against a cluster; this
         command is routed as a single-shard, key command and is never split
@@ -1304,11 +1310,17 @@ class TimeSeriesCommands:
         Query an explicit list of time-series over a range in reverse direction
         and return timestamp-major rows ordered by decreasing timestamp.
 
-        Each returned row is ``[timestamp, [value_for_key_0, value_for_key_1,
-        ...]]`` where the value array preserves the input ``keys`` order. A key
-        with no sample (or no aggregation bucket) at a row's timestamp is
-        reported as ``NaN``, which is indistinguishable from a stored or
-        aggregated ``NaN``.
+        Each returned row is ``[timestamp, [value, ...]]``. With no aggregation
+        -- or a single-aggregator spec per key -- the value array holds exactly
+        one value per queried key, in the input ``keys`` order. When a per-key
+        AGGREGATION spec lists several aggregators (e.g. ``"avg,max"``), that key
+        contributes one value per aggregator in the order the aggregators were
+        listed, and the row's value array is those per-key blocks concatenated in
+        ``keys`` order. For example ``keys=[a, b]`` with
+        ``aggregators=["avg,max", "sum"]`` yields ``[a_avg, a_max, b_sum]`` for
+        every row. A key (or aggregator column) with no sample or aggregation
+        bucket at a row's timestamp is reported as ``NaN``, which is
+        indistinguishable from a stored or aggregated ``NaN``.
 
         All keys must hash to the same slot when used against a cluster; this
         command is routed as a single-shard, key command and is never split

--- a/redis/commands/timeseries/utils.py
+++ b/redis/commands/timeseries/utils.py
@@ -64,10 +64,13 @@ def parse_n_range(response, **kwargs):
     """Parse the TS.NRANGE / TS.NREVRANGE response.
 
     The wire shape is ``[[timestamp, [value_0, value_1, ...]], ...]`` where the
-    value array preserves input key order and ``values`` length equals the
-    number of queried keys. Rows are returned in server order (never re-sorted
-    or reversed), and a missing raw sample or missing aggregation bucket is kept
-    as ``float('nan')`` rather than converted to ``None``.
+    value array preserves input key order. Its length equals the number of
+    queried keys, except when a per-key AGGREGATION spec lists multiple
+    aggregators: each such key then contributes one value per aggregator (in
+    spec order), concatenated in key order. Rows are returned in server order
+    (never re-sorted or reversed), and a missing raw sample or missing
+    aggregation bucket is kept as ``float('nan')`` rather than converted to
+    ``None``.
     """
     if not response:
         return []

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -1770,6 +1770,31 @@ async def test_nrange_aggregation_one_per_key(decoded_r: redis.Redis):
 
 @pytest.mark.redismod
 @skip_if_server_version_lt("8.9.0")
+async def test_nrange_multiple_aggregators_per_key_layout(decoded_r: redis.Redis):
+    # A per-key spec may list several aggregators. That key then contributes one
+    # value per aggregator (in spec order), and each row's value array is the
+    # per-key blocks concatenated in key order: here [a_avg, a_max, b_sum].
+    # key a: bucket [0,10) avg=2 max=3; bucket [10,20) avg=15 max=20
+    for ts, val in [(0, 1.0), (5, 3.0), (10, 10.0), (15, 20.0)]:
+        await decoded_r.ts().add("{s}:a", ts, val)
+    # key b: bucket [0,10) sum=10; bucket [10,20) sum=7
+    for ts, val in [(0, 5.0), (5, 5.0), (10, 7.0)]:
+        await decoded_r.ts().add("{s}:b", ts, val)
+
+    res = await decoded_r.ts().nrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators=["avg,max", "sum"],
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[0, [2.0, 3.0, 10.0]], [10, [15.0, 20.0, 7.0]]])
+    # 2 columns for key a (avg, max) + 1 for key b (sum).
+    assert all(len(row[1]) == 3 for row in res)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
 async def test_nrange_count_limits_rows(decoded_r: redis.Redis):
     for ts in range(5):
         await decoded_r.ts().add("{s}:a", ts, ts)

--- a/tests/test_asyncio/test_timeseries.py
+++ b/tests/test_asyncio/test_timeseries.py
@@ -1786,29 +1786,25 @@ async def test_nrange_empty_result(decoded_r: redis.Redis):
 
 @pytest.mark.redismod
 @skip_if_server_version_lt("8.9.0")
-async def test_nrange_single_aggregator_applies_to_all_keys(decoded_r: redis.Redis):
-    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
-        await decoded_r.ts().add("{s}:a", ts, val)
-    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
-        await decoded_r.ts().add("{s}:b", ts, val)
-
-    # A single aggregator string is expanded to one token per key; here
-    # "max" is applied to both series.
-    res = await decoded_r.ts().nrange(
-        ["{s}:a", "{s}:b"],
-        from_time=0,
-        to_time=20,
-        aggregators="max",
-        bucket_size_msec=10,
-    )
-    _assert_nrange_rows(res, [[0, [2.0, 6.0]], [10, [4.0, 8.0]]])
+async def test_nrange_single_aggregator_multi_key_raises(decoded_r: redis.Redis):
+    # A single aggregator is NOT broadcast across keys (RedisTimeSeries PR
+    # #2079): with more than one key, each needs its own spec token. Raised
+    # client-side before any server round trip.
+    with pytest.raises(redis.DataError, match="one aggregation spec per key"):
+        await decoded_r.ts().nrange(
+            ["{s}:a", "{s}:b"],
+            from_time=0,
+            to_time=20,
+            aggregators="max",
+            bucket_size_msec=10,
+        )
 
 
 @pytest.mark.redismod
 @skip_if_server_version_lt("8.9.0")
 async def test_nrange_aggregator_count_mismatch_raises(decoded_r: redis.Redis):
-    # An aggregator list whose length differs from the key count is invalid.
-    with pytest.raises(redis.DataError, match="one aggregator per key"):
+    # A spec list whose length differs from the key count is invalid.
+    with pytest.raises(redis.DataError, match="one aggregation spec per key"):
         await decoded_r.ts().nrange(
             ["{s}:a", "{s}:b"],
             from_time=0,

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -4,6 +4,7 @@ from time import sleep
 
 import pytest
 import redis
+from redis.commands.timeseries.commands import TimeSeriesCommands
 
 from .conftest import (
     _get_client,
@@ -2019,6 +2020,31 @@ def test_nrange_aggregation_one_per_key(client):
 
 @pytest.mark.redismod
 @skip_if_server_version_lt("8.9.0")
+def test_nrange_multiple_aggregators_per_key_layout(client):
+    # A per-key spec may list several aggregators. That key then contributes one
+    # value per aggregator (in spec order), and each row's value array is the
+    # per-key blocks concatenated in key order: here [a_avg, a_max, b_sum].
+    # key a: bucket [0,10) avg=2 max=3; bucket [10,20) avg=15 max=20
+    for ts, val in [(0, 1.0), (5, 3.0), (10, 10.0), (15, 20.0)]:
+        client.ts().add("{s}:a", ts, val)
+    # key b: bucket [0,10) sum=10; bucket [10,20) sum=7
+    for ts, val in [(0, 5.0), (5, 5.0), (10, 7.0)]:
+        client.ts().add("{s}:b", ts, val)
+
+    res = client.ts().nrange(
+        ["{s}:a", "{s}:b"],
+        from_time=0,
+        to_time=20,
+        aggregators=["avg,max", "sum"],
+        bucket_size_msec=10,
+    )
+    _assert_nrange_rows(res, [[0, [2.0, 3.0, 10.0]], [10, [15.0, 20.0, 7.0]]])
+    # 2 columns for key a (avg, max) + 1 for key b (sum).
+    assert all(len(row[1]) == 3 for row in res)
+
+
+@pytest.mark.redismod
+@skip_if_server_version_lt("8.9.0")
 def test_nrange_count_limits_rows(client):
     for ts in range(5):
         client.ts().add("{s}:a", ts, ts)
@@ -2070,8 +2096,6 @@ def test_nrange_aggregation_builds_one_spec_token_per_key():
     # Server-free: each per-key spec is its own token and may hold multiple
     # comma-separated aggregators -> AGGREGATION avg,max sum 1000 for two keys
     # (RedisTimeSeries PR #2079; no broadcast, no single comma-joined token).
-    from redis.commands.timeseries.commands import TimeSeriesCommands
-
     params = []
     TimeSeriesCommands._append_n_aggregation(params, ["avg,max", "sum"], 1000, 2)
     assert params == ["AGGREGATION", "avg,max", "sum", 1000]
@@ -2079,8 +2103,6 @@ def test_nrange_aggregation_builds_one_spec_token_per_key():
 
 def test_nrange_aggregation_single_key_single_spec():
     # Server-free: a bare string is the single-key spec (may be comma-joined).
-    from redis.commands.timeseries.commands import TimeSeriesCommands
-
     params = []
     TimeSeriesCommands._append_n_aggregation(params, "avg,max", 1000, 1)
     assert params == ["AGGREGATION", "avg,max", 1000]

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -2034,29 +2034,29 @@ def test_nrange_empty_result(client):
 
 @pytest.mark.redismod
 @skip_if_server_version_lt("8.9.0")
-def test_nrange_single_aggregator_applies_to_all_keys(client):
-    for ts, val in [(0, 1.0), (1, 2.0), (10, 3.0), (11, 4.0)]:
-        client.ts().add("{s}:a", ts, val)
-    for ts, val in [(0, 5.0), (1, 6.0), (10, 7.0), (11, 8.0)]:
-        client.ts().add("{s}:b", ts, val)
-
-    # A single aggregator string is expanded to one token per key; here
-    # "max" is applied to both series.
-    res = client.ts().nrange(
-        ["{s}:a", "{s}:b"],
-        from_time=0,
-        to_time=20,
-        aggregators="max",
-        bucket_size_msec=10,
-    )
-    _assert_nrange_rows(res, [[0, [2.0, 6.0]], [10, [4.0, 8.0]]])
+def test_nrange_single_aggregator_multi_key_raises(client):
+    # A single aggregator is NOT broadcast across keys (RedisTimeSeries PR
+    # #2079): with more than one key, each needs its own spec token. Raised
+    # client-side before any server round trip.
+    with pytest.raises(
+        redis.exceptions.DataError, match="one aggregation spec per key"
+    ):
+        client.ts().nrange(
+            ["{s}:a", "{s}:b"],
+            from_time=0,
+            to_time=20,
+            aggregators="max",
+            bucket_size_msec=10,
+        )
 
 
 @pytest.mark.redismod
 @skip_if_server_version_lt("8.9.0")
 def test_nrange_aggregator_count_mismatch_raises(client):
-    # An aggregator list whose length differs from the key count is invalid.
-    with pytest.raises(redis.exceptions.DataError, match="one aggregator per key"):
+    # A spec list whose length differs from the key count is invalid.
+    with pytest.raises(
+        redis.exceptions.DataError, match="one aggregation spec per key"
+    ):
         client.ts().nrange(
             ["{s}:a", "{s}:b"],
             from_time=0,
@@ -2064,6 +2064,26 @@ def test_nrange_aggregator_count_mismatch_raises(client):
             aggregators=["min"],
             bucket_size_msec=10,
         )
+
+
+def test_nrange_aggregation_builds_one_spec_token_per_key():
+    # Server-free: each per-key spec is its own token and may hold multiple
+    # comma-separated aggregators -> AGGREGATION avg,max sum 1000 for two keys
+    # (RedisTimeSeries PR #2079; no broadcast, no single comma-joined token).
+    from redis.commands.timeseries.commands import TimeSeriesCommands
+
+    params = []
+    TimeSeriesCommands._append_n_aggregation(params, ["avg,max", "sum"], 1000, 2)
+    assert params == ["AGGREGATION", "avg,max", "sum", 1000]
+
+
+def test_nrange_aggregation_single_key_single_spec():
+    # Server-free: a bare string is the single-key spec (may be comma-joined).
+    from redis.commands.timeseries.commands import TimeSeriesCommands
+
+    params = []
+    TimeSeriesCommands._append_n_aggregation(params, "avg,max", 1000, 1)
+    assert params == ["AGGREGATION", "avg,max", 1000]
 
 
 @pytest.mark.redismod


### PR DESCRIPTION
### Description of change

Fixed aggregators behaviour according to recent changes [PR](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2079).

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for multi-key callers that passed one aggregator string expecting broadcast; behavior now matches server semantics and fails fast client-side.
> 
> **Overview**
> Updates **`TS.NRANGE` / `TS.NREVRANGE`** aggregation handling to match [RedisTimeSeries PR #2079](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2079).
> 
> **`_append_n_aggregation`** no longer **broadcasts** a single aggregator string across all keys. It now requires **exactly one aggregation spec per key** (a bare string counts as the spec for a **single-key** query only). Each spec may list **comma-separated aggregators** (e.g. `["avg,max", "sum"]` → wire `AGGREGATION avg,max sum <bucket>`). Mismatching spec count vs. key count raises **`DataError`** with updated messaging.
> 
> **Docs** for `nrange` / `nrevrange` and **`parse_n_range`** describe the wider value columns when a key uses multiple aggregators (per-key blocks concatenated in key order).
> 
> **Tests** cover multi-aggregator layout, client-side rejection of `aggregators="max"` with two keys, and server-free checks of `_append_n_aggregation` param building.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af20e5e3c1714c65796f4b05ab2d226a505a9fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->