### PR TITLE
fix(asyncio): reject connection URLs missing the scheme separator

### DIFF
--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1766,11 +1766,10 @@ class ConnectKwargs(TypedDict, total=False):
 
 
 def parse_url(url: str) -> ConnectKwargs:
-    if not (
-        url.startswith("redis://")
-        or url.startswith("rediss://")
-        or url.startswith("unix://")
-    ):
+    # Scheme names are case-insensitive (RFC 3986), so normalize before the
+    # prefix check; the "://" is required so a URL like "redis:foo" (which
+    # urlparse would still report as the "redis" scheme) is rejected.
+    if not url.lower().startswith(("redis://", "rediss://", "unix://")):
         raise ValueError(
             "Redis URL must specify one of the following schemes "
             "(redis://, rediss://, unix://)"

--- a/redis/asyncio/connection.py
+++ b/redis/asyncio/connection.py
@@ -1766,6 +1766,16 @@ class ConnectKwargs(TypedDict, total=False):
 
 
 def parse_url(url: str) -> ConnectKwargs:
+    if not (
+        url.startswith("redis://")
+        or url.startswith("rediss://")
+        or url.startswith("unix://")
+    ):
+        raise ValueError(
+            "Redis URL must specify one of the following schemes "
+            "(redis://, rediss://, unix://)"
+        )
+
     parsed: ParseResult = urlparse(url)
     kwargs: ConnectKwargs = {}
 
@@ -1795,7 +1805,7 @@ def parse_url(url: str) -> ConnectKwargs:
             kwargs["path"] = unquote(parsed.path)
         kwargs["connection_class"] = UnixDomainSocketConnection
 
-    elif parsed.scheme in ("redis", "rediss"):
+    else:  # implied:  parsed.scheme in ("redis", "rediss")
         if parsed.hostname:
             kwargs["host"] = unquote(parsed.hostname)
         if parsed.port:
@@ -1811,12 +1821,6 @@ def parse_url(url: str) -> ConnectKwargs:
 
         if parsed.scheme == "rediss":
             kwargs["connection_class"] = SSLConnection
-
-    else:
-        valid_schemes = "redis://, rediss://, unix://"
-        raise ValueError(
-            f"Redis URL must specify one of the following schemes ({valid_schemes})"
-        )
 
     return kwargs
 

--- a/redis/connection.py
+++ b/redis/connection.py
@@ -2328,11 +2328,10 @@ URL_QUERY_ARGUMENT_PARSERS = {
 
 
 def parse_url(url):
-    if not (
-        url.startswith("redis://")
-        or url.startswith("rediss://")
-        or url.startswith("unix://")
-    ):
+    # Scheme names are case-insensitive (RFC 3986), so normalize before the
+    # prefix check; the "://" is required so a URL like "redis:foo" (which
+    # urlparse would still report as the "redis" scheme) is rejected.
+    if not url.lower().startswith(("redis://", "rediss://", "unix://")):
         raise ValueError(
             "Redis URL must specify one of the following "
             "schemes (redis://, rediss://, unix://)"

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -676,6 +676,14 @@ class TestConnectionPoolURLParsing:
         assert pool.connection_class == redis.Connection
         assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
+        ssl_pool = redis.ConnectionPool.from_url("REDISS://my.host")
+        assert ssl_pool.connection_class == redis.SSLConnection
+        assert_kwargs_subset(ssl_pool.connection_kwargs, {"host": "my.host"})
+
+        unix_pool = redis.ConnectionPool.from_url("UNIX:///tmp/redis.sock")
+        assert unix_pool.connection_class == redis.UnixDomainSocketConnection
+        assert_kwargs_subset(unix_pool.connection_kwargs, {"path": "/tmp/redis.sock"})
+
 
 @pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -670,6 +670,12 @@ class TestConnectionPoolURLParsing:
             "(redis://, rediss://, unix://)"
         )
 
+    def test_uppercase_scheme_is_accepted(self):
+        # URL schemes are case-insensitive (RFC 3986)
+        pool = redis.ConnectionPool.from_url("REDIS://my.host")
+        assert pool.connection_class == redis.Connection
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
+
 
 @pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -662,6 +662,14 @@ class TestConnectionPoolURLParsing:
             "(redis://, rediss://, unix://)"
         )
 
+    def test_invalid_scheme_raises_error_when_double_slash_missing(self):
+        with pytest.raises(ValueError) as cm:
+            redis.ConnectionPool.from_url("redis:foo.bar.com:12345")
+        assert str(cm.value) == (
+            "Redis URL must specify one of the following schemes "
+            "(redis://, rediss://, unix://)"
+        )
+
 
 @pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -611,6 +611,12 @@ class TestConnectionPoolURLParsing:
             "(redis://, rediss://, unix://)"
         )
 
