### PR TITLE
Clarify connection health check timeouts

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -969,7 +969,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             await self.send_command(
                 "HELLO", self.protocol, "AUTH", *auth_args, check_health=False
             )
-            response = await self.read_response()
+            response = await self._read_response_with_health_check()
             if response.get(b"proto") != int(self.protocol) and response.get(
                 "proto"
             ) != int(self.protocol):
@@ -980,14 +980,14 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
             await self.send_command("AUTH", *auth_args, check_health=False)
 
             try:
-                auth_response = await self.read_response()
+                auth_response = await self._read_response_with_health_check()
             except AuthenticationWrongNumberOfArgsError:
                 # a username and password were specified but the Redis
                 # server seems to be < 6.0.0 which expects a single password
                 # arg. retry auth with just the password.
                 # https://github.com/andymccurdy/redis-py/issues/1274
                 await self.send_command("AUTH", auth_args[-1], check_health=False)
-                auth_response = await self.read_response()
+                auth_response = await self._read_response_with_health_check()
 
             if str_if_bytes(auth_response) != "OK":
                 raise AuthenticationError("Invalid Username or Password")
@@ -1000,7 +1000,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                 self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
                 self._parser.on_connect(self)
             await self.send_command("HELLO", self.protocol, check_health=check_health)
-            response = await self.read_response()
+            response = await self._read_response_with_health_check()
             # if response.get(b"proto") != self.protocol and response.get(
             #     "proto"
             # ) != self.protocol:
@@ -1021,7 +1021,7 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
                 self.client_name,
                 check_health=check_health,
             )
-            if str_if_bytes(await self.read_response()) != "OK":
+            if str_if_bytes(await self._read_response_with_health_check()) != "OK":
                 raise ConnectionError("Error setting client name")
 
         # Set the library name and version from driver_info, pipeline for lower startup latency
@@ -1055,12 +1055,12 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
         # read responses from pipeline
         for _ in range(sum([lib_name_sent, lib_version_sent])):
             try:
-                await self.read_response()
+                await self._read_response_with_health_check()
             except ResponseError:
                 pass
 
         if self.db:
-            if str_if_bytes(await self.read_response()) != "OK":
+            if str_if_bytes(await self._read_response_with_health_check()) != "OK":
                 raise ConnectionError("Invalid Database")
 
     async def disconnect(
@@ -1145,8 +1145,17 @@ class AbstractConnection(AsyncMaintNotificationsAbstractConnection):
     async def _send_ping(self):
         """Send PING, expect PONG in return"""
         await self.send_command("PING", check_health=False)
-        if str_if_bytes(await self.read_response()) != "PONG":
+        if str_if_bytes(await self._read_response_with_health_check()) != "PONG":
             raise ConnectionError("Bad response from PING health check")
+
+    async def _read_response_with_health_check(self):
+        """Read a response while establishing or checking a connection."""
+        try:
+            return await self.read_response()
+        except TimeoutError as error:
+            raise ConnectionError(
+                f"Timeout during connection health check to {self._host_error()}"
+            ) from error
 
     async def _ping_failed(self, error, failure_count):
         """Function to call when PING fails"""

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -1152,7 +1152,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             self.send_command(
                 "HELLO", self.protocol, "AUTH", *auth_args, check_health=False
             )
-            self.handshake_metadata = self.read_response()
+            self.handshake_metadata = self._read_response_with_health_check()
             # if response.get(b"proto") != self.protocol and response.get(
             #     "proto"
             # ) != self.protocol:
@@ -1163,14 +1163,14 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
             self.send_command("AUTH", *auth_args, check_health=False)
 
             try:
-                auth_response = self.read_response()
+                auth_response = self._read_response_with_health_check()
             except AuthenticationWrongNumberOfArgsError:
                 # a username and password were specified but the Redis
                 # server seems to be < 6.0.0 which expects a single password
                 # arg. retry auth with just the password.
                 # https://github.com/andymccurdy/redis-py/issues/1274
                 self.send_command("AUTH", auth_args[-1], check_health=False)
-                auth_response = self.read_response()
+                auth_response = self._read_response_with_health_check()
 
             if str_if_bytes(auth_response) != "OK":
                 raise AuthenticationError("Invalid Username or Password")
@@ -1183,7 +1183,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
                 self._parser.on_connect(self)
             self.send_command("HELLO", self.protocol, check_health=check_health)
-            self.handshake_metadata = self.read_response()
+            self.handshake_metadata = self._read_response_with_health_check()
             if (
                 self.handshake_metadata.get(b"proto") != self.protocol
                 and self.handshake_metadata.get("proto") != self.protocol
@@ -1203,7 +1203,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                 self.client_name,
                 check_health=check_health,
             )
-            if str_if_bytes(self.read_response()) != "OK":
+            if str_if_bytes(self._read_response_with_health_check()) != "OK":
                 raise ConnectionError("Error setting client name")
 
         # Set the library name and version from driver_info
@@ -1216,7 +1216,7 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                     self.driver_info.formatted_name,
                     check_health=check_health,
                 )
