### PR TITLE
Distinguish connection health check timeouts

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -888,6 +888,11 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                     if asyncio.iscoroutinefunction(self.redis_connect_func)
                     else self.redis_connect_func(self)
                 )
+        except TimeoutError as error:
+            await self.disconnect()
+            raise ConnectionError(
+                f"Timeout during connection health check to {self._host_error()}"
+            ) from error
         except RedisError:
             # clean up after any error in on_connect
             await self.disconnect()

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1084,6 +1084,11 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             else:
                 # Use the passed function redis_connect_func
                 self.redis_connect_func(self)
+        except TimeoutError as error:
+            self.disconnect()
+            raise ConnectionError(
+                f"Timeout during connection health check to {self._host_error()}"
+            ) from error
         except RedisError:
             # clean up after any error in on_connect
             self.disconnect()

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -256,6 +256,22 @@ async def test_client_setinfo_skipped_with_explicit_none(connection_kwargs):
     conn.read_response.assert_not_awaited()
 
 
+async def test_connect_check_health_timeout_is_connection_error():
+    conn = Connection(protocol=3, driver_info=None)
+    conn._connect = mock.AsyncMock()
+    conn._parser.on_connect = mock.Mock()
+    conn.send_command = mock.AsyncMock()
+    conn.read_response = mock.AsyncMock(
+        side_effect=TimeoutError("Timeout reading from localhost:6379")
+    )
+    conn.disconnect = mock.AsyncMock()
+
+    with pytest.raises(ConnectionError, match="connection health check"):
+        await conn.connect_check_health(retry_socket_connect=False)
+
+    conn.disconnect.assert_awaited_once_with()
+
+
 @pytest.mark.onlynoncluster
 async def test_invalid_response(create_redis):
     r = await create_redis(single_connection_client=True)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -631,6 +631,21 @@ class TestConnection:
             assert _connect.call_count == 1
             self.clear(conn)
 
+    def test_connect_check_health_timeout_is_connection_error(self):
+        conn = Connection(protocol=3, driver_info=None)
+        conn._connect = mock.Mock()
+        conn._parser.on_connect = mock.Mock()
+        conn.send_command = mock.Mock()
+        conn.read_response = mock.Mock(
+            side_effect=TimeoutError("Timeout reading from localhost:6379")
+        )
+        conn.disconnect = mock.Mock()
+
+        with pytest.raises(ConnectionError, match="connection health check"):
+            conn.connect_check_health(retry_socket_connect=False)
+
+        conn.disconnect.assert_called_once_with()
+
     # Client-internal test: builds a default localhost Connection and mocks the
     # socket to count handshake retries, so it needs a co-located server rather
     # than a remote managed Redis Enterprise endpoint.


### PR DESCRIPTION
## What

Convert a timeout raised while establishing and health-checking a connection into `ConnectionError`, while preserving `TimeoutError` for response reads after a command has been sent. This lets callers distinguish a write that may have reached Redis from a connection that was never usable.

The behavior is mirrored in sync and asyncio connection implementations, and the existing disconnect cleanup path is preserved.

## Tests

- Added deterministic sync and asyncio regression tests for handshake read timeouts.
- `tests/test_connection.py`: 93 passed, 1 skipped
- `tests/test_asyncio/test_connection.py`: 65 passed, 1 skipped
- Ruff check, format, and `git diff --check` pass.

Fixes #4240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error types on the connect path, which can affect retry and exception-handling logic for callers that only caught TimeoutError during connect.
> 
> **Overview**
> **Connect-time read timeouts** during the post-socket handshake (`on_connect_check_health` / custom `redis_connect_func`) are now turned into **`ConnectionError`** with a clear “connection health check” message, after **`disconnect()`**—matching the existing cleanup for other handshake failures.
> 
> **`TimeoutError` is unchanged** for timeouts while reading a command response, so callers can tell “connection never became usable” from “a write may have reached Redis.”
> 
> The same behavior is applied in **sync** (`redis/connection.py`) and **asyncio** (`redis/asyncio/connection.py`). **Regression tests** cover both stacks when `read_response` times out during `connect_check_health`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e0eac05c1fee437193c3d609d86ca8d0d0bae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->