+    def test_uppercase_scheme_is_accepted(self):
+        # URL schemes are case-insensitive (RFC 3986)
+        pool = redis.ConnectionPool.from_url("REDIS://my.host")
+        assert pool.connection_class == redis.Connection
+        assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
+
 
 @pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -617,6 +617,14 @@ class TestConnectionPoolURLParsing:
         assert pool.connection_class == redis.Connection
         assert_kwargs_subset(pool.connection_kwargs, {"host": "my.host"})
 
+        ssl_pool = redis.ConnectionPool.from_url("REDISS://my.host")
+        assert ssl_pool.connection_class == redis.SSLConnection
+        assert_kwargs_subset(ssl_pool.connection_kwargs, {"host": "my.host"})
+
+        unix_pool = redis.ConnectionPool.from_url("UNIX:///tmp/redis.sock")
+        assert unix_pool.connection_class == redis.UnixDomainSocketConnection
+        assert_kwargs_subset(unix_pool.connection_kwargs, {"path": "/tmp/redis.sock"})
+
 
 @pytest.mark.fixed_client
 class TestBlockingConnectionPoolURLParsing:


### PR DESCRIPTION
## Summary

The async `parse_url` in `redis/asyncio/connection.py` validated the URL scheme with `urlparse(url).scheme`, which accepts a URL that has a valid scheme name but is missing the `://` separator, for example `redis:foo.bar.com:12345`. In that case `urlparse` reports the scheme as `redis` with an empty netloc, so the function returned partial kwargs (no host/port) and the async client silently connected to the default host instead of raising.

The sync `parse_url` in `redis/connection.py` already guards against this up front and has a dedicated test (`test_invalid_scheme_raises_error_when_double_slash_missing`), but the async copy did not, so `redis.from_url("redis:foo.bar.com:12345")` and `redis.asyncio.from_url("redis:foo.bar.com:12345")` behaved differently.

## Changes

- Add the same up-front scheme check that the sync version uses, so a URL missing the `redis://`, `rediss://`, or `unix://` prefix raises `ValueError` with the same message. The now-unreachable trailing `else` branch is removed, matching the structure of the sync implementation.
- Add `test_invalid_scheme_raises_error_when_double_slash_missing` to the async connection-pool URL-parsing tests, mirroring the existing sync test.

## Testing

Verified that async `parse_url` / `ConnectionPool.from_url` now raises for `redis:foo.bar.com:12345`, `localhost`, and `http://localhost`, while valid `redis://`, `rediss://`, and `unix://` URLs (including host, port, db, and querystring options) still parse exactly as before. The sync and async implementations now return matching results for these inputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized URL parsing only; behavior change is stricter rejection of bad URLs and broader acceptance of uppercase schemes on sync, with no auth or wire-protocol impact.
> 
> **Overview**
> **Sync and async `parse_url` now validate connection URLs the same way** before `urlparse`: the string must start with `redis://`, `rediss://`, or `unix://` (case-insensitive). Malformed values such as `redis:foo.bar.com:12345` raise `ValueError` instead of being accepted—async previously treated them as a valid `redis` scheme with no host and could connect to defaults.
> 
> The async parser gains the sync-style upfront check and drops the redundant trailing invalid-scheme branch. **Sync** `parse_url` switches from case-sensitive `startswith` to `url.lower().startswith(...)`, so **`REDIS://`, `REDISS://`, and `UNIX://` are now accepted** on the sync client as well.
> 
> Tests cover the missing-`://` case for async and uppercase schemes for both sync and async `ConnectionPool.from_url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7137e006820a659cde2ac128f13a85aab689978d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Behavior change (for release notes)

While aligning the sync and async parsers and addressing review feedback, the checks are now case-insensitive per RFC 3986. As a result the **sync** `redis.from_url()` now also accepts uppercase schemes such as `REDIS://`, `REDISS://`, and `UNIX://` (the `urlparse`-based async parser already accepted these). This is a released-behavior change for the sync parser worth noting in the release notes; the missing-separator case (e.g. `redis:foo.bar.com:12345`) is still rejected.

Requiring the `://` separator also tightens two undocumented input forms on the **async** side, which the sync parser has rejected since #2343: the single-slash `unix:/tmp/redis.sock` form (only `unix:///tmp/redis.sock` is documented) and URLs with leading whitespace or control characters, e.g. a value read from a `.env` file as `"\nredis://host"`. Both previously worked on async because `urlparse` tolerated them, and both now raise `ValueError` with the same "Redis URL must specify one of the following schemes" message. Upgraders hitting that error should add the missing slash or strip the URL; trailing whitespace is unaffected.

