### PR TITLE
Fix JSON.set_path key derivation to strip only the file extension

### DIFF
--- a/redis/commands/json/__init__.py
+++ b/redis/commands/json/__init__.py
@@ -346,10 +346,11 @@ class AsyncJSON(_JSONBase):
 
         for file_path in file_paths:
             try:
-                # TODO: rsplit(".") splits on all dots, mishandling paths
-                # with dots in directories (e.g. /data/v1.2/file.json).
-                # Should be rsplit(".", 1) — fix in a separate PR.
-                file_name = file_path.rsplit(".")[0]
+                # Strip only the file extension (the final dot-separated
+                # component). Using rsplit(".", 1) avoids truncating paths
+                # that contain dots in a directory or file name, e.g.
+                # /data/v1.2/file.json -> /data/v1.2/file.
+                file_name = file_path.rsplit(".", 1)[0]
                 await self.set_file(
                     file_name,
                     json_path,

--- a/redis/commands/json/commands.py
+++ b/redis/commands/json/commands.py
@@ -704,10 +704,11 @@ class JSONCommands:
             for file in files:
                 file_path = os.path.join(root, file)
                 try:
-                    # TODO: rsplit(".") splits on all dots, mishandling paths
-                    # with dots in directories (e.g. /data/v1.2/file.json).
-                    # Should be rsplit(".", 1) — fix in a separate PR.
-                    file_name = file_path.rsplit(".")[0]
+                    # Strip only the file extension (the final dot-separated
+                    # component). Using rsplit(".", 1) avoids truncating paths
+                    # that contain dots in a directory or file name, e.g.
+                    # /data/v1.2/file.json -> /data/v1.2/file.
+                    file_name = file_path.rsplit(".", 1)[0]
                     self.set_file(
                         file_name,
                         json_path,

--- a/tests/test_asyncio/test_json.py
+++ b/tests/test_asyncio/test_json.py
@@ -1142,3 +1142,35 @@ async def test_toggle_dollar(decoded_r: redis.Redis):
     # Test missing key
     with pytest.raises(exceptions.ResponseError):
         await decoded_r.json().toggle("non_existing_doc", "$..a")
+
+
+async def test_set_path_key_strips_only_extension(monkeypatch):
+    # Regression test: JSON.set_path must strip only the file extension when
+    # deriving the key, so a path containing dots in a directory (e.g. a
+    # versioned "v1.2" folder) is not truncated at the first dot. set_file is
+    # stubbed so this runs without a server.
+    import json
+    import os
+    import tempfile
+
+    root = tempfile.mkdtemp()
+    dotted_dir = os.path.join(root, "v1.2")
+    os.makedirs(dotted_dir)
+    json_file = os.path.join(dotted_dir, "data.json")
+    with open(json_file, "w") as fp:
+        fp.write(json.dumps({"hello": "world"}))
+
+    json_client = redis.Redis().json()
+    captured = []
+
+    async def fake_set_file(name, *args, **kwargs):
+        captured.append(name)
+        return True
+
+    monkeypatch.setattr(json_client, "set_file", fake_set_file)
+
+    result = await json_client.set_path(Path.root_path(), root)
+
+    expected_key = json_file[: -len(".json")]
+    assert captured == [expected_key]
+    assert result == {json_file: True}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1620,10 +1620,15 @@ def test_set_file(client):
 @pytest.mark.redismod
 def test_set_path(client):
     import json
+    import os
     import tempfile
 
     root = tempfile.mkdtemp()
-    sub = tempfile.mkdtemp(dir=root)
+    # Place the file under a directory whose name contains a dot, to guard
+    # against the derived key being truncated at the first dot rather than at
+    # the file extension.
+    sub = os.path.join(root, "v1.2")
+    os.makedirs(sub)
     jsonfile = tempfile.mkstemp(suffix=".json", dir=sub)[1]
     nojsonfile = tempfile.mkstemp(dir=root)[1]
 
@@ -1635,4 +1640,36 @@ def test_set_path(client):
     result = {jsonfile: True, nojsonfile: False}
     assert client.json().set_path(Path.root_path(), root) == result
     res = {"hello": "world"}
-    assert client.json().get(jsonfile.rsplit(".")[0]) == res
+    assert client.json().get(jsonfile.rsplit(".", 1)[0]) == res
+
+
+def test_set_path_key_strips_only_extension(monkeypatch):
+    # Regression test: JSON.set_path must strip only the file extension when
+    # deriving the key, so a path containing dots in a directory (e.g. a
+    # versioned "v1.2" folder) is not truncated at the first dot. set_file is
+    # stubbed so this runs without a server.
+    import json
+    import os
+    import tempfile
+
+    root = tempfile.mkdtemp()
+    dotted_dir = os.path.join(root, "v1.2")
+    os.makedirs(dotted_dir)
+    json_file = os.path.join(dotted_dir, "data.json")
+    with open(json_file, "w") as fp:
+        fp.write(json.dumps({"hello": "world"}))
+
+    json_client = redis.Redis().json()
+    captured = []
+
+    def fake_set_file(name, *args, **kwargs):
+        captured.append(name)
+        return True
+
+    monkeypatch.setattr(json_client, "set_file", fake_set_file)
+
+    result = json_client.set_path(Path.root_path(), root)
+
+    expected_key = json_file[: -len(".json")]
+    assert captured == [expected_key]
+    assert result == {json_file: True}


### PR DESCRIPTION
## Summary

`JSONCommands.set_path` and its async mirror `AsyncJSON.set_path` build the Redis key for each file with `file_path.rsplit(".")[0]`, which splits on every dot. Any path with a dot before the extension gets truncated at the first dot and produces the wrong key. This is the fix the existing `TODO` in both files asked for.

Examples of the key that gets created:

| File on disk | Before (buggy) | After (fixed) |
|---|---|---|
| `/data/file.json` | `/data/file` | `/data/file` |
| `/data/v1.2/file.json` | `/data/v1` | `/data/v1.2/file` |
| `/data/config.dev.json` | `/data/config` | `/data/config.dev` |

So anyone using a versioned directory (like `v1.2`) or a multi-dot filename silently ends up with truncated keys.

## Fix

Use `rsplit(".", 1)` in both the sync (`redis/commands/json/commands.py`) and async (`redis/commands/json/__init__.py`) implementations, so only the final extension is stripped. This matches the intent noted in the existing `TODO` comments, which are now resolved.

## Tests

- Added sync and async regression tests (`test_set_path_key_strips_only_extension`) that stub `set_file` and assert the derived key. They need no server, so they run in normal CI. Verified they fail on the old code and pass on the fixed code.
- Updated the existing `redismod` `test_set_path` to place the file under a dotted directory (`v1.2`), so it also guards this against a live server.

`ruff check` and `ruff format` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bugfix in JSON bulk-import key naming with targeted tests; behavior change only affects callers who relied on the incorrect truncated keys.
> 
> **Overview**
> **`set_path`** now derives each Redis key with **`rsplit(".", 1)[0]`** instead of **`rsplit(".")[0]`**, in both sync (`commands.py`) and async (`__init__.py`) JSON clients. Only the final extension is removed, so paths with dots in directory or basename segments (e.g. `v1.2/data.json` → `…/v1.2/data`, not truncated at the first dot) get the correct key.
> 
> Regression coverage adds **`test_set_path_key_strips_only_extension`** (sync and async, stubbed `set_file`), and the existing **`test_set_path`** integration test uses a `v1.2` subdirectory and asserts the fixed key shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5890a8d82d3644f8acd4d9525a0a8936510a8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->