### PR TITLE
Report test metrics once a night instead of from every CI job

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -49,9 +49,6 @@ inputs:
   client-libs-test-image:
     description: 'Client libs test image tag'
     required: false
-  otlp-auth-token:
-    description: 'OTLP authorization token for CI visibility metrics'
-    required: false
 runs:
   using: "composite"
   steps:
@@ -175,8 +172,6 @@ runs:
     - name: Run tests
       run: |
         set -e
-
-        mkdir -p junit-results
 
         run_tests() {
           local test_config=$1
@@ -314,35 +309,6 @@ runs:
         echo "Cluster nodes:"
         redis-cli -p 16379 CLUSTER NODES
       shell: bash
-
-    - name: Normalize JUnit XML for metrics
-      if: ${{ !cancelled() && inputs.otlp-auth-token != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-      continue-on-error: true
-      run: |
-        python - <<'PY'
-        import glob
-        import xml.etree.ElementTree as ET
-
-        for path in glob.glob("junit-results/*.xml"):
-            tree = ET.parse(path)
-            root = tree.getroot()
-            if root.tag == "testsuites" and root.get("time") is None:
-                total = sum(float(ts.get("time") or 0) for ts in root.findall("testsuite"))
-                root.set("time", f"{total:.6f}")
-                tree.write(path, xml_declaration=True, encoding="utf-8")
-        PY
-      shell: bash
-
-    - name: Self Report Metrics
-      if: ${{ !cancelled() && inputs.otlp-auth-token != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-      continue-on-error: true
-      uses: redis-developer/cae-otel-ci-visibility@v2
-      with:
-        junit-xml-folder: "junit-results"
-        otlp-endpoint: "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/metrics"
-        otlp-headers: "Authorization=Basic ${{ inputs.otlp-auth-token }}"
-      env:
-        OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
 
     - name: Upload test results and profiling data
       uses: actions/upload-artifact@v7

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -115,7 +115,6 @@ jobs:
             # runners are added. Run them once, on the current Redis version's
             # cluster cell.
             run-multidb-integration: ${{ (matrix.redis-version == needs.redis_version.outputs.CURRENT && matrix.test-config == 'default-unified_responses-cluster') && 'true' || 'false' }}
-            otlp-auth-token: ${{ secrets.SELF_CHECK_OTEL_AUTHORIZATION_TOKEN }}
 
   python-compatibility-tests:
     runs-on: ubuntu-latest
@@ -155,7 +154,6 @@ jobs:
           parser-backend: ${{ matrix.parser-backend }}
           redis-version: ${{ matrix.redis-version }}
           test-config: ${{ matrix.test-config }}
-          otlp-auth-token: ${{ secrets.SELF_CHECK_OTEL_AUTHORIZATION_TOKEN }}
 
   pypy-compatibility-tests:
     runs-on: ubuntu-latest
@@ -198,7 +196,6 @@ jobs:
           parser-backend: ${{ matrix.parser-backend }}
           redis-version: ${{ matrix.redis-version }}
           test-config: ${{ matrix.test-config }}
-          otlp-auth-token: ${{ secrets.SELF_CHECK_OTEL_AUTHORIZATION_TOKEN }}
 
   hiredis-tests:
     runs-on: ubuntu-latest
@@ -240,7 +237,6 @@ jobs:
           redis-version: ${{ matrix.redis-version }}
           hiredis-version: ${{ matrix.hiredis-version }}
           test-config: ${{ matrix.test-config }}
-          otlp-auth-token: ${{ secrets.SELF_CHECK_OTEL_AUTHORIZATION_TOKEN }}
 
   uvloop-tests:
     runs-on: ubuntu-latest
@@ -281,7 +277,6 @@ jobs:
           redis-version: ${{ matrix.redis-version }}
           event-loop: ${{ matrix.event-loop }}
           test-config: ${{ matrix.test-config }}
-          otlp-auth-token: ${{ secrets.SELF_CHECK_OTEL_AUTHORIZATION_TOKEN }}
 
   build-and-test-package:
     name: Validate building and installing the package

--- a/.github/workflows/nightly-metrics.yaml
+++ b/.github/workflows/nightly-metrics.yaml
@@ -1,0 +1,82 @@
+name: Nightly test metrics
+
+# Once a day, run the redis-py standalone test suite (master, default
+# client configuration, modules included) against a Redis server built
+# from redis' unstable branch, and report per-test durations to Grafana
+# for performance regression tracking.
+
+on:
+  schedule:
+    - cron: '30 3 * * *' # nightly, staggered from the 01:00 CI run
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-metrics
+  cancel-in-progress: false
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  nightly-metrics:
+    name: Redis unstable; test metrics
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      # Secrets can't be used in `if:` conditions, so a first step checks
+      # the token and later steps are gated on its output. Without the
+      # secret the job prints a warning and skips everything.
+      - name: Check for the metrics token
+        id: gate
+        env:
+          OTEL_TOKEN: ${{ secrets.OTEL_CI_VISIBILITY_TOKEN }}
+        run: |
+          if [ -z "$OTEL_TOKEN" ]; then
+            echo "::warning::The OTEL_CI_VISIBILITY_TOKEN secret is not set; skipping the nightly metrics run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v7
+        if: steps.gate.outputs.run == 'true'
+
+      - name: Resolve latest unstable Redis image
+        id: unstable-image
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          # Pick the newest tag client-side instead of relying on the API's
+          # ordering parameter.
+          tag=$(curl -sf "https://hub.docker.com/v2/repositories/redislabs/client-libs-test/tags?page_size=100&name=unstable-" \
+            | jq -r '.results | max_by(.last_updated) | .name // empty')
+          if [ -z "$tag" ]; then
+            echo "::error::Could not resolve an unstable client-libs-test image tag from Docker Hub"
+            exit 1
+          fi
+          echo "Using image tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        if: steps.gate.outputs.run == 'true'
+        uses: ./.github/actions/run-tests
+        with:
+          python-version: '3.12'
+          parser-backend: 'plain'
+          # The server under test is the unstable image resolved above;
+          # redis-version only drives run-tests' setup branching and the
+          # artifact name, and it must be numeric.
+          redis-version: '8.10'
+          client-libs-test-image: ${{ steps.unstable-image.outputs.tag }}
+          # One config, so each test reports exactly one duration per night.
+          test-config: 'default-legacy_responses-standalone'
+
+      - name: Report test metrics
+        # Report even when tests fail, but not when the run was cancelled.
+        if: ${{ !cancelled() && steps.gate.outputs.run == 'true' }}
+        uses: redis-developer/cae-otel-ci-visibility@v4
+        with:
+          junit-xml-folder: 'junit-results'
+          otlp-endpoint: 'https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/metrics'
+          otlp-headers: 'Authorization=Basic ${{ secrets.OTEL_CI_VISIBILITY_TOKEN }}'
+          server-version: 'unstable'


### PR DESCRIPTION
run-tests action has two steps that upload test timings. They have never run, because the secret they need was never created. If someone created the secret today, every CI run would upload metrics from about 350 matrix jobs. We don't need that much data: one measurement per test per day is enough.

This removes the metrics steps and the otlp-auth-token input from run-tests, and the token lines from integration.yaml. 

Regular CI no longer has any metrics code. Pytest reports keep going to the junit-results folder: tasks.py creates it and writes the reports there, which is why the extra mkdir in run-tests was redundant and is removed too. The reports are better off out of the repo root, and the nightly reads them from there.

A new workflow, nightly-metrics.yaml, runs once a day. It starts the newest redis-py build,  runs the full test-config sweep in one job, and uploads the results with redis-developer/cae-otel-ci-visibility@v4.

The workflow needs an OTEL_CI_VISIBILITY_TOKEN repository secret. Until the secret exists, the workflow prints a warning and skips itself, so this can merge before the secret is set up. To roll back, delete the workflow file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application or test logic changes, only where metrics are sent.
> 
> **Overview**
> **Moves per-test timing export out of the integration matrix** so Grafana gets one measurement per test per day instead of hundreds of duplicate uploads if the OTLP secret were enabled.
> 
> The `run-tests` composite action **drops** the `otlp-auth-token` input, JUnit normalization, and `cae-otel-ci-visibility` self-report steps, plus a redundant `mkdir` for `junit-results` (pytest still writes there via `tasks.py`). **Integration** jobs no longer pass `SELF_CHECK_OTEL_AUTHORIZATION_TOKEN`.
> 
> A new **`nightly-metrics.yaml`** workflow runs on a daily schedule (and `workflow_dispatch`). It **no-ops with a warning** when `OTEL_CI_VISIBILITY_TOKEN` is missing, otherwise resolves the newest `unstable-*` `client-libs-test` image, runs a single `default-legacy_responses-standalone` job against that server, and reports metrics with **`cae-otel-ci-visibility@v4`** (including `server-version: unstable`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a085be72508521db46cb9c3c5850217bd0999d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->