### PR TITLE
perf/fix: Use lazy logging in pub/sub push handlers to avoid formatting discarded debug messages

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -127,7 +127,7 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
 
     def handle_pubsub_push_response(self, response):
         logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        logger.debug("Push response: %s", response)
         return response
 
     def on_connect(self, connection, **kwargs):
@@ -282,7 +282,7 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
 
     async def handle_pubsub_push_response(self, response):
         logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        logger.debug("Push response: %s", response)
         return response
 
     def on_connect(self, connection):

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -26,7 +26,7 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
 
     def handle_pubsub_push_response(self, response):
         logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        logger.debug("Push response: %s", response)
         return response
 
     def read_response(
@@ -171,7 +171,7 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
 
     async def handle_pubsub_push_response(self, response):
         logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        logger.debug("Push response: %s", response)
         return response
 
     async def read_response(


### PR DESCRIPTION
### Description of change

Fixes #4230.

`handle_pubsub_push_response` builds its debug message by concatenation, which Python evaluates as an argument expression before `logger.debug` is called. `str(response)` therefore runs for every pub/sub message even when DEBUG is disabled, and the result is discarded. No logging configuration avoids it.

This switches the four copies (sync and async, hiredis and RESP3 parsers) to lazy `%s` formatting.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with identical output when DEBUG is enabled; no protocol, API, or control-flow changes.
> 
> **Overview**
> Fixes unnecessary work on every pub/sub push when DEBUG logging is off.
> 
> **`handle_pubsub_push_response`** in the hiredis and RESP3 parsers (sync and async) no longer builds the debug string with `"Push response: " + str(response)`. That forced **`str(response)`** on every push before **`logger.debug`** could skip the message. All four copies now use **`logger.debug("Push response: %s", response)`** so formatting runs only when the `push_response` logger is at DEBUG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d98bc2b02979800fdcc2cf211ead46e8c35d5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->