### PR TITLE
fix: Using lazy-logging in pub/sub push handler with more efficient string conversion

### DIFF
--- a/redis/_parsers/hiredis.py
+++ b/redis/_parsers/hiredis.py
@@ -19,6 +19,11 @@ from .socket import (
     SERVER_CLOSED_CONNECTION_ERROR,
 )
 
+# Resolved once at import time rather than per message: the pub/sub push handler
+# is on the hot path (called for every message) and ``getLogger`` is a locked
+# dict lookup.
+_pubsub_push_logger = getLogger("push_response")
+
 # Used to signal that hiredis-py does not have enough data to parse.
 # Using `False` or `None` is not reliable, given that the parser can
 # return `False` or `None` for legitimate reasons from RESP payloads.
@@ -126,8 +131,9 @@ class _HiredisParser(BaseParser, PushNotificationsParser):
             pass
 
     def handle_pubsub_push_response(self, response):
-        logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        # Lazy ``%s`` formatting: ``str(response)`` is only paid when DEBUG is
+        # actually enabled, not on every message.
+        _pubsub_push_logger.debug("Push response: %s", response)
         return response
 
     def on_connect(self, connection, **kwargs):
@@ -281,8 +287,9 @@ class _AsyncHiredisParser(AsyncBaseParser, AsyncPushNotificationsParser):
         self._hiredis_PushNotificationType = None
 
     async def handle_pubsub_push_response(self, response):
-        logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        # Lazy ``%s`` formatting: ``str(response)`` is only paid when DEBUG is
+        # actually enabled, not on every message.
+        _pubsub_push_logger.debug("Push response: %s", response)
         return response
 
     def on_connect(self, connection):

--- a/redis/_parsers/resp3.py
+++ b/redis/_parsers/resp3.py
@@ -12,6 +12,11 @@ from .base import (
 )
 from .socket import SERVER_CLOSED_CONNECTION_ERROR
 
+# Resolved once at import time rather than per message: the pub/sub push handler
+# is on the hot path (called for every message) and ``getLogger`` is a locked
+# dict lookup.
+_pubsub_push_logger = getLogger("push_response")
+
 
 class _RESP3Parser(_RESPBase, PushNotificationsParser):
     """RESP3 protocol implementation"""
@@ -25,8 +30,9 @@ class _RESP3Parser(_RESPBase, PushNotificationsParser):
         self.invalidation_push_handler_func = None
 
     def handle_pubsub_push_response(self, response):
-        logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        # Lazy ``%s`` formatting: ``str(response)`` is only paid when DEBUG is
+        # actually enabled, not on every message.
+        _pubsub_push_logger.debug("Push response: %s", response)
         return response
 
     def read_response(
@@ -170,8 +176,9 @@ class _AsyncRESP3Parser(_AsyncRESPBase, AsyncPushNotificationsParser):
         self.invalidation_push_handler_func = None
 
     async def handle_pubsub_push_response(self, response):
-        logger = getLogger("push_response")
-        logger.debug("Push response: " + str(response))
+        # Lazy ``%s`` formatting: ``str(response)`` is only paid when DEBUG is
+        # actually enabled, not on every message.
+        _pubsub_push_logger.debug("Push response: %s", response)
         return response
 
     async def read_response(


### PR DESCRIPTION

### Description of change

Closes #4230 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only performance tweak on parser internals with no API or protocol behavior changes.
> 
> **Overview**
> Optimizes the **pub/sub push response** debug path in `hiredis.py` and `resp3.py` (sync and async parsers) so high-volume pub/sub traffic does less work when debug logging is off.
> 
> A module-level `_pubsub_push_logger` replaces per-message `getLogger("push_response")`, and debug lines use **`%s` lazy formatting** instead of concatenating with `str(response)`, so stringification only happens when DEBUG is enabled. **Behavior is unchanged** for callers; only logging cost on the hot path is reduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9d2b4385ab110daaf5fb9cf70201057eb55fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->