### PR TITLE
Pass zrevrange key as a list in options["keys"] to match sibling range commands

### DIFF
--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -8988,7 +8988,7 @@ class SortedSetCommands(CommandsProtocol):
         if withscores:
             pieces.append(b"WITHSCORES")
         options = {"withscores": withscores, "score_cast_func": score_cast_func}
-        options["keys"] = name
+        options["keys"] = [name]
         return self.execute_command(*pieces, **options)
 
     @overload

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -110,6 +110,47 @@ class TestCache:
                 "cache": DefaultCache(CacheConfig(max_size=5)),
                 "single_connection_client": False,
             },
+        ],
+        ids=["single", "pool"],
+        indirect=True,
+    )
+    @pytest.mark.onlynoncluster
+    def test_zrevrange_cache_key_uses_whole_key(self, r, r2):
+        # Regression: zrevrange stored options["keys"] as a bare string, so the
+        # cache key was built from the key's individual characters
+        # (("m", "y", "z", ...)) instead of the whole key. Verify the result is
+        # cached under redis_keys=("myzset",) and invalidated when the set
+        # changes from another client.
+        cache = r.get_cache()
+        r.delete("myzset")
+        r.zadd("myzset", {"a": 1, "b": 2})
+        # populate the local cache
+        assert r.zrevrange("myzset", 0, -1) == [b"b", b"a"]
+        # the entry must be stored under the whole key, not per-character
+        cache_key = CacheKey(
+            command="ZREVRANGE",
+            redis_keys=("myzset",),
+            redis_args=("ZREVRANGE", "myzset", 0, -1),
+        )
+        assert cache.get(cache_key) is not None
+        # change the sorted set from a second client (causes invalidation)
+        r2.zadd("myzset", {"c": 3})
+        # Add a small delay to allow invalidation to be processed
+        time.sleep(0.1)
+        # a fresh value is fetched and re-cached
+        assert r.zrevrange("myzset", 0, -1) == [b"c", b"b", b"a"]
+
+    @pytest.mark.parametrize(
+        "r",
+        [
+            {
+                "cache": DefaultCache(CacheConfig(max_size=5)),
+                "single_connection_client": True,
+            },
+            {
+                "cache": DefaultCache(CacheConfig(max_size=5)),
+                "single_connection_client": False,
+            },
             {
                 "cache": DefaultCache(CacheConfig(max_size=5)),
                 "single_connection_client": False,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5222,16 +5222,6 @@ class TestRedisCommands:
             [[b"a3", "3.0"], [b"a2", "2.0"]],
         )
 
-    def test_zrevrange_passes_key_as_list(self, r):
-        # zrevrange must pass its key in a list, like the sibling range
-        # commands (zrange, zrangebyscore, zrevrangebyscore). Passing a bare
-        # string means downstream consumers that iterate options["keys"]
-        # (e.g. client-side cache key construction) walk it character by
-        # character instead of treating it as a single key.
-        with mock.patch.object(r, "execute_command", return_value=[]) as execute_command:
-            r.zrevrange("myzset", 0, -1)
-        assert execute_command.call_args.kwargs["keys"] == ["myzset"]
-
     def test_zrevrangebyscore(self, r):
         r.zadd("a", {"a1": 1, "a2": 2, "a3": 3, "a4": 4, "a5": 5})
         assert r.zrevrangebyscore("a", 4, 2) == [b"a4", b"a3", b"a2"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5222,6 +5222,16 @@ class TestRedisCommands:
             [[b"a3", "3.0"], [b"a2", "2.0"]],
         )
 
+    def test_zrevrange_passes_key_as_list(self, r):
+        # zrevrange must pass its key in a list, like the sibling range
+        # commands (zrange, zrangebyscore, zrevrangebyscore). Passing a bare
+        # string means downstream consumers that iterate options["keys"]
+        # (e.g. client-side cache key construction) walk it character by
+        # character instead of treating it as a single key.
+        with mock.patch.object(r, "execute_command", return_value=[]) as execute_command:
+            r.zrevrange("myzset", 0, -1)
+        assert execute_command.call_args.kwargs["keys"] == ["myzset"]
+
     def test_zrevrangebyscore(self, r):
         r.zadd("a", {"a1": 1, "a2": 2, "a3": 3, "a4": 4, "a5": 5})
         assert r.zrevrangebyscore("a", 4, 2) == [b"a4", b"a3", b"a2"]


### PR DESCRIPTION
## Summary

`SortedSetCommands.zrevrange` stores its key in `options["keys"]` as a **bare string**, while every sibling range command passes it as a **list**:

```python
# zrange / _zrange
options["keys"] = [name]
# zrangebyscore
options["keys"] = [name]
# zrevrangebyscore
options["keys"] = [name]
# zrevrange  <-- inconsistent
options["keys"] = name
```

## Impact

`options["keys"]` is consumed as a sequence of keys. When it is a bare string, consumers iterate it **character by character**. The clearest case is client-side caching in `redis/connection.py`:

```python
self._current_command_cache_key = CacheKey(
    command=args[0], redis_keys=tuple(kwargs.get("keys")), redis_args=args
)
```

For `zrevrange("myzset", 0, -1)` this builds `redis_keys=('m', 'y', 'z', 's', 'e', 't')` instead of `('myzset',)`, so the cache key / invalidation mapping for `zrevrange` is wrong.

## Fix

Wrap the key in a list, matching the other range commands:

```diff
-        options["keys"] = name
+        options["keys"] = [name]
```

## Tests

Added `test_zrevrange_passes_key_as_list`, which mocks `execute_command` and asserts `zrevrange` passes `keys=["myzset"]`. It fails on the previous behavior (`"myzset" != ["myzset"]`) and passes with the fix. Verified locally without a server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line behavioral fix in command options plus cache regression tests; no auth, security, or broad API changes.
> 
> **Overview**
> **`zrevrange`** now sets `options["keys"]` to `[name]` instead of a bare string, aligning with **`zrange`**, **`zrangebyscore`**, and other range commands.
> 
> That fixes client-side caching: `redis_keys` is built from `tuple(kwargs["keys"])`, so a string key was iterated **per character** (`('m','y','z',...)`) rather than as a single Redis key (`('myzset',)`), breaking cache lookup and invalidation for **`ZREVRANGE`**.
> 
> A regression test exercises cached **`zrevrange`** results and invalidation when the sorted set is updated from another client (single-connection and pool modes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0d891ab733310178e36734f4498a72914709fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->