### PR TITLE
Testing with 8.10 GA

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ env:
   # for example after 8.2.1 is published, 8.2 image contains 8.2.1 content
   CURRENT_REDIS_VERSION: '8.8.0'
   REDIS_VERSION_CUSTOM_MAP: >-
-    8.10:8.10-rc2
+    8.10:8.10.0
 
 jobs:
   dependency-audit:


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI env mapping change with no application or library code touched.
> 
> **Overview**
> Updates CI so matrix jobs labeled **Redis 8.10** use the **8.10.0** GA server image instead of **8.10-rc2**.
> 
> The only change is `REDIS_VERSION_CUSTOM_MAP` in `integration.yaml` (`8.10:8.10.0`). The `run-tests` action still resolves matrix `redis-version` **8.10** to `CLIENT_LIBS_TEST_IMAGE_TAG` via that map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5985513f15c41fa84bed76faf8569c9dc164d40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->