-                self.read_response()
+                self._read_response_with_health_check()
         except ResponseError:
             pass
 
@@ -1229,14 +1229,14 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
                     self.driver_info.lib_version,
                     check_health=check_health,
                 )
-                self.read_response()
+                self._read_response_with_health_check()
         except ResponseError:
             pass
 
         # if a database is specified, switch to it
         if self.db:
             self.send_command("SELECT", self.db, check_health=check_health)
-            if str_if_bytes(self.read_response()) != "OK":
+            if str_if_bytes(self._read_response_with_health_check()) != "OK":
                 raise ConnectionError("Invalid Database")
 
     def disconnect(self, *args, **kwargs):
@@ -1317,8 +1317,17 @@ class AbstractConnection(MaintNotificationsAbstractConnection, ConnectionInterfa
     def _send_ping(self):
         """Send PING, expect PONG in return"""
         self.send_command("PING", check_health=False)
-        if str_if_bytes(self.read_response()) != "PONG":
+        if str_if_bytes(self._read_response_with_health_check()) != "PONG":
             raise ConnectionError("Bad response from PING health check")
+
+    def _read_response_with_health_check(self):
+        """Read a response while establishing or checking a connection."""
+        try:
+            return self.read_response()
+        except TimeoutError as error:
+            raise ConnectionError(
+                f"Timeout during connection health check to {self._host_error()}"
+            ) from error
 
     def _ping_failed(self, error, failure_count):
         """Function to call when PING fails"""

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -414,6 +414,19 @@ async def test_connect_with_retries():
 
 
 @pytest.mark.fixed_client
+async def test_connection_health_check_timeout_is_connection_error():
+    conn = Connection()
+    conn.read_response = mock.AsyncMock(side_effect=TimeoutError("read timeout"))
+
+    with pytest.raises(
+        ConnectionError, match="Timeout during connection health check"
+    ) as raised:
+        await conn._read_response_with_health_check()
+
+    assert isinstance(raised.value.__cause__, TimeoutError)
+
+
+@pytest.mark.fixed_client
 async def test_connect_timeout_error_without_retry():
     """Test that the _connect function is not being retried if retry_on_timeout is
     set to False"""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -543,6 +543,17 @@ def test_redis_client_default_driver_info():
 
 @pytest.mark.fixed_client
 class TestConnection:
+    def test_connection_health_check_timeout_is_connection_error(self):
+        conn = Connection()
+        conn.read_response = mock.Mock(side_effect=TimeoutError("read timeout"))
+
+        with pytest.raises(
+            ConnectionError, match="Timeout during connection health check"
+        ) as raised:
+            conn._read_response_with_health_check()
+
+        assert isinstance(raised.value.__cause__, TimeoutError)
+
     def test_disconnect(self):
         conn = Connection()
         mock_sock = mock.Mock()


### PR DESCRIPTION
## Summary\n\nFixes #4240\n\nA timeout while reading a response during connection establishment or a connection health PING is currently reported as the same TimeoutError used for command response reads after a write. This change converts only health-check/connection-establishment response timeouts to ConnectionError with an explicit message, preserving the original timeout as the exception cause.\n\nThe sync and asyncio connection implementations now share the same behavior.\n\n## Tests\n\n- python -m pytest tests/test_connection.py tests/test_asyncio/test_connection.py -k 'connection_health_check_timeout or connect_timeout_error_without_retry' -q\n- python -m ruff check redis/connection.py redis/asyncio/connection.py tests/test_connection.py tests/test_asyncio/test_connection.py\n- python -m compileall -q redis/connection.py redis/asyncio/connection.py\n\nThe full connection test files require a local Redis server; the relevant unit tests pass without one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow exception-mapping change on connect/PING paths only, with sync/async parity and targeted unit tests; no change to post-connect command timeout behavior.
> 
> **Overview**
> **Connection establishment and health PING reads** now go through `_read_response_with_health_check()` instead of calling `read_response()` directly. If a read times out in those paths, redis-py raises **`ConnectionError`** with a message like *"Timeout during connection health check to …"*, with the original **`TimeoutError`** chained as `__cause__`.
> 
> The same helper is wired through the connect handshake (HELLO/AUTH, CLIENT SETNAME/SETINFO, SELECT) and **`_send_ping`** in both **`redis/connection.py`** and **`redis/asyncio/connection.py`**. Ordinary command response reads are unchanged and still surface **`TimeoutError`** when the socket read times out.
> 
> Unit tests assert the new exception type, message, and cause for sync and asyncio connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e5905c93c1042c30dd3b6e143795555fdea675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->