### PR TITLE
Add network-level repro verifying fix for #3741 (PR #3863)

### DIFF
--- a/PROXY_REPRO.md
+++ b/PROXY_REPRO.md
@@ -1,0 +1,84 @@
+# Network-level verification of the fix for redis/redis-py#3741
+
+This branch reproduces, at the real TCP level (not a mock), the bug
+described in [redis/redis-py#3741](https://github.com/redis/redis-py/issues/3741)
+and verifies that [PR #3863](https://github.com/redis/redis-py/pull/3863)
+fixes it.
+
+## Summary
+
+- `proxy.py` — a small async TCP proxy that sits between a redis-py client
+  and a real Redis server. It forces a genuine TCP RST (via `SO_LINGER`,
+  linger=0) on the first N connection attempts it accepts, then passes
+  every connection after that straight through to the real backend.
+- `demo_proxy_repro.py` — connects a `redis.asyncio.connection.Connection`
+  through that proxy, using the retry configuration from the original bug
+  report (`Retry(ExponentialBackoff(cap=10, base=1), 25)`).
+
+Because the RST is a real kernel-level TCP event (not a Python-level
+exception injection), this reproduces the exact class of failure the
+original reporter saw in production
+(`ConnectionResetError: [Errno 104] Connection reset by peer`
+mid-handshake).
+
+## Results
+
+**On `742b13bd`** (the commit immediately before #3863 merged):
+```
+$ python demo_proxy_repro.py --port 6500
+connecting...
+FAILED TO CONNECT: ConnectionError: ...
+```
+Proxy log shows exactly **one** connection attempt, then nothing — the
+handshake write (`CLIENT SETINFO LIB-NAME`; default protocol is RESP2 so
+no `HELLO` is sent) failed once and was never retried, despite 25 retries
+being configured.
+
+**On `master`** (after #3863 / commit `4a6c2c0f`):
+```
+$ python demo_proxy_repro.py --port 6500
+connecting...
+CONNECTED: True
+PING response: b'PONG'
+```
+Proxy log shows two forced resets followed by a successful pass-through —
+`connect()` retried the full connect+handshake flow and recovered.
+
+## How to run it yourself
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e . && pip install pytest pytest-asyncio mock
+
+# start a throwaway real Redis
+redis-server --port 6398 --daemonize yes --pidfile redis-test.pid --logfile redis-test.log
+
+# terminal 1: the proxy
+python proxy.py --listen-port 6500 --backend-port 6398 --reset-count 2
+
+# terminal 2: pre-fix
+git checkout 742b13bd && pip install -e . --no-deps
+python demo_proxy_repro.py --port 6500   # expect: FAILED TO CONNECT after 1 attempt
+
+# restart the proxy in terminal 1 (resets its counter), then in terminal 2:
+git checkout master && pip install -e . --no-deps
+python demo_proxy_repro.py --port 6500   # expect: CONNECTED: True, PONG
+```
+
+## Why this needed care to get right
+
+Two things will silently give you a false pass if you're not careful:
+
+1. **Don't let the raw socket connect fail** — if there's nothing listening
+   at all, the connect-level retry (which now wraps everything, post-#3863)
+   will retry the TCP connect itself with real exponential backoff sleeps,
+   making the test hang rather than fail fast. Point the client at a proxy
+   that completes the TCP handshake before resetting, not at a closed port.
+
+2. **Don't set `health_check_interval`** in the demo client config. If set,
+   `check_health()` sends a `PING` before any real handshake command, and
+   that `PING` already goes through its own independent
+   `retry.call_with_retry` — a mechanism that predates #3863 and was never
+   broken. That pre-existing retry loop will recover from resets on *both*
+   the pre-fix and post-fix commit, making them indistinguishable and
+   masking the actual bug/fix being tested.

--- a/demo_proxy_repro.py
+++ b/demo_proxy_repro.py
@@ -1,0 +1,64 @@
+"""
+Point a redis-py async Connection at the proxy (proxy.py) instead of
+directly at Redis, using the reporter's exact retry configuration from
+https://github.com/redis/redis-py/issues/3741, and see whether it
+survives the proxy's simulated resets.
+
+Usage:
+    python demo_proxy_repro.py --port 6500
+"""
+import argparse
+import asyncio
+
+from redis.asyncio.connection import Connection
+from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, required=True)
+    args = parser.parse_args()
+
+    conn = Connection(
+        port=args.port,
+        socket_keepalive=True,
+        socket_connect_timeout=15,
+        socket_timeout=5,
+        retry=Retry(ExponentialBackoff(cap=10, base=1), 25),
+        retry_on_error=[RedisConnectionError, ConnectionResetError],
+        # NOTE: health_check_interval is intentionally NOT set here.
+        # If it were, check_health()'s PING would be the first write on a
+        # fresh connection, and PING failures are recovered by their own
+        # independent retry.call_with_retry() -- a mechanism that predates
+        # PR #3863 and was never broken. That masks the actual bug: it
+        # makes pre-fix and post-fix code behave identically against this
+        # proxy, because the pre-existing PING retry does all the
+        # recovering instead of the connect()-level retry PR #3863 added.
+        # Leaving it unset means the first write on a fresh connection is
+        # the real (and, pre-fix, genuinely unprotected) handshake command.
+    )
+
+    print("connecting...", flush=True)
+    try:
+        await conn.connect()
+    except Exception as e:
+        print(f"FAILED TO CONNECT: {type(e).__name__}: {e}", flush=True)
+        return
+
+    print("CONNECTED:", conn.is_connected, flush=True)
+    pong = await conn.retry.call_with_retry(
+        lambda: _ping(conn), lambda e: conn.disconnect()
+    )
+    print("PING response:", pong, flush=True)
+    await conn.disconnect()
+
+
+async def _ping(conn):
+    await conn.send_command("PING")
+    return await conn.read_response()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/proxy.py
+++ b/proxy.py
@@ -1,0 +1,92 @@
+"""
+A tiny TCP proxy that sits between redis-py and a real Redis server.
+
+For the first RESET_COUNT connections it accepts, it forces a TCP RST
+(via SO_LINGER with linger=0) instead of a clean close or a normal
+handshake -- this is what makes the client see a real
+`ConnectionResetError`, at the OS/socket level, not a Python-level mock.
+
+After RESET_COUNT resets, every subsequent connection is transparently
+proxied through to the real backend Redis server.
+
+Usage:
+    python proxy.py --listen-port 6500 --backend-port 6399 --reset-count 2
+"""
+import argparse
+import asyncio
+import socket
+import struct
+
+
+async def pipe(src: asyncio.StreamReader, dst: asyncio.StreamWriter):
+    try:
+        while True:
+            data = await src.read(4096)
+            if not data:
+                break
+            dst.write(data)
+            await dst.drain()
+    except (ConnectionResetError, BrokenPipeError):
+        pass
+    finally:
+        dst.close()
+
+
+def make_handler(backend_host, backend_port, reset_count, state):
+    async def handle(reader, writer):
+        state["attempt"] += 1
+        n = state["attempt"]
+
+        if n <= reset_count:
+            print(f"[proxy] attempt {n}: forcing RST (simulated reset)", flush=True)
+            sock = writer.get_extra_info("socket")
+            # linger=0 close sends a raw RST instead of a clean FIN
+            sock.setsockopt(
+                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+            )
+            writer.close()
+            return
+
+        print(f"[proxy] attempt {n}: passing through to real backend", flush=True)
+        try:
+            backend_reader, backend_writer = await asyncio.open_connection(
+                backend_host, backend_port
+            )
+        except OSError as e:
+            print(f"[proxy] could not reach backend: {e}", flush=True)
+            writer.close()
+            return
+
+        await asyncio.gather(
+            pipe(reader, backend_writer),
+            pipe(backend_reader, writer),
+        )
+
+    return handle
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen-port", type=int, required=True)
+    parser.add_argument("--backend-port", type=int, required=True)
+    parser.add_argument("--backend-host", default="127.0.0.1")
+    parser.add_argument("--reset-count", type=int, default=2)
+    args = parser.parse_args()
+
+    state = {"attempt": 0}
+    handler = make_handler(
+        args.backend_host, args.backend_port, args.reset_count, state
+    )
+    server = await asyncio.start_server(handler, "127.0.0.1", args.listen_port)
+    print(
+        f"[proxy] listening on 127.0.0.1:{args.listen_port} -> "
+        f"{args.backend_host}:{args.backend_port} "
+        f"(first {args.reset_count} attempts will be RST)",
+        flush=True,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_asyncio/test_repro_3741.py
+++ b/tests/test_asyncio/test_repro_3741.py
@@ -1,0 +1,172 @@
+"""
+Repro for https://github.com/redis/redis-py/issues/3741
+
+Reporter's config (async redis-om on top of redis-py):
+    socket_keepalive=True
+    socket_connect_timeout=15
+    socket_timeout=5
+    retry=Retry(ExponentialBackoff(cap=10, base=1), 25)
+    retry_on_error=[ConnectionError, TimeoutError, ConnectionResetError]
+    health_check_interval=5
+
+Observed error (from debug logs in the issue):
+    ConnectionResetError: [Errno 104] Connection reset by peer
+raised while the client was (re)establishing a connection -- i.e. during
+the handshake, not while writing the user's actual command.
+
+petyaslavova's diagnosis: get_connection() opens a new socket and runs
+handshake commands (AUTH / HELLO / CLIENT SETINFO etc.) to configure it;
+failures during that handshake step were NOT covered by the retry policy,
+even though the client was configured with 25 retries.
+
+petyaslavova's claim to verify: PR #3863 wrapped the whole
+connect+handshake flow in `retry.call_with_retry`, so this should now
+retry per the configured policy instead of raising on the first reset.
+"""
+
+from errno import ECONNRESET
+from unittest.mock import patch
+
+import pytest
+from redis.asyncio.connection import Connection
+from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff, NoBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError
+import asyncio
+from errno import ECONNRESET
+from unittest.mock import patch
+
+
+RESETS_BEFORE_SUCCESS = 2
+
+
+@pytest.mark.fixed_client
+async def test_3741_handshake_reset_retries_using_reporter_config():
+    """
+    Simulate a ConnectionResetError happening mid-handshake, using the
+    reporter's own retry configuration. Before PR #3863, this raised
+    immediately on the first reset. After the fix, it should retry and
+    succeed once the transient failure clears.
+    """
+    # NOTE: health_check_interval is set (matching the reporter's config),
+    # which means check_health() fires a PING before the first handshake
+    # command. That PING already goes through its own independent
+    # `retry.call_with_retry` (see Connection.check_health) -- a mechanism
+    # that predates PR #3863 and was never broken. To isolate the actual
+    # bug (handshake commands like HELLO/AUTH not being retried), we must
+    # only fail the HELLO write specifically, not just "the first N writes".
+    resets_raised = {"n": 0}
+    real_writelines = None
+
+    def flaky_writelines(self, data):
+        chunk = data[0] if isinstance(data, (list, tuple)) else data
+        # default protocol is RESP2, so no HELLO is sent -- the first
+        # handshake command actually written is CLIENT SETINFO LIB-NAME
+        is_handshake_cmd = b"LIB-NAME" in chunk
+        if is_handshake_cmd and resets_raised["n"] < RESETS_BEFORE_SUCCESS:
+            resets_raised["n"] += 1
+            raise ConnectionResetError(ECONNRESET, "Connection reset by peer")
+        return real_writelines(self, data)
+
+    import asyncio
+
+    real_writelines = asyncio.StreamWriter.writelines
+
+    with patch.object(
+        asyncio.StreamWriter, "writelines", new=flaky_writelines
+    ):
+        conn = Connection(
+            port=6399,
+            socket_keepalive=True,
+            socket_connect_timeout=15,
+            socket_timeout=5,
+            retry=Retry(ExponentialBackoff(cap=10, base=1), 25),
+            retry_on_error=[RedisConnectionError, ConnectionResetError],
+            health_check_interval=5,
+        )
+        await conn.connect()
+
+        # If the handshake retry gap from #3741 were still open, the very
+        # first ConnectionResetError would have propagated out of connect()
+        # and this line would never be reached.
+        assert conn.is_connected
+        assert resets_raised["n"] == RESETS_BEFORE_SUCCESS, (
+            "expected exactly 2 handshake resets before recovery, got "
+            f"{resets_raised['n']}"
+        )
+        await conn.disconnect()
+
+
+# (bytes that identify the target handshake command on the wire,
+#  extra Connection kwargs needed to make that command actually get sent)
+HANDSHAKE_FAULT_CASES = [
+    pytest.param(b"HELLO", {"protocol": 3}, id="hello"),
+    pytest.param(b"SELECT", {"db": 1}, id="select"),
+    pytest.param(b"LIB-NAME", {}, id="client-setinfo"),
+]
+
+
+@pytest.mark.fixed_client
+@pytest.mark.parametrize("trigger_bytes, extra_conn_kwargs", HANDSHAKE_FAULT_CASES)
+async def test_3741_handshake_reset_retries_parametrized(
+    trigger_bytes, extra_conn_kwargs
+):
+    """
+    Parametrized #3741 repro: inject a ConnectionResetError on each
+    handshake command in turn (HELLO, AUTH, SELECT, CLIENT SETINFO) and
+    confirm the connection retries and recovers no matter which handshake
+    step is the one that gets reset.
+    """
+    resets_raised = {"n": 0}
+    real_writelines = asyncio.StreamWriter.writelines
+
+    def flaky_writelines(self, data):
+        chunk = data[0] if isinstance(data, (list, tuple)) else data
+        if trigger_bytes in chunk and resets_raised["n"] < RESETS_BEFORE_SUCCESS:
+            resets_raised["n"] += 1
+            raise ConnectionResetError(ECONNRESET, "Connection reset by peer")
+        return real_writelines(self, data)
+
+    with patch.object(asyncio.StreamWriter, "writelines", new=flaky_writelines):
+        conn = Connection(
+            port=6399,
+            socket_keepalive=True,
+            socket_connect_timeout=15,
+            socket_timeout=5,
+            retry=Retry(ExponentialBackoff(cap=10, base=1), 25),
+            retry_on_error=[RedisConnectionError, ConnectionResetError],
+            health_check_interval=5,
+            **extra_conn_kwargs,
+        )
+        await conn.connect()
+
+        assert conn.is_connected
+        assert resets_raised["n"] == RESETS_BEFORE_SUCCESS, (
+            f"expected exactly {RESETS_BEFORE_SUCCESS} resets on "
+            f"{trigger_bytes!r} before recovery, got {resets_raised['n']}"
+        )
+        await conn.disconnect()
+
+
+@pytest.mark.fixed_client
+async def test_3741_handshake_reset_exhausts_configured_retries():
+    """
+    Sanity check on the other edge: if the reset never clears, the client
+    should still eventually give up with a clean ConnectionError, having
+    made the number of attempts the retry policy allows (not just 1).
+    """
+    with patch.object(
+        __import__("asyncio").StreamWriter, "writelines"
+    ) as writelines:
+        writelines.side_effect = ConnectionResetError(
+            ECONNRESET, "Connection reset by peer"
+        )
+        conn = Connection(
+            port=6399,
+            retry=Retry(NoBackoff(), 4),
+            retry_on_error=[RedisConnectionError, ConnectionResetError],
+        )
+        with pytest.raises(RedisConnectionError):
+            await conn.connect()
+
+        assert writelines.call_count == 5


### PR DESCRIPTION
### Description of change

_Please provide a description of the change here._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and standalone repro tooling only; no changes to redis-py connection or retry runtime code.
> 
> **Overview**
> Adds **verification** that **#3741** (handshake `ConnectionResetError` not honoring retry) is fixed by **#3863**, without changing library behavior.
> 
> **`tests/test_asyncio/test_repro_3741.py`** patches `asyncio.StreamWriter.writelines` to raise resets on specific handshake bytes (`LIB-NAME`, `HELLO`, `SELECT`) and asserts `Connection.connect()` retries and recovers—or exhausts retries when failures never clear. Tests target handshake writes (not blind “first N writes”) so `health_check_interval`’s separate PING retry does not mask the bug.
> 
> **`proxy.py`** and **`demo_proxy_repro.py`** provide a **real TCP RST** repro via `SO_LINGER`; the demo uses the issue reporter’s retry settings and **omits** `health_check_interval` so the first protected write is the real handshake. **`PROXY_REPRO.md`** documents expected pre/post-#3863 behavior and run steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba38699a86aa4f02f9234adfc29e1f3a3ff34b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->