### PR TITLE
docs: add hash examples notebook

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,3 +15,4 @@ Examples
    examples/timeseries_examples
    examples/redis-stream-example
    examples/opentelemetry_api_examples
+   examples/hash_examples

--- a/docs/examples/hash_examples.ipynb
+++ b/docs/examples/hash_examples.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Redis Hash Examples\n",
+    "\n",
+    "This notebook demonstrates how to work with Redis Hashes using redis-py.\n",
+    "Hashes are maps between string fields and string values, making them perfect\n",
+    "for representing objects (e.g., a user profile)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis\n",
+    "\n",
+    "r = redis.Redis(host='localhost', port=6379, decode_responses=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set and get a single field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hset('user:1', 'name', 'Alice')\n",
+    "print(r.hget('user:1', 'name'))  # Alice"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set multiple fields at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hset('user:1', mapping={\n",
+    "    'name': 'Alice',\n",
+    "    'age': '30',\n",
+    "    'email': 'alice@example.com'\n",
+    "})\n",
+    "print(r.hgetall('user:1'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check if a field exists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(r.hexists('user:1', 'email'))   # True\n",
+    "print(r.hexists('user:1', 'phone'))   # False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get all fields and values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(r.hkeys('user:1'))    # ['name', 'age', 'email']\n",
+    "print(r.hvals('user:1'))    # ['Alice', '30', 'alice@example.com']\n",
+    "print(r.hlen('user:1'))     # 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Increment a numeric field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hset('user:1', 'age', '30')\n",
+    "r.hincrby('user:1', 'age', 1)\n",
+    "print(r.hget('user:1', 'age'))  # 31"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.hdel('user:1', 'email')\n",
+    "print(r.hgetall('user:1'))  # email is gone"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.delete('user:1')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/examples/hash_examples.ipynb
+++ b/docs/examples/hash_examples.ipynb
@@ -13,8 +13,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.417009Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.416888Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.808201Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.807431Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import redis\n",
@@ -31,9 +38,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.813788Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.813653Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.818089Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.817298Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice\n"
+     ]
+    }
+   ],
    "source": [
     "r.hset('user:1', 'name', 'Alice')\n",
     "print(r.hget('user:1', 'name'))  # Alice"
@@ -48,9 +70,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.841066Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.840910Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.844744Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.843820Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'Alice', 'age': '30', 'email': 'alice@example.com'}\n"
+     ]
+    }
+   ],
    "source": [
     "r.hset('user:1', mapping={\n",
     "    'name': 'Alice',\n",
@@ -69,9 +106,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.845946Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.845825Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.848762Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.848013Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
    "source": [
     "print(r.hexists('user:1', 'email'))   # True\n",
     "print(r.hexists('user:1', 'phone'))   # False"
@@ -86,9 +139,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.852766Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.852655Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.855978Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.855270Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['name', 'age', 'email']\n",
+      "['Alice', '30', 'alice@example.com']\n",
+      "3\n"
+     ]
+    }
+   ],
    "source": [
     "print(r.hkeys('user:1'))    # ['name', 'age', 'email']\n",
     "print(r.hvals('user:1'))    # ['Alice', '30', 'alice@example.com']\n",
@@ -104,9 +174,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.857013Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.856907Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.860065Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.859302Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "31\n"
+     ]
+    }
+   ],
    "source": [
     "r.hset('user:1', 'age', '30')\n",
     "r.hincrby('user:1', 'age', 1)\n",
@@ -122,9 +207,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.861131Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.861021Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.863698Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.863086Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'Alice', 'age': '31'}\n"
+     ]
+    }
+   ],
    "source": [
     "r.hdel('user:1', 'email')\n",
     "print(r.hgetall('user:1'))  # email is gone"
@@ -139,9 +239,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:54:27.865006Z",
+     "iopub.status.busy": "2026-07-30T17:54:27.864903Z",
+     "iopub.status.idle": "2026-07-30T17:54:27.868887Z",
+     "shell.execute_reply": "2026-07-30T17:54:27.868186Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "r.delete('user:1')"
    ]
@@ -154,8 +272,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/hash_examples.ipynb
+++ b/docs/examples/hash_examples.ipynb
@@ -14,14 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.417009Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.416888Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.808201Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.807431Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import redis\n",
@@ -39,14 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.813788Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.813653Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.818089Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.817298Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -71,14 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.841066Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.840910Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.844744Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.843820Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -107,14 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.845946Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.845825Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.848762Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.848013Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -134,20 +106,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Get all fields and values"
+    "## Get all fields and values\n",
+    "\n",
+    "Note that Redis does not guarantee any particular order for hash fields,\n",
+    "so don't rely on the order of the `hkeys()` and `hvals()` results."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.852766Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.852655Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.855978Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.855270Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -160,8 +128,8 @@
     }
    ],
    "source": [
-    "print(r.hkeys('user:1'))    # ['name', 'age', 'email']\n",
-    "print(r.hvals('user:1'))    # ['Alice', '30', 'alice@example.com']\n",
+    "print(r.hkeys('user:1'))\n",
+    "print(r.hvals('user:1'))\n",
     "print(r.hlen('user:1'))     # 3"
    ]
   },
@@ -175,14 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.857013Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.856907Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.860065Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.859302Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -208,14 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.861131Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.861021Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.863698Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.863086Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -240,14 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-30T17:54:27.865006Z",
-     "iopub.status.busy": "2026-07-30T17:54:27.864903Z",
-     "iopub.status.idle": "2026-07-30T17:54:27.868887Z",
-     "shell.execute_reply": "2026-07-30T17:54:27.868186Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
### Description of change

Picks up #4154 by @baraiz, which has gone quiet for a few weeks. The notebook itself was already approved — the docs build failed only because it was committed without saved cell outputs, so nbsphinx tried to execute it in CI (no python3 kernel there), exactly as @petyaslavova diagnosed on that PR.

This keeps the original two commits and adds one on top that runs the notebook against a local Redis and saves the outputs, matching the other notebooks in `docs/examples/`.

Relates to #1744

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Redis Hash** examples notebook to the docs and wires it into the examples toctree via `docs/examples.rst`.
> 
> The notebook walks through common hash commands with redis-py (`hset`/`hget`, `mapping`, `hexists`, `hkeys`/`hvals`/`hlen`, `hincrby`, `hdel`, cleanup) using a `user:1` profile-style key. **Cell outputs are committed** so nbsphinx can render the page in CI without executing against a live Redis, consistent with the other notebooks under `docs/examples/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99d9c5ea088b75eeb35dd21c51f1950d48987ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->