### PR TITLE
Fix return_field ignoring decode_field for aliased fields

### DIFF
--- a/redis/commands/search/query.py
+++ b/redis/commands/search/query.py
@@ -76,7 +76,11 @@ class Query:
         - **encoding**: The encoding to use when decoding the field
         """
         self._return_fields.append(field)
-        self._return_fields_decode_as[field] = encoding if decode_field else None
+        # The server returns an aliased field under its alias, so the encoding
+        # has to be recorded under the name the response will carry.
+        self._return_fields_decode_as[field if as_field is None else as_field] = (
+            encoding if decode_field else None
+        )
         if as_field is not None:
             self._return_fields += ("AS", as_field)
         return self

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1500,6 +1500,55 @@ class TestBaseSearchFunctionality(SearchTestsBase):
         assert res.docs[0].vector_emb == raw
 
     @pytest.mark.redismod
+    def test_binary_field_survives_alias_with_decode_field_false(self, client):
+        # Regression test: return_field() used to key the decode-encoding map
+        # by the field identifier instead of the AS alias, so an aliased
+        # binary field was decoded (and silently truncated) instead of being
+        # kept raw. Covered against a real server across the protocol /
+        # legacy_responses matrix that CI runs this suite under.
+        fake_vec = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+
+        index_name = "aliased_binary_index"
+        client.hset(f"{index_name}:1", mapping={"vector_emb": fake_vec.tobytes()})
+
+        client.ft(index_name).create_index(
+            fields=(
+                VectorField(
+                    "vector_emb",
+                    algorithm="HNSW",
+                    attributes={
+                        "TYPE": "FLOAT32",
+                        "DIM": 4,
+                        "DISTANCE_METRIC": "COSINE",
+                    },
+                ),
+            ),
+            definition=IndexDefinition(
+                prefix=[f"{index_name}:"], index_type=IndexType.HASH
+            ),
+        )
+        self.waitForIndex(client, index_name)
+
+        query = Query("*").return_field(
+            "vector_emb", as_field="emb", decode_field=False
+        )
+        result = client.ft(index_name).search(query=query, query_params={})
+
+        if expects_resp3_shape(client):
+            results = result["results"]
+            assert len(results) > 0, f"Returned search results are empty: {result}"
+            attributes = results[0]["extra_attributes"]
+        else:
+            docs = result.docs
+            assert len(docs) > 0, f"Returned search results are empty: {result}"
+            attributes = docs[0]
+
+        decoded_vec = np.frombuffer(attributes["emb"], dtype=np.float32)
+        assert np.array_equal(decoded_vec, fake_vec), (
+            "The aliased binary field was not preserved intact"
+        )
+
+    @pytest.mark.redismod
     def test_synupdate(self, client):
         definition = IndexDefinition(index_type=IndexType.HASH)
         client.ft().create_index(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1473,6 +1473,32 @@ class TestBaseSearchFunctionality(SearchTestsBase):
             "The text field is not decoded correctly"
         )
 
+    def test_return_field_encoding_is_keyed_by_alias(self):
+        # The server returns an aliased field under its alias, so that is the
+        # name the response is looked up under when decoding.
+        query = Query("*").return_field(
+            "$.vector_emb", as_field="vector_emb", decode_field=False
+        )
+        assert query._return_fields_decode_as == {"vector_emb": None}
+        assert query.get_args()[:4] == ["*", "RETURN", 3, "$.vector_emb"]
+
+        raw = b"\x00\x01\x82\xff"
+        res = Result(
+            [1, "doc:1", ["vector_emb", raw]],
+            True,
+            field_encodings=query._return_fields_decode_as,
+        )
+        assert res.docs[0].vector_emb == raw
+
+        res = Result.from_resp3(
+            {
+                "total_results": 1,
+                "results": [{"id": "doc:1", "extra_attributes": {"vector_emb": raw}}],
+            },
+            field_encodings=query._return_fields_decode_as,
+        )
+        assert res.docs[0].vector_emb == raw
+
     @pytest.mark.redismod
     def test_synupdate(self, client):
         definition = IndexDefinition(index_type=IndexType.HASH)


### PR DESCRIPTION
### Description of change

`Query.return_field()` records the per-field encoding under the field
identifier, but the server returns an aliased field under its alias, so the
lookup in `Result` never matches and `decode_field=False` is ignored:
```python
Query("*").return_field("$.vector_emb", as_field="vector_emb", decode_field=False)
# _return_fields_decode_as == {'$.vector_emb': None}, response key is 'vector_emb'
```
Because `to_string` decodes with `errors="ignore"`, a binary field is not just
decoded but silently truncated — `b"\x00\x01\x82\xff"` comes back as
`'\x00\x01'`, with no error raised. The same call without `as_field` works.

`HybridQuery._set_load_field_encodings` already keys this same map by the alias
when `AS` is present; this makes `return_field` consistent with it.

Keying by the alias fixes it. The generated command arguments are unchanged.
Added a test covering both the RESP2 and RESP3 result paths.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to search query result decoding with added tests; no API or command-shape changes.
> 
> **Overview**
> Fixes **`Query.return_field()`** so `_return_fields_decode_as` is keyed by the response field name: the **`AS` alias** when present, otherwise the original field id. Redis returns aliased fields under the alias, so the old key caused **`decode_field=False`** (and custom encodings) to be ignored and binary payloads to be decoded/truncated via `errors="ignore"`.
> 
> Command arguments are unchanged; behavior now matches **`HybridQuery._set_load_field_encodings`**. New unit tests cover RESP2/RESP3 **`Result`** decoding, plus a **`redismod`** integration test for aliased binary vector fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef13aa7cc7344aa36a39e5b8b6b8aa82d262ff11